### PR TITLE
Update 5e-SRD-StartingEquipment.json

### DIFF
--- a/5e-SRD-StartingEquipment.json
+++ b/5e-SRD-StartingEquipment.json
@@ -805,7 +805,7 @@
 	},
 	"starting_equipment": [{
 	"item": { "url": "http://www.dnd5eapi.co/api/equipment/145", "name": "Spellbook"}, "quantity": 1}],
-	"choices_to_make": 4,
+	"choices_to_make": 3,
 	"choice_1": [{
 		"choose": 1,
 		"type": "equipment",


### PR DESCRIPTION
Fixing a bug where the wizard "choices_to_make" was equal to 4 but had only 3 choices.
(set "choices_to_make": 3)