### PR TITLE
fix dragonborn damage resistance id

### DIFF
--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -340,7 +340,7 @@
 			},
 			{
 				"name": "Damage Resistance (Dragonborn)",
-				"url": "http://www.dnd5eapi.co/api/traits/36"
+				"url": "http://www.dnd5eapi.co/api/traits/18"
 			}
 
 		],


### PR DESCRIPTION
This trait had the wrong id, so the link wasn't working