### PR TITLE
I wanted to update the Half-Elf race so that the structure was the sa…

### DIFF
--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -483,8 +483,60 @@
 			"type": "languages",
 			"from": [
 				{
-					"url": "http://www.dnd5eapi.co/api/languages",
-					"name": "Any"
+					"name":"Dwarvish",
+					"url":"http://www.dnd5eapi.co/api/languages/2"
+				},
+				{
+					"name":"Giant",
+					"url":"http://www.dnd5eapi.co/api/languages/4"
+				},
+				{
+					"name":"Gnomish",
+					"url":"http://www.dnd5eapi.co/api/languages/5"
+				},
+				{
+					"name":"Goblin",
+					"url":"http://www.dnd5eapi.co/api/languages/6"
+				},
+				{
+					"name":"Halfling",
+					"url":"http://www.dnd5eapi.co/api/languages/7"
+				},
+				{
+					"name":"Orc",
+					"url":"http://www.dnd5eapi.co/api/languages/8"
+				},
+				{
+					"name":"Abyssal",
+					"url":"http://www.dnd5eapi.co/api/languages/9"
+				},
+				{
+					"name":"Celestial",
+					"url":"http://www.dnd5eapi.co/api/languages/10"
+				},
+				{
+					"name":"Draconic",
+					"url":"http://www.dnd5eapi.co/api/languages/11"
+				},
+				{
+					"name":"Deep Speech",
+					"url":"http://www.dnd5eapi.co/api/languages/12"
+				},
+				{
+					"name":"Infernal",
+					"url":"http://www.dnd5eapi.co/api/languages/13"
+				},
+				{
+					"name":"Primordial",
+					"url":"http://www.dnd5eapi.co/api/languages/14"
+				},
+				{
+					"name":"Sylvan",
+					"url":"http://www.dnd5eapi.co/api/languages/15"
+				},
+				{
+					"name":"Undercommon",
+					"url":"http://www.dnd5eapi.co/api/languages/16"
 				}
 			]
 		},


### PR DESCRIPTION
…me as Human in regards to picking additional languages. On Human, the languages are listed out in the api endpoint, but previously on Half-Elf it simply said any and pointed to the languages endpoint. Hopefully this provides easier querying. I also noticed on the api that I am accessing, Half-Elf has languages listed as common and Gnomish, whereas on the code I cloned it is listed as common and half-elf, which is the correct information. Perhaps the api is behind the actual database?