### PR TITLE
Fix typical speakers based on the SRD:

### DIFF
--- a/5e-SRD-Languages.json
+++ b/5e-SRD-Languages.json
@@ -79,14 +79,14 @@
 	"index": 12,
 	"name": "Deep Speech",
 	"type": "Exotic",
-	"typical_speakers": ["Mindflayers", "Beholders"],
+	"typical_speakers": ["Aboleths", "Cloakers"],
 	"script": "none",
 	"url": "http://www.dnd5eapi.co/api/languages/12"
 }, {
 	"index": 13,
 	"name": "Infernal",
 	"type": "Exotic",
-	"typical_speakers": ["Devils", "Tieflings"],
+	"typical_speakers": ["Devils"],
 	"script": "Infernal",
 	"url": "http://www.dnd5eapi.co/api/languages/13"
 }, {
@@ -100,14 +100,14 @@
 	"index": 15,
 	"name": "Sylvan",
 	"type": "Exotic",
-	"typical_speakers": ["Fey Creatures"],
+	"typical_speakers": ["Fey creatures"],
 	"script": "Elvish",
 	"url": "http://www.dnd5eapi.co/api/languages/15"
 }, {
 	"index": 16,
 	"name": "Undercommon",
 	"type": "Exotic",
-	"typical_speakers": ["Underdark Traders"],
+	"typical_speakers": ["Underdark traders"],
 	"script": "Elvish",
 	"url": "http://www.dnd5eapi.co/api/languages/16"
 }]


### PR DESCRIPTION
* change deep speech typical speakers from mindflayers and beholders to aboleths and cloakers;
* remove tieflings from infernal typical speakers;
* fix word casing for fey creatures and underdark traders.

See SRD 5.1, page 59.