### PR TITLE
add High/Dark Elf subraces to Elf race

### DIFF
--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -146,6 +146,14 @@
 			{
 				"url": "http://www.dnd5eapi.co/api/subraces/2",
 				"name": "High Elf"
+			},
+			{
+				"url": "http://www.dnd5eapi.co/api/subraces/5",
+				"name": "Wood Elf"
+			},
+			{
+				"url": "http://www.dnd5eapi.co/api/subraces/6",
+				"name": "Dark Elf (Drow)"
 			}
 		],
 		"url": "http://www.dnd5eapi.co/api/races/2"


### PR DESCRIPTION
This should fix #46 . The subraces exist in 5e-SRD-Subraces.json, but are not in the Elf race's `subraces` array in 5e-SRD-Races.json. This change adds them to that array so they appear in the /races/ data for the Elf race