### PR TITLE
Added 2h_damage to Trident

### DIFF
--- a/5e-SRD-Equipment.json
+++ b/5e-SRD-Equipment.json
@@ -986,6 +986,14 @@
 		"normal": 20,
 		"long": 60
 	},
+	"2h_damage": {
+		"dice_count": 1,
+		"dice_value": 8,
+		"damage_type": {
+			"url": "http://www.dnd5eapi.co/api/damage-types/8",
+			"name": "Piercing"
+		}
+	},
 	"url": "http://www.dnd5eapi.co/api/equipment/29"
 }, {
 	"index": 30,


### PR DESCRIPTION
Trident was missing 2h_damage that all the Versatile weapons have.