### PR TITLE
Update 5edatabase/5e-SRD-Test

### DIFF
--- a/5e-SRD-Test.json
+++ b/5e-SRD-Test.json
@@ -2454,7 +2454,7 @@
 			"url": "http://www.dnd5eapi.co/api/classes/fighter"
 		},
 		"subclass": {},
-		"url": "http://www.dnd5eapi.co/api/classes/f/14"
+		"url": "http://www.dnd5eapi.co/api/classes/fighter/level/14"
 	},
 	{
 		"level": 15,


### PR DESCRIPTION
Fixing a bug where fighter/level/14 was writen f/14 and API call didn't work.