### PR TITLE
Updating 5e-database 5e_SRD-Subraces

### DIFF
--- a/5e-SRD-Subraces.json
+++ b/5e-SRD-Subraces.json
@@ -15,7 +15,7 @@
 			1,
 			0
 		],
-		"starting_proficiencies:": [],
+		"starting_proficiencies": [],
 		"starting_proficiency_options": {
 			
 		},
@@ -48,7 +48,7 @@
 			0,
 			0
 		],
-		"starting_proficiencies:": [
+		"starting_proficiencies": [
 			{
 				"url": "http://www.dnd5eapi.co/api/proficiencies/42",
 				"name": "Longswords"
@@ -207,7 +207,7 @@
 			0,
 			1
 		],
-		"starting_proficiencies:": [],
+		"starting_proficiencies": [],
 		"starting_proficiency_options": {
 			
 		},
@@ -240,7 +240,7 @@
 			0,
 			0
 		],
-		"starting_proficiencies:": [
+		"starting_proficiencies": [
 			{
 				"url": "http://www.dnd5eapi.co/api/proficiencies/2",
 				"name": "Medium armor"
@@ -275,7 +275,7 @@
 			1,
 			0
 		],
-		"starting_proficiencies:": [
+		"starting_proficiencies": [
 			{
 				"url": "http://www.dnd5eapi.co/api/proficiencies/42",
 				"name": "Longswords"
@@ -327,7 +327,7 @@
 			0,
 			1
 		],
-		"starting_proficiencies:": [
+		"starting_proficiencies": [
 			{
 				"url": "http://www.dnd5eapi.co/api/proficiencies/46",
 				"name": "Rapiers"


### PR DESCRIPTION
Fixing a bug where "starting_proficiencies" was writen "starting_proficiencies:" with 2 points at the end