### PR TITLE
Added CHA of 18 to Aboleth

### DIFF
--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -14,6 +14,7 @@
 	"constitution": 15,
 	"intelligence": 18,
 	"wisdom": 15,
+	"charisma": 18,
 	"constitution_save": 6,
 	"intelligence_save": 8,
 	"wisdom_save": 6,


### PR DESCRIPTION
Aboleth monster was missing base CHA stat.
This was a little test to make sure I had the connection through to your repo right.
I plan to help more.