### PR TITLE
Race Trait Url correction, added missing traits, added missing subraces

### DIFF
--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -75,8 +75,12 @@
 				"url": "http://www.dnd5eapi.co/api/traits/2"
 			},
 			{
-				"name": "Stonecunning",
+				"name": "Dwarven Combat Training",
 				"url": "http://www.dnd5eapi.co/api/traits/3"
+			},
+			{
+				"name": "Stonecunning",
+				"url": "http://www.dnd5eapi.co/api/traits/4"
 			}
 		],
 		"subraces": [
@@ -126,23 +130,39 @@
 		"language_desc": "You can speak, read, and write Common and Elvish. Elvish is fluid, with subtle intonations and intricate grammar. Elven literature is rich and varied, and their songs and poems are famous among other races. Many bards learn their language so they can add Elvish ballads to their repertoires.",
 		"traits": [
 			{
+				"name": "Keen Senses",
+				"url": "http://www.dnd5eapi.co/api/traits/6"
+			}
+			{
 				"name": "Darkvision (Elf)",
-				"url": "http://www.dnd5eapi.co/api/traits/5"
+				"url": "http://www.dnd5eapi.co/api/traits/1"
 			},
 			{
 				"name": "Fey Ancestry",
-				"url": "http://www.dnd5eapi.co/api/traits/6"
+				"url": "http://www.dnd5eapi.co/api/traits/7"
 			},
 			{
 				"name": "Trance",
-				"url": "http://www.dnd5eapi.co/api/traits/7"
-			}
+				"url": "http://www.dnd5eapi.co/api/traits/8"
+			},
+			{
+				"name": "Elf Weapon Training",
+				"url": "http://www.dnd5eapi.co/api/traits/9"
+			},
+			
 		],
 		"subraces": [
 			{
 				"url": "http://www.dnd5eapi.co/api/subraces/2",
 				"name": "High Elf"
-			}
+			},
+			{
+				"name": "Wood Elf",
+				"url": "http://www.dnd5eapi.co/api/subraces/5"
+			},
+			{
+				"name": "Dark Elf (Drow)"
+				"url": "http://www.dnd5eapi.co/api/subraces/6"
 		],
 		"url": "http://www.dnd5eapi.co/api/races/2"
 	},
@@ -179,15 +199,15 @@
 		"traits": [
 			{
 				"name": "Brave",
-				"url": "http://www.dnd5eapi.co/api/traits/21"
+				"url": "http://www.dnd5eapi.co/api/traits/13"
 			},
 			{
 				"name": "Halfling Nimbleness",
-				"url": "http://www.dnd5eapi.co/api/traits/22"
+				"url": "http://www.dnd5eapi.co/api/traits/14"
 			},
 			{
 				"name": "Lucky",
-				"url": "http://www.dnd5eapi.co/api/traits/23"
+				"url": "http://www.dnd5eapi.co/api/traits/12"
 			}
 		],
 		"subraces": [
@@ -358,11 +378,11 @@
 		"traits": [
 			{
 				"name": "Draconic Ancestry",
-				"url": "http://www.dnd5eapi.co/api/traits/24"
+				"url": "http://www.dnd5eapi.co/api/traits/16"
 			},
 			{
 				"name": "Breath Weapon",
-				"url": "http://www.dnd5eapi.co/api/traits/25"
+				"url": "http://www.dnd5eapi.co/api/traits/17"
 			},
 			{
 				"name": "Damage Resistance (Dragonborn)",
@@ -593,15 +613,15 @@
 		"traits": [
 			{
 				"name": "Darkvision (Half-Elf)",
-				"url": "http://www.dnd5eapi.co/api/traits/48"
+				"url": "http://www.dnd5eapi.co/api/traits/1"
 			},
 			{
 				"name": "Fey Ancestry",
-				"url": "http://www.dnd5eapi.co/api/traits/49"
+				"url": "http://www.dnd5eapi.co/api/traits/7"
 			},
 			{
 				"name": "Skill Versatility",
-				"url": "http://www.dnd5eapi.co/api/traits/50"
+				"url": "http://www.dnd5eapi.co/api/traits/22"
 			}
 
 		],
@@ -652,15 +672,19 @@
 		"traits": [
 			{
 				"name": "Darkvision (Half-Orc)",
-				"url": "http://www.dnd5eapi.co/api/traits/51"
+				"url": "http://www.dnd5eapi.co/api/traits/1"
+			},
+			{
+				"name": "Menacing",
+				"url": "http://www.dnd5eapi.co/api/traits/23"
 			},
 			{
 				"name": "Savage Attacks",
-				"url": "http://www.dnd5eapi.co/api/traits/52"
+				"url": "http://www.dnd5eapi.co/api/traits/25"
 			},
 			{
 				"name": "Restless Endurance",
-				"url": "http://www.dnd5eapi.co/api/traits/53"
+				"url": "http://www.dnd5eapi.co/api/traits/24"
 			}
 
 		],
@@ -706,15 +730,15 @@
 		"traits": [
 			{
 				"name": "Darkvision (Tiefling)",
-				"url": "http://www.dnd5eapi.co/api/traits/54"
+				"url": "http://www.dnd5eapi.co/api/traits/1"
 			},
 			{
 				"name": "Hellish Resistance",
-				"url": "http://www.dnd5eapi.co/api/traits/55"
+				"url": "http://www.dnd5eapi.co/api/traits/26"
 			},
 			{
 				"name": "Infernal Legacy",
-				"url": "http://www.dnd5eapi.co/api/traits/56"
+				"url": "http://www.dnd5eapi.co/api/traits/27"
 			}
 		],
 		"trait_options": {},

--- a/5e-SRD-Races.json
+++ b/5e-SRD-Races.json
@@ -163,6 +163,7 @@
 			{
 				"name": "Dark Elf (Drow)"
 				"url": "http://www.dnd5eapi.co/api/subraces/6"
+			}
 		],
 		"url": "http://www.dnd5eapi.co/api/races/2"
 	},


### PR DESCRIPTION
Mostly just corrected the urls, but also added some missing traits and added two subraces missing from the elven race (Woodland Elf and Dark Elf) 