### PR TITLE
Halfelf

### DIFF
--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -483,8 +483,60 @@
 			"type": "languages",
 			"from": [
 				{
-					"url": "http://www.dnd5eapi.co/api/languages",
-					"name": "Any"
+					"name":"Dwarvish",
+					"url":"http://www.dnd5eapi.co/api/languages/2"
+				},
+				{
+					"name":"Giant",
+					"url":"http://www.dnd5eapi.co/api/languages/4"
+				},
+				{
+					"name":"Gnomish",
+					"url":"http://www.dnd5eapi.co/api/languages/5"
+				},
+				{
+					"name":"Goblin",
+					"url":"http://www.dnd5eapi.co/api/languages/6"
+				},
+				{
+					"name":"Halfling",
+					"url":"http://www.dnd5eapi.co/api/languages/7"
+				},
+				{
+					"name":"Orc",
+					"url":"http://www.dnd5eapi.co/api/languages/8"
+				},
+				{
+					"name":"Abyssal",
+					"url":"http://www.dnd5eapi.co/api/languages/9"
+				},
+				{
+					"name":"Celestial",
+					"url":"http://www.dnd5eapi.co/api/languages/10"
+				},
+				{
+					"name":"Draconic",
+					"url":"http://www.dnd5eapi.co/api/languages/11"
+				},
+				{
+					"name":"Deep Speech",
+					"url":"http://www.dnd5eapi.co/api/languages/12"
+				},
+				{
+					"name":"Infernal",
+					"url":"http://www.dnd5eapi.co/api/languages/13"
+				},
+				{
+					"name":"Primordial",
+					"url":"http://www.dnd5eapi.co/api/languages/14"
+				},
+				{
+					"name":"Sylvan",
+					"url":"http://www.dnd5eapi.co/api/languages/15"
+				},
+				{
+					"name":"Undercommon",
+					"url":"http://www.dnd5eapi.co/api/languages/16"
 				}
 			]
 		},

--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -470,12 +470,12 @@
 		"starting_proficiency_options": {},
 		"languages": [
 			{
-				"url": "http://www.dnd5eapi.co/api/languages/1",
-				"name": "Common"
+				"name": "Common",
+				"url": "http://www.dnd5eapi.co/api/languages/1"
 			},
 			{
-				"url": "http://www.dnd5eapi.co/api/languages/3",
-				"name": "Elvish"
+				"name": "Elvish",
+				"url": "http://www.dnd5eapi.co/api/languages/3"
 			}
 		],
 		"language_options": {


### PR DESCRIPTION
This PR is to update the optional languages on the Half-Elf. Under the Human race endpoint, the optional languages are listed out in an array which makes querying easy. Under the Half-Elf, they were listed as "Any" with a link to the Languages endpoint. I thought that this fix would make for easier querying. Also, I noticed that the code here is out of sync with the actual API, under Half-Elf the second language is still listed as Gnomish whereas in the code it was fixed to "Elvish" as of 6 months ago. 