### PR TITLE
fix class levels urls

### DIFF
--- a/5e-SRD-Classes.json
+++ b/5e-SRD-Classes.json
@@ -2,6 +2,7 @@
 	{
 		"index": 1,
 		"name": "Barbarian",
+    "description": "Barbarians come alive in the chaos of combat. They can enter a berserk state where rage takes over, giving them superhuman strength and resilience. A barbarian can draw on this reservoir of fury only a few times without resting, but those few rages are usually sufficient to defeat whatever threats arise.",
 		"hit_die": 12,
 		"proficiency_choices": [
 			{
@@ -275,6 +276,7 @@
 	{
 		"index": 3,
 		"name": "Cleric",
+    "description": "Divine magic, as the name suggests, is the power of the gods, flowing from them into the world. Clerics are conduits for that power, manifesting it as miraculous effects. The gods don\'t grant this power to everyone who seeks it, but only to those chosen to fulfill a high calling. Harnessing divine magic doesn\'t rely on study or training. A cleric might learn formulaic prayers and ancient rites, but the ability to cast cleric spells relies on devotion and an intuitive sense of a deity\'s wishes. Clerics combine the helpful magic of healing and inspiring their allies with spells that harm and hinder foes. They can provoke awe and dread, lay curses of plague or poison, and even call down flames from heaven to consume their enemies. For those evildoers who will benefit most from a mace to the head, clerics depend on their combat training to let them wade into melee with the power of the gods on their side.",
 		"hit_die": 8,
 		"proficiency_choices": [
 			{
@@ -578,6 +580,7 @@
 	{
 		"index": 6,
 		"name": "Monk",
+    "description": "Monks make careful study of a magical energy that most monastic traditions call ki. Monks harness this power within themselves to create magical effects and exceed their bodies' physical capabilities, and some of their special attacks can hinder the flow of ki in their opponents.",
 		"hit_die": 8,
 		"proficiency_choices": [
 			{
@@ -865,6 +868,7 @@
 	{
 		"index": 8,
 		"name": "Ranger",
+    "description": "Warriors of the wilderness, rangers specialize in hunting the monsters that threaten the edges of civilization--humanoid raiders, rampaging beasts and monstrosities, terrible giants and deadly dragons. They learn to track their quarry as a predator does, moving stealthily through the wilds and hiding themselves in brush and rubble. Rangers focus their combat training on techniques that are particularly useful against their specific favored foes.",
 		"hit_die": 10,
 		"proficiency_choices": [
 			{

--- a/5e-SRD-Classes.json
+++ b/5e-SRD-Classes.json
@@ -72,7 +72,7 @@
 			"class": "Barbarian"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Barbarian/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/barbarian/levels",
 			"class": "Barbarian"
 		},
 		"subclasses": [
@@ -257,7 +257,7 @@
 			"class": "Bard"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Bard/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/bard/levels",
 			"class": "Bard"
 		},
 		"subclasses": [
@@ -337,7 +337,7 @@
 			"class": "Cleric"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Cleric/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/cleric/levels",
 			"class": "Cleric"
 		},
 		"subclasses": [
@@ -469,7 +469,7 @@
 			"class": "Druid"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Druid/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/druid/levels",
 			"class": "Druid"
 		},
 		"subclasses": [
@@ -561,7 +561,7 @@
 			"class": "Fighter"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Fighter/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/fighter/levels",
 			"class": "Fighter"
 		},
 		"subclasses": [
@@ -764,7 +764,7 @@
 			"class": "Monk"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Monk/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/monk/levels",
 			"class": "Monk"
 		},
 		"subclasses": [
@@ -847,7 +847,7 @@
 			"class": "Paladin"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Paladin/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/paladin/levels",
 			"class": "Paladin"
 		},
 		"subclasses": [
@@ -943,7 +943,7 @@
 			"class": "Ranger"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Ranger/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/ranger/levels",
 			"class": "Ranger"
 		},
 		"subclasses": [
@@ -1059,7 +1059,7 @@
 			"class": "Rogue"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Rogue/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/rogue/levels",
 			"class": "Rogue"
 		},
 		"subclasses": [
@@ -1142,7 +1142,7 @@
 			"class": "Sorcerer"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Sorcerer/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/sorcerer/levels",
 			"class": "Sorcerer"
 		},
 		"subclasses": [
@@ -1222,7 +1222,7 @@
 			"class": "Warlock"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Warlock/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/warlock/levels",
 			"class": "Warlock"
 		},
 		"subclasses": [
@@ -1306,7 +1306,7 @@
 			"class": "Wizard"
 		},
 		"class_levels": {
-			"url": "http://www.dnd5eapi.co/api/classes/Wizard/levels",
+			"url": "http://www.dnd5eapi.co/api/classes/wizard/levels",
 			"class": "Wizard"
 		},
 		"subclasses": [

--- a/5e-SRD-Languages.json
+++ b/5e-SRD-Languages.json
@@ -93,7 +93,7 @@
 	"index": 14,
 	"name": "Primordial",
 	"type": "Exotic",
-	"typical_speakers": ["Elementa;s"],
+	"typical_speakers": ["Elementals"],
 	"script": "Dwarvish",
 	"url": "http://www.dnd5eapi.co/api/languages/14"
 }, {

--- a/5e-SRD-StartingEquipment.json
+++ b/5e-SRD-StartingEquipment.json
@@ -805,7 +805,7 @@
 	},
 	"starting_equipment": [{
 	"item": { "url": "http://www.dnd5eapi.co/api/equipment/145", "name": "Spellbook"}, "quantity": 1}],
-	"choices_to_make": 4,
+	"choices_to_make": 3,
 	"choice_1": [{
 		"choose": 1,
 		"type": "equipment",

--- a/5e-SRD-Traits.json
+++ b/5e-SRD-Traits.json
@@ -104,7 +104,7 @@
             },
             {"name":"High Elf"},
             {
-                "name":"Hlf-Elf"
+                "name":"Half-Elf"
             }
         ],
         "name":"Fey Ancestry",


### PR DESCRIPTION
this is broken on the demo site as well where following 

http://www.dnd5eapi.co/api/classes/Barbarian/levels

just returns an empty array but

http://www.dnd5eapi.co/api/classes/barbarian/levels

returns useful data