### PR TITLE
Update 5e-SRD-Levels.json

### DIFF
--- a/5e-SRD-Levels.json
+++ b/5e-SRD-Levels.json
@@ -3048,7 +3048,7 @@
       "url": "http://www.dnd5eapi.co/api/classes/fighter"
     },
     "subclass": {},
-    "url": "http://www.dnd5eapi.co/api/classes/f/14"
+    "url": "http://www.dnd5eapi.co/api/classes/fighter/level/14"
   },
   {
     "level": 15,


### PR DESCRIPTION
Fixing a bug where fighter level 14 url was "http://www.dnd5eapi.co/api/classes/f/14" instead of "http://www.dnd5eapi.co/api/classes/fighter/level/14"