### PR TITLE
Convert monster desc to lists

### DIFF
--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -34,11 +34,15 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The aboleth can breathe air and water."
+        "desc": [
+          "The aboleth can breathe air and water."
+        ]
       },
       {
         "name": "Mucous Cloud",
-        "desc": "While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within 5 ft. of it must make a DC 14 Constitution saving throw. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater.",
+        "desc": [
+          "While underwater, the aboleth is surrounded by transformative mucus. A creature that touches the aboleth or that hits it with a melee attack while within 5 ft. of it must make a DC 14 Constitution saving throw. On a failure, the creature is diseased for 1d4 hours. The diseased creature can breathe only underwater."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -50,17 +54,23 @@
       },
       {
         "name": "Probing Telepathy",
-        "desc": "If a creature communicates telepathically with the aboleth, the aboleth learns the creature's greatest desires if the aboleth can see the creature."
+        "desc": [
+          "If a creature communicates telepathically with the aboleth, the aboleth learns the creature's greatest desires if the aboleth can see the creature."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The aboleth makes three tentacle attacks."
+        "desc": [
+          "The aboleth makes three tentacle attacks."
+        ]
       },
       {
         "name": "Tentacle",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by heal or another disease-curing spell of 6th level or higher. When the creature is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes unless moisture is applied to the skin before 10 minutes have passed.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute and can be removed by any magic that cures disease. After 1 minute, the diseased creature's skin becomes translucent and slimy, the creature can't regain hit points unless it is underwater, and the disease can be removed only by heal or another disease-curing spell of 6th level or higher. When the creature is outside a body of water, it takes 6 (1d12) acid damage every 10 minutes unless moisture is applied to the skin before 10 minutes have passed."
+        ],
         "attack_bonus": 9,
         "dc": {
           "dc_type": {
@@ -83,7 +93,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: 15 (3d6 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft. one target. Hit: 15 (3d6 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -98,7 +110,10 @@
       },
       {
         "name": "Enslave (3/day)",
-        "desc": "The aboleth targets one creature it can see within 30 ft. of it. The target must succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target. The charmed target is under the aboleth's control and can't take reactions, and the aboleth and the target can communicate telepathically with each other over any distance.\nWhenever the charmed target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth.",
+        "desc": [
+          "The aboleth targets one creature it can see within 30 ft. of it. The target must succeed on a DC 14 Wisdom saving throw or be magically charmed by the aboleth until the aboleth dies or until it is on a different plane of existence from the target. The charmed target is under the aboleth's control and can't take reactions, and the aboleth and the target can communicate telepathically with each other over any distance.",
+          "Whenever the charmed target takes damage, the target can repeat the saving throw. On a success, the effect ends. No more than once every 24 hours, the target can also repeat the saving throw when it is at least 1 mile away from the aboleth."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -112,15 +127,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The aboleth makes a Wisdom (Perception) check."
+        "desc": [
+          "The aboleth makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Swipe",
-        "desc": "The aboleth makes one tail attack."
+        "desc": [
+          "The aboleth makes one tail attack."
+        ]
       },
       {
         "name": "Psychic Drain (Costs 2 Actions)",
-        "desc": "One creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth regains hit points equal to the damage the creature takes.",
+        "desc": [
+          "One creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth regains hit points equal to the damage the creature takes."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -167,13 +188,19 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (3 slots): bless, cure wounds, sanctuary"
+        "desc": [
+          "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:",
+          "- Cantrips (at will): light, sacred flame, thaumaturgy",
+          "- 1st level (3 slots): bless, cure wounds, sanctuary"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Club",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -228,21 +255,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) acid damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -262,7 +297,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -277,7 +314,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -292,7 +331,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -304,7 +345,9 @@
       },
       {
         "name": "Acid Breath (Recharge 5-6)",
-        "desc": "The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales acid in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -328,15 +371,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -417,21 +466,29 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dracolich fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dracolich fails a saving throw, it can choose to succeed instead."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The dracolich has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The dracolich has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dracolich can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dracolich can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -451,7 +508,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -466,7 +525,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -481,7 +542,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dracolich's choice that is within 120 feet of the dracolich and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dracolich's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dracolich's choice that is within 120 feet of the dracolich and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dracolich's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -493,7 +556,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dracolich exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 20 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dracolich exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 20 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -517,15 +582,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dracolich makes a Wisdom (Perception) check."
+        "desc": [
+          "The dracolich makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dracolich makes a tail attack."
+        "desc": [
+          "The dracolich makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dracolich beats its tattered wings. Each creature within 10 ft. of the dracolich must succeed on a DC 21 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. After beating its wings this way, the dracolich can fly up to half its flying speed.",
+        "desc": [
+          "The dracolich beats its tattered wings. Each creature within 10 ft. of the dracolich must succeed on a DC 21 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. After beating its wings this way, the dracolich can fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -587,17 +658,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage plus 5 (1d10) lightning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -617,7 +694,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -632,7 +711,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -647,7 +728,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -659,7 +742,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales lightning in a 90-foot line that is 5 ft. wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -683,15 +768,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -755,17 +846,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -780,7 +877,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -795,7 +894,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -810,7 +911,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours ."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -822,7 +925,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 45 (13d6) fire damage on a failed save, or half as much damage on a successful one.",
+          "Sleep Breath. The dragon exhales sleep gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -901,21 +1008,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 18 (2d10 + 7) piercing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -930,7 +1045,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 14 (2d6 + 7) slashing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -945,7 +1062,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 15 ft., one target. Hit: 16 (2d8 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -960,7 +1079,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -972,7 +1093,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nLightning Breath. The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.\nRepulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Lightning Breath. The dragon exhales lightning in a 90-foot line that is 5 feet wide. Each creature in that line must make a DC 19 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
+          "Repulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 19 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."
+        ],
         "attacks": [
           {
             "name": "Lightning Breath",
@@ -1012,15 +1137,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 20 Dexterity saving throw or take 14 (2d6 + 7) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1083,17 +1214,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1108,7 +1245,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1123,7 +1262,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1138,7 +1279,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -1150,7 +1293,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nAcid Breath. The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.\nSlowing Breath. The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Acid Breath. The dragon exhales acid in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 54 (12d8) acid damage on a failed save, or half as much damage on a successful one.",
+          "Slowing Breath. The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 18 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        ],
         "attacks": [
           {
             "name": "Acid Breath",
@@ -1190,15 +1337,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1262,21 +1415,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1291,7 +1452,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1306,7 +1469,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1321,7 +1486,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -1333,7 +1500,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 66 (12d10) fire damage on a failed save, or half as much damage on a successful one.\nWeakening Breath. The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 21 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 66 (12d10) fire damage on a failed save, or half as much damage on a successful one.",
+          "Weakening Breath. The dragon exhales gas in a 60-foot cone. Each creature in that area must succeed on a DC 21 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -1373,15 +1544,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1451,21 +1628,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 7 (2d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 7 (2d6) poison damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1485,7 +1670,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1500,7 +1687,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -1515,7 +1704,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours ."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -1527,7 +1718,9 @@
       },
       {
         "name": "Poison Breath (Recharge 5-6)",
-        "desc": "The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 56 (16d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales poisonous gas in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 56 (16d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -1551,15 +1744,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1621,17 +1820,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 7 (2d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 7 (2d6) fire damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1651,7 +1856,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1666,7 +1873,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -1681,7 +1890,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -1693,7 +1904,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 63 (18d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales fire in a 60-foot cone. Each creature in that area must make a DC 21 Dexterity saving throw, taking 63 (18d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1715,7 +1928,12 @@
       },
       {
         "name": "Lair Actions",
-        "desc": "On initiative count 20 (losing initiative ties), the dragon takes a lair action to cause one of the following effects: the dragon can't use the same effect two rounds in a row:\n- Magma erupts from a point on the ground the dragon can see within 120 feet of it, creating a 20-foot-high, 5-foot-radius geyser. Each creature in the geyser's area must make a DC 15 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.\n- A tremor shakes the lair in a 60-foot-radius around the dragon. Each creature other than the dragon on the ground in that area must succeed on a DC 15 Dexterity saving throw or be knocked prone.\n- Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point the dragon can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 13 Constitution saving throw or be poisoned until the end of its turn. While poisoned in this way, a creature is incapacitated.",
+        "desc": [
+          "On initiative count 20 (losing initiative ties), the dragon takes a lair action to cause one of the following effects: the dragon can't use the same effect two rounds in a row:",
+          "- Magma erupts from a point on the ground the dragon can see within 120 feet of it, creating a 20-foot-high, 5-foot-radius geyser. Each creature in the geyser's area must make a DC 15 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.",
+          "- A tremor shakes the lair in a 60-foot-radius around the dragon. Each creature other than the dragon on the ground in that area must succeed on a DC 15 Dexterity saving throw or be knocked prone.",
+          "- Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point the dragon can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 13 Constitution saving throw or be poisoned until the end of its turn. While poisoned in this way, a creature is incapacitated."
+        ],
         "attacks": [
           {
             "name": "Magma Eruption",
@@ -1766,15 +1984,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -1837,17 +2061,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -1862,7 +2092,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -1877,7 +2109,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -1892,7 +2126,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -1904,7 +2140,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 20 Constitution saving throw, taking 58 (13d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a DC 20 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Cold Breath. The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 20 Constitution saving throw, taking 58 (13d8) cold damage on a failed save, or half as much damage on a successful one.",
+          "Paralyzing Breath. The dragon exhales paralyzing gas in a 60-foot cone. Each creature in that area must succeed on a DC 20 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Cold Breath",
@@ -1944,15 +2184,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2015,21 +2261,29 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": [
+          "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 4 (1d8) cold damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -2049,7 +2303,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -2064,7 +2320,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 15 ft., one target. Hit: 15 (2d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -2079,7 +2337,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 ft. of the dragon and aware of it must succeed on a DC 14 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -2091,7 +2351,9 @@
       },
       {
         "name": "Cold Breath (Recharge 5-6)",
-        "desc": "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales an icy blast in a 60-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -2115,15 +2377,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2215,17 +2483,23 @@
     "special_abilities": [
       {
         "name": "Air Form",
-        "desc": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": [
+          "The elemental makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -2240,7 +2514,10 @@
       },
       {
         "name": "Whirlwind (Recharge 4-6)",
-        "desc": "Each creature in the elemental's space must make a DC 13 Strength saving throw. On a failure, a target takes 15 (3d8 + 2) bludgeoning damage and is flung up 20 feet away from the elemental in a random direction and knocked prone. If a thrown target strikes an object, such as a wall or floor, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 13 Dexterity saving throw or take the same damage and be knocked prone.\nIf the saving throw is successful, the target takes half the bludgeoning damage and isn't flung away or knocked prone."
+        "desc": [
+          "Each creature in the elemental's space must make a DC 13 Strength saving throw. On a failure, a target takes 15 (3d8 + 2) bludgeoning damage and is flung up 20 feet away from the elemental in a random direction and knocked prone. If a thrown target strikes an object, such as a wall or floor, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 13 Dexterity saving throw or take the same damage and be knocked prone.",
+          "If the saving throw is successful, the target takes half the bludgeoning damage and isn't flung away or knocked prone."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/14"
@@ -2284,21 +2561,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage.",
+        "desc": [
+          "Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -2318,7 +2603,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -2333,7 +2620,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 20 ft ., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 20 ft ., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -2348,7 +2637,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -2360,7 +2651,9 @@
       },
       {
         "name": "Acid Breath (Recharge 5-6)",
-        "desc": "The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 67 (15d8) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales acid in a 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 67 (15d8) acid damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2384,15 +2677,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2454,11 +2753,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage plus 11 (2d10) lightning damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage plus 11 (2d10) lightning damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2478,7 +2781,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2493,7 +2798,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2508,7 +2815,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -2520,7 +2829,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2535,15 +2846,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2607,17 +2924,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -2632,7 +2955,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -2647,7 +2972,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -2662,7 +2989,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 18 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -2674,7 +3003,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons:\nFire Breath. The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+        "desc": [
+          "The dragon uses one of the following breath weapons:",
+          "Fire Breath. The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.",
+          "Sleep Breath. The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -2712,21 +3045,30 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        "desc": [
+          "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).",
+          "In a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2789,21 +3131,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 15 ft., one target. Hit: 20 (2d10 + 9) piercing damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2818,7 +3168,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 10 ft., one target. Hit: 16 (2d6 + 9) slashing damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2833,7 +3185,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +16 to hit, reach 20 ft., one target. Hit: 18 (2d8 + 9) bludgeoning damage."
+        ],
         "attack_bonus": 16,
         "damage": [
           {
@@ -2848,7 +3202,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 20 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -2860,7 +3216,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nLightning Breath. The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.\nRepulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 23 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Lightning Breath. The dragon exhales lightning in a 120-foot line that is 10 feet wide. Each creature in that line must make a DC 23 Dexterity saving throw, taking 88 (16d10) lightning damage on a failed save, or half as much damage on a successful one.",
+          "Repulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 23 Strength saving throw. On a failed save, the creature is pushed 60 feet away from the dragon."
+        ],
         "attacks": [
           {
             "name": "Lightning Breath",
@@ -2898,21 +3258,30 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        "desc": [
+          "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).",
+          "In a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 24 Dexterity saving throw or take 16 (2d6 + 9) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -2975,17 +3344,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3000,7 +3375,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3015,7 +3392,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3030,7 +3409,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3042,7 +3423,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nAcid Breath. The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 63 (14d8) acid damage on a failed save, or half as much damage on a successful one.\nSlowing Breath. The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 22 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Acid Breath. The dragon exhales acid in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 22 Dexterity saving throw, taking 63 (14d8) acid damage on a failed save, or half as much damage on a successful one.",
+          "Slowing Breath. The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 22 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        ],
         "attacks": [
           {
             "name": "Acid Breath",
@@ -3080,21 +3465,30 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        "desc": [
+          "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).",
+          "In a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3158,21 +3552,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3187,7 +3589,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3202,7 +3606,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3217,7 +3623,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 24 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 24 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3229,7 +3637,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 71 (13d10) fire damage on a failed save, or half as much damage on a successful one.\nWeakening Breath. The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 71 (13d10) fire damage on a failed save, or half as much damage on a successful one.",
+          "Weakening Breath. The dragon exhales gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -3267,21 +3679,30 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        "desc": [
+          "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).",
+          "In a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3351,21 +3772,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 10 (3d6) poison damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3388,7 +3817,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 22 (4d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 10 ft., one target. Hit: 22 (4d6 + 8) slashing damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3403,7 +3834,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -3418,7 +3851,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 19 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3430,7 +3865,9 @@
       },
       {
         "name": "Poison Breath (Recharge 5-6)",
-        "desc": "The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales poisonous gas in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 77 (22d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -3454,15 +3891,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 23 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3524,17 +3967,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage plus 14 (4d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage plus 14 (4d6) fire damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3557,7 +4006,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3572,7 +4023,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3587,7 +4040,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3599,7 +4054,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales fire in a 90-foot cone. Each creature in that area must make a DC 24 Dexterity saving throw, taking 91 (26d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3623,15 +4080,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3694,17 +4157,23 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 15 ft., one target. Hit: 21 (2d10 + 10) piercing damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3719,7 +4188,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 10 ft., one target. Hit: 17 (2d6 + 10) slashing damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3734,7 +4205,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +17 to hit, reach 20 ft., one target. Hit: 19 (2d8 + 10) bludgeoning damage."
+        ],
         "attack_bonus": 17,
         "damage": [
           {
@@ -3749,7 +4222,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 21 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3761,7 +4236,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Cold Breath. The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.",
+          "Paralyzing Breath. The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Cold Breath",
@@ -3799,21 +4278,30 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).\nIn a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        "desc": [
+          "The dragon magically polymorphs into a humanoid or beast that has a challenge rating no higher than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the dragon's choice).",
+          "In a new form, the dragon retains its alignment, hit points, Hit Dice, ability to speak, proficiencies, Legendary Resistance, lair actions, and Intelligence, Wisdom, and Charisma scores, as well as this action. Its statistics and capabilities are otherwise replaced by those of the new form, except any class features or legendary actions of that form."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 25 Dexterity saving throw or take 17 (2d6 + 10) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -3876,21 +4364,29 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": [
+          "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the dragon fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the dragon fails a saving throw, it can choose to succeed instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) cold damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -3913,7 +4409,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -3928,7 +4426,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 20 ft., one target. Hit: 17 (2d8 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -3943,7 +4443,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours .",
+        "desc": [
+          "Each creature of the dragon's choice that is within 120 feet of the dragon and aware of it must succeed on a DC 16 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the dragon's Frightful Presence for the next 24 hours ."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -3955,7 +4457,9 @@
       },
       {
         "name": "Cold Breath (Recharge 5-6)",
-        "desc": "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (l6d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (l6d8) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -3979,15 +4483,21 @@
     "legendary_actions": [
       {
         "name": "Detect",
-        "desc": "The dragon makes a Wisdom (Perception) check."
+        "desc": [
+          "The dragon makes a Wisdom (Perception) check."
+        ]
       },
       {
         "name": "Tail Attack",
-        "desc": "The dragon makes a tail attack."
+        "desc": [
+          "The dragon makes a tail attack."
+        ]
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": [
+          "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -4059,25 +4569,42 @@
     "special_abilities": [
       {
         "name": "Inscrutable",
-        "desc": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        "desc": [
+          "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The sphinx's weapon attacks are magical."
+        "desc": [
+          "The sphinx's weapon attacks are magical."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, spare the dying, thaumaturgy\n- 1st level (4 slots): command, detect evil and good, detect magic\n- 2nd level (3 slots): lesser restoration, zone of truth\n- 3rd level (3 slots): dispel magic, tongues\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, greater restoration\n- 6th level (1 slot): heroes' feast"
+        "desc": [
+          "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:",
+          "- Cantrips (at will): sacred flame, spare the dying, thaumaturgy",
+          "- 1st level (4 slots): command, detect evil and good, detect magic",
+          "- 2nd level (3 slots): lesser restoration, zone of truth",
+          "- 3rd level (3 slots): dispel magic, tongues",
+          "- 4th level (3 slots): banishment, freedom of movement",
+          "- 5th level (2 slots): flame strike, greater restoration",
+          "- 6th level (1 slot): heroes' feast"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sphinx makes two claw attacks."
+        "desc": [
+          "The sphinx makes two claw attacks."
+        ]
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 17 (2d10 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 17 (2d10 + 6) slashing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -4092,7 +4619,12 @@
       },
       {
         "name": "Roar (3/Day)",
-        "desc": "The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.\n\nFirst Roar. Each creature that fails a DC 18 Wisdom saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.\n\nSecond Roar. Each creature that fails a DC 18 Wisdom saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.\n\nThird Roar. Each creature makes a DC 18 Constitution saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn't knocked prone.",
+        "desc": [
+          "The sphinx emits a magical roar. Each time it roars before finishing a long rest, the roar is louder and the effect is different, as detailed below. Each creature within 500 feet of the sphinx and able to hear the roar must make a saving throw.",
+          "First Roar. Each creature that fails a DC 18 Wisdom saving throw is frightened for 1 minute. A frightened creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+          "Second Roar. Each creature that fails a DC 18 Wisdom saving throw is deafened and frightened for 1 minute. A frightened creature is paralyzed and can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+          "Third Roar. Each creature makes a DC 18 Constitution saving throw. On a failed save, a creature takes 44 (8d10) thunder damage and is knocked prone. On a successful save, the creature takes half as much damage and isn't knocked prone."
+        ],
         "attacks": [
           {
             "name": "First Roar",
@@ -4143,15 +4675,21 @@
     "legendary_actions": [
       {
         "name": "Claw Attack",
-        "desc": "The sphinx makes one claw attack."
+        "desc": [
+          "The sphinx makes one claw attack."
+        ]
       },
       {
         "name": "Teleport (Costs 2 Actions)",
-        "desc": "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        "desc": [
+          "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Cast a Spell (Costs 3 Actions)",
-        "desc": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        "desc": [
+          "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/25"
@@ -4221,21 +4759,29 @@
     "special_abilities": [
       {
         "name": "Antimagic Susceptibility",
-        "desc": "The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        "desc": [
+          "The armor is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the armor must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the armor remains motionless, it is indistinguishable from a normal suit of armor."
+        "desc": [
+          "While the armor remains motionless, it is indistinguishable from a normal suit of armor."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The armor makes two melee attacks."
+        "desc": [
+          "The armor makes two melee attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -4281,7 +4827,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage plus 3 (1d6) acid damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage plus 3 (1d6) acid damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the ankheg can bite only the grappled creature and has advantage on attack rolls to do so."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -4304,7 +4852,9 @@
       },
       {
         "name": "Acid Spray (Recharge 6)",
-        "desc": "The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled. Each creature in that line must make a DC 13 Dexterity saving throw, taking 10 (3d6) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled. Each creature in that line must make a DC 13 Dexterity saving throw, taking 10 (3d6) acid damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -4359,11 +4909,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ape makes two fist attacks."
+        "desc": [
+          "The ape makes two fist attacks."
+        ]
       },
       {
         "name": "Fist",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -4378,7 +4932,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +5 to hit, range 25/50 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -4430,17 +4986,34 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The archmage has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The archmage has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp\n- 1st level (4 slots): detect magic, identify, mage armor*, magic missile\n- 2nd level (3 slots): detect thoughts, mirror image, misty step\n- 3rd level (3 slots): counterspell, fly, lightning bolt\n- 4th level (3 slots): banishment, fire shield, stoneskin*\n- 5th level (3 slots): cone of cold, scrying, wall of force\n- 6th level (1 slot): globe of invulnerability\n- 7th level (1 slot): teleport\n- 8th level (1 slot): mind blank*\n- 9th level (1 slot): time stop\n* The archmage casts these spells on itself before combat."
+        "desc": [
+          "The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:",
+          "- Cantrips (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp",
+          "- 1st level (4 slots): detect magic, identify, mage armor*, magic missile",
+          "- 2nd level (3 slots): detect thoughts, mirror image, misty step",
+          "- 3rd level (3 slots): counterspell, fly, lightning bolt",
+          "- 4th level (3 slots): banishment, fire shield, stoneskin*",
+          "- 5th level (3 slots): cone of cold, scrying, wall of force",
+          "- 6th level (1 slot): globe of invulnerability",
+          "- 7th level (1 slot): teleport",
+          "- 8th level (1 slot): mind blank*",
+          "- 9th level (1 slot): time stop",
+          "* The archmage casts these spells on itself before combat."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Dagger",
-        "desc": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -4493,25 +5066,35 @@
     "special_abilities": [
       {
         "name": "Assassinate",
-        "desc": "During its first turn, the assassin has advantage on attack rolls against any creature that hasn't taken a turn. Any hit the assassin scores against a surprised creature is a critical hit."
+        "desc": [
+          "During its first turn, the assassin has advantage on attack rolls against any creature that hasn't taken a turn. Any hit the assassin scores against a surprised creature is a critical hit."
+        ]
       },
       {
         "name": "Evasion",
-        "desc": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+        "desc": [
+          "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+        ]
       },
       {
         "name": "Sneak Attack (1/Turn)",
-        "desc": "The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll."
+        "desc": [
+          "The assassin deals an extra 13 (4d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the assassin that isn't incapacitated and the assassin doesn't have disadvantage on the attack roll."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The assassin makes two shortsword attacks."
+        "desc": [
+          "The assassin makes two shortsword attacks."
+        ]
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -4542,7 +5125,9 @@
       },
       {
         "name": "Light Crossbow",
-        "desc": "Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Ranged Weapon Attack: +6 to hit, range 80/320 ft., one target. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -4607,13 +5192,17 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the shrub remains motionless, it is indistinguishable from a normal shrub."
+        "desc": [
+          "While the shrub remains motionless, it is indistinguishable from a normal shrub."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Rake",
-        "desc": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) slashing damage."
+        ],
         "attack_bonus": 1,
         "damage": [
           {
@@ -4663,13 +5252,17 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the tree remains motionless, it is indistinguishable from a normal tree."
+        "desc": [
+          "While the tree remains motionless, it is indistinguishable from a normal tree."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -4714,7 +5307,9 @@
     "actions": [
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -4768,7 +5363,9 @@
     "special_abilities": [
       {
         "name": "Heated Body",
-        "desc": "A creature that touches the azer or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage.",
+        "desc": [
+          "A creature that touches the azer or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -4782,7 +5379,9 @@
       },
       {
         "name": "Heated Weapons",
-        "desc": "When the azer hits with a metal melee weapon, it deals an extra 3 (1d6) fire damage (included in the attack).",
+        "desc": [
+          "When the azer hits with a metal melee weapon, it deals an extra 3 (1d6) fire damage (included in the attack)."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -4796,13 +5395,17 @@
       },
       {
         "name": "Illumination",
-        "desc": "The azer sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        "desc": [
+          "The azer sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Warhammer",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage, or 8 (1d10 + 3) bludgeoning damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage, or 8 (1d10 + 3) bludgeoning damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -4856,13 +5459,17 @@
     "special_abilities": [
       {
         "name": "Pack Tactics",
-        "desc": "The baboon has advantage on an attack roll against a creature if at least one of the baboon's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The baboon has advantage on an attack roll against a creature if at least one of the baboon's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage."
+        ],
         "attack_bonus": 1,
         "damage": [
           {
@@ -4908,13 +5515,17 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -4976,7 +5587,9 @@
     "special_abilities": [
       {
         "name": "Death Throes",
-        "desc": "When the balor dies, it explodes, and each creature within 30 feet of it must make a DC 20 Dexterity saving throw, taking 70 (20d6) fire damage on a failed save, or half as much damage on a successful one. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons.",
+        "desc": [
+          "When the balor dies, it explodes, and each creature within 30 feet of it must make a DC 20 Dexterity saving throw, taking 70 (20d6) fire damage on a failed save, or half as much damage on a successful one. The explosion ignites flammable objects in that area that aren't being worn or carried, and it destroys the balor's weapons."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -4998,7 +5611,9 @@
       },
       {
         "name": "Fire Aura",
-        "desc": "At the start of each of the balor's turns, each creature within 5 feet of it takes 10 (3d6) fire damage, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage.",
+        "desc": [
+          "At the start of each of the balor's turns, each creature within 5 feet of it takes 10 (3d6) fire damage, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the balor or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -5012,21 +5627,29 @@
       },
       {
         "name": "Magic Resistance",
-        "desc": "The balor has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The balor has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The balor's weapon attacks are magical."
+        "desc": [
+          "The balor's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The balor makes two attacks: one with its longsword and one with its whip."
+        "desc": [
+          "The balor makes two attacks: one with its longsword and one with its whip."
+        ]
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) slashing damage plus 13 (3d8) lightning damage. If the balor scores a critical hit, it rolls damage dice three times, instead of twice.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) slashing damage plus 13 (3d8) lightning damage. If the balor scores a critical hit, it rolls damage dice three times, instead of twice."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -5049,7 +5672,9 @@
       },
       {
         "name": "Whip",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 30 ft., one target. Hit: 15 (2d6 + 8) slashing damage plus 10 (3d6) fire damage, and the target must succeed on a DC 20 Strength saving throw or be pulled up to 25 feet toward the balor.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 30 ft., one target. Hit: 15 (2d6 + 8) slashing damage plus 10 (3d6) fire damage, and the target must succeed on a DC 20 Strength saving throw or be pulled up to 25 feet toward the balor."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -5072,11 +5697,17 @@
       },
       {
         "name": "Teleport",
-        "desc": "The balor magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        "desc": [
+          "The balor magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA balor has a 50 percent chance of summoning 1d8 vrocks, 1d6 hezrous, 1d4 glabrezus, 1d3 nalfeshnees, 1d2 mariliths, or one goristro.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A balor has a 50 percent chance of summoning 1d8 vrocks, 1d6 hezrous, 1d4 glabrezus, 1d3 nalfeshnees, 1d2 mariliths, or one goristro.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/37"
@@ -5110,7 +5741,9 @@
     "actions": [
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -5125,7 +5758,9 @@
       },
       {
         "name": "Light Crossbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -5175,11 +5810,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers."
+        "desc": [
+          "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers."
+        ]
       },
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5194,7 +5833,9 @@
       },
       {
         "name": "Dagger",
-        "desc": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5211,7 +5852,9 @@
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The captain adds 2 to its AC against one melee attack that would hit it. To do so, the captain must see the attacker and be wielding a melee weapon."
+        "desc": [
+          "The captain adds 2 to its AC against one melee attack that would hit it. To do so, the captain must see the attacker and be wielding a melee weapon."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/39"
@@ -5263,7 +5906,9 @@
     "special_abilities": [
       {
         "name": "Barbed Hide",
-        "desc": "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it.",
+        "desc": [
+          "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -5278,21 +5923,29 @@
       },
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice."
+        "desc": [
+          "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice."
+        ]
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft ., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft ., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -5307,7 +5960,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -5322,7 +5977,9 @@
       },
       {
         "name": "Hurl Flame",
-        "desc": "Ranged Spell Attack: +5 to hit, range 150 ft., one target. Hit: 10 (3d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire.",
+        "desc": [
+          "Ranged Spell Attack: +5 to hit, range 150 ft., one target. Hit: 10 (3d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5367,7 +6024,11 @@
     "special_abilities": [
       {
         "name": "Petrifying Gaze",
-        "desc": "If a creature starts its turn within 30 ft. of the basilisk and the two of them can see each other, the basilisk can force the creature to make a DC 12 Constitution saving throw if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.\nA creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.\nIf the basilisk sees its reflection within 30 ft. of it in bright light, it mistakes itself for a rival and targets itself with its gaze.",
+        "desc": [
+          "If a creature starts its turn within 30 ft. of the basilisk and the two of them can see each other, the basilisk can force the creature to make a DC 12 Constitution saving throw if the basilisk isn't incapacitated. On a failed save, the creature magically begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified until freed by the greater restoration spell or other magic.",
+          "A creature that isn't surprised can avert its eyes to avoid the saving throw at the start of its turn. If it does so, it can't see the basilisk until the start of its next turn, when it can avert its eyes again. If it looks at the basilisk in the meantime, it must immediately make the save.",
+          "If the basilisk sees its reflection within 30 ft. of it in bright light, it mistakes itself for a rival and targets itself with its gaze."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -5381,7 +6042,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage plus 7 (2d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage plus 7 (2d6) poison damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5435,17 +6098,23 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The bat can't use its blindsight while deafened."
+        "desc": [
+          "The bat can't use its blindsight while deafened."
+        ]
       },
       {
         "name": "Keen Hearing",
-        "desc": "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        "desc": [
+          "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +0 to hit, reach 5 ft., one creature. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -5504,25 +6173,35 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Steadfast",
-        "desc": "The devil can't be frightened while it can see an allied creature within 30 feet of it."
+        "desc": [
+          "The devil can't be frightened while it can see an allied creature within 30 feet of it."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes two attacks: one with its beard and one with its glaive."
+        "desc": [
+          "The devil makes two attacks: one with its beard and one with its glaive."
+        ]
       },
       {
         "name": "Beard",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target can't regain hit points. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5537,7 +6216,9 @@
       },
       {
         "name": "Glaive",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 8 (1d10 + 3) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 10 ft., one target. Hit: 8 (1d10 + 3) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 12 Constitution saving throw or lose 5 (1d10) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 5 (1d10). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5587,12 +6268,16 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The behir makes two attacks: one with its bite and one to constrict.",
+        "desc": [
+          "The behir makes two attacks: one with its bite and one to constrict."
+        ],
         "attack_bonus": 0
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -5607,7 +6292,9 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one Large or smaller creature. Hit: 17 (2d10 + 6) bludgeoning damage plus 17 (2d10 + 6) slashing damage. The target is grappled (escape DC 16) if the behir isn't already constricting a creature, and the target is restrained until this grapple ends.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one Large or smaller creature. Hit: 17 (2d10 + 6) bludgeoning damage plus 17 (2d10 + 6) slashing damage. The target is grappled (escape DC 16) if the behir isn't already constricting a creature, and the target is restrained until this grapple ends."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -5630,7 +6317,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The behir exhales a line of lightning that is 20 ft. long and 5 ft. wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 66 (12d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -5652,7 +6341,10 @@
       },
       {
         "name": "Swallow",
-        "desc": "The behir makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects outside the behir, and it takes 21 (6d6) acid damage at the start of each of the behir's turns. A behir can have only one creature swallowed at a time.\nIf the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 ft. of the behir. If the behir dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 ft. of movement, exiting prone.",
+        "desc": [
+          "The behir makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is also swallowed, and the grapple ends. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects outside the behir, and it takes 21 (6d6) acid damage at the start of each of the behir's turns. A behir can have only one creature swallowed at a time.",
+          "If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 ft. of the behir. If the behir dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 ft. of movement, exiting prone."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -5696,13 +6388,17 @@
     "special_abilities": [
       {
         "name": "Reckless",
-        "desc": "At the start of its turn, the berserker can gain advantage on all melee weapon attack rolls during that turn, but attack rolls against it have advantage until the start of its next turn."
+        "desc": [
+          "At the start of its turn, the berserker can gain advantage on all melee weapon attack rolls during that turn, but attack rolls against it have advantage until the start of its next turn."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Greataxe",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5748,17 +6444,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The bear makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -5773,7 +6475,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -5828,13 +6532,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) acid damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -5857,7 +6565,9 @@
       },
       {
         "name": "Acid Breath (Recharge 5-6)",
-        "desc": "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (Sd8) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (Sd8) acid damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -5940,11 +6650,15 @@
     "special_abilities": [
       {
         "name": "Amorphous",
-        "desc": "The pudding can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The pudding can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       },
       {
         "name": "Corrosive Form",
-        "desc": "A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes 4 (1d8) acid damage. Any nonmagical weapon made of metal or wood that hits the pudding corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage. The pudding can eat through 2-inch-thick, nonmagical wood or metal in 1 round.",
+        "desc": [
+          "A creature that touches the pudding or hits it with a melee attack while within 5 feet of it takes 4 (1d8) acid damage. Any nonmagical weapon made of metal or wood that hits the pudding corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits the pudding is destroyed after dealing damage. The pudding can eat through 2-inch-thick, nonmagical wood or metal in 1 round."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -5958,13 +6672,17 @@
       },
       {
         "name": "Spider Climb",
-        "desc": "The pudding can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The pudding can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Pseudopod",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage plus 18 (4d8) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage plus 18 (4d8) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -5989,7 +6707,9 @@
     "reactions": [
       {
         "name": "Split",
-        "desc": "When a pudding that is Medium or larger is subjected to lightning or slashing damage, it splits into two new puddings if it has at least 10 hit points. Each new pudding has hit points equal to half the original pudding's, rounded down. New puddings are one size smaller than the original pudding."
+        "desc": [
+          "When a pudding that is Medium or larger is subjected to lightning or slashing damage, it splits into two new puddings if it has at least 10 hit points. Each new pudding has hit points equal to half the original pudding's, rounded down. New puddings are one size smaller than the original pudding."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/48"
@@ -6025,13 +6745,17 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The dog has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The dog has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -6046,7 +6770,9 @@
       },
       {
         "name": "Teleport (Recharge 4-6)",
-        "desc": "The dog magically teleports, along with any equipment it is wearing or carrying, up to 40 ft. to an unoccupied space it can see. Before or after teleporting, the dog can make one bite attack."
+        "desc": [
+          "The dog magically teleports, along with any equipment it is wearing or carrying, up to 40 ft. to an unoccupied space it can see. Before or after teleporting, the dog can make one bite attack."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/49"
@@ -6082,17 +6808,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The hawk has advantage on an attack roll against a creature if at least one of the hawk's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The hawk has advantage on an attack roll against a creature if at least one of the hawk's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -6147,7 +6879,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage plus 3 (1d6) lightning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage plus 3 (1d6) lightning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -6170,7 +6904,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -6222,7 +6958,9 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 3 (1d6) slashing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone.",
+        "desc": [
+          "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 3 (1d6) slashing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -6236,13 +6974,17 @@
       },
       {
         "name": "Relentless (Recharges after a Short or Long Rest)",
-        "desc": "If the boar takes 7 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        "desc": [
+          "If the boar takes 7 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Tusk",
-        "desc": "Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage.",
+        "desc": [
+          "Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -6304,21 +7046,29 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three attacks: two with its claws and one with its sting."
+        "desc": [
+          "The devil makes three attacks: two with its claws and one with its sting."
+        ]
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 8 (1d8 + 4) slashing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -6333,7 +7083,9 @@
       },
       {
         "name": "Sting",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success ."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -6396,7 +7148,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -6411,7 +7165,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 14 (4d6) fire damage on a failed save, or half as much damage on a successful one.",
+          "Sleep Breath. The dragon exhales sleep gas in a 15-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw or fall unconscious for 1 minute. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -6489,13 +7247,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -6510,7 +7272,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nLightning Breath. The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 16 (3d10) lightning damage on a failed save, or half as much damage on a successful one.\nRepulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 12 Strength saving throw. On a failed save, the creature is pushed 30 feet away from the dragon.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Lightning Breath. The dragon exhales lightning in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 12 Dexterity saving throw, taking 16 (3d10) lightning damage on a failed save, or half as much damage on a successful one.",
+          "Repulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 12 Strength saving throw. On a failed save, the creature is pushed 30 feet away from the dragon."
+        ],
         "attacks": [
           {
             "name": "Lightning Breath",
@@ -6580,17 +7346,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The bear makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
+        "desc": [
+          "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -6605,7 +7377,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -6652,17 +7426,23 @@
     "special_abilities": [
       {
         "name": "Brute",
-        "desc": "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
+        "desc": [
+          "A melee weapon deals one extra die of its damage when the bugbear hits with it (included in the attack)."
+        ]
       },
       {
         "name": "Surprise Attack",
-        "desc": "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."
+        "desc": [
+          "If the bugbear surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 7 (2d6) damage from the attack."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Morningstar",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 11 (2d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -6677,7 +7457,9 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 9 (2d6 + 2) piercing damage in melee or 5 (1d6 + 2) piercing damage at range.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 9 (2d6 + 2) piercing damage in melee or 5 (1d6 + 2) piercing damage at range."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -6724,13 +7506,17 @@
     "special_abilities": [
       {
         "name": "Standing Leap",
-        "desc": "The bulette's long jump is up to 30 ft. and its high jump is up to 15 ft., with or without a running start."
+        "desc": [
+          "The bulette's long jump is up to 30 ft. and its high jump is up to 15 ft., with or without a running start."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 30 (4d12 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 30 (4d12 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -6745,7 +7531,9 @@
       },
       {
         "name": "Deadly Leap",
-        "desc": "If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its ft. in a space that contains one or more other creatures. Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take 14 (3d6 + 4) bludgeoning damage plus 14 (3d6 + 4) slashing damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space."
+        "desc": [
+          "If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its ft. in a space that contains one or more other creatures. Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take 14 (3d6 + 4) bludgeoning damage plus 14 (3d6 + 4) slashing damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/58"
@@ -6779,7 +7567,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -6826,21 +7616,29 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The carrion crawler has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The carrion crawler has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The carrion crawler can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The carrion crawler can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The carrion crawler makes two attacks: one with its tentacles and one with its bite."
+        "desc": [
+          "The carrion crawler makes two attacks: one with its tentacles and one with its bite."
+        ]
       },
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one creature. Hit: 4 (1d4 + 2) poison damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the poison on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one creature. Hit: 4 (1d4 + 2) poison damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the poison on itself on a success."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -6855,7 +7653,9 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -6903,13 +7703,17 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The cat has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The cat has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -6956,17 +7760,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The bear makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (1d8 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (1d8 + 5) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -6981,7 +7791,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -7029,7 +7841,9 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra 10 (3d6) piercing damage.",
+        "desc": [
+          "If the centaur moves at least 30 ft. straight toward a target and then hits it with a pike attack on the same turn, the target takes an extra 10 (3d6) piercing damage."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -7045,11 +7859,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow."
+        "desc": [
+          "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow."
+        ]
       },
       {
         "name": "Pike",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 9 (1d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7064,7 +7882,9 @@
       },
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7079,7 +7899,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -7138,21 +7960,29 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes two attacks with its chains."
+        "desc": [
+          "The devil makes two attacks with its chains."
+        ]
       },
       {
         "name": "Chain",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) slashing damage. The target is grappled (escape DC 14) if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained and takes 7 (2d6) piercing damage at the start of each of its turns.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) slashing damage. The target is grappled (escape DC 14) if the devil isn't already grappling a creature. Until this grapple ends, the target is restrained and takes 7 (2d6) piercing damage at the start of each of its turns."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -7167,13 +7997,18 @@
       },
       {
         "name": "Animate Chains (Recharges after a Short or Long Rest)",
-        "desc": "Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.\nEach animated chain is an object with AC 20, 20 hit points, resistance to piercing damage, and immunity to psychic and thunder damage. When the devil uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the devil is incapacitated or dies."
+        "desc": [
+          "Up to four chains the devil can see within 60 feet of it magically sprout razor-edged barbs and animate under the devil's control, provided that the chains aren't being worn or carried.",
+          "Each animated chain is an object with AC 20, 20 hit points, resistance to piercing damage, and immunity to psychic and thunder damage. When the devil uses Multiattack on its turn, it can use each animated chain to make one additional chain attack. An animated chain can grapple one creature of its own but can't make attacks while grappling. An animated chain reverts to its inanimate state if reduced to 0 hit points or if the devil is incapacitated or dies."
+        ]
       }
     ],
     "reactions": [
       {
         "name": "Unnerving Mask",
-        "desc": "When a creature the devil can see starts its turn within 30 feet of the devil, the devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. If the creature can see the devil, it must succeed on a DC 14 Wisdom saving throw or be frightened until the end of its turn.",
+        "desc": [
+          "When a creature the devil can see starts its turn within 30 feet of the devil, the devil can create the illusion that it looks like one of the creature's departed loved ones or bitter enemies. If the creature can see the devil, it must succeed on a DC 14 Wisdom saving throw or be frightened until the end of its turn."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -7217,11 +8052,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."
+        "desc": [
+          "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -7236,7 +8075,9 @@
       },
       {
         "name": "Horns",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -7251,7 +8092,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -7266,7 +8109,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 31 (7d8) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon head exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 31 (7d8) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -7327,21 +8172,29 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The chuul can breathe air and water."
+        "desc": [
+          "The chuul can breathe air and water."
+        ]
       },
       {
         "name": "Sense Magic",
-        "desc": "The chuul senses magic within 120 feet of it at will. This trait otherwise works like the detect magic spell but isn't itself magical."
+        "desc": [
+          "The chuul senses magic within 120 feet of it at will. This trait otherwise works like the detect magic spell but isn't itself magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once."
+        "desc": [
+          "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once."
+        ]
       },
       {
         "name": "Pincer",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage. The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn't have two other creatures grappled.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage. The target is grappled (escape DC 14) if it is a Large or smaller creature and the chuul doesn't have two other creatures grappled."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7356,7 +8209,9 @@
       },
       {
         "name": "Tentacles",
-        "desc": "One creature grappled by the chuul must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "One creature grappled by the chuul must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. Until this poison ends, the target is paralyzed. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -7428,33 +8283,47 @@
     "special_abilities": [
       {
         "name": "Acid Absorption",
-        "desc": "Whenever the golem is subjected to acid damage, it takes no damage and instead regains a number of hit points equal to the acid damage dealt."
+        "desc": [
+          "Whenever the golem is subjected to acid damage, it takes no damage and instead regains a number of hit points equal to the acid damage dealt."
+        ]
       },
       {
         "name": "Berserk",
-        "desc": "Whenever the golem starts its turn with 60 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points."
+        "desc": [
+          "Whenever the golem starts its turn with 60 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points."
+        ]
       },
       {
         "name": "Immutable Form",
-        "desc": "The golem is immune to any spell or effect that would alter its form."
+        "desc": [
+          "The golem is immune to any spell or effect that would alter its form."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The golem has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The golem has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The golem's weapon attacks are magical."
+        "desc": [
+          "The golem's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": [
+          "The golem makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. The target dies if this attack reduces its hit point maximum to 0. The reduction lasts until removed by the greater restoration spell or other magic."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -7469,7 +8338,9 @@
       },
       {
         "name": "Haste (Recharge 5-6)",
-        "desc": "Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."
+        "desc": [
+          "Until the end of its next turn, the golem magically gains a +2 bonus to its AC, has advantage on Dexterity saving throws, and can use its slam attack as a bonus action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/67"
@@ -7505,25 +8376,35 @@
     "special_abilities": [
       {
         "name": "Damage Transfer",
-        "desc": "While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down). and that creature takes the other half."
+        "desc": [
+          "While attached to a creature, the cloaker takes only half the damage dealt to it (rounded down). and that creature takes the other half."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the cloaker remains motionless without its underside exposed, it is indistinguishable from a dark leather cloak."
+        "desc": [
+          "While the cloaker remains motionless without its underside exposed, it is indistinguishable from a dark leather cloak."
+        ]
       },
       {
         "name": "Light Sensitivity",
-        "desc": "While in bright light, the cloaker has disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in bright light, the cloaker has disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The cloaker makes two attacks: one with its bite and one with its tail."
+        "desc": [
+          "The cloaker makes two attacks: one with its bite and one with its tail."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 10 (2d6 + 3) piercing damage, and if the target is Large or smaller, the cloaker attaches to it. If the cloaker has advantage against the target, the cloaker attaches to the target's head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 10 (2d6 + 3) piercing damage, and if the target is Large or smaller, the cloaker attaches to it. If the cloaker has advantage against the target, the cloaker attaches to the target's head, and the target is blinded and unable to breathe while the cloaker is attached. While attached, the cloaker can make this attack only against the target and has advantage on the attack roll. The cloaker can detach itself by spending 5 feet of its movement. A creature, including the target, can take its action to detach the cloaker by succeeding on a DC 16 Strength check."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7538,7 +8419,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 7 (1d8 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 7 (1d8 + 3) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7553,7 +8436,9 @@
       },
       {
         "name": "Moan",
-        "desc": "Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must succeed on a DC 13 Wisdom saving throw or become frightened until the end of the cloaker's next turn. If a creature's saving throw is successful, the creature is immune to the cloaker's moan for the next 24 hours.",
+        "desc": [
+          "Each creature within 60 feet of the cloaker that can hear its moan and that isn't an aberration must succeed on a DC 13 Wisdom saving throw or become frightened until the end of the cloaker's next turn. If a creature's saving throw is successful, the creature is immune to the cloaker's moan for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -7565,7 +8450,11 @@
       },
       {
         "name": "Phantasms (Recharges after a Short or Long Rest)",
-        "desc": "The cloaker magically creates three illusory duplicates of itself if it isn't in bright light. The duplicates move with it and mimic its actions, shifting position so as to make it impossible to track which cloaker is the real one. If the cloaker is ever in an area of bright light, the duplicates disappear.\nWhenever any creature targets the cloaker with an attack or a harmful spell while a duplicate remains, that creature rolls randomly to determine whether it targets the cloaker or one of the duplicates. A creature is unaffected by this magical effect if it can't see or if it relies on senses other than sight.\nA duplicate has the cloaker's AC and uses its saving throws. If an attack hits a duplicate, or if a duplicate fails a saving throw against an effect that deals damage, the duplicate disappears."
+        "desc": [
+          "The cloaker magically creates three illusory duplicates of itself if it isn't in bright light. The duplicates move with it and mimic its actions, shifting position so as to make it impossible to track which cloaker is the real one. If the cloaker is ever in an area of bright light, the duplicates disappear.",
+          "Whenever any creature targets the cloaker with an attack or a harmful spell while a duplicate remains, that creature rolls randomly to determine whether it targets the cloaker or one of the duplicates. A creature is unaffected by this magical effect if it can't see or if it relies on senses other than sight.",
+          "A duplicate has the cloaker's AC and uses its saving throws. If an attack hits a duplicate, or if a duplicate fails a saving throw against an effect that deals damage, the duplicate disappears."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/68"
@@ -7604,21 +8493,32 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The giant has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The giant has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The giant's innate spellcasting ability is Charisma. It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, fog cloud, light\n3/day each: feather fall, fly, misty step, telekinesis\n1/day each: control weather, gaseous form"
+        "desc": [
+          "The giant's innate spellcasting ability is Charisma. It can innately cast the following spells, requiring no material components:",
+          "At will: detect magic, fog cloud, light",
+          "3/day each: feather fall, fly, misty step, telekinesis",
+          "1/day each: control weather, gaseous form"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two morningstar attacks."
+        "desc": [
+          "The giant makes two morningstar attacks."
+        ]
       },
       {
         "name": "Morningstar",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 10 ft., one target. Hit: 21 (3d8 + 8) piercing damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -7633,7 +8533,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: 30 (4d10 + 8) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +12 to hit, range 60/240 ft., one target. Hit: 30 (4d10 + 8) bludgeoning damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -7679,7 +8581,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) piercing damage, and the target must succeed on a DC 11 Constitution saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) piercing damage, and the target must succeed on a DC 11 Constitution saving throw against being magically petrified. On a failed save, the creature begins to turn to stone and is restrained. It must repeat the saving throw at the end of its next turn. On a success, the effect ends. On a failure, the creature is petrified for 24 hours."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -7724,7 +8628,9 @@
     "actions": [
       {
         "name": "Club",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -7770,7 +8676,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -7785,7 +8693,9 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the creature is restrained, and the snake can't constrict another target."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -7840,7 +8750,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -7855,7 +8767,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nAcid Breath. The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 18 (4d8) acid damage on a failed save, or half as much damage on a successful one.\nSlowing Breath. The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Acid Breath. The dragon exhales acid in an 20-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 18 (4d8) acid damage on a failed save, or half as much damage on a successful one.",
+          "Slowing Breath. The dragon exhales gas in a 1 5-foot cone. Each creature in that area must succeed on a DC 11 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        ],
         "attacks": [
           {
             "name": "Acid Breath",
@@ -7932,21 +8848,32 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The couatl's spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:\n\nAt will: detect evil and good, detect magic, detect thoughts\n3/day each: bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield\n1/day each: dream, greater restoration, scrying"
+        "desc": [
+          "The couatl's spellcasting ability is Charisma (spell save DC 14). It can innately cast the following spells, requiring only verbal components:",
+          "At will: detect evil and good, detect magic, detect thoughts",
+          "3/day each: bless, create food and water, cure wounds, lesser restoration, protection from poison, sanctuary, shield",
+          "1/day each: dream, greater restoration, scrying"
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The couatl's weapon attacks are magical."
+        "desc": [
+          "The couatl's weapon attacks are magical."
+        ]
       },
       {
         "name": "Shielded Mind",
-        "desc": "The couatl is immune to scrying and to any effect that would sense its emotions, read its thoughts, or detect its location."
+        "desc": [
+          "The couatl is immune to scrying and to any effect that would sense its emotions, read its thoughts, or detect its location."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one creature. Hit: 8 (1d6 + 5) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one creature. Hit: 8 (1d6 + 5) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 24 hours. Until this poison ends, the target is unconscious. Another creature can use an action to shake the target awake."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -7961,7 +8888,9 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one Medium or smaller creature. Hit: 10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one Medium or smaller creature. Hit: 10 (2d6 + 3) bludgeoning damage, and the target is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the couatl can't constrict another target."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -7976,7 +8905,10 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).\nIn a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form."
+        "desc": [
+          "The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).",
+          "In a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/74"
@@ -8012,13 +8944,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The crab can breathe air and water."
+        "desc": [
+          "The crab can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -8065,13 +9001,17 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "The crocodile can hold its breath for 15 minutes."
+        "desc": [
+          "The crocodile can hold its breath for 15 minutes."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained, and the crocodile can't bite another target"
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -8119,21 +9059,32 @@
     "special_abilities": [
       {
         "name": "Dark Devotion",
-        "desc": "The fanatic has advantage on saving throws against being charmed or frightened."
+        "desc": [
+          "The fanatic has advantage on saving throws against being charmed or frightened."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:\n\nCantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): command, inflict wounds, shield of faith\n- 2nd level (3 slots): hold person, spiritual weapon"
+        "desc": [
+          "The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:",
+          "Cantrips (at will): light, sacred flame, thaumaturgy",
+          "- 1st level (4 slots): command, inflict wounds, shield of faith",
+          "- 2nd level (3 slots): hold person, spiritual weapon"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The fanatic makes two melee attacks."
+        "desc": [
+          "The fanatic makes two melee attacks."
+        ]
       },
       {
         "name": "Dagger",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -8180,13 +9131,17 @@
     "special_abilities": [
       {
         "name": "Dark Devotion",
-        "desc": "The cultist has advantage on saving throws against being charmed or frightened."
+        "desc": [
+          "The cultist has advantage on saving throws against being charmed or frightened."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -8233,17 +9188,25 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The darkmantle can't use its blindsight while deafened."
+        "desc": [
+          "The darkmantle can't use its blindsight while deafened."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the darkmantle remains motionless, it is indistinguishable from a cave formation such as a stalactite or stalagmite."
+        "desc": [
+          "While the darkmantle remains motionless, it is indistinguishable from a cave formation such as a stalactite or stalagmite."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Crush",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d6 + 3) bludgeoning damage, and the darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way.\nWhile attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. The darkmantle's speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.\nA creature can detach the darkmantle by making a successful DC 13 Strength check as an action. On its turn, the darkmantle can detach itself from the target by using 5 feet of movement.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 6 (1d6 + 3) bludgeoning damage, and the darkmantle attaches to the target. If the target is Medium or smaller and the darkmantle has advantage on the attack roll, it attaches by engulfing the target's head, and the target is also blinded and unable to breathe while the darkmantle is attached in this way.",
+          "While attached to the target, the darkmantle can attack no other creature except the target but has advantage on its attack rolls. The darkmantle's speed also becomes 0, it can't benefit from any bonus to its speed, and it moves with the target.",
+          "A creature can detach the darkmantle by making a successful DC 13 Strength check as an action. On its turn, the darkmantle can detach itself from the target by using 5 feet of movement."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -8258,7 +9221,9 @@
       },
       {
         "name": "Darkness Aura (1/day)",
-        "desc": "A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. The darkness lasts as long as the darkmantle maintains concentration, up to 10 minutes (as if concentrating on a spell). Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled."
+        "desc": [
+          "A 15-foot radius of magical darkness extends out from the darkmantle, moves with it, and spreads around corners. The darkness lasts as long as the darkmantle maintains concentration, up to 10 minutes (as if concentrating on a spell). Darkvision can't penetrate this darkness, and no natural light can illuminate it. If any of the darkness overlaps with an area of light created by a spell of 2nd level or lower, the spell creating the light is dispelled."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/79"
@@ -8294,17 +9259,23 @@
     "special_abilities": [
       {
         "name": "Two-Headed",
-        "desc": "The dog has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, or knocked unconscious."
+        "desc": [
+          "The dog has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, or knocked unconscious."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dog makes two bite attacks."
+        "desc": [
+          "The dog makes two bite attacks."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -8352,21 +9323,31 @@
     "special_abilities": [
       {
         "name": "Stone Camouflage",
-        "desc": "The gnome has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        "desc": [
+          "The gnome has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        ]
       },
       {
         "name": "Gnome Cunning",
-        "desc": "The gnome has advantage on Intelligence, Wisdom, and Charisma saving throws against magic."
+        "desc": [
+          "The gnome has advantage on Intelligence, Wisdom, and Charisma saving throws against magic."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The gnome's innate spellcasting ability is Intelligence (spell save DC 11). It can innately cast the following spells, requiring no material components:\nAt will: nondetection (self only)\n1/day each: blindness/deafness, blur, disguise self"
+        "desc": [
+          "The gnome's innate spellcasting ability is Intelligence (spell save DC 11). It can innately cast the following spells, requiring no material components:",
+          "At will: nondetection (self only)",
+          "1/day each: blindness/deafness, blur, disguise self"
+        ]
       }
     ],
     "actions": [
       {
         "name": "War Pick",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -8381,7 +9362,9 @@
       },
       {
         "name": "Poisoned Dart",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 12 Constitution saving throw or be poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success"
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -8426,7 +9409,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -8492,25 +9477,37 @@
     "special_abilities": [
       {
         "name": "Angelic Weapons",
-        "desc": "The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an extra 4d8 radiant damage (included in the attack)."
+        "desc": [
+          "The deva's weapon attacks are magical. When the deva hits with any weapon, the weapon deals an extra 4d8 radiant damage (included in the attack)."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The deva's spellcasting ability is Charisma (spell save DC 17). The deva can innately cast the following spells, requiring only verbal components:\nAt will: detect evil and good\n1/day each: commune, raise dead"
+        "desc": [
+          "The deva's spellcasting ability is Charisma (spell save DC 17). The deva can innately cast the following spells, requiring only verbal components:",
+          "At will: detect evil and good",
+          "1/day each: commune, raise dead"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The deva has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The deva has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The deva makes two melee attacks."
+        "desc": [
+          "The deva makes two melee attacks."
+        ]
       },
       {
         "name": "Mace",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage plus 18 (4d8) radiant damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage plus 18 (4d8) radiant damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -8533,11 +9530,16 @@
       },
       {
         "name": "Healing Touch (3/Day)",
-        "desc": "The deva touches another creature. The target magically regains 20 (4d8 + 2) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        "desc": [
+          "The deva touches another creature. The target magically regains 20 (4d8 + 2) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        ]
       },
       {
         "name": "Change Shape",
-        "desc": "The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva's choice).\nIn a new form, the deva retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and special senses are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks."
+        "desc": [
+          "The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva's choice).",
+          "In a new form, the deva retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and special senses are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/83"
@@ -8573,17 +9575,23 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -8635,25 +9643,42 @@
     "special_abilities": [
       {
         "name": "Elemental Demise",
-        "desc": "If the djinni dies, its body disintegrates into a warm breeze, leaving behind only equipment the djinni was wearing or carrying."
+        "desc": [
+          "If the djinni dies, its body disintegrates into a warm breeze, leaving behind only equipment the djinni was wearing or carrying."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The djinni's innate spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\nAt will: detect evil and good, detect magic, thunderwave 3/day each: create food and water (can create wine instead of water), tongues, wind walk\n1/day each: conjure elemental (air elemental only), creation, gaseous form, invisibility, major image, plane shift"
+        "desc": [
+          "The djinni's innate spellcasting ability is Charisma (spell save DC 17, +9 to hit with spell attacks). It can innately cast the following spells, requiring no material components:",
+          "At will: detect evil and good, detect magic, thunderwave 3/day each: create food and water (can create wine instead of water), tongues, wind walk",
+          "1/day each: conjure elemental (air elemental only), creation, gaseous form, invisibility, major image, plane shift"
+        ]
       },
       {
         "name": "Variant: Genie Powers",
-        "desc": "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.\n\nDisguises.\nSome genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.\nWishes.\nThe genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.\nTo be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        "desc": [
+          "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.",
+          "Disguises.",
+          "Some genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.",
+          "Wishes.",
+          "The genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.",
+          "To be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The djinni makes three scimitar attacks."
+        "desc": [
+          "The djinni makes three scimitar attacks."
+        ]
       },
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage plus 3 (1d6) lightning or thunder damage (djinni's choice).",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage plus 3 (1d6) lightning or thunder damage (djinni's choice)."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -8690,7 +9715,10 @@
       },
       {
         "name": "Create Whirlwind",
-        "desc": "A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell). Any creature but the djinni that enters the whirlwind must succeed on a DC 18 Strength saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.\nA creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind.",
+        "desc": [
+          "A 5-foot-radius, 30-foot-tall cylinder of swirling air magically forms on a point the djinni can see within 120 feet of it. The whirlwind lasts as long as the djinni maintains concentration (as if concentrating on a spell). Any creature but the djinni that enters the whirlwind must succeed on a DC 18 Strength saving throw or be restrained by it. The djinni can move the whirlwind up to 60 feet as an action, and creatures restrained by the whirlwind move with it. The whirlwind ends if the djinni loses sight of it.",
+          "A creature can use its action to free a creature restrained by the whirlwind, including itself, by succeeding on a DC 18 Strength check. If the check succeeds, the creature is no longer restrained and moves to the nearest space outside the whirlwind."
+        ],
         "dc": {
           "dc_type": {
             "name": "STR",
@@ -8739,25 +9767,35 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The doppelganger can use its action to polymorph into a Small or Medium humanoid it has seen, or back into its true form. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Ambusher",
-        "desc": "The doppelganger has advantage on attack rolls against any creature it has surprised."
+        "desc": [
+          "The doppelganger has advantage on attack rolls against any creature it has surprised."
+        ]
       },
       {
         "name": "Surprise Attack",
-        "desc": "If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack."
+        "desc": [
+          "If the doppelganger surprises a creature and hits it with an attack during the first round of combat, the target takes an extra 10 (3d6) damage from the attack."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The doppelganger makes two melee attacks."
+        "desc": [
+          "The doppelganger makes two melee attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -8772,7 +9810,9 @@
       },
       {
         "name": "Read Thoughts",
-        "desc": "The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target."
+        "desc": [
+          "The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/86"
@@ -8806,7 +9846,9 @@
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -8857,17 +9899,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon turtle can breathe air and water."
+        "desc": [
+          "The dragon turtle can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks."
+        "desc": [
+          "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) piercing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -8882,7 +9930,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 16 (2d8 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 16 (2d8 + 7) slashing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -8897,7 +9947,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 15 ft., one target. Hit: 26 (3d12 + 7) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be pushed up to 10 feet away from the dragon turtle and knocked prone."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -8912,7 +9964,9 @@
       },
       {
         "name": "Steam Breath (Recharge 5-6)",
-        "desc": "The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 52 (15d6) fire damage on a failed save, or half as much damage on a successful one. Being underwater doesn't grant resistance against this damage.",
+        "desc": [
+          "The dragon turtle exhales scalding steam in a 60-foot cone. Each creature in that area must make a DC 18 Constitution saving throw, taking 52 (15d6) fire damage on a failed save, or half as much damage on a successful one. Being underwater doesn't grant resistance against this damage."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -8975,11 +10029,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dretch makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The dretch makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -8994,7 +10052,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 5 (2d4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 5 (2d4) slashing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -9009,7 +10069,9 @@
       },
       {
         "name": "Fetid Cloud (1/Day)",
-        "desc": "A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it. Any creature that starts its turn in that area must succeed on a DC 11 Constitution saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions.",
+        "desc": [
+          "A 10-foot radius of disgusting green gas extends out from the dretch. The gas spreads around corners, and its area is lightly obscured. It lasts for 1 minute or until a strong wind disperses it. Any creature that starts its turn in that area must succeed on a DC 11 Constitution saving throw or be poisoned until the start of its next turn. While poisoned in this way, the target can take either an action or a bonus action on its turn, not both, and can't take reactions."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -9054,33 +10116,49 @@
     "special_abilities": [
       {
         "name": "Fey Ancestry",
-        "desc": "The drider has advantage on saving throws against being charmed, and magic can't put the drider to sleep."
+        "desc": [
+          "The drider has advantage on saving throws against being charmed, and magic can't put the drider to sleep."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The drider's innate spellcasting ability is Wisdom (spell save DC 13). The drider can innately cast the following spells, requiring no material components:\nAt will: dancing lights\n1/day each: darkness, faerie fire"
+        "desc": [
+          "The drider's innate spellcasting ability is Wisdom (spell save DC 13). The drider can innately cast the following spells, requiring no material components:",
+          "At will: dancing lights",
+          "1/day each: darkness, faerie fire"
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The drider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The drider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the drider has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the drider has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The drider ignores movement restrictions caused by webbing."
+        "desc": [
+          "The drider ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack."
+        "desc": [
+          "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 2 (1d4) piercing damage plus 9 (2d8) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 2 (1d4) piercing damage plus 9 (2d8) poison damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -9103,7 +10181,9 @@
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -9132,7 +10212,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage.",
+        "desc": [
+          "Ranged Weapon Attack: +6 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) poison damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -9187,21 +10269,31 @@
     "special_abilities": [
       {
         "name": "Fey Ancestry",
-        "desc": "The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
+        "desc": [
+          "The drow has advantage on saving throws against being charmed, and magic can't put the drow to sleep."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The drow's spellcasting ability is Charisma (spell save DC 11). It can innately cast the following spells, requiring no material components:\nAt will: dancing lights\n1/day each: darkness, faerie fire"
+        "desc": [
+          "The drow's spellcasting ability is Charisma (spell save DC 11). It can innately cast the following spells, requiring no material components:",
+          "At will: dancing lights",
+          "1/day each: darkness, faerie fire"
+        ]
       },
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the drow has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9216,7 +10308,9 @@
       },
       {
         "name": "Hand Crossbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned for 1 hour. If the saving throw fails by 5 or more, the target is also unconscious while poisoned in this way. The target wakes up if it takes damage or if another creature takes an action to shake it awake."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9264,13 +10358,20 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared:\n\n- Cantrips (at will): druidcraft, produce flame, shillelagh\n- 1st level (4 slots): entangle, longstrider, speak with animals, thunderwave\n- 2nd level (3 slots): animal messenger, barkskin"
+        "desc": [
+          "The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared:",
+          "- Cantrips (at will): druidcraft, produce flame, shillelagh",
+          "- 1st level (4 slots): entangle, longstrider, speak with animals, thunderwave",
+          "- 2nd level (3 slots): animal messenger, barkskin"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Quarterstaff",
-        "desc": "Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 6 (1d8 + 2) bludgeoning damage with shillelagh or if wielded with two hands.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit (+4 to hit with shillelagh), reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage, or 6 (1d8 + 2) bludgeoning damage with shillelagh or if wielded with two hands."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -9331,25 +10432,38 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The dryad's innate spellcasting ability is Charisma (spell save DC 14). The dryad can innately cast the following spells, requiring no material components:\n\nAt will: druidcraft\n3/day each: entangle, goodberry\n1/day each: barkskin, pass without trace, shillelagh"
+        "desc": [
+          "The dryad's innate spellcasting ability is Charisma (spell save DC 14). The dryad can innately cast the following spells, requiring no material components:",
+          "At will: druidcraft",
+          "3/day each: entangle, goodberry",
+          "1/day each: barkskin, pass without trace, shillelagh"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The dryad has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The dryad has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Speak with Beasts and Plants",
-        "desc": "The dryad can communicate with beasts and plants as if they shared a language."
+        "desc": [
+          "The dryad can communicate with beasts and plants as if they shared a language."
+        ]
       },
       {
         "name": "Tree Stride",
-        "desc": "Once on her turn, the dryad can use 10 ft. of her movement to step magically into one living tree within her reach and emerge from a second living tree within 60 ft. of the first tree, appearing in an unoccupied space within 5 ft. of the second tree. Both trees must be large or bigger."
+        "desc": [
+          "Once on her turn, the dryad can use 10 ft. of her movement to step magically into one living tree within her reach and emerge from a second living tree within 60 ft. of the first tree, appearing in an unoccupied space within 5 ft. of the second tree. Both trees must be large or bigger."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Club",
-        "desc": "Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1 d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1 d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -9364,7 +10478,11 @@
       },
       {
         "name": "Fey Charm",
-        "desc": "The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must succeed on a DC 14 Wisdom saving throw or be magically charmed. The charmed creature regards the dryad as a trusted friend to be heeded and protected. Although the target isn't under the dryad's control, it takes the dryad's requests or actions in the most favorable way it can.\nEach time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.\nThe dryad can have no more than one humanoid and up to three beasts charmed at a time.",
+        "desc": [
+          "The dryad targets one humanoid or beast that she can see within 30 feet of her. If the target can see the dryad, it must succeed on a DC 14 Wisdom saving throw or be magically charmed. The charmed creature regards the dryad as a trusted friend to be heeded and protected. Although the target isn't under the dryad's control, it takes the dryad's requests or actions in the most favorable way it can.",
+          "Each time the dryad or its allies do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the dryad dies, is on a different plane of existence from the target, or ends the effect as a bonus action. If a target's saving throw is successful, the target is immune to the dryad's Fey Charm for the next 24 hours.",
+          "The dryad can have no more than one humanoid and up to three beasts charmed at a time."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -9408,21 +10526,29 @@
     "special_abilities": [
       {
         "name": "Duergar Resilience",
-        "desc": "The duergar has advantage on saving throws against poison, spells, and illusions, as well as to resist being charmed or paralyzed."
+        "desc": [
+          "The duergar has advantage on saving throws against poison, spells, and illusions, as well as to resist being charmed or paralyzed."
+        ]
       },
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the duergar has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the duergar has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Enlarge (Recharges after a Short or Long Rest)",
-        "desc": "For 1 minute, the duergar magically increases in size, along with anything it is wearing or carrying. While enlarged, the duergar is Large, doubles its damage dice on Strength-based weapon attacks (included in the attacks), and makes Strength checks and Strength saving throws with advantage. If the duergar lacks the room to become Large, it attains the maximum size possible in the space available."
+        "desc": [
+          "For 1 minute, the duergar magically increases in size, along with anything it is wearing or carrying. While enlarged, the duergar is Large, doubles its damage dice on Strength-based weapon attacks (included in the attacks), and makes Strength checks and Strength saving throws with advantage. If the duergar lacks the room to become Large, it attains the maximum size possible in the space available."
+        ]
       },
       {
         "name": "War Pick",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage, or 11 (2d8 + 2) piercing damage while enlarged.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage, or 11 (2d8 + 2) piercing damage while enlarged."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9437,7 +10563,9 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 9 (2d6 + 2) piercing damage while enlarged.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 9 (2d6 + 2) piercing damage while enlarged."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9452,7 +10580,9 @@
       },
       {
         "name": "Invisibility (Recharges after a Short or Long Rest)",
-        "desc": "The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it ."
+        "desc": [
+          "The duergar magically turns invisible until it attacks, casts a spell, or uses its Enlarge, or until its concentration is broken, up to 1 hour (as if concentrating on a spell). Any equipment the duergar wears or carries is invisible with it ."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/94"
@@ -9498,7 +10628,9 @@
     "special_abilities": [
       {
         "name": "Death Burst",
-        "desc": "When the mephit dies, it explodes in a burst of dust. Each creature within 5 ft. of it must then succeed on a DC 10 Constitution saving throw or be blinded for 1 minute. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "When the mephit dies, it explodes in a burst of dust. Each creature within 5 ft. of it must then succeed on a DC 10 Constitution saving throw or be blinded for 1 minute. A blinded creature can repeat the saving throw on each of its turns, ending the effect on itself on a success."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -9510,13 +10642,17 @@
       },
       {
         "name": "Innate Spellcasting (1/Day)",
-        "desc": "The mephit can innately cast sleep, requiring no material components. Its innate spellcasting ability is Charisma."
+        "desc": [
+          "The mephit can innately cast sleep, requiring no material components. Its innate spellcasting ability is Charisma."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9531,7 +10667,9 @@
       },
       {
         "name": "Blinding Breath (Recharge 6)",
-        "desc": "The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a DC 10 Dexterity saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a DC 10 Dexterity saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -9543,7 +10681,9 @@
       },
       {
         "name": "Variant: Summon Mephits (1/Day)",
-        "desc": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/95"
@@ -9579,13 +10719,17 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -9658,21 +10802,29 @@
     "special_abilities": [
       {
         "name": "Earth Glide",
-        "desc": "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn't disturb the material it moves through."
+        "desc": [
+          "The elemental can burrow through nonmagical, unworked earth and stone. While doing so, the elemental doesn't disturb the material it moves through."
+        ]
       },
       {
         "name": "Siege Monster",
-        "desc": "The elemental deals double damage to objects and structures."
+        "desc": [
+          "The elemental deals double damage to objects and structures."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": [
+          "The elemental makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -9723,25 +10875,43 @@
     "special_abilities": [
       {
         "name": "Elemental Demise",
-        "desc": "If the efreeti dies, its body disintegrates in a flash of fire and puff of smoke, leaving behind only equipment the djinni was wearing or carrying."
+        "desc": [
+          "If the efreeti dies, its body disintegrates in a flash of fire and puff of smoke, leaving behind only equipment the djinni was wearing or carrying."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The efreeti's innate spell casting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic\n3/day: enlarge/reduce, tongues\n1/day each: conjure elemental (fire elemental only), gaseous form, invisibility, major image, plane shift, wall of fire"
+        "desc": [
+          "The efreeti's innate spell casting ability is Charisma (spell save DC 15, +7 to hit with spell attacks). It can innately cast the following spells, requiring no material components:",
+          "At will: detect magic",
+          "3/day: enlarge/reduce, tongues",
+          "1/day each: conjure elemental (fire elemental only), gaseous form, invisibility, major image, plane shift, wall of fire"
+        ]
       },
       {
         "name": "Variant: Genie Powers",
-        "desc": "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.\n\nDisguises.\nSome genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.\nWishes.\nThe genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.\nTo be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        "desc": [
+          "Genies have a variety of magical capabilities, including spells. A few have even greater powers that allow them to alter their appearance or the nature of reality.",
+          "Disguises.",
+          "Some genies can veil themselves in illusion to pass as other similarly shaped creatures. Such genies can innately cast the disguise self spell at will, often with a longer duration than is normal for that spell. Mightier genies can cast the true polymorph spell one to three times per day, possibly with a longer duration than normal. Such genies can change only their own shape, but a rare few can use the spell on other creatures and objects as well.",
+          "Wishes.",
+          "The genie power to grant wishes is legendary among mortals. Only the most potent genies, such as those among the nobility, can do so. A particular genie that has this power can grant one to three wishes to a creature that isn't a genie. Once a genie has granted its limit of wishes, it can't grant wishes again for some amount of time (usually 1 year). and cosmic law dictates that the same genie can expend its limit of wishes on a specific creature only once in that creature's existence.",
+          "To be granted a wish, a creature within 60 feet of the genie states a desired effect to it. The genie can then cast the wish spell on the creature's behalf to bring about the effect. Depending on the genie's nature, the genie might try to pervert the intent of the wish by exploiting the wish's poor wording. The perversion of the wording is usually crafted to be to the genie's benefit."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The efreeti makes two scimitar attacks or uses its Hurl Flame twice."
+        "desc": [
+          "The efreeti makes two scimitar attacks or uses its Hurl Flame twice."
+        ]
       },
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage plus 7 (2d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage plus 7 (2d6) fire damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -9764,7 +10934,9 @@
       },
       {
         "name": "Hurl Flame",
-        "desc": "Ranged Spell Attack: +7 to hit, range 120 ft., one target. Hit: 17 (5d6) fire damage.",
+        "desc": [
+          "Ranged Spell Attack: +7 to hit, range 120 ft., one target. Hit: 17 (5d6) fire damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -9809,13 +10981,17 @@
     "special_abilities": [
       {
         "name": "Trampling Charge",
-        "desc": "If the elephant moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action."
+        "desc": [
+          "If the elephant moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the elephant can make one stomp attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) piercing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -9830,7 +11006,9 @@
       },
       {
         "name": "Stomp",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -9875,13 +11053,17 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -9896,7 +11078,9 @@
       },
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one prone creature. Hit: 8 (2d4 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one prone creature. Hit: 8 (2d4 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -9957,21 +11141,29 @@
     "special_abilities": [
       {
         "name": "Hellish Weapons",
-        "desc": "The erinyes's weapon attacks are magical and deal an extra 13 (3d8) poison damage on a hit (included in the attacks)."
+        "desc": [
+          "The erinyes's weapon attacks are magical and deal an extra 13 (3d8) poison damage on a hit (included in the attacks)."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The erinyes has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The erinyes has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The erinyes makes three attacks"
+        "desc": [
+          "The erinyes makes three attacks"
+        ]
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands, plus 13 (3d8) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage, or 9 (1d10 + 4) slashing damage if used with two hands, plus 13 (3d8) poison damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -10008,7 +11200,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 13 (3d8) poison damage, and the target must succeed on a DC 14 Constitution saving throw or be poisoned. The poison lasts until it is removed by the lesser restoration spell or similar magic.",
+        "desc": [
+          "Ranged Weapon Attack: +7 to hit, range 150/600 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 13 (3d8) poison damage, and the target must succeed on a DC 14 Constitution saving throw or be poisoned. The poison lasts until it is removed by the lesser restoration spell or similar magic."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -10031,13 +11225,17 @@
       },
       {
         "name": "Variant: Rope of Entanglement",
-        "desc": "Some erinyes carry a rope of entanglement (detailed in the Dungeon Master's Guide). When such an erinyes uses its Multiattack, the erinyes can use the rope in place of two of the attacks."
+        "desc": [
+          "Some erinyes carry a rope of entanglement (detailed in the Dungeon Master's Guide). When such an erinyes uses its Multiattack, the erinyes can use the rope in place of two of the attacks."
+        ]
       }
     ],
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The erinyes adds 4 to its AC against one melee attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon."
+        "desc": [
+          "The erinyes adds 4 to its AC against one melee attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/101"
@@ -10075,25 +11273,35 @@
     "special_abilities": [
       {
         "name": "Spider Climb",
-        "desc": "The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The ettercap can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Sense",
-        "desc": "While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web."
+        "desc": [
+          "While in contact with a web, the ettercap knows the exact location of any other creature in contact with the same web."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The ettercap ignores movement restrictions caused by webbing."
+        "desc": [
+          "The ettercap ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ettercap makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The ettercap makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage plus 4 (1d8) poison damage. The target must succeed on a DC 11 Constitution saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 6 (1d8 + 2) piercing damage plus 4 (1d8) poison damage. The target must succeed on a DC 11 Constitution saving throw or be poisoned for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10116,7 +11324,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10131,12 +11341,16 @@
       },
       {
         "name": "Web (Recharge 5-6)",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/60 ft., one Large or smaller creature. Hit: The creature is restrained by webbing. As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, is vulnerable to fire damage and immune to bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/60 ft., one Large or smaller creature. Hit: The creature is restrained by webbing. As an action, the restrained creature can make a DC 11 Strength check, escaping from the webbing on a success. The effect ends if the webbing is destroyed. The webbing has AC 10, 5 hit points, is vulnerable to fire damage and immune to bludgeoning damage."
+        ],
         "attack_bonus": 4
       },
       {
         "name": "Variant: Web Garrote",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one Medium or Small creature against which the ettercap has advantage on the attack roll. Hit: 4 (1d4 + 2) bludgeoning damage, and the target is grappled (escape DC 12). Until this grapple ends, the target can't breathe, and the ettercap has advantage on attack rolls against it.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one Medium or Small creature against which the ettercap has advantage on the attack roll. Hit: 4 (1d4 + 2) bludgeoning damage, and the target is grappled (escape DC 12). Until this grapple ends, the target can't breathe, and the ettercap has advantage on attack rolls against it."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10182,21 +11396,29 @@
     "special_abilities": [
       {
         "name": "Two Heads",
-        "desc": "The ettin has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."
+        "desc": [
+          "The ettin has advantage on Wisdom (Perception) checks and on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious."
+        ]
       },
       {
         "name": "Wakeful",
-        "desc": "When one of the ettin's heads is asleep, its other head is awake."
+        "desc": [
+          "When one of the ettin's heads is asleep, its other head is awake."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ettin makes two attacks: one with its battleaxe and one with its morningstar."
+        "desc": [
+          "The ettin makes two attacks: one with its battleaxe and one with its morningstar."
+        ]
       },
       {
         "name": "Battleaxe",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -10211,7 +11433,9 @@
       },
       {
         "name": "Morningstar",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -10294,7 +11518,9 @@
     "special_abilities": [
       {
         "name": "Fire Form",
-        "desc": "The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 (1d10) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 (1d10) fire damage at the start of each of its turns.",
+        "desc": [
+          "The elemental can move through a space as narrow as 1 inch wide without squeezing. A creature that touches the elemental or hits it with a melee attack while within 5 ft. of it takes 5 (1d10) fire damage. In addition, the elemental can enter a hostile creature's space and stop there. The first time it enters a creature's space on a turn, that creature takes 5 (1d10) fire damage and catches fire; until someone takes an action to douse the fire, the creature takes 5 (1d10) fire damage at the start of each of its turns."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -10308,21 +11534,29 @@
       },
       {
         "name": "Illumination",
-        "desc": "The elemental sheds bright light in a 30-foot radius and dim light in an additional 30 ft.."
+        "desc": [
+          "The elemental sheds bright light in a 30-foot radius and dim light in an additional 30 ft.."
+        ]
       },
       {
         "name": "Water Susceptibility",
-        "desc": "For every 5 ft. the elemental moves in water, or for every gallon of water splashed on it, it takes 1 cold damage."
+        "desc": [
+          "For every 5 ft. the elemental moves in water, or for every gallon of water splashed on it, it takes 1 cold damage."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two touch attacks."
+        "desc": [
+          "The elemental makes two touch attacks."
+        ]
       },
       {
         "name": "Touch",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 5 (1d10) fire damage at the start of each of its turns.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) fire damage. If the target is a creature or a flammable object, it ignites. Until a creature takes an action to douse the fire, the target takes 5 (1d10) fire damage at the start of each of its turns."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -10374,11 +11608,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatsword attacks."
+        "desc": [
+          "The giant makes two greatsword attacks."
+        ]
       },
       {
         "name": "Greatsword",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 28 (6d6 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 28 (6d6 + 7) slashing damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -10393,7 +11631,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +11 to hit, range 60/240 ft., one target. Hit: 29 (4d10 + 7) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +11 to hit, range 60/240 ft., one target. Hit: 29 (4d10 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -10467,37 +11707,54 @@
     "special_abilities": [
       {
         "name": "Berserk",
-        "desc": "Whenever the golem starts its turn with 40 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points.\nThe golem's creator, if within 60 feet of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a DC 15 Charisma (Persuasion) check. If the check succeeds, the golem ceases being berserk. If it takes damage while still at 40 hit points or fewer, the golem might go berserk again."
+        "desc": [
+          "Whenever the golem starts its turn with 40 hit points or fewer, roll a d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object, with preference for an object smaller than itself. Once the golem goes berserk, it continues to do so until it is destroyed or regains all its hit points.",
+          "The golem's creator, if within 60 feet of the berserk golem, can try to calm it by speaking firmly and persuasively. The golem must be able to hear its creator, who must take an action to make a DC 15 Charisma (Persuasion) check. If the check succeeds, the golem ceases being berserk. If it takes damage while still at 40 hit points or fewer, the golem might go berserk again."
+        ]
       },
       {
         "name": "Aversion of Fire",
-        "desc": "If the golem takes fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn."
+        "desc": [
+          "If the golem takes fire damage, it has disadvantage on attack rolls and ability checks until the end of its next turn."
+        ]
       },
       {
         "name": "Immutable Form",
-        "desc": "The golem is immune to any spell or effect that would alter its form."
+        "desc": [
+          "The golem is immune to any spell or effect that would alter its form."
+        ]
       },
       {
         "name": "Lightning Absorption",
-        "desc": "Whenever the golem is subjected to lightning damage, it takes no damage and instead regains a number of hit points equal to the lightning damage dealt."
+        "desc": [
+          "Whenever the golem is subjected to lightning damage, it takes no damage and instead regains a number of hit points equal to the lightning damage dealt."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The golem has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The golem has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The golem's weapon attacks are magical."
+        "desc": [
+          "The golem's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": [
+          "The golem makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -10544,13 +11801,17 @@
     "special_abilities": [
       {
         "name": "Flyby",
-        "desc": "The snake doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        "desc": [
+          "The snake doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1 piercing damage plus 7 (3d4) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 1 piercing damage plus 7 (3d4) poison damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -10638,17 +11899,23 @@
     "special_abilities": [
       {
         "name": "Antimagic Susceptibility",
-        "desc": "The sword is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        "desc": [
+          "The sword is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the sword must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the sword remains motionless and isn't flying, it is indistinguishable from a normal sword."
+        "desc": [
+          "While the sword remains motionless and isn't flying, it is indistinguishable from a normal sword."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -10696,11 +11963,15 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The frog can breathe air and water"
+        "desc": [
+          "The frog can breathe air and water"
+        ]
       },
       {
         "name": "Standing Leap",
-        "desc": "The frog's long jump is up to 10 ft. and its high jump is up to 5 ft., with or without a running start."
+        "desc": [
+          "The frog's long jump is up to 10 ft. and its high jump is up to 5 ft., with or without a running start."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/109"
@@ -10741,11 +12012,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greataxe attacks."
+        "desc": [
+          "The giant makes two greataxe attacks."
+        ]
       },
       {
         "name": "Greataxe",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 25 (3d12 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 25 (3d12 + 6) slashing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -10760,7 +12035,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -10823,17 +12100,23 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the gargoyle remains motion less, it is indistinguishable from an inanimate statue."
+        "desc": [
+          "While the gargoyle remains motion less, it is indistinguishable from an inanimate statue."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gargoyle makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The gargoyle makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10848,7 +12131,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10918,17 +12203,26 @@
     "special_abilities": [
       {
         "name": "Ooze Cube",
-        "desc": "The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has disadvantage on the saving throw.\nCreatures inside the cube can be seen but have total cover.\nA creature within 5 feet of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful DC 12 Strength check, and the creature making the attempt takes 10 (3d6) acid damage.\nThe cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time."
+        "desc": [
+          "The cube takes up its entire space. Other creatures can enter the space, but a creature that does so is subjected to the cube's Engulf and has disadvantage on the saving throw.",
+          "Creatures inside the cube can be seen but have total cover.",
+          "A creature within 5 feet of the cube can take an action to pull a creature or object out of the cube. Doing so requires a successful DC 12 Strength check, and the creature making the attempt takes 10 (3d6) acid damage.",
+          "The cube can hold only one Large creature or up to four Medium or smaller creatures inside it at a time."
+        ]
       },
       {
         "name": "Transparent",
-        "desc": "Even when the cube is in plain sight, it takes a successful DC 15 Wisdom (Perception) check to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube."
+        "desc": [
+          "Even when the cube is in plain sight, it takes a successful DC 15 Wisdom (Perception) check to spot a cube that has neither moved nor attacked. A creature that tries to enter the cube's space while unaware of the cube is surprised by the cube."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Pseudopod",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) acid damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -10943,7 +12237,12 @@
       },
       {
         "name": "Engulf",
-        "desc": "The cube moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the cube enters a creature's space, the creature must make a DC 12 Dexterity saving throw.\nOn a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.\nOn a failed save, the cube enters the creature's space, and the creature takes 10 (3d6) acid damage and is engulfed. The engulfed creature can't breathe, is restrained, and takes 21 (6d6) acid damage at the start of each of the cube's turns. When the cube moves, the engulfed creature moves with it.\nAn engulfed creature can try to escape by taking an action to make a DC 12 Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the cube.",
+        "desc": [
+          "The cube moves up to its speed. While doing so, it can enter Large or smaller creatures' spaces. Whenever the cube enters a creature's space, the creature must make a DC 12 Dexterity saving throw.",
+          "On a successful save, the creature can choose to be pushed 5 feet back or to the side of the cube. A creature that chooses not to be pushed suffers the consequences of a failed saving throw.",
+          "On a failed save, the cube enters the creature's space, and the creature takes 10 (3d6) acid damage and is engulfed. The engulfed creature can't breathe, is restrained, and takes 21 (6d6) acid damage at the start of each of the cube's turns. When the cube moves, the engulfed creature moves with it.",
+          "An engulfed creature can try to escape by taking an action to make a DC 12 Strength check. On a success, the creature escapes and enters a space of its choice within 5 feet of the cube."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -11002,7 +12301,9 @@
     "special_abilities": [
       {
         "name": "Stench",
-        "desc": "Any creature that starts its turn within 5 ft. of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours.",
+        "desc": [
+          "Any creature that starts its turn within 5 ft. of the ghast must succeed on a DC 10 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the ghast's Stench for 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -11014,13 +12315,17 @@
       },
       {
         "name": "Turn Defiance",
-        "desc": "The ghast and any ghouls within 30 ft. of it have advantage on saving throws against effects that turn undead."
+        "desc": [
+          "The ghast and any ghouls within 30 ft. of it have advantage on saving throws against effects that turn undead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 12 (2d8 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 12 (2d8 + 3) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -11035,7 +12340,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a creature other than an undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -11129,17 +12436,23 @@
     "special_abilities": [
       {
         "name": "Ethereal Sight",
-        "desc": "The ghost can see 60 ft. into the Ethereal Plane when it is on the Material Plane, and vice versa."
+        "desc": [
+          "The ghost can see 60 ft. into the Ethereal Plane when it is on the Material Plane, and vice versa."
+        ]
       },
       {
         "name": "Incorporeal Movement",
-        "desc": "The ghost can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        "desc": [
+          "The ghost can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Withering Touch",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 17 (4d6 + 3) necrotic damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 17 (4d6 + 3) necrotic damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -11154,11 +12467,15 @@
       },
       {
         "name": "Etherealness",
-        "desc": "The ghost enters the Ethereal Plane from the Material Plane, or vice versa. It is visible on the Material Plane while it is in the Border Ethereal, and vice versa, yet it can't affect or be affected by anything on the other plane."
+        "desc": [
+          "The ghost enters the Ethereal Plane from the Material Plane, or vice versa. It is visible on the Material Plane while it is in the Border Ethereal, and vice versa, yet it can't affect or be affected by anything on the other plane."
+        ]
       },
       {
         "name": "Horrifying Visage",
-        "desc": "Each non-undead creature within 60 ft. of the ghost that can see it must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 + 10 years. A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a greater restoration spell, but only within 24 hours of it occurring.",
+        "desc": [
+          "Each non-undead creature within 60 ft. of the ghost that can see it must succeed on a DC 13 Wisdom saving throw or be frightened for 1 minute. If the save fails by 5 or more, the target also ages 1d4 + 10 years. A frightened target can repeat the saving throw at the end of each of its turns, ending the frightened condition on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to this ghost's Horrifying Visage for the next 24 hours. The aging effect can be reversed with a greater restoration spell, but only within 24 hours of it occurring."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -11170,7 +12487,10 @@
       },
       {
         "name": "Possession (Recharge 6)",
-        "desc": "One humanoid that the ghost can see within 5 ft. of it must succeed on a DC 13 Charisma saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.\nThe possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends.",
+        "desc": [
+          "One humanoid that the ghost can see within 5 ft. of it must succeed on a DC 13 Charisma saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.",
+          "The possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends."
+        ],
         "dc": {
           "dc_type": {
             "name": "CHA",
@@ -11217,7 +12537,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -11232,7 +12554,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -11280,11 +12604,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ape makes two fist attacks."
+        "desc": [
+          "The ape makes two fist attacks."
+        ]
       },
       {
         "name": "Fist",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 22 (3d10 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -11299,7 +12627,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit: 30 (7d6 + 6) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +9 to hit, range 50/100 ft., one target. Hit: 30 (7d6 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -11345,17 +12675,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The badger has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The badger makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The badger makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -11370,7 +12706,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -11416,17 +12754,23 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The bat can't use its blindsight while deafened."
+        "desc": [
+          "The bat can't use its blindsight while deafened."
+        ]
       },
       {
         "name": "Keen Hearing",
-        "desc": "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        "desc": [
+          "The bat has advantage on Wisdom (Perception) checks that rely on hearing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -11471,17 +12815,23 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the boar moves at least 20 ft. straight toward a target and then hits it with a tusk attack on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Relentless (Recharges after a Short or Long Rest)",
-        "desc": "If the boar takes 10 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        "desc": [
+          "If the boar takes 10 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Tusk",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -11527,7 +12877,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Bite. Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or take 10 (3d6) poison damage. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": [
+          "Bite. Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or take 10 (3d6) poison damage. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -11574,7 +12926,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -11589,7 +12943,9 @@
       },
       {
         "name": "Constrict",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 13 (2d8 + 4) bludgeoning damage, and the target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can't constrict another target.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 13 (2d8 + 4) bludgeoning damage, and the target is grappled (escape DC 16). Until this grapple ends, the creature is restrained, and the snake can't constrict another target."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -11636,13 +12992,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The crab can breathe air and water."
+        "desc": [
+          "The crab can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage, and the target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage, and the target is grappled (escape DC 11). The crab has two claws, each of which can grapple only one target."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -11689,17 +13049,23 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "The crocodile can hold its breath for 30 minutes."
+        "desc": [
+          "The crocodile can hold its breath for 30 minutes."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The crocodile makes two attacks: one with its bite and one with its tail."
+        "desc": [
+          "The crocodile makes two attacks: one with its bite and one with its tail."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 21 (3d10 + 5) piercing damage, and the target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 21 (3d10 + 5) piercing damage, and the target is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the crocodile can't bite another target."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -11714,7 +13080,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target not grappled by the crocodile. Hit: 14 (2d8 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target not grappled by the crocodile. Hit: 14 (2d8 + 5) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -11761,17 +13129,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The eagle has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The eagle makes two attacks: one with its beak and one with its talons."
+        "desc": [
+          "The eagle makes two attacks: one with its beak and one with its talons."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -11786,7 +13160,9 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -11832,13 +13208,17 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the elk moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -11853,7 +13233,9 @@
       },
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one prone creature. Hit: 22 (4d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one prone creature. Hit: 22 (4d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -11898,13 +13280,17 @@
     "special_abilities": [
       {
         "name": "Illumination",
-        "desc": "The beetle sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        "desc": [
+          "The beetle sheds bright light in a 10-foot radius and dim light for an additional 10 ft.."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 2 (1d6 - 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 2 (1d6 - 1) slashing damage."
+        ],
         "attack_bonus": 1,
         "damage": [
           {
@@ -11952,17 +13338,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The frog can breathe air and water"
+        "desc": [
+          "The frog can breathe air and water"
+        ]
       },
       {
         "name": "Standing Leap",
-        "desc": "The frog's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        "desc": [
+          "The frog's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage, and the target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage, and the target is grappled (escape DC 11). Until this grapple ends, the target is restrained, and the frog can't bite another target."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -11977,7 +13369,9 @@
       },
       {
         "name": "Swallow",
-        "desc": "The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 5 (2d4) acid damage at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone."
+        "desc": [
+          "The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 5 (2d4) acid damage at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/127"
@@ -12011,17 +13405,23 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 5 (2d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 5 (2d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Sure-Footed",
-        "desc": "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        "desc": [
+          "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -12067,13 +13467,17 @@
     "special_abilities": [
       {
         "name": "Rampage",
-        "desc": "When the hyena reduces a creature to 0 hit points with a melee attack on its turn, the hyena can take a bonus action to move up to half its speed and make a bite attack."
+        "desc": [
+          "When the hyena reduces a creature to 0 hit points with a melee attack on its turn, the hyena can take a bonus action to move up to half its speed and make a bite attack."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -12119,17 +13523,23 @@
     "special_abilities": [
       {
         "name": "Variant: Hold Breath",
-        "desc": "The lizard can hold its breath for 15 minutes. (A lizard that has this trait also has a swimming speed of 30 feet.)"
+        "desc": [
+          "The lizard can hold its breath for 15 minutes. (A lizard that has this trait also has a swimming speed of 30 feet.)"
+        ]
       },
       {
         "name": "Variant: Spider Climb",
-        "desc": "The lizard can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The lizard can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12177,21 +13587,29 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "While out of water, the octopus can hold its breath for 1 hour."
+        "desc": [
+          "While out of water, the octopus can hold its breath for 1 hour."
+        ]
       },
       {
         "name": "Underwater Camouflage",
-        "desc": "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        "desc": [
+          "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The octopus can breathe only underwater."
+        "desc": [
+          "The octopus can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 15 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage. If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 15 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage. If the target is a creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained, and the octopus can't use its tentacles on another target."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -12206,7 +13624,9 @@
       },
       {
         "name": "Ink Cloud (Recharges after a Short or Long Rest)",
-        "desc": "A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+        "desc": [
+          "A 20-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/131"
@@ -12243,17 +13663,23 @@
     "special_abilities": [
       {
         "name": "Flyby",
-        "desc": "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        "desc": [
+          "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        ]
       },
       {
         "name": "Keen Hearing and Sight",
-        "desc": "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        "desc": [
+          "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 8 (2d6 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 8 (2d6 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -12300,7 +13726,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 6 (1d4 + 4) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 6 (1d4 + 4) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -12345,17 +13773,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The rat has advantage on an attack roll against a creature if at least one of the rat's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The rat has advantage on an attack roll against a creature if at least one of the rat's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12400,7 +13834,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 10 Constitution saving throw or contract a disease. Until the disease is cured, the target can't regain hit points except by magical means, and the target's hit point maximum decreases by 3 (1d6) every 24 hours. If the target's hit point maximum drops to 0 as a result of this disease, the target dies."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12445,7 +13881,9 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple only one target."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12460,11 +13898,15 @@
       },
       {
         "name": "Multiattack",
-        "desc": "The scorpion makes three attacks: two with its claws and one with its sting."
+        "desc": [
+          "The scorpion makes three attacks: two with its claws and one with its sting."
+        ]
       },
       {
         "name": "Sting",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 12 Constitution saving throw, taking 22 (4d10) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 12 Constitution saving throw, taking 22 (4d10) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12510,17 +13952,23 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) bludgeoning damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the sea horse moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 7 (2d6) bludgeoning damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The sea horse can breathe only underwater."
+        "desc": [
+          "The sea horse can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -12566,17 +14014,23 @@
     "special_abilities": [
       {
         "name": "Blood Frenzy",
-        "desc": "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        "desc": [
+          "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The shark can breathe only underwater."
+        "desc": [
+          "The shark can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 22 (3d10 + 6) piercing damage.",
+        "desc": [
+          "Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 22 (3d10 + 6) piercing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -12623,21 +14077,29 @@
     "special_abilities": [
       {
         "name": "Spider Climb",
-        "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Sense",
-        "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        "desc": [
+          "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The spider ignores movement restrictions caused by webbing."
+        "desc": [
+          "The spider ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 9 (2d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 7 (1d8 + 3) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 9 (2d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -12652,7 +14114,9 @@
       },
       {
         "name": "Web (Recharge 5-6)",
-        "desc": "Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to fire damage; immunity to bludgeoning, poison, and psychic damage).",
+        "desc": [
+          "Ranged Weapon Attack: +5 to hit, range 30/60 ft., one creature. Hit: The target is restrained by webbing. As an action, the restrained target can make a DC 12 Strength check, bursting the webbing on a success. The webbing can also be attacked and destroyed (AC 10; hp 5; vulnerability to fire damage; immunity to bludgeoning, poison, and psychic damage)."
+        ],
         "attack_bonus": 5
       }
     ],
@@ -12688,17 +14152,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The toad can breathe air and water"
+        "desc": [
+          "The toad can breathe air and water"
+        ]
       },
       {
         "name": "Standing Leap",
-        "desc": "The toad's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        "desc": [
+          "The toad's long jump is up to 20 ft. and its high jump is up to 10 ft., with or without a running start."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 5 (1d10) poison damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 5 (1d10) poison damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the toad can't bite another target."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12721,7 +14191,10 @@
       },
       {
         "name": "Swallow",
-        "desc": "The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes 10 (3d6) acid damage at the start of each of the toad's turns. The toad can have only one target swallowed at a time.\nIf the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
+        "desc": [
+          "The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes 10 (3d6) acid damage at the start of each of the toad's turns. The toad can have only one target swallowed at a time.",
+          "If the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/140"
@@ -12757,21 +14230,29 @@
     "special_abilities": [
       {
         "name": "Keen Sight and Smell",
-        "desc": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        "desc": [
+          "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vulture makes two attacks: one with its beak and one with its talons."
+        "desc": [
+          "The vulture makes two attacks: one with its beak and one with its talons."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12786,7 +14267,9 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12833,7 +14316,9 @@
     "actions": [
       {
         "name": "Sting",
-        "desc": "Sting. Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": [
+          "Sting. Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -12880,13 +14365,17 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage.",
+        "desc": [
+          "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -12934,21 +14423,29 @@
     "special_abilities": [
       {
         "name": "Spider Climb",
-        "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Sense",
-        "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        "desc": [
+          "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The spider ignores movement restrictions caused by webbing."
+        "desc": [
+          "The spider ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": [
+          "Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -12999,11 +14496,15 @@
     "special_abilities": [
       {
         "name": "Aberrant Ground",
-        "desc": "The ground in a 10-foot radius around the mouther is doughlike difficult terrain. Each creature that starts its turn in that area must succeed on a DC 10 Strength saving throw or have its speed reduced to 0 until the start of its next turn."
+        "desc": [
+          "The ground in a 10-foot radius around the mouther is doughlike difficult terrain. Each creature that starts its turn in that area must succeed on a DC 10 Strength saving throw or have its speed reduced to 0 until the start of its next turn."
+        ]
       },
       {
         "name": "Gibbering",
-        "desc": "The mouther babbles incoherently while it can see any creature and isn't incapacitated. Each creature that starts its turn within 20 feet of the mouther and can hear the gibbering must succeed on a DC 10 Wisdom saving throw. On a failure, the creature can't take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack.",
+        "desc": [
+          "The mouther babbles incoherently while it can see any creature and isn't incapacitated. Each creature that starts its turn within 20 feet of the mouther and can hear the gibbering must succeed on a DC 10 Wisdom saving throw. On a failure, the creature can't take reactions until the start of its next turn and rolls a d8 to determine what it does during its turn. On a 1 to 4, the creature does nothing. On a 5 or 6, the creature takes no action or bonus action and uses all its movement to move in a randomly determined direction. On a 7 or 8, the creature makes a melee attack against a randomly determined creature within its reach or does nothing if it can't make such an attack."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -13017,11 +14518,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."
+        "desc": [
+          "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."
+        ]
       },
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 17 (5d6) piercing damage. If the target is Medium or smaller, it must succeed on a DC 10 Strength saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 17 (5d6) piercing damage. If the target is Medium or smaller, it must succeed on a DC 10 Strength saving throw or be knocked prone. If the target is killed by this damage, it is absorbed into the mouther."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -13036,7 +14541,9 @@
       },
       {
         "name": "Blinding Spittle (Recharge 5-6)",
-        "desc": "The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must succeed on a DC 13 Dexterity saving throw or be blinded until the end of the mouther's next turn.",
+        "desc": [
+          "The mouther spits a chemical glob at a point it can see within 15 feet of it. The glob explodes in a blinding flash of light on impact. Each creature within 5 feet of the flash must succeed on a DC 13 Dexterity saving throw or be blinded until the end of the mouther's next turn."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -13094,21 +14601,31 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The glabrezu's spellcasting ability is Intelligence (spell save DC 16). The glabrezu can innately cast the following spells, requiring no material components:\nAt will: darkness, detect magic, dispel magic\n1/day each: confusion, fly, power word stun"
+        "desc": [
+          "The glabrezu's spellcasting ability is Intelligence (spell save DC 16). The glabrezu can innately cast the following spells, requiring no material components:",
+          "At will: darkness, detect magic, dispel magic",
+          "1/day each: confusion, fly, power word stun"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The glabrezu has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The glabrezu has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."
+        "desc": [
+          "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."
+        ]
       },
       {
         "name": "Pincer",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). The glabrezu has two pincers, each of which can grapple only one target."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -13123,7 +14640,9 @@
       },
       {
         "name": "Fist",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -13138,7 +14657,11 @@
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA glabrezu has a 30 percent chance of summoning 1d3 vrocks, 1d2 hezrous, or one glabrezu.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A glabrezu has a 30 percent chance of summoning 1d3 vrocks, 1d2 hezrous, or one glabrezu.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/146"
@@ -13177,21 +14700,29 @@
     "special_abilities": [
       {
         "name": "Brave",
-        "desc": "The gladiator has advantage on saving throws against being frightened."
+        "desc": [
+          "The gladiator has advantage on saving throws against being frightened."
+        ]
       },
       {
         "name": "Brute",
-        "desc": "A melee weapon deals one extra die of its damage when the gladiator hits with it (included in the attack)."
+        "desc": [
+          "A melee weapon deals one extra die of its damage when the gladiator hits with it (included in the attack)."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gladiator makes three melee attacks or two ranged attacks."
+        "desc": [
+          "The gladiator makes three melee attacks or two ranged attacks."
+        ]
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -13220,7 +14751,9 @@
       },
       {
         "name": "Shield Bash",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 9 (2d4 + 4) bludgeoning damage. If the target is a Medium or smaller creature, it must succeed on a DC 15 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 9 (2d4 + 4) bludgeoning damage. If the target is a Medium or smaller creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -13237,7 +14770,9 @@
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.",
+        "desc": [
+          "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon."
+        ],
         "attack_bonus": 0
       }
     ],
@@ -13272,13 +14807,17 @@
     "special_abilities": [
       {
         "name": "Rampage",
-        "desc": "When the gnoll reduces a creature to 0 hit points with a melee attack on its turn, the gnoll can take a bonus action to move up to half its speed and make a bite attack."
+        "desc": [
+          "When the gnoll reduces a creature to 0 hit points with a melee attack on its turn, the gnoll can take a bonus action to move up to half its speed and make a bite attack."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13293,7 +14832,9 @@
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13322,7 +14863,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -13367,17 +14910,23 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 2 (1d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 10 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the goat moves at least 20 ft. straight toward a target and then hits it with a ram attack on the same turn, the target takes an extra 2 (1d4) bludgeoning damage. If the target is a creature, it must succeed on a DC 10 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Sure-Footed",
-        "desc": "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        "desc": [
+          "The goat has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -13423,13 +14972,17 @@
     "special_abilities": [
       {
         "name": "Nimble Escape",
-        "desc": "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+        "desc": [
+          "The goblin can take the Disengage or Hide action as a bonus action on each of its turns."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Scimitar",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13444,7 +14997,9 @@
       },
       {
         "name": "Shortbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13499,13 +15054,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -13520,7 +15079,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 22 (4d10) fire damage on a failed save, or half as much damage on a successful one.\nWeakening Breath. The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 22 (4d10) fire damage on a failed save, or half as much damage on a successful one.",
+          "Weakening Breath. The dragon exhales gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -13594,13 +15157,17 @@
     "special_abilities": [
       {
         "name": "Trampling Charge",
-        "desc": "If the gorgon moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 16 Strength saving throw or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action."
+        "desc": [
+          "If the gorgon moves at least 20 feet straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 16 Strength saving throw or be knocked prone. If the target is prone, the gorgon can make one attack with its hooves against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (2d12 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 18 (2d12 + 5) piercing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -13615,7 +15182,9 @@
       },
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 16 (2d10 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -13630,7 +15199,9 @@
       },
       {
         "name": "Petrifying Breath (Recharge 5-6)",
-        "desc": "The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw. On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the greater restoration spell or other magic.",
+        "desc": [
+          "The gorgon exhales petrifying gas in a 30-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw. On a failed save, a target begins to turn to stone and is restrained. The restrained target must repeat the saving throw at the end of its next turn. On a success, the effect ends on the target. On a failure, the target is petrified until freed by the greater restoration spell or other magic."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -13703,21 +15274,30 @@
     "special_abilities": [
       {
         "name": "Amorphous",
-        "desc": "The ooze can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The ooze can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       },
       {
         "name": "Corrode Metal",
-        "desc": "Any nonmagical weapon made of metal that hits the ooze corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage.\nThe ooze can eat through 2-inch-thick, nonmagical metal in 1 round."
+        "desc": [
+          "Any nonmagical weapon made of metal that hits the ooze corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal that hits the ooze is destroyed after dealing damage.",
+          "The ooze can eat through 2-inch-thick, nonmagical metal in 1 round."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the ooze remains motionless, it is indistinguishable from an oily pool or wet rock."
+        "desc": [
+          "While the ooze remains motionless, it is indistinguishable from an oily pool or wet rock."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Pseudopod",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage plus 7 (2d6) acid damage, and if the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage plus 7 (2d6) acid damage, and if the target is wearing nonmagical metal armor, its armor is partly corroded and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -13785,13 +15365,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 3 (1d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 3 (1d6) poison damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13814,7 +15398,9 @@
       },
       {
         "name": "Poison Breath (Recharge 5-6)",
-        "desc": "The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 11 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 11 Constitution saving throw, taking 21 (6d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -13870,33 +15456,57 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The hag can breathe air and water."
+        "desc": [
+          "The hag can breathe air and water."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The hag's innate spellcasting ability is Charisma (spell save DC 12). She can innately cast the following spells, requiring no material components:\n\nAt will: dancing lights, minor illusion, vicious mockery"
+        "desc": [
+          "The hag's innate spellcasting ability is Charisma (spell save DC 12). She can innately cast the following spells, requiring no material components:",
+          "At will: dancing lights, minor illusion, vicious mockery"
+        ]
       },
       {
         "name": "Mimicry",
-        "desc": "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful DC 14 Wisdom (Insight) check."
+        "desc": [
+          "The hag can mimic animal sounds and humanoid voices. A creature that hears the sounds can tell they are imitations with a successful DC 14 Wisdom (Insight) check."
+        ]
       },
       {
         "name": "Hag Coven",
-        "desc": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        "desc": [
+          "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.",
+          "A coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        ]
       },
       {
         "name": "Shared Spellcasting (Coven Only)",
-        "desc": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n- 1st level (4 slots): identify, ray of sickness\n- 2nd level (3 slots): hold person, locate object\n- 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n- 4th level (3 slots): phantasmal killer, polymorph\n- 5th level (2 slots): contact other plane, scrying\n- 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        "desc": [
+          "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:",
+          "- 1st level (4 slots): identify, ray of sickness",
+          "- 2nd level (3 slots): hold person, locate object",
+          "- 3rd level (3 slots): bestow curse, counterspell, lightning bolt",
+          "- 4th level (3 slots): phantasmal killer, polymorph",
+          "- 5th level (2 slots): contact other plane, scrying",
+          "- 6th level (1 slot): eye bite",
+          "For casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        ]
       },
       {
         "name": "Hag Eye (Coven Only)",
-        "desc": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        "desc": [
+          "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.",
+          "A hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -13911,11 +15521,16 @@
       },
       {
         "name": "Illusory Appearance",
-        "desc": "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like another creature of her general size and humanoid shape. The illusion ends if the hag takes a bonus action to end it or if she dies.\nThe changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have smooth skin, but someone touching her would feel her rough flesh. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 20 Intelligence (Investigation) check to discern that the hag is disguised."
+        "desc": [
+          "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like another creature of her general size and humanoid shape. The illusion ends if the hag takes a bonus action to end it or if she dies.",
+          "The changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have smooth skin, but someone touching her would feel her rough flesh. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 20 Intelligence (Investigation) check to discern that the hag is disguised."
+        ]
       },
       {
         "name": "Invisible Passage",
-        "desc": "The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her."
+        "desc": [
+          "The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/155"
@@ -13952,17 +15567,23 @@
     "special_abilities": [
       {
         "name": "Stone Camouflage",
-        "desc": "The grick has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        "desc": [
+          "The grick has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."
+        "desc": [
+          "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."
+        ]
       },
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -13977,7 +15598,9 @@
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -14024,17 +15647,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The griffon has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The griffon has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The griffon makes two attacks: one with its beak and one with its claws."
+        "desc": [
+          "The griffon makes two attacks: one with its beak and one with its claws."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -14049,7 +15678,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -14102,21 +15733,29 @@
     "special_abilities": [
       {
         "name": "Blind Senses",
-        "desc": "The grimlock can't use its blindsight while deafened and unable to smell."
+        "desc": [
+          "The grimlock can't use its blindsight while deafened and unable to smell."
+        ]
       },
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The grimlock has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The grimlock has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Stone Camouflage",
-        "desc": "The grimlock has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        "desc": [
+          "The grimlock has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Spiked Bone Club",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) bludgeoning damage plus 2 (1d4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) bludgeoning damage plus 2 (1d4) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14170,7 +15809,9 @@
     "actions": [
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -14245,17 +15886,30 @@
     "special_abilities": [
       {
         "name": "Rejuvenation",
-        "desc": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        "desc": [
+          "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:\n\n- Cantrips (at will): mending, sacred flame, thaumaturgy\n- 1st level (4 slots): command, cure wounds, shield of faith\n- 2nd level (3 slots): calm emotions, hold person\n- 3rd level (3 slots): bestow curse, clairvoyance\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, geas\n- 6th level (1 slot): true seeing"
+        "desc": [
+          "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:",
+          "- Cantrips (at will): mending, sacred flame, thaumaturgy",
+          "- 1st level (4 slots): command, cure wounds, shield of faith",
+          "- 2nd level (3 slots): calm emotions, hold person",
+          "- 3rd level (3 slots): bestow curse, clairvoyance",
+          "- 4th level (3 slots): banishment, freedom of movement",
+          "- 5th level (2 slots): flame strike, geas",
+          "- 6th level (1 slot): true seeing"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one creature. Hit: 8 (1d8 + 4) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one creature. Hit: 8 (1d8 + 4) piercing damage, and the target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -14270,7 +15924,9 @@
       },
       {
         "name": "Spit Poison",
-        "desc": "Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: The target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Ranged Weapon Attack: +8 to hit, range 15/30 ft., one creature. Hit: The target must make a DC 15 Constitution saving throw, taking 45 (10d8) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 8
       }
     ],
@@ -14323,25 +15979,41 @@
     "special_abilities": [
       {
         "name": "Inscrutable",
-        "desc": "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        "desc": [
+          "The sphinx is immune to any effect that would sense its emotions or read its thoughts, as well as any divination spell that it refuses. Wisdom (Insight) checks made to ascertain the sphinx's intentions or sincerity have disadvantage."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The sphinx's weapon attacks are magical."
+        "desc": [
+          "The sphinx's weapon attacks are magical."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, prestidigitation\n- 1st level (4 slots): detect magic, identify, shield\n- 2nd level (3 slots): darkness, locate object, suggestion\n- 3rd level (3 slots): dispel magic, remove curse, tongues\n- 4th level (3 slots): banishment, greater invisibility\n- 5th level (1 slot): legend lore"
+        "desc": [
+          "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:",
+          "- Cantrips (at will): mage hand, minor illusion, prestidigitation",
+          "- 1st level (4 slots): detect magic, identify, shield",
+          "- 2nd level (3 slots): darkness, locate object, suggestion",
+          "- 3rd level (3 slots): dispel magic, remove curse, tongues",
+          "- 4th level (3 slots): banishment, greater invisibility",
+          "- 5th level (1 slot): legend lore"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sphinx makes two claw attacks."
+        "desc": [
+          "The sphinx makes two claw attacks."
+        ]
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -14358,15 +16030,21 @@
     "legendary_actions": [
       {
         "name": "Claw Attack",
-        "desc": "The sphinx makes one claw attack."
+        "desc": [
+          "The sphinx makes one claw attack."
+        ]
       },
       {
         "name": "Teleport (Costs 2 Actions)",
-        "desc": "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        "desc": [
+          "The sphinx magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Cast a Spell (Costs 3 Actions)",
-        "desc": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        "desc": [
+          "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/161"
@@ -14402,11 +16080,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        "desc": [
+          "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        ]
       },
       {
         "name": "Longsword",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.",
+        "desc": [
+          "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14435,7 +16117,9 @@
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14450,7 +16134,9 @@
       },
       {
         "name": "Heavy Crossbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -14465,7 +16151,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The veteran exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The veteran exhales fire in a 15-foot cone. Each creature in that area must make a DC 15 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -14518,11 +16206,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The harpy makes two attacks: one with its claws and one with its club."
+        "desc": [
+          "The harpy makes two attacks: one with its claws and one with its club."
+        ]
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -14537,7 +16229,9 @@
       },
       {
         "name": "Club",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -14552,7 +16246,11 @@
       },
       {
         "name": "Luring Song",
-        "desc": "The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a DC 11 Wisdom saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.\nWhile charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 ft. away from the harpy, the must move on its turn toward the harpy by the most direct route. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, a target can repeat the saving throw. A creature can also repeat the saving throw at the end of each of its turns. If a creature's saving throw is successful, the effect ends on it.\nA target that successfully saves is immune to this harpy's song for the next 24 hours."
+        "desc": [
+          "The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a DC 11 Wisdom saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.",
+          "While charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 ft. away from the harpy, the must move on its turn toward the harpy by the most direct route. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, a target can repeat the saving throw. A creature can also repeat the saving throw at the end of each of its turns. If a creature's saving throw is successful, the effect ends on it.",
+          "A target that successfully saves is immune to this harpy's song for the next 24 hours."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/163"
@@ -14588,13 +16286,17 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The hawk has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14642,17 +16344,23 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The hound has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The hound has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The hound has advantage on an attack roll against a creature if at least one of the hound's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The hound has advantage on an attack roll against a creature if at least one of the hound's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 7 (2d6) fire damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14675,7 +16383,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The hound exhales fire in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The hound exhales fire in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -14742,11 +16452,15 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The hezrou has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The hezrou has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Stench",
-        "desc": "Any creature that starts its turn within 10 feet of the hezrou must succeed on a DC 14 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou's stench for 24 hours.",
+        "desc": [
+          "Any creature that starts its turn within 10 feet of the hezrou must succeed on a DC 14 Constitution saving throw or be poisoned until the start of its next turn. On a successful saving throw, the creature is immune to the hezrou's stench for 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -14760,11 +16474,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hezrou makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The hezrou makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -14779,7 +16497,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -14794,7 +16514,11 @@
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA hezrou has a 30 percent chance of summoning 2d6 dretches or one hezrou.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A hezrou has a 30 percent chance of summoning 2d6 dretches or one hezrou.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/166"
@@ -14829,11 +16553,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatclub attacks."
+        "desc": [
+          "The giant makes two greatclub attacks."
+        ]
       },
       {
         "name": "Greatclub",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 18 (3d8 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 18 (3d8 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -14848,7 +16576,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +8 to hit, range 60/240 ft., one target. Hit: 21 (3d10 + 5) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +8 to hit, range 60/240 ft., one target. Hit: 21 (3d10 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -14895,17 +16625,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The hippogriff has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The hippogriff has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hippogriff makes two attacks: one with its beak and one with its claws."
+        "desc": [
+          "The hippogriff makes two attacks: one with its beak and one with its claws."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14920,7 +16656,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -14965,13 +16703,17 @@
     "special_abilities": [
       {
         "name": "Martial Advantage",
-        "desc": "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated."
+        "desc": [
+          "Once per turn, the hobgoblin can deal an extra 7 (2d6) damage to a creature it hits with a weapon attack if that creature is within 5 ft. of an ally of the hobgoblin that isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage, or 6 (1d10 + 1) slashing damage if used with two hands.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) slashing damage, or 6 (1d10 + 1) slashing damage if used with two hands."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -15000,7 +16742,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +3 to hit, range 150/600 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -15057,13 +16801,17 @@
     "special_abilities": [
       {
         "name": "Telepathic Bond",
-        "desc": "While the homunculus is on the same plane of existence as its master, it can magically convey what it senses to its master, and the two can communicate telepathically."
+        "desc": [
+          "While the homunculus is on the same plane of existence as its master, it can magically convey what it senses to its master, and the two can communicate telepathically."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or be poisoned for 1 minute. If the saving throw fails by 5 or more, the target is instead poisoned for 5 (1d10) minutes and unconscious while poisoned in this way."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -15124,21 +16872,29 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."
+        "desc": [
+          "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."
+        ]
       },
       {
         "name": "Fork",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (2d8 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (2d8 + 6) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -15153,7 +16909,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 10 (1d8 + 6) piercing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 17 Constitution saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 10 (1d8 + 6) piercing damage. If the target is a creature other than an undead or a construct, it must succeed on a DC 17 Constitution saving throw or lose 10 (3d6) hit points at the start of each of its turns due to an infernal wound. Each time the devil hits the wounded target with this attack, the damage dealt by the wound increases by 10 (3d6). Any creature can take an action to stanch the wound with a successful DC 12 Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -15168,7 +16926,9 @@
       },
       {
         "name": "Hurl Flame",
-        "desc": "Ranged Spell Attack: +7 to hit, range 150 ft., one target. Hit: 14 (4d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire.",
+        "desc": [
+          "Ranged Spell Attack: +7 to hit, range 150 ft., one target. Hit: 14 (4d6) fire damage. If the target is a flammable object that isn't being worn or carried, it also catches fire."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -15214,17 +16974,23 @@
     "special_abilities": [
       {
         "name": "Blood Frenzy",
-        "desc": "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        "desc": [
+          "The shark has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The shark can breathe only underwater."
+        "desc": [
+          "The shark can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -15271,29 +17037,43 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "The hydra can hold its breath for 1 hour."
+        "desc": [
+          "The hydra can hold its breath for 1 hour."
+        ]
       },
       {
         "name": "Multiple Heads",
-        "desc": "The hydra has five heads. While it has more than one head, the hydra has advantage on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious.\nWhenever the hydra takes 25 or more damage in a single turn, one of its heads dies. If all its heads die, the hydra dies.\nAt the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken fire damage since its last turn. The hydra regains 10 hit points for each head regrown in this way."
+        "desc": [
+          "The hydra has five heads. While it has more than one head, the hydra has advantage on saving throws against being blinded, charmed, deafened, frightened, stunned, and knocked unconscious.",
+          "Whenever the hydra takes 25 or more damage in a single turn, one of its heads dies. If all its heads die, the hydra dies.",
+          "At the end of its turn, it grows two heads for each of its heads that died since its last turn, unless it has taken fire damage since its last turn. The hydra regains 10 hit points for each head regrown in this way."
+        ]
       },
       {
         "name": "Reactive Heads",
-        "desc": "For each head the hydra has beyond one, it gets an extra reaction that can be used only for opportunity attacks."
+        "desc": [
+          "For each head the hydra has beyond one, it gets an extra reaction that can be used only for opportunity attacks."
+        ]
       },
       {
         "name": "Wakeful",
-        "desc": "While the hydra sleeps, at least one of its heads is awake."
+        "desc": [
+          "While the hydra sleeps, at least one of its heads is awake."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hydra makes as many bite attacks as it has heads."
+        "desc": [
+          "The hydra makes as many bite attacks as it has heads."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 10 (1d10 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 10 (1d10 + 5) piercing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -15339,13 +17119,17 @@
     "special_abilities": [
       {
         "name": "Pack Tactics",
-        "desc": "The hyena has advantage on an attack roll against a creature if at least one of the hyena's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The hyena has advantage on an attack roll against a creature if at least one of the hyena's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage.",
+        "desc": [
+          "Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -15404,21 +17188,29 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the devil's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the devil's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The devil has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The devil has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."
+        "desc": [
+          "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) piercing damage plus 10 (3d6) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) piercing damage plus 10 (3d6) cold damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -15441,7 +17233,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 10 (2d4 + 5) slashing damage plus 10 (3d6) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 10 (2d4 + 5) slashing damage plus 10 (3d6) cold damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -15464,7 +17258,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack:+10 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage.",
+        "desc": [
+          "Melee Weapon Attack:+10 to hit, reach 10 ft., one target. Hit: 12 (2d6 + 5) bludgeoning damage plus 10 (3d6) cold damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -15487,7 +17283,11 @@
       },
       {
         "name": "Wall of Ice",
-        "desc": "The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.\nWhen the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a DC 17 Dexterity saving throw, taking 35 (10d6) cold damage on a failed save, or half as much damage on a successful one.\nThe wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to fire damage, and immunity to acid, cold, necrotic, poison, and psychic damage. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a DC 17 Constitution saving throw, taking 17 (5d6) cold damage on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes."
+        "desc": [
+          "The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.",
+          "When the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a DC 17 Dexterity saving throw, taking 35 (10d6) cold damage on a failed save, or half as much damage on a successful one.",
+          "The wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to fire damage, and immunity to acid, cold, necrotic, poison, and psychic damage. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a DC 17 Constitution saving throw, taking 17 (5d6) cold damage on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/175"
@@ -15535,7 +17335,9 @@
     "special_abilities": [
       {
         "name": "Death Burst",
-        "desc": "When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a DC 10 Dexterity saving throw, taking 4 (1d8) slashing damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "When the mephit dies, it explodes in a burst of jagged ice. Each creature within 5 ft. of it must make a DC 10 Dexterity saving throw, taking 4 (1d8) slashing damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -15557,17 +17359,23 @@
       },
       {
         "name": "False Appearance",
-        "desc": "While the mephit remains motionless, it is indistinguishable from an ordinary shard of ice."
+        "desc": [
+          "While the mephit remains motionless, it is indistinguishable from an ordinary shard of ice."
+        ]
       },
       {
         "name": "Innate Spellcasting (1/Day)",
-        "desc": "The mephit can innately cast fog cloud, requiring no material components. Its innate spellcasting ability is Charisma."
+        "desc": [
+          "The mephit can innately cast fog cloud, requiring no material components. Its innate spellcasting ability is Charisma."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) cold damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -15590,7 +17398,9 @@
       },
       {
         "name": "Frost Breath (Recharge 6)",
-        "desc": "The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 5 (2d4) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 5 (2d4) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -15612,7 +17422,9 @@
       },
       {
         "name": "Variant: Summon Mephits (1/Day)",
-        "desc": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/176"
@@ -15662,25 +17474,35 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The imp can use its action to polymorph into a beast form that resembles a rat (speed 20 ft.), a raven (20 ft., fly 60 ft.), or a spider (20 ft., climb 20 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The imp can use its action to polymorph into a beast form that resembles a rat (speed 20 ft.), a raven (20 ft., fly 60 ft.), or a spider (20 ft., climb 20 ft.), or back into its true form. Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the imp's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the imp's darkvision."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The imp has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The imp has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Variant: Familiar",
-        "desc": "The imp can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the quasit senses as long as they are within 1 mile of each other. While the imp is within 10 feet of its master, the master shares the quasit's Magic Resistance trait. At any time and for any reason, the imp can end its service as a familiar, ending the telepathic bond."
+        "desc": [
+          "The imp can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the quasit senses as long as they are within 1 mile of each other. While the imp is within 10 feet of its master, the master shares the quasit's Magic Resistance trait. At any time and for any reason, the imp can end its service as a familiar, ending the telepathic bond."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Sting (Bite in Beast Form)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must make on a DC 11 Constitution saving throw, taking 10 (3d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 5,
         "damage": {
           "damage_type": {
@@ -15693,7 +17515,9 @@
       },
       {
         "name": "Invisibility",
-        "desc": "The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it."
+        "desc": [
+          "The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/177"
@@ -15768,21 +17592,29 @@
     "special_abilities": [
       {
         "name": "Invisibility",
-        "desc": "The stalker is invisible."
+        "desc": [
+          "The stalker is invisible."
+        ]
       },
       {
         "name": "Faultless Tracker",
-        "desc": "The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner."
+        "desc": [
+          "The stalker is given a quarry by its summoner. The stalker knows the direction and distance to its quarry as long as the two of them are on the same plane of existence. The stalker also knows the location of its summoner."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The stalker makes two slam attacks."
+        "desc": [
+          "The stalker makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -15857,29 +17689,41 @@
     "special_abilities": [
       {
         "name": "Fire Absorption",
-        "desc": "Whenever the golem is subjected to fire damage, it takes no damage and instead regains a number of hit points equal to the fire damage dealt."
+        "desc": [
+          "Whenever the golem is subjected to fire damage, it takes no damage and instead regains a number of hit points equal to the fire damage dealt."
+        ]
       },
       {
         "name": "Immutable Form",
-        "desc": "The golem is immune to any spell or effect that would alter its form."
+        "desc": [
+          "The golem is immune to any spell or effect that would alter its form."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The golem has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The golem has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The golem's weapon attacks are magical."
+        "desc": [
+          "The golem's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two melee attacks."
+        "desc": [
+          "The golem makes two melee attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -15894,7 +17738,9 @@
       },
       {
         "name": "Sword",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 23 (3d10 + 7) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 23 (3d10 + 7) slashing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -15909,7 +17755,9 @@
       },
       {
         "name": "Poison Breath (Recharge 5-6)",
-        "desc": "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (l0d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The golem exhales poisonous gas in a 15-foot cone. Each creature in that area must make a DC 19 Constitution saving throw, taking 45 (l0d8) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -15962,17 +17810,23 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The jackal has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The jackal has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The jackal has advantage on an attack roll against a creature if at least one of the jackal's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The jackal has advantage on an attack roll against a creature if at least one of the jackal's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +1 to hit, reach 5 ft., one target. Hit: 1 (1d4 - 1) piercing damage."
+        ],
         "attack_bonus": 1,
         "damage": [
           {
@@ -16018,21 +17872,29 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The whale can't use its blindsight while deafened."
+        "desc": [
+          "The whale can't use its blindsight while deafened."
+        ]
       },
       {
         "name": "Hold Breath",
-        "desc": "The whale can hold its breath for 30 minutes"
+        "desc": [
+          "The whale can hold its breath for 30 minutes"
+        ]
       },
       {
         "name": "Keen Hearing",
-        "desc": "The whale has advantage on Wisdom (Perception) checks that rely on hearing."
+        "desc": [
+          "The whale has advantage on Wisdom (Perception) checks that rely on hearing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 21 (5d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 21 (5d6 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -16079,17 +17941,23 @@
     "special_abilities": [
       {
         "name": "Brave",
-        "desc": "The knight has advantage on saving throws against being frightened."
+        "desc": [
+          "The knight has advantage on saving throws against being frightened."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The knight makes two melee attacks."
+        "desc": [
+          "The knight makes two melee attacks."
+        ]
       },
       {
         "name": "Greatsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16104,7 +17972,9 @@
       },
       {
         "name": "Heavy Crossbow",
-        "desc": "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -16119,13 +17989,17 @@
       },
       {
         "name": "Leadership (Recharges after a Short or Long Rest)",
-        "desc": "For 1 minute, the knight can utter a special command or warning whenever a nonhostile creature that it can see within 30 ft. of it makes an attack roll or a saving throw. The creature can add a d4 to its roll provided it can hear and understand the knight. A creature can benefit from only one Leadership die at a time. This effect ends if the knight is incapacitated."
+        "desc": [
+          "For 1 minute, the knight can utter a special command or warning whenever a nonhostile creature that it can see within 30 ft. of it makes an attack roll or a saving throw. The creature can add a d4 to its roll provided it can hear and understand the knight. A creature can benefit from only one Leadership die at a time. This effect ends if the knight is incapacitated."
+        ]
       }
     ],
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The knight adds 2 to its AC against one melee attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon."
+        "desc": [
+          "The knight adds 2 to its AC against one melee attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/182"
@@ -16159,17 +18033,23 @@
     "special_abilities": [
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the kobold has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The kobold has advantage on an attack roll against a creature if at least one of the kobold's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Dagger",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16184,7 +18064,9 @@
       },
       {
         "name": "Sling",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16247,25 +18129,35 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The kraken can breathe air and water."
+        "desc": [
+          "The kraken can breathe air and water."
+        ]
       },
       {
         "name": "Freedom of Movement",
-        "desc": "The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. It can spend 5 feet of movement to escape from nonmagical restraints or being grappled."
+        "desc": [
+          "The kraken ignores difficult terrain, and magical effects can't reduce its speed or cause it to be restrained. It can spend 5 feet of movement to escape from nonmagical restraints or being grappled."
+        ]
       },
       {
         "name": "Siege Monster",
-        "desc": "The kraken deals double damage to objects and structures."
+        "desc": [
+          "The kraken deals double damage to objects and structures."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling."
+        "desc": [
+          "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 23 (3d8 + 10) piercing damage. If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the kraken, and it takes 42 (12d6) acid damage at the start of each of the kraken's turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the kraken. If the kraken dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 23 (3d8 + 10) piercing damage. If the target is a Large or smaller creature grappled by the kraken, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the kraken, and it takes 42 (12d6) acid damage at the start of each of the kraken's turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the kraken. If the kraken dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -16280,7 +18172,9 @@
       },
       {
         "name": "Tentacle",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 30 ft., one target. Hit: 20 (3d6 + 10) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 30 ft., one target. Hit: 20 (3d6 + 10) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained. The kraken has ten tentacles, each of which can grapple one target."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -16295,11 +18189,15 @@
       },
       {
         "name": "Fling",
-        "desc": "One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. If a thrown target strikes a solid surface, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 18 Dexterity saving throw or take the same damage and be knocked prone."
+        "desc": [
+          "One Large or smaller object held or creature grappled by the kraken is thrown up to 60 feet in a random direction and knocked prone. If a thrown target strikes a solid surface, the target takes 3 (1d6) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a DC 18 Dexterity saving throw or take the same damage and be knocked prone."
+        ]
       },
       {
         "name": "Lightning Storm",
-        "desc": "The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. A target must make a DC 23 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The kraken magically creates three bolts of lightning, each of which can strike a target the kraken can see within 120 feet of it. A target must make a DC 23 Dexterity saving throw, taking 22 (4d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -16323,17 +18221,23 @@
     "legendary_actions": [
       {
         "name": "Tentacle Attack or Fling",
-        "desc": "The kraken makes one tentacle attack or uses its Fling.",
+        "desc": [
+          "The kraken makes one tentacle attack or uses its Fling."
+        ],
         "attack_bonus": 0
       },
       {
         "name": "Lightning Storm (Costs 2 Actions)",
-        "desc": "The kraken uses Lightning Storm.",
+        "desc": [
+          "The kraken uses Lightning Storm."
+        ],
         "attack_bonus": 0
       },
       {
         "name": "Ink Cloud (Costs 3 Actions)",
-        "desc": "While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a DC 23 Constitution saving throw, taking 16 (3d10) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn.",
+        "desc": [
+          "While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a DC 23 Constitution saving throw, taking 16 (3d10) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn."
+        ],
         "attack_bonus": 0
       }
     ],
@@ -16371,17 +18275,23 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The lamia's innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components. At will: disguise self (any humanoid form), major image 3/day each: charm person, mirror image, scrying, suggestion 1/day: geas"
+        "desc": [
+          "The lamia's innate spellcasting ability is Charisma (spell save DC 13). It can innately cast the following spells, requiring no material components. At will: disguise self (any humanoid form), major image 3/day each: charm person, mirror image, scrying, suggestion 1/day: geas"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."
+        "desc": [
+          "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."
+        ]
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16396,7 +18306,9 @@
       },
       {
         "name": "Dagger",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16411,7 +18323,9 @@
       },
       {
         "name": "Intoxicating Touch",
-        "desc": "Melee Spell Attack: +5 to hit, reach 5 ft., one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks."
+        "desc": [
+          "Melee Spell Attack: +5 to hit, reach 5 ft., one creature. Hit: The target is magically cursed for 1 hour. Until the curse ends, the target has disadvantage on Wisdom saving throws and all ability checks."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/185"
@@ -16463,17 +18377,23 @@
     "special_abilities": [
       {
         "name": "Devil's Sight",
-        "desc": "Magical darkness doesn't impede the lemure's darkvision."
+        "desc": [
+          "Magical darkness doesn't impede the lemure's darkvision."
+        ]
       },
       {
         "name": "Hellish Rejuvenation",
-        "desc": "A lemure that dies in the Nine Hells comes back to life with all its hit points in 1d10 days unless it is killed by a good-aligned creature with a bless spell cast on that creature or its remains are sprinkled with holy water."
+        "desc": [
+          "A lemure that dies in the Nine Hells comes back to life with all its hit points in 1d10 days unless it is killed by a good-aligned creature with a bless spell cast on that creature or its remains are sprinkled with holy water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Fist",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -16553,25 +18473,45 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the lich fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the lich fails a saving throw, it can choose to succeed instead."
+        ]
       },
       {
         "name": "Rejuvenation",
-        "desc": "If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its hit points and becoming active again. The new body appears within 5 feet of the phylactery."
+        "desc": [
+          "If it has a phylactery, a destroyed lich gains a new body in 1d10 days, regaining all its hit points and becoming active again. The new body appears within 5 feet of the phylactery."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, prestidigitation, ray of frost\n- 1st level (4 slots): detect magic, magic missile, shield, thunderwave\n- 2nd level (3 slots): detect thoughts, invisibility, Melf's acid arrow, mirror image\n- 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball\n- 4th level (3 slots): blight, dimension door\n- 5th level (3 slots): cloudkill, scrying\n- 6th level (1 slot): disintegrate, globe of invulnerability\n- 7th level (1 slot): finger of death, plane shift\n- 8th level (1 slot): dominate monster, power word stun\n- 9th level (1 slot): power word kill"
+        "desc": [
+          "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:",
+          "- Cantrips (at will): mage hand, prestidigitation, ray of frost",
+          "- 1st level (4 slots): detect magic, magic missile, shield, thunderwave",
+          "- 2nd level (3 slots): detect thoughts, invisibility, Melf's acid arrow, mirror image",
+          "- 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball",
+          "- 4th level (3 slots): blight, dimension door",
+          "- 5th level (3 slots): cloudkill, scrying",
+          "- 6th level (1 slot): disintegrate, globe of invulnerability",
+          "- 7th level (1 slot): finger of death, plane shift",
+          "- 8th level (1 slot): dominate monster, power word stun",
+          "- 9th level (1 slot): power word kill"
+        ]
       },
       {
         "name": "Turn Resistance",
-        "desc": "The lich has advantage on saving throws against any effect that turns undead."
+        "desc": [
+          "The lich has advantage on saving throws against any effect that turns undead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Paralyzing Touch",
-        "desc": "Melee Spell Attack: +12 to hit, reach 5 ft., one creature. Hit: 10 (3d6) cold damage. The target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Spell Attack: +12 to hit, reach 5 ft., one creature. Hit: 10 (3d6) cold damage. The target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -16588,15 +18528,21 @@
     "legendary_actions": [
       {
         "name": "Cantrip",
-        "desc": "The lich casts a cantrip."
+        "desc": [
+          "The lich casts a cantrip."
+        ]
       },
       {
         "name": "Paralyzing Touch (Costs 2 Actions)",
-        "desc": "The lich uses its Paralyzing Touch."
+        "desc": [
+          "The lich uses its Paralyzing Touch."
+        ]
       },
       {
         "name": "Frightening Gaze (Costs 2 Actions)",
-        "desc": "The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a DC 18 Wisdom saving throw against this magic or become frightened for 1 minute. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the lich's gaze for the next 24 hours.",
+        "desc": [
+          "The lich fixes its gaze on one creature it can see within 10 feet of it. The target must succeed on a DC 18 Wisdom saving throw against this magic or become frightened for 1 minute. The frightened target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a target's saving throw is successful or the effect ends for it, the target is immune to the lich's gaze for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -16608,7 +18554,9 @@
       },
       {
         "name": "Disrupt Life (Costs 3 Actions)",
-        "desc": "Each living creature within 20 feet of the lich must make a DC 18 Constitution saving throw against this magic, taking 21 (6d6) necrotic damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Each living creature within 20 feet of the lich must make a DC 18 Constitution saving throw against this magic, taking 21 (6d6) necrotic damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -16662,25 +18610,35 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The lion has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The lion has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The lion has advantage on an attack roll against a creature if at least one of the lion's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The lion has advantage on an attack roll against a creature if at least one of the lion's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       },
       {
         "name": "Pounce",
-        "desc": "If the lion moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the lion can make one bite attack against it as a bonus action."
+        "desc": [
+          "If the lion moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the lion can make one bite attack against it as a bonus action."
+        ]
       },
       {
         "name": "Running Leap",
-        "desc": "With a 10-foot running start, the lion can long jump up to 25 ft.."
+        "desc": [
+          "With a 10-foot running start, the lion can long jump up to 25 ft.."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16695,7 +18653,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16741,7 +18701,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -16790,17 +18752,23 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "The lizardfolk can hold its breath for 15 minutes."
+        "desc": [
+          "The lizardfolk can hold its breath for 15 minutes."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lizardfolk makes two melee attacks, each one with a different weapon."
+        "desc": [
+          "The lizardfolk makes two melee attacks, each one with a different weapon."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16815,7 +18783,9 @@
       },
       {
         "name": "Heavy Club",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16830,7 +18800,9 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16845,7 +18817,9 @@
       },
       {
         "name": "Spiked Shield",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -16894,13 +18868,23 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n- 1st level (4 slots): detect magic, mage armor, magic missile, shield\n- 2nd level (3 slots): misty step, suggestion\n- 3rd level (3 slots): counterspell, fireball, fly\n- 4th level (3 slots): greater invisibility, ice storm\n- 5th level (1 slot): cone of cold"
+        "desc": [
+          "The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:",
+          "- Cantrips (at will): fire bolt, light, mage hand, prestidigitation",
+          "- 1st level (4 slots): detect magic, mage armor, magic missile, shield",
+          "- 2nd level (3 slots): misty step, suggestion",
+          "- 3rd level (3 slots): counterspell, fireball, fly",
+          "- 4th level (3 slots): greater invisibility, ice storm",
+          "- 5th level (1 slot): cone of cold"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Dagger",
-        "desc": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -16957,7 +18941,9 @@
     "special_abilities": [
       {
         "name": "Death Burst",
-        "desc": "When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "When the mephit dies, it explodes in a burst of lava. Each creature within 5 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -16979,17 +18965,23 @@
       },
       {
         "name": "False Appearance",
-        "desc": "While the mephit remains motionless, it is indistinguishable from an ordinary mound of magma."
+        "desc": [
+          "While the mephit remains motionless, it is indistinguishable from an ordinary mound of magma."
+        ]
       },
       {
         "name": "Innate Spellcasting (1/Day)",
-        "desc": "The mephit can innately cast heat metal (spell save DC 10), requiring no material components. Its innate spellcasting ability is Charisma."
+        "desc": [
+          "The mephit can innately cast heat metal (spell save DC 10), requiring no material components. Its innate spellcasting ability is Charisma."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft ., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft ., one creature. Hit: 3 (1d4 + 1) slashing damage plus 2 (1d4) fire damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -17012,7 +19004,9 @@
       },
       {
         "name": "Fire Breath (Recharge 6)",
-        "desc": "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -17034,7 +19028,9 @@
       },
       {
         "name": "Variant: Summon Mephits (1/Day)",
-        "desc": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/192"
@@ -17072,7 +19068,9 @@
     "special_abilities": [
       {
         "name": "Death Burst",
-        "desc": "When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited.",
+        "desc": [
+          "When the magmin dies, it explodes in a burst of fire and magma. Each creature within 10 ft. of it must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one. Flammable objects that aren't being worn or carried in that area are ignited."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -17094,13 +19092,17 @@
       },
       {
         "name": "Ignited Illumination",
-        "desc": "As a bonus action, the magmin can set itself ablaze or extinguish its flames. While ablaze, the magmin sheds bright light in a 10-foot radius and dim light for an additional 10 ft."
+        "desc": [
+          "As a bonus action, the magmin can set itself ablaze or extinguish its flames. While ablaze, the magmin sheds bright light in a 10-foot radius and dim light for an additional 10 ft."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Touch",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d6) fire damage. If the target is a creature or a flammable object, it ignites. Until a target takes an action to douse the fire, the target takes 3 (1d6) fire damage at the end of each of its turns.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d6) fire damage. If the target is a creature or a flammable object, it ignites. Until a target takes an action to douse the fire, the target takes 3 (1d6) fire damage at the end of each of its turns."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -17145,13 +19147,17 @@
     "special_abilities": [
       {
         "name": "Trampling Charge",
-        "desc": "If the mammoth moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 18 Strength saving throw or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action."
+        "desc": [
+          "If the mammoth moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 18 Strength saving throw or be knocked prone. If the target is prone, the mammoth can make one stomp attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 25 (4d8 + 7) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 25 (4d8 + 7) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -17166,7 +19172,9 @@
       },
       {
         "name": "Stomp",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one prone creature. Hit: 29 (4d10 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one prone creature. Hit: 29 (4d10 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -17212,17 +19220,23 @@
     "special_abilities": [
       {
         "name": "Tail Spike Regrowth",
-        "desc": "The manticore has twenty-four tail spikes. Used spikes regrow when the manticore finishes a long rest."
+        "desc": [
+          "The manticore has twenty-four tail spikes. Used spikes regrow when the manticore finishes a long rest."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."
+        "desc": [
+          "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17237,7 +19251,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17252,7 +19268,9 @@
       },
       {
         "name": "Tail Spike",
-        "desc": "Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: 7 (1d8 + 3) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +5 to hit, range 100/200 ft., one target. Hit: 7 (1d8 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17313,25 +19331,35 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The marilith has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The marilith has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The marilith's weapon attacks are magical."
+        "desc": [
+          "The marilith's weapon attacks are magical."
+        ]
       },
       {
         "name": "Reactive",
-        "desc": "The marilith can take one reaction on every turn in combat."
+        "desc": [
+          "The marilith can take one reaction on every turn in combat."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The marilith can make seven attacks: six with its longswords and one with its tail."
+        "desc": [
+          "The marilith can make seven attacks: six with its longswords and one with its tail."
+        ]
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -17346,7 +19374,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one creature. Hit: 15 (2d10 + 4) bludgeoning damage. If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one creature. Hit: 15 (2d10 + 4) bludgeoning damage. If the target is Medium or smaller, it is grappled (escape DC 19). Until this grapple ends, the target is restrained, the marilith can automatically hit the target with its tail, and the marilith can't make tail attacks against other targets."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -17361,17 +19391,25 @@
       },
       {
         "name": "Teleport",
-        "desc": "The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        "desc": [
+          "The marilith magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA marilith has a 50 percent chance of summoning 1d6 vrocks, 1d4 hezrous, 1d3 glabrezus, 1d2 nalfeshnees, or one marilith.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A marilith has a 50 percent chance of summoning 1d6 vrocks, 1d4 hezrous, 1d3 glabrezus, 1d2 nalfeshnees, or one marilith.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The marilith adds 5 to its AC against one melee attack that would hit it. To do so, the marilith must see the attacker and be wielding a melee weapon."
+        "desc": [
+          "The marilith adds 5 to its AC against one melee attack that would hit it. To do so, the marilith must see the attacker and be wielding a melee weapon."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/196"
@@ -17406,13 +19444,17 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The mastiff has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The mastiff has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -17461,7 +19503,11 @@
     "special_abilities": [
       {
         "name": "Petrifying Gaze",
-        "desc": "When a creature that can see the medusa's eyes starts its turn within 30 ft. of the medusa, the medusa can force it to make a DC 14 Constitution saving throw if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.\nUnless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.\nIf the medusa sees itself reflected on a polished surface within 30 ft. of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze.",
+        "desc": [
+          "When a creature that can see the medusa's eyes starts its turn within 30 ft. of the medusa, the medusa can force it to make a DC 14 Constitution saving throw if the medusa isn't incapacitated and can see the creature. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn to stone and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature is freed by the greater restoration spell or other magic.",
+          "Unless surprised, a creature can avert its eyes to avoid the saving throw at the start of its turn. If the creature does so, it can't see the medusa until the start of its next turn, when it can avert its eyes again. If the creature looks at the medusa in the meantime, it must immediately make the save.",
+          "If the medusa sees itself reflected on a polished surface within 30 ft. of it and in an area of bright light, the medusa is, due to its curse, affected by its own gaze."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -17475,11 +19521,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow."
+        "desc": [
+          "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow."
+        ]
       },
       {
         "name": "Snake Hair",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage plus 14 (4d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage plus 14 (4d6) poison damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17502,7 +19552,9 @@
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17517,7 +19569,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage.",
+        "desc": [
+          "Ranged Weapon Attack: +5 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage plus 7 (2d6) poison damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17572,13 +19626,17 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The merfolk can breathe air and water."
+        "desc": [
+          "The merfolk can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 3 (1d6) piercing damage, or 4 (1d8) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +2 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 3 (1d6) piercing damage, or 4 (1d8) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -17638,17 +19696,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The merrow can breathe air and water."
+        "desc": [
+          "The merrow can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The merrow makes two attacks: one with its bite and one with its claws or harpoon."
+        "desc": [
+          "The merrow makes two attacks: one with its bite and one with its claws or harpoon."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17663,7 +19727,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (2d4 + 4) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17678,7 +19744,9 @@
       },
       {
         "name": "Harpoon",
-        "desc": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a Huge or smaller creature, it must succeed on a Strength contest against the merrow or be pulled up to 20 feet toward the merrow."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17731,25 +19799,35 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The mimic can use its action to polymorph into an object or back into its true, amorphous form. Its statistics are the same in each form. Any equipment it is wearing or carrying isn 't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The mimic can use its action to polymorph into an object or back into its true, amorphous form. Its statistics are the same in each form. Any equipment it is wearing or carrying isn 't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Adhesive (Object Form Only)",
-        "desc": "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it (escape DC 13). Ability checks made to escape this grapple have disadvantage."
+        "desc": [
+          "The mimic adheres to anything that touches it. A Huge or smaller creature adhered to the mimic is also grappled by it (escape DC 13). Ability checks made to escape this grapple have disadvantage."
+        ]
       },
       {
         "name": "False Appearance (Object Form Only)",
-        "desc": "While the mimic remains motionless, it is indistinguishable from an ordinary object."
+        "desc": [
+          "While the mimic remains motionless, it is indistinguishable from an ordinary object."
+        ]
       },
       {
         "name": "Grappler",
-        "desc": "The mimic has advantage on attack rolls against any creature grappled by it."
+        "desc": [
+          "The mimic has advantage on attack rolls against any creature grappled by it."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Pseudopod",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage. If the mimic is in object form, the target is subjected to its Adhesive trait.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage. If the mimic is in object form, the target is subjected to its Adhesive trait."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17764,7 +19842,9 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) piercing damage plus 4 (1d8) acid damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -17818,21 +19898,29 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 ft. away and knocked prone."
+        "desc": [
+          "If the minotaur moves at least 10 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 ft. away and knocked prone."
+        ]
       },
       {
         "name": "Labyrinthine Recall",
-        "desc": "The minotaur can perfectly recall any path it has traveled."
+        "desc": [
+          "The minotaur can perfectly recall any path it has traveled."
+        ]
       },
       {
         "name": "Reckless",
-        "desc": "At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn."
+        "desc": [
+          "At the start of its turn, the minotaur can gain advantage on all melee weapon attack rolls it makes during that turn, but attack rolls against it have advantage until the start of its next turn."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Greataxe",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17847,7 +19935,9 @@
       },
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17905,13 +19995,17 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."
+        "desc": [
+          "If the skeleton moves at least 10 feet straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be pushed up to 10 feet away and knocked prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Greataxe",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 17 (2d12 + 4) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17926,7 +20020,9 @@
       },
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -17971,17 +20067,23 @@
     "special_abilities": [
       {
         "name": "Beast of Burden",
-        "desc": "The mule is considered to be a Large animal for the purpose of determining its carrying capacity."
+        "desc": [
+          "The mule is considered to be a Large animal for the purpose of determining its carrying capacity."
+        ]
       },
       {
         "name": "Sure-Footed",
-        "desc": "The mule has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        "desc": [
+          "The mule has advantage on Strength and Dexterity saving throws made against effects that would knock it prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -18055,11 +20157,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": [
+          "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        ]
       },
       {
         "name": "Rotting Fist",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage plus 10 (3d6) necrotic damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage plus 10 (3d6) necrotic damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -18082,7 +20188,9 @@
       },
       {
         "name": "Dreadful Glare",
-        "desc": "The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must succeed on a DC 11 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies (but not mummy lords) for the next 24 hours.",
+        "desc": [
+          "The mummy targets one creature it can see within 60 ft. of it. If the target can see the mummy, it must succeed on a DC 11 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies (but not mummy lords) for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -18157,25 +20265,42 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The mummy lord has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The mummy lord has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Rejuvenation",
-        "desc": "A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its hit points and becoming active again. The new body appears within 5 feet of the mummy lord's heart."
+        "desc": [
+          "A destroyed mummy lord gains a new body in 24 hours if its heart is intact, regaining all its hit points and becoming active again. The new body appears within 5 feet of the mummy lord's heart."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, thaumaturgy\n- 1st level (4 slots): command, guiding bolt, shield of faith\n- 2nd level (3 slots): hold person, silence, spiritual weapon\n- 3rd level (3 slots): animate dead, dispel magic\n- 4th level (3 slots): divination, guardian of faith\n- 5th level (2 slots): contagion, insect plague\n- 6th level (1 slot): harm"
+        "desc": [
+          "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:",
+          "- Cantrips (at will): sacred flame, thaumaturgy",
+          "- 1st level (4 slots): command, guiding bolt, shield of faith",
+          "- 2nd level (3 slots): hold person, silence, spiritual weapon",
+          "- 3rd level (3 slots): animate dead, dispel magic",
+          "- 4th level (3 slots): divination, guardian of faith",
+          "- 5th level (2 slots): contagion, insect plague",
+          "- 6th level (1 slot): harm"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": [
+          "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        ]
       },
       {
         "name": "Rotting Fist",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage plus 21 (6d6) necrotic damage. If the target is a creature, it must succeed on a DC 16 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 14 (3d6 + 4) bludgeoning damage plus 21 (6d6) necrotic damage. If the target is a creature, it must succeed on a DC 16 Constitution saving throw or be cursed with mummy rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 (3d6) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies, and its body turns to dust. The curse lasts until removed by the remove curse spell or other magic."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -18198,7 +20323,9 @@
       },
       {
         "name": "Dreadful Glare",
-        "desc": "The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a DC 16 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours.",
+        "desc": [
+          "The mummy lord targets one creature it can see within 60 feet of it. If the target can see the mummy lord, it must succeed on a DC 16 Wisdom saving throw against this magic or become frightened until the end of the mummy's next turn. If the target fails the saving throw by 5 or more, it is also paralyzed for the same duration. A target that succeeds on the saving throw is immune to the Dreadful Glare of all mummies and mummy lords for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -18212,11 +20339,15 @@
     "legendary_actions": [
       {
         "name": "Attack",
-        "desc": "The mummy lord makes one attack with its rotting fist or uses its Dreadful Glare."
+        "desc": [
+          "The mummy lord makes one attack with its rotting fist or uses its Dreadful Glare."
+        ]
       },
       {
         "name": "Blinding Dust",
-        "desc": "Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a DC 16 Constitution saving throw or be blinded until the end of the creature's next turn.",
+        "desc": [
+          "Blinding dust and sand swirls magically around the mummy lord. Each creature within 5 feet of the mummy lord must succeed on a DC 16 Constitution saving throw or be blinded until the end of the creature's next turn."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -18228,7 +20359,9 @@
       },
       {
         "name": "Blasphemous Word (Costs 2 Actions)",
-        "desc": "The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a DC 16 Constitution saving throw or be stunned until the end of the mummy lord's next turn.",
+        "desc": [
+          "The mummy lord utters a blasphemous word. Each non-undead creature within 10 feet of the mummy lord that can hear the magical utterance must succeed on a DC 16 Constitution saving throw or be stunned until the end of the mummy lord's next turn."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -18240,11 +20373,15 @@
       },
       {
         "name": "Channel Negative Energy (Costs 2 Actions)",
-        "desc": "The mummy lord magically unleashes negative energy. Creatures within 60 feet of the mummy lord, including ones behind barriers and around corners, can't regain hit points until the end of the mummy lord's next turn."
+        "desc": [
+          "The mummy lord magically unleashes negative energy. Creatures within 60 feet of the mummy lord, including ones behind barriers and around corners, can't regain hit points until the end of the mummy lord's next turn."
+        ]
       },
       {
         "name": "Whirlwind of Sand (Costs 2 Actions)",
-        "desc": "The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can't be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession."
+        "desc": [
+          "The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can't be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/206"
@@ -18295,17 +20432,23 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The nalfeshnee has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The nalfeshnee has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 32 (5d10 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 32 (5d10 + 5) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -18320,7 +20463,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 15 (3d6 + 5) slashing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -18335,7 +20480,9 @@
       },
       {
         "name": "Horror Nimbus (Recharge 5-6)",
-        "desc": "The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours.",
+        "desc": [
+          "The nalfeshnee magically emits scintillating, multicolored light. Each creature within 15 feet of the nalfeshnee that can see the light must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the nalfeshnee's Horror Nimbus for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -18347,11 +20494,17 @@
       },
       {
         "name": "Teleport",
-        "desc": "The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        "desc": [
+          "The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA nalfeshnee has a 50 percent chance of summoning 1d4 vrocks, 1d3 hezrous, 1d2 glabrezus, or one nalfeshnee.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A nalfeshnee has a 50 percent chance of summoning 1d4 vrocks, 1d3 hezrous, 1d2 glabrezus, or one nalfeshnee.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/207"
@@ -18398,33 +20551,60 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The hag's innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, magic missile\n2/day each: plane shift (self only), ray of enfeeblement, sleep"
+        "desc": [
+          "The hag's innate spellcasting ability is Charisma (spell save DC 14, +6 to hit with spell attacks). She can innately cast the following spells, requiring no material components:",
+          "At will: detect magic, magic missile",
+          "2/day each: plane shift (self only), ray of enfeeblement, sleep"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The hag has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The hag has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Night Hag Items",
-        "desc": "A night hag carries two very rare magic items that she must craft for herself If either object is lost, the night hag will go to great lengths to retrieve it, as creating a new tool takes time and effort.\nHeartstone: This lustrous black gem allows a night hag to become ethereal while it is in her possession. The touch of a heartstone also cures any disease. Crafting a heartstone takes 30 days.\nSoul Bag: When an evil humanoid dies as a result of a night hag's Nightmare Haunting, the hag catches the soul in this black sack made of stitched flesh. A soul bag can hold only one evil soul at a time, and only the night hag who crafted the bag can catch a soul with it. Crafting a soul bag takes 7 days and a humanoid sacrifice (whose flesh is used to make the bag)."
+        "desc": [
+          "A night hag carries two very rare magic items that she must craft for herself If either object is lost, the night hag will go to great lengths to retrieve it, as creating a new tool takes time and effort.",
+          "Heartstone: This lustrous black gem allows a night hag to become ethereal while it is in her possession. The touch of a heartstone also cures any disease. Crafting a heartstone takes 30 days.",
+          "Soul Bag: When an evil humanoid dies as a result of a night hag's Nightmare Haunting, the hag catches the soul in this black sack made of stitched flesh. A soul bag can hold only one evil soul at a time, and only the night hag who crafted the bag can catch a soul with it. Crafting a soul bag takes 7 days and a humanoid sacrifice (whose flesh is used to make the bag)."
+        ]
       },
       {
         "name": "Hag Coven",
-        "desc": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        "desc": [
+          "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.",
+          "A coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        ]
       },
       {
         "name": "Shared Spellcasting (Coven Only)",
-        "desc": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n- 1st level (4 slots): identify, ray of sickness\n- 2nd level (3 slots): hold person, locate object\n- 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n- 4th level (3 slots): phantasmal killer, polymorph\n- 5th level (2 slots): contact other plane, scrying\n- 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        "desc": [
+          "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:",
+          "- 1st level (4 slots): identify, ray of sickness",
+          "- 2nd level (3 slots): hold person, locate object",
+          "- 3rd level (3 slots): bestow curse, counterspell, lightning bolt",
+          "- 4th level (3 slots): phantasmal killer, polymorph",
+          "- 5th level (2 slots): contact other plane, scrying",
+          "- 6th level (1 slot): eye bite",
+          "For casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        ]
       },
       {
         "name": "Hag Eye (Coven Only)",
-        "desc": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        "desc": [
+          "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.",
+          "A hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws (Hag Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -18439,15 +20619,21 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The hag magically polymorphs into a Small or Medium female humanoid, or back into her true form. Her statistics are the same in each form. Any equipment she is wearing or carrying isn't transformed. She reverts to her true form if she dies."
+        "desc": [
+          "The hag magically polymorphs into a Small or Medium female humanoid, or back into her true form. Her statistics are the same in each form. Any equipment she is wearing or carrying isn't transformed. She reverts to her true form if she dies."
+        ]
       },
       {
         "name": "Etherealness",
-        "desc": "The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a heartstone in her possession."
+        "desc": [
+          "The hag magically enters the Ethereal Plane from the Material Plane, or vice versa. To do so, the hag must have a heartstone in her possession."
+        ]
       },
       {
         "name": "Nightmare Haunting (1/Day)",
-        "desc": "While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic."
+        "desc": [
+          "While on the Ethereal Plane, the hag magically touches a sleeping humanoid on the Material Plane. A protection from evil and good spell cast on the target prevents this contact, as does a magic circle. As long as the contact persists, the target has dreadful visions. If these visions last for at least 1 hour, the target gains no benefit from its rest, and its hit point maximum is reduced by 5 (1d10). If this effect reduces the target's hit point maximum to 0, the target dies, and if the target was evil, its soul is trapped in the hag's soul bag. The reduction to the target's hit point maximum lasts until removed by the greater restoration spell or similar magic."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/208"
@@ -18484,17 +20670,23 @@
     "special_abilities": [
       {
         "name": "Confer Fire Resistance",
-        "desc": "The nightmare can grant resistance to fire damage to anyone riding it."
+        "desc": [
+          "The nightmare can grant resistance to fire damage to anyone riding it."
+        ]
       },
       {
         "name": "Illumination",
-        "desc": "The nightmare sheds bright light in a 10-foot radius and dim light for an additional 10 feet."
+        "desc": [
+          "The nightmare sheds bright light in a 10-foot radius and dim light for an additional 10 feet."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage plus 7 (2d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage plus 7 (2d6) fire damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -18517,7 +20709,9 @@
       },
       {
         "name": "Ethereal Stride",
-        "desc": "The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."
+        "desc": [
+          "The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/209"
@@ -18554,7 +20748,9 @@
     "actions": [
       {
         "name": "Rapier",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -18571,7 +20767,9 @@
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The noble adds 2 to its AC against one melee attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon."
+        "desc": [
+          "The noble adds 2 to its AC against one melee attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/210"
@@ -18636,17 +20834,23 @@
     "special_abilities": [
       {
         "name": "Amorphous",
-        "desc": "The jelly can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The jelly can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The jelly can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The jelly can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Pseudopod",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) bludgeoning damage plus 3 (1d6) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) bludgeoning damage plus 3 (1d6) acid damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -18671,7 +20875,9 @@
     "reactions": [
       {
         "name": "Split",
-        "desc": "When a jelly that is Medium or larger is subjected to lightning or slashing damage, it splits into two new jellies if it has at least 10 hit points. Each new jelly has hit points equal to half the original jelly's, rounded down. New jellies are one size smaller than the original jelly."
+        "desc": [
+          "When a jelly that is Medium or larger is subjected to lightning or slashing damage, it splits into two new jellies if it has at least 10 hit points. Each new jelly has hit points equal to half the original jelly's, rounded down. New jellies are one size smaller than the original jelly."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/211"
@@ -18708,21 +20914,29 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "While out of water, the octopus can hold its breath for 30 minutes."
+        "desc": [
+          "While out of water, the octopus can hold its breath for 30 minutes."
+        ]
       },
       {
         "name": "Underwater Camouflage",
-        "desc": "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        "desc": [
+          "The octopus has advantage on Dexterity (Stealth) checks made while underwater."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The octopus can breathe only underwater."
+        "desc": [
+          "The octopus can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Tentacles",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage, and the target is grappled (escape DC 10). Until this grapple ends, the octopus can't use its tentacles on another target.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage, and the target is grappled (escape DC 10). Until this grapple ends, the octopus can't use its tentacles on another target."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -18737,7 +20951,9 @@
       },
       {
         "name": "Ink Cloud (Recharges after a Short or Long Rest)",
-        "desc": "A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action.",
+        "desc": [
+          "A 5-foot-radius cloud of ink extends all around the octopus if it is underwater. The area is heavily obscured for 1 minute, although a significant current can disperse the ink. After releasing the ink, the octopus can use the Dash action as a bonus action."
+        ],
         "attack_bonus": 0
       }
     ],
@@ -18772,7 +20988,9 @@
     "actions": [
       {
         "name": "Greatclub",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -18787,7 +21005,9 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 11 (2d6 + 4) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +6 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 11 (2d6 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -18840,13 +21060,17 @@
     "special_abilities": [
       {
         "name": "Undead Fortitude",
-        "desc": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        "desc": [
+          "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Morningstar",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -18899,25 +21123,37 @@
     "special_abilities": [
       {
         "name": "Innate Spellcasting",
-        "desc": "The oni's innate spellcasting ability is Charisma (spell save DC 13). The oni can innately cast the following spells, requiring no material components:\n\nAt will: darkness, invisibility\n1/day each: charm person, cone of cold, gaseous form, sleep"
+        "desc": [
+          "The oni's innate spellcasting ability is Charisma (spell save DC 13). The oni can innately cast the following spells, requiring no material components:",
+          "At will: darkness, invisibility",
+          "1/day each: charm person, cone of cold, gaseous form, sleep"
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The oni's weapon attacks are magical."
+        "desc": [
+          "The oni's weapon attacks are magical."
+        ]
       },
       {
         "name": "Regeneration",
-        "desc": "The oni regains 10 hit points at the start of its turn if it has at least 1 hit point."
+        "desc": [
+          "The oni regains 10 hit points at the start of its turn if it has at least 1 hit point."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The oni makes two attacks, either with its claws or its glaive."
+        "desc": [
+          "The oni makes two attacks, either with its claws or its glaive."
+        ]
       },
       {
         "name": "Claw (Oni Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -18932,7 +21168,9 @@
       },
       {
         "name": "Glaive",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) slashing damage, or 9 (1d10 + 4) slashing damage in Small or Medium form.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) slashing damage, or 9 (1d10 + 4) slashing damage in Small or Medium form."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -18947,7 +21185,9 @@
       },
       {
         "name": "Change Shape",
-        "desc": "The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size."
+        "desc": [
+          "The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/215"
@@ -18982,13 +21222,17 @@
     "special_abilities": [
       {
         "name": "Aggressive",
-        "desc": "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+        "desc": [
+          "As a bonus action, the orc can move up to its speed toward a hostile creature that it can see."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Greataxe",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 9 (1d12 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -19003,7 +21247,9 @@
       },
       {
         "name": "Javelin",
-        "desc": "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +5 to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -19049,17 +21295,23 @@
     "special_abilities": [
       {
         "name": "Limited Telepathy",
-        "desc": "The otyugh can magically transmit simple messages and images to any creature within 120 ft. of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond."
+        "desc": [
+          "The otyugh can magically transmit simple messages and images to any creature within 120 ft. of it that can understand a language. This form of telepathy doesn't allow the receiving creature to telepathically respond."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The otyugh makes three attacks: one with its bite and two with its tentacles."
+        "desc": [
+          "The otyugh makes three attacks: one with its bite and two with its tentacles."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d8 + 3) piercing damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d8 + 3) piercing damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw against disease or become poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw, reducing its hit point maximum by 5 (1d10) on a failure. The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -19074,7 +21326,9 @@
       },
       {
         "name": "Tentacle",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 7 (1d8 + 3) bludgeoning damage plus 4 (1d8) piercing damage. If the target is Medium or smaller, it is grappled (escape DC 13) and restrained until the grapple ends. The otyugh has two tentacles, each of which can grapple one target."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -19097,7 +21351,9 @@
       },
       {
         "name": "Tentacle Slam",
-        "desc": "The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a DC 14 Constitution saving throw or take 10 (2d6 + 3) bludgeoning damage and be stunned until the end of the otyugh's next turn. On a successful save, the target takes half the bludgeoning damage and isn't stunned.",
+        "desc": [
+          "The otyugh slams creatures grappled by it into each other or a solid surface. Each creature must succeed on a DC 14 Constitution saving throw or take 10 (2d6 + 3) bludgeoning damage and be stunned until the end of the otyugh's next turn. On a successful save, the target takes half the bludgeoning damage and isn't stunned."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -19142,17 +21398,23 @@
     "special_abilities": [
       {
         "name": "Flyby",
-        "desc": "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        "desc": [
+          "The owl doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+        ]
       },
       {
         "name": "Keen Hearing and Sight",
-        "desc": "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        "desc": [
+          "The owl has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -19198,17 +21460,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight and Smell",
-        "desc": "The owlbear has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        "desc": [
+          "The owlbear has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The owlbear makes two attacks: one with its beak and one with its claws."
+        "desc": [
+          "The owlbear makes two attacks: one with its beak and one with its claws."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 10 (1d10 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one creature. Hit: 10 (1d10 + 5) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -19223,7 +21491,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -19271,17 +21541,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The panther has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The panther has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Pounce",
-        "desc": "If the panther moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the panther can make one bite attack against it as a bonus action."
+        "desc": [
+          "If the panther moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 12 Strength saving throw or be knocked prone. If the target is prone, the panther can make one bite attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -19296,7 +21572,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -19346,7 +21624,9 @@
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -19393,21 +21673,29 @@
     "special_abilities": [
       {
         "name": "Ethereal Jaunt",
-        "desc": "As a bonus action, the spider can magically shift from the Material Plane to the Ethereal Plane, or vice versa."
+        "desc": [
+          "As a bonus action, the spider can magically shift from the Material Plane to the Ethereal Plane, or vice versa."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The spider ignores movement restrictions caused by webbing."
+        "desc": [
+          "The spider ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 18 (4d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (1d10 + 2) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 18 (4d8) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -19467,7 +21755,9 @@
     "special_abilities": [
       {
         "name": "Fear Aura",
-        "desc": "Any creature hostile to the pit fiend that starts its turn within 20 feet of the pit fiend must make a DC 21 Wisdom saving throw, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours.",
+        "desc": [
+          "Any creature hostile to the pit fiend that starts its turn within 20 feet of the pit fiend must make a DC 21 Wisdom saving throw, unless the pit fiend is incapacitated. On a failed save, the creature is frightened until the start of its next turn. If a creature's saving throw is successful, the creature is immune to the pit fiend's Fear Aura for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -19479,25 +21769,37 @@
       },
       {
         "name": "Magic Resistance",
-        "desc": "The pit fiend has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The pit fiend has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The pit fiend's weapon attacks are magical."
+        "desc": [
+          "The pit fiend's weapon attacks are magical."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The pit fiend's spellcasting ability is Charisma (spell save DC 21). The pit fiend can innately cast the following spells, requiring no material components:\nAt will: detect magic, fireball\n3/day each: hold monster, wall of fire"
+        "desc": [
+          "The pit fiend's spellcasting ability is Charisma (spell save DC 21). The pit fiend can innately cast the following spells, requiring no material components:",
+          "At will: detect magic, fireball",
+          "3/day each: hold monster, wall of fire"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail."
+        "desc": [
+          "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) piercing damage. The target must succeed on a DC 21 Constitution saving throw or become poisoned. While poisoned in this way, the target can't regain hit points, and it takes 21 (6d6) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) piercing damage. The target must succeed on a DC 21 Constitution saving throw or become poisoned. While poisoned in this way, the target can't regain hit points, and it takes 21 (6d6) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -19512,7 +21814,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: 17 (2d8 + 8) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: 17 (2d8 + 8) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -19527,7 +21831,9 @@
       },
       {
         "name": "Mace",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -19542,7 +21848,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 24 (3d1O + 8) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 24 (3d1O + 8) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -19608,29 +21916,44 @@
     "special_abilities": [
       {
         "name": "Angelic Weapons",
-        "desc": "The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an extra 5d8 radiant damage (included in the attack)."
+        "desc": [
+          "The planetar's weapon attacks are magical. When the planetar hits with any weapon, the weapon deals an extra 5d8 radiant damage (included in the attack)."
+        ]
       },
       {
         "name": "Divine Awareness",
-        "desc": "The planetar knows if it hears a lie."
+        "desc": [
+          "The planetar knows if it hears a lie."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The planetar's spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:\nAt will: detect evil and good, invisibility (self only)\n3/day each: blade barrier, dispel evil and good, flame strike, raise dead\n1/day each: commune, control weather, insect plague"
+        "desc": [
+          "The planetar's spellcasting ability is Charisma (spell save DC 20). The planetar can innately cast the following spells, requiring no material components:",
+          "At will: detect evil and good, invisibility (self only)",
+          "3/day each: blade barrier, dispel evil and good, flame strike, raise dead",
+          "1/day each: commune, control weather, insect plague"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The planetar has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The planetar has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The planetar makes two melee attacks."
+        "desc": [
+          "The planetar makes two melee attacks."
+        ]
       },
       {
         "name": "Greatsword",
-        "desc": "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 21 (4d6 + 7) slashing damage plus 22 (5d8) radiant damage.",
+        "desc": [
+          "Melee Weapon Attack: +12 to hit, reach 5 ft., one target. Hit: 21 (4d6 + 7) slashing damage plus 22 (5d8) radiant damage."
+        ],
         "attack_bonus": 12,
         "damage": [
           {
@@ -19653,7 +21976,9 @@
       },
       {
         "name": "Healing Touch (4/Day)",
-        "desc": "The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        "desc": [
+          "The planetar touches another creature. The target magically regains 30 (6d8 + 3) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/224"
@@ -19690,13 +22015,17 @@
     "special_abilities": [
       {
         "name": "Hold Breath",
-        "desc": "The plesiosaurus can hold its breath for 1 hour."
+        "desc": [
+          "The plesiosaurus can hold its breath for 1 hour."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 10 ft., one target. Hit: 14 (3d6 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -19742,7 +22071,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a DC 10 Constitution saving throw, taking 5 (2d4) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a DC 10 Constitution saving throw, taking 5 (2d4) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -19789,17 +22120,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The bear has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": [
+          "The bear makes two attacks: one with its bite and one with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (1d8 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (1d8 + 5) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -19814,7 +22151,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -19859,7 +22198,9 @@
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -19907,17 +22248,27 @@
     "special_abilities": [
       {
         "name": "Divine Eminence",
-        "desc": "As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra 10 (3d6) radiant damage to a target on a hit. This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st."
+        "desc": [
+          "As a bonus action, the priest can expend a spell slot to cause its melee weapon attacks to magically deal an extra 10 (3d6) radiant damage to a target on a hit. This benefit lasts until the end of the turn. If the priest expends a spell slot of 2nd level or higher, the extra damage increases by 1d6 for each level above 1st."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): cure wounds, guiding bolt, sanctuary\n- 2nd level (3 slots): lesser restoration, spiritual weapon\n- 3rd level (2 slots): dispel magic, spirit guardians"
+        "desc": [
+          "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:",
+          "- Cantrips (at will): light, sacred flame, thaumaturgy",
+          "- 1st level (4 slots): cure wounds, guiding bolt, sanctuary",
+          "- 2nd level (3 slots): lesser restoration, spiritual weapon",
+          "- 3rd level (2 slots): dispel magic, spirit guardians"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Mace",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) bludgeoning damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -19965,25 +22316,35 @@
     "special_abilities": [
       {
         "name": "Keen Senses",
-        "desc": "The pseudodragon has advantage on Wisdom (Perception) checks that rely on sight, hearing, or smell."
+        "desc": [
+          "The pseudodragon has advantage on Wisdom (Perception) checks that rely on sight, hearing, or smell."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The pseudodragon has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The pseudodragon has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Limited Telepathy",
-        "desc": "The pseudodragon can magically communicate simple ideas, emotions, and images telepathically with any creature within 100 ft. of it that can understand a language."
+        "desc": [
+          "The pseudodragon can magically communicate simple ideas, emotions, and images telepathically with any creature within 100 ft. of it that can understand a language."
+        ]
       },
       {
         "name": "Variant: Familiar",
-        "desc": "The pseudodragon can serve another creature as a familiar, forming a magic, telepathic bond with that willing companion. While the two are bonded, the companion can sense what the pseudodragon senses as long as they are within 1 mile of each other. While the pseudodragon is within 10 feet of its companion, the companion shares the pseudodragon's Magic Resistance trait. At any time and for any reason, the pseudodragon can end its service as a familiar, ending the telepathic bond."
+        "desc": [
+          "The pseudodragon can serve another creature as a familiar, forming a magic, telepathic bond with that willing companion. While the two are bonded, the companion can sense what the pseudodragon senses as long as they are within 1 mile of each other. While the pseudodragon is within 10 feet of its companion, the companion shares the pseudodragon's Magic Resistance trait. At any time and for any reason, the pseudodragon can end its service as a familiar, ending the telepathic bond."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -19998,7 +22359,9 @@
       },
       {
         "name": "Sting",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 4 (1d4 + 2) piercing damage, and the target must succeed on a DC 11 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target falls unconscious for the same duration, or until it takes damage or another creature uses an action to shake it awake."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -20046,17 +22409,24 @@
     "special_abilities": [
       {
         "name": "Tunneler",
-        "desc": "The worm can burrow through solid rock at half its burrow speed and leaves a 10-foot-diameter tunnel in its wake."
+        "desc": [
+          "The worm can burrow through solid rock at half its burrow speed and leaves a 10-foot-diameter tunnel in its wake."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The worm makes two attacks: one with its bite and one with its stinger."
+        "desc": [
+          "The worm makes two attacks: one with its bite and one with its stinger."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 22 (3d8 + 9) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 19 Dexterity saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes 21 (6d6) acid damage at the start of each of the worm's turns.\nIf the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the worm. If the worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 22 (3d8 + 9) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 19 Dexterity saving throw or be swallowed by the worm. A swallowed creature is blinded and restrained, it has total cover against attacks and other effects outside the worm, and it takes 21 (6d6) acid damage at the start of each of the worm's turns.",
+          "If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the worm. If the worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -20071,7 +22441,9 @@
       },
       {
         "name": "Tail Stinger",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one creature. Hit: 19 (3d6 + 9) piercing damage, and the target must make a DC 19 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one creature. Hit: 19 (3d6 + 9) piercing damage, and the target must make a DC 19 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -20129,21 +22501,29 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form . Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed . It reverts to its true form if it dies."
+        "desc": [
+          "The quasit can use its action to polymorph into a beast form that resembles a bat (speed 10 ft. fly 40 ft.), a centipede (40 ft., climb 40 ft.), or a toad (40 ft., swim 40 ft.), or back into its true form . Its statistics are the same in each form, except for the speed changes noted. Any equipment it is wearing or carrying isn't transformed . It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The quasit has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The quasit has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Variant: Familiar",
-        "desc": "The quasit can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the quasit senses as long as they are within 1 mile of each other. While the quasit is within 10 feet of its master, the master shares the quasit's Magic Resistance trait. At any time and for any reason, the quasit can end its service as a familiar, ending the telepathic bond."
+        "desc": [
+          "The quasit can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are bonded, the master can sense what the quasit senses as long as they are within 1 mile of each other. While the quasit is within 10 feet of its master, the master shares the quasit's Magic Resistance trait. At any time and for any reason, the quasit can end its service as a familiar, ending the telepathic bond."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claw (Bite in Beast Form)",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft ., one target. Hit: 5 (1d4 + 3) piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 5 (2d4) poison damage and become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -20158,7 +22538,9 @@
       },
       {
         "name": "Scare (1/day)",
-        "desc": "One creature of the quasit's choice within 20 ft. of it must succeed on a DC 10 Wisdom saving throw or be frightened for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success.",
+        "desc": [
+          "One creature of the quasit's choice within 20 ft. of it must succeed on a DC 10 Wisdom saving throw or be frightened for 1 minute. The target can repeat the saving throw at the end of each of its turns, with disadvantage if the quasit is within line of sight, ending the effect on itself on a success."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -20170,7 +22552,9 @@
       },
       {
         "name": "Invisibility",
-        "desc": "The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it."
+        "desc": [
+          "The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/232"
@@ -20204,17 +22588,23 @@
     "special_abilities": [
       {
         "name": "Blood Frenzy",
-        "desc": "The quipper has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        "desc": [
+          "The quipper has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The quipper can breathe only underwater."
+        "desc": [
+          "The quipper can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -20265,21 +22655,32 @@
     "special_abilities": [
       {
         "name": "Limited Magic Immunity",
-        "desc": "The rakshasa can't be affected or detected by spells of 6th level or lower unless it wishes to be. It has advantage on saving throws against all other spells and magical effects."
+        "desc": [
+          "The rakshasa can't be affected or detected by spells of 6th level or lower unless it wishes to be. It has advantage on saving throws against all other spells and magical effects."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The rakshasa's innate spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The rakshasa can innately cast the following spells, requiring no material components:\n\nAt will: detect thoughts, disguise self, mage hand, minor illusion\n3/day each: charm person, detect magic, invisibility, major image, suggestion\n1/day each: dominate person, fly, plane shift, true seeing"
+        "desc": [
+          "The rakshasa's innate spellcasting ability is Charisma (spell save DC 18, +10 to hit with spell attacks). The rakshasa can innately cast the following spells, requiring no material components:",
+          "At will: detect thoughts, disguise self, mage hand, minor illusion",
+          "3/day each: charm person, detect magic, invisibility, major image, suggestion",
+          "1/day each: dominate person, fly, plane shift, true seeing"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The rakshasa makes two claw attacks"
+        "desc": [
+          "The rakshasa makes two claw attacks"
+        ]
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 9 (2d6 + 2) slashing damage, and the target is cursed if it is a creature. The magical curse takes effect whenever the target takes a short or long rest, filling the target's thoughts with horrible images and dreams. The cursed target gains no benefit from finishing a short or long rest. The curse lasts until it is lifted by a remove curse spell or similar magic."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -20324,13 +22725,17 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -20377,13 +22782,17 @@
     "special_abilities": [
       {
         "name": "Mimicry",
-        "desc": "The raven can mimic simple sounds it has heard, such as a person whispering, a baby crying, or an animal chittering. A creature that hears the sounds can tell they are imitations with a successful DC 10 Wisdom (Insight) check."
+        "desc": [
+          "The raven can mimic simple sounds it has heard, such as a person whispering, a baby crying, or an animal chittering. A creature that hears the sounds can tell they are imitations with a successful DC 10 Wisdom (Insight) check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -20438,7 +22847,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage plus 3 (1d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage plus 3 (1d6) fire damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -20461,7 +22872,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC l3 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC l3 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -20514,17 +22927,23 @@
     "special_abilities": [
       {
         "name": "Pack Tactics",
-        "desc": "The shark has advantage on an attack roll against a creature if at least one of the shark's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The shark has advantage on an attack roll against a creature if at least one of the shark's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The shark can breathe only underwater."
+        "desc": [
+          "The shark can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -20573,7 +22992,9 @@
     "special_abilities": [
       {
         "name": "Heated Body",
-        "desc": "A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage.",
+        "desc": [
+          "A creature that touches the remorhaz or hits it with a melee attack while within 5 feet of it takes 10 (3d6) fire damage."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -20589,7 +23010,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 40 (6d10 + 7) piercing damage plus 10 (3d6) fire damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +11 to hit, reach 10 ft., one target. Hit: 40 (6d10 + 7) piercing damage plus 10 (3d6) fire damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the remorhaz can't bite another target."
+        ],
         "attack_bonus": 11,
         "damage": [
           {
@@ -20612,7 +23035,10 @@
       },
       {
         "name": "Swallow",
-        "desc": "The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes 21 (6d6) acid damage at the start of each of the remorhaz's turns.\nIf the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet oft he remorhaz. If the remorhaz dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
+        "desc": [
+          "The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes 21 (6d6) acid damage at the start of each of the remorhaz's turns.",
+          "If the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet oft he remorhaz. If the remorhaz dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/239"
@@ -20646,13 +23072,17 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the rhinoceros moves at least 20 ft. straight toward a target and then hits it with a gore attack on the same turn, the target takes an extra 9 (2d8) bludgeoning damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 14 (2d8 + 5) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -20697,7 +23127,9 @@
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (2d4 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -20748,17 +23180,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight",
-        "desc": "The roc has advantage on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "The roc has advantage on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The roc makes two attacks: one with its beak and one with its talons."
+        "desc": [
+          "The roc makes two attacks: one with its beak and one with its talons."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 27 (4d8 + 9) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 10 ft., one target. Hit: 27 (4d8 + 9) piercing damage."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -20773,7 +23211,9 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 23 (4d6 + 9) slashing damage, and the target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can't use its talons on another target.",
+        "desc": [
+          "Melee Weapon Attack: +13 to hit, reach 5 ft., one target. Hit: 23 (4d6 + 9) slashing damage, and the target is grappled (escape DC 19). Until this grapple ends, the target is restrained, and the roc can't use its talons on another target."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -20821,25 +23261,35 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the roper remains motionless, it is indistinguishable from a normal cave formation, such as a stalagmite."
+        "desc": [
+          "While the roper remains motionless, it is indistinguishable from a normal cave formation, such as a stalagmite."
+        ]
       },
       {
         "name": "Grasping Tendrils",
-        "desc": "The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; 10 hit points; immunity to poison and psychic damage). Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a DC 15 Strength check against it."
+        "desc": [
+          "The roper can have up to six tendrils at a time. Each tendril can be attacked (AC 20; 10 hit points; immunity to poison and psychic damage). Destroying a tendril deals no damage to the roper, which can extrude a replacement tendril on its next turn. A tendril can also be broken if a creature takes an action and succeeds on a DC 15 Strength check against it."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The roper can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The roper can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite."
+        "desc": [
+          "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 22 (4d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 22 (4d8 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -20854,12 +23304,16 @@
       },
       {
         "name": "Tendril",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 50 ft., one creature. Hit: The target is grappled (escape DC 15). Until the grapple ends, the target is restrained and has disadvantage on Strength checks and Strength saving throws, and the roper can't use the same tendril on another target.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 50 ft., one creature. Hit: The target is grappled (escape DC 15). Until the grapple ends, the target is restrained and has disadvantage on Strength checks and Strength saving throws, and the roper can't use the same tendril on another target."
+        ],
         "attack_bonus": 7
       },
       {
         "name": "Reel",
-        "desc": "The roper pulls each creature grappled by it up to 25 ft. straight toward it."
+        "desc": [
+          "The roper pulls each creature grappled by it up to 25 ft. straight toward it."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/243"
@@ -20925,21 +23379,29 @@
     "special_abilities": [
       {
         "name": "Antimagic Susceptibility",
-        "desc": "The rug is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        "desc": [
+          "The rug is incapacitated while in the area of an antimagic field. If targeted by dispel magic, the rug must succeed on a Constitution saving throw against the caster's spell save DC or fall unconscious for 1 minute."
+        ]
       },
       {
         "name": "Damage Transfer",
-        "desc": "While it is grappling a creature, the rug takes only half the damage dealt to it, and the creature grappled by the rug takes the other half."
+        "desc": [
+          "While it is grappling a creature, the rug takes only half the damage dealt to it, and the creature grappled by the rug takes the other half."
+        ]
       },
       {
         "name": "False Appearance",
-        "desc": "While the rug remains motionless, it is indistinguishable from a normal rug."
+        "desc": [
+          "While the rug remains motionless, it is indistinguishable from a normal rug."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Smother",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one Medium or smaller creature. Hit: The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes 10 (2d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one Medium or smaller creature. Hit: The creature is grappled (escape DC 13). Until this grapple ends, the target is restrained, blinded, and at risk of suffocating, and the rug can't smother another target. In addition, at the start of each of the target's turns, the target takes 10 (2d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5
       }
     ],
@@ -20974,17 +23436,23 @@
     "special_abilities": [
       {
         "name": "Iron Scent",
-        "desc": "The rust monster can pinpoint, by scent, the location of ferrous metal within 30 feet of it."
+        "desc": [
+          "The rust monster can pinpoint, by scent, the location of ferrous metal within 30 feet of it."
+        ]
       },
       {
         "name": "Rust Metal",
-        "desc": "Any nonmagical weapon made of metal that hits the rust monster corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Non magical ammunition made of metal that hits the rust monster is destroyed after dealing damage."
+        "desc": [
+          "Any nonmagical weapon made of metal that hits the rust monster corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Non magical ammunition made of metal that hits the rust monster is destroyed after dealing damage."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 5 (1d8 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -20999,7 +23467,10 @@
       },
       {
         "name": "Antennae",
-        "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
+        "desc": [
+          "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.",
+          "If the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/245"
@@ -21035,17 +23506,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Pounce",
-        "desc": "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        "desc": [
+          "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (1d10 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (1d10 + 5) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -21060,7 +23537,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -21107,25 +23586,35 @@
     "special_abilities": [
       {
         "name": "Blood Frenzy",
-        "desc": "The sahuagin has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        "desc": [
+          "The sahuagin has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        ]
       },
       {
         "name": "Limited Amphibiousness",
-        "desc": "The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating."
+        "desc": [
+          "The sahuagin can breathe air and water, but it needs to be submerged at least once every 4 hours to avoid suffocating."
+        ]
       },
       {
         "name": "Shark Telepathy",
-        "desc": "The sahuagin can magically command any shark within 120 feet of it, using a limited telepathy."
+        "desc": [
+          "The sahuagin can magically command any shark within 120 feet of it, using a limited telepathy."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear."
+        "desc": [
+          "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -21140,7 +23629,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 3 (1d4 + 1) slashing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -21155,7 +23646,9 @@
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -21220,7 +23713,9 @@
     "special_abilities": [
       {
         "name": "Heated Body",
-        "desc": "A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes 7 (2d6) fire damage.",
+        "desc": [
+          "A creature that touches the salamander or hits it with a melee attack while within 5 ft. of it takes 7 (2d6) fire damage."
+        ],
         "damage": [
           {
             "damage_type": {
@@ -21234,17 +23729,23 @@
       },
       {
         "name": "Heated Weapons",
-        "desc": "Any metal melee weapon the salamander wields deals an extra 3 (1d6) fire damage on a hit (included in the attack)."
+        "desc": [
+          "Any metal melee weapon the salamander wields deals an extra 3 (1d6) fire damage on a hit (included in the attack)."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The salamander makes two attacks: one with its spear and one with its tail."
+        "desc": [
+          "The salamander makes two attacks: one with its spear and one with its tail."
+        ]
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -21281,7 +23782,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage plus 7 (2d6) fire damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage plus 7 (2d6) fire damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, the salamander can automatically hit the target with its tail, and the salamander can't make tail attacks against other targets."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -21337,13 +23840,17 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The satyr has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The satyr has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Ram",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 6 (2d4 + 1) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -21358,7 +23865,9 @@
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1 d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1 d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -21373,7 +23882,9 @@
       },
       {
         "name": "Shortbow",
-        "desc": "Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +5 to hit, range 80/320 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -21388,7 +23899,9 @@
       },
       {
         "name": "Variant: Panpipes",
-        "desc": "Gentle Lullaby. The creature falls asleep and is unconscious for 1 minute. The effect ends if the creature takes damage or if someone takes an action to shake the creature awake."
+        "desc": [
+          "Gentle Lullaby. The creature falls asleep and is unconscious for 1 minute. The effect ends if the creature takes damage or if someone takes an action to shake the creature awake."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/249"
@@ -21422,7 +23935,9 @@
     "actions": [
       {
         "name": "Sting",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must make a DC 9 Constitution saving throw, taking 4 (1d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must make a DC 9 Constitution saving throw, taking 4 (1d8) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -21471,17 +23986,23 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Sight",
-        "desc": "The scout has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        "desc": [
+          "The scout has advantage on Wisdom (Perception) checks that rely on hearing or sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The scout makes two melee attacks or two ranged attacks."
+        "desc": [
+          "The scout makes two melee attacks or two ranged attacks."
+        ]
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -21496,7 +24017,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -21542,29 +24065,51 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The hag can breathe air and water."
+        "desc": [
+          "The hag can breathe air and water."
+        ]
       },
       {
         "name": "Horrific Appearance",
-        "desc": "Any humanoid that starts its turn within 30 feet of the hag and can see the hag's true form must make a DC 11 Wisdom saving throw. On a failed save, the creature is frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the hag is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Horrific Appearance for the next 24 hours.\nUnless the target is surprised or the revelation of the hag's true form is sudden, the target can avert its eyes and avoid making the initial saving throw. Until the start of its next turn, a creature that averts its eyes has disadvantage on attack rolls against the hag."
+        "desc": [
+          "Any humanoid that starts its turn within 30 feet of the hag and can see the hag's true form must make a DC 11 Wisdom saving throw. On a failed save, the creature is frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the hag is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the hag's Horrific Appearance for the next 24 hours.",
+          "Unless the target is surprised or the revelation of the hag's true form is sudden, the target can avert its eyes and avoid making the initial saving throw. Until the start of its next turn, a creature that averts its eyes has disadvantage on attack rolls against the hag."
+        ]
       },
       {
         "name": "Hag Coven",
-        "desc": "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.\nA coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        "desc": [
+          "When hags must work together, they form covens, in spite of their selfish natures. A coven is made up of hags of any type, all of whom are equals within the group. However, each of the hags continues to desire more personal power.",
+          "A coven consists of three hags so that any arguments between two hags can be settled by the third. If more than three hags ever come together, as might happen if two covens come into conflict, the result is usually chaos."
+        ]
       },
       {
         "name": "Shared Spellcasting (Coven Only)",
-        "desc": "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:\n\n- 1st level (4 slots): identify, ray of sickness\n- 2nd level (3 slots): hold person, locate object\n- 3rd level (3 slots): bestow curse, counterspell, lightning bolt\n- 4th level (3 slots): phantasmal killer, polymorph\n- 5th level (2 slots): contact other plane, scrying\n- 6th level (1 slot): eye bite\n\nFor casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        "desc": [
+          "While all three members of a hag coven are within 30 feet of one another, they can each cast the following spells from the wizard's spell list but must share the spell slots among themselves:",
+          "- 1st level (4 slots): identify, ray of sickness",
+          "- 2nd level (3 slots): hold person, locate object",
+          "- 3rd level (3 slots): bestow curse, counterspell, lightning bolt",
+          "- 4th level (3 slots): phantasmal killer, polymorph",
+          "- 5th level (2 slots): contact other plane, scrying",
+          "- 6th level (1 slot): eye bite",
+          "For casting these spells, each hag is a 12th-level spellcaster that uses Intelligence as her spellcasting ability. The spell save DC is 12+the hag's Intelligence modifier, and the spell attack bonus is 4+the hag's Intelligence modifier."
+        ]
       },
       {
         "name": "Hag Eye (Coven Only)",
-        "desc": "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.\nA hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        "desc": [
+          "A hag coven can craft a magic item called a hag eye, which is made from a real eye coated in varnish and often fitted to a pendant or other wearable item. The hag eye is usually entrusted to a minion for safekeeping and transport. A hag in the coven can take an action to see what the hag eye sees if the hag eye is on the same plane of existence. A hag eye has AC 10, 1 hit point, and darkvision with a radius of 60 feet. If it is destroyed, each coven member takes 3d10 psychic damage and is blinded for 24 hours.",
+          "A hag coven can have only one hag eye at a time, and creating a new one requires all three members of the coven to perform a ritual. The ritual takes 1 hour, and the hags can't perform it while blinded. During the ritual, if the hags take any action other than performing the ritual, they must start over."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -21579,7 +24124,9 @@
       },
       {
         "name": "Death Glare",
-        "desc": "The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must succeed on a DC 11 Wisdom saving throw against this magic or drop to 0 hit points.",
+        "desc": [
+          "The hag targets one frightened creature she can see within 30 ft. of her. If the target can see the hag, it must succeed on a DC 11 Wisdom saving throw against this magic or drop to 0 hit points."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -21591,7 +24138,10 @@
       },
       {
         "name": "Illusory Appearance",
-        "desc": "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.\nThe changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised."
+        "desc": [
+          "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.",
+          "The changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/252"
@@ -21625,7 +24175,9 @@
     "special_abilities": [
       {
         "name": "Water Breathing",
-        "desc": "The sea horse can breathe only underwater."
+        "desc": [
+          "The sea horse can breathe only underwater."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/253"
@@ -21705,21 +24257,30 @@
     "special_abilities": [
       {
         "name": "Amorphous",
-        "desc": "The shadow can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The shadow can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       },
       {
         "name": "Shadow Stealth",
-        "desc": "While in dim light or darkness, the shadow can take the Hide action as a bonus action. Its stealth bonus is also improved to +6."
+        "desc": [
+          "While in dim light or darkness, the shadow can take the Hide action as a bonus action. Its stealth bonus is also improved to +6."
+        ]
       },
       {
         "name": "Sunlight Weakness",
-        "desc": "While in sunlight, the shadow has disadvantage on attack rolls, ability checks, and saving throws."
+        "desc": [
+          "While in sunlight, the shadow has disadvantage on attack rolls, ability checks, and saving throws."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Strength Drain",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) necrotic damage, and the target's Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.\nIf a non-evil humanoid dies from this attack, a new shadow rises from the corpse 1d4 hours later.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d6 + 2) necrotic damage, and the target's Strength score is reduced by 1d4. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest.",
+          "If a non-evil humanoid dies from this attack, a new shadow rises from the corpse 1d4 hours later."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -21784,17 +24345,23 @@
     "special_abilities": [
       {
         "name": "Lightning Absorption",
-        "desc": "Whenever the shambling mound is subjected to lightning damage, it takes no damage and regains a number of hit points equal to the lightning damage dealt."
+        "desc": [
+          "Whenever the shambling mound is subjected to lightning damage, it takes no damage and regains a number of hit points equal to the lightning damage dealt."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it."
+        "desc": [
+          "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -21809,7 +24376,9 @@
       },
       {
         "name": "Engulf",
-        "desc": "The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a DC 14 Constitution saving throw at the start of each of the mound's turns or take 13 (2d8 + 4) bludgeoning damage. If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time."
+        "desc": [
+          "The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a DC 14 Constitution saving throw at the start of each of the mound's turns or take 13 (2d8 + 4) bludgeoning damage. If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/255"
@@ -21866,25 +24435,35 @@
     "special_abilities": [
       {
         "name": "Bound",
-        "desc": "The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian."
+        "desc": [
+          "The shield guardian is magically bound to an amulet. As long as the guardian and its amulet are on the same plane of existence, the amulet's wearer can telepathically call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet's wearer, half of any damage the wearer takes (rounded up) is transferred to the guardian."
+        ]
       },
       {
         "name": "Regeneration",
-        "desc": "The shield guardian regains 10 hit points at the start of its turn if it has at least 1 hit. point."
+        "desc": [
+          "The shield guardian regains 10 hit points at the start of its turn if it has at least 1 hit. point."
+        ]
       },
       {
         "name": "Spell Storing",
-        "desc": "A spellcaster who wears the shield guardian's amulet can cause the guardian to store one spell of 4th level or lower. To do so, the wearer must cast the spell on the guardian. The spell has no effect but is stored within the guardian. When commanded to do so by the wearer or when a situation arises that was predefined by the spellcaster, the guardian casts the stored spell with any parameters set by the original caster, requiring no components. When the spell is cast or a new spell is stored, any previously stored spell is lost."
+        "desc": [
+          "A spellcaster who wears the shield guardian's amulet can cause the guardian to store one spell of 4th level or lower. To do so, the wearer must cast the spell on the guardian. The spell has no effect but is stored within the guardian. When commanded to do so by the wearer or when a situation arises that was predefined by the spellcaster, the guardian casts the stored spell with any parameters set by the original caster, requiring no components. When the spell is cast or a new spell is stored, any previously stored spell is lost."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The guardian makes two fist attacks."
+        "desc": [
+          "The guardian makes two fist attacks."
+        ]
       },
       {
         "name": "Fist",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -21901,7 +24480,9 @@
     "reactions": [
       {
         "name": "Shield",
-        "desc": "When a creature makes an attack against the wearer of the guardian's amulet, the guardian grants a +2 bonus to the wearer's AC if the guardian is within 5 feet of the wearer."
+        "desc": [
+          "When a creature makes an attack against the wearer of the guardian's amulet, the guardian grants a +2 bonus to the wearer's AC if the guardian is within 5 feet of the wearer."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/256"
@@ -21948,13 +24529,17 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."
+        "desc": [
+          "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Shriek",
-        "desc": "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward"
+        "desc": [
+          "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward"
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/257"
@@ -21997,7 +24582,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 9 (1d10 + 4) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -22012,7 +24599,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 13 Constitution saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Cold Breath. The dragon exhales an icy blast in a 15-foot cone. Each creature in that area must make a DC 13 Constitution saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one.",
+          "Paralyzing Breath. The dragon exhales paralyzing gas in a 15-foot cone. Each creature in that area must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Cold Breath",
@@ -22087,7 +24678,9 @@
     "actions": [
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22102,7 +24695,9 @@
       },
       {
         "name": "Shortbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 80/320 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22175,29 +24770,44 @@
     "special_abilities": [
       {
         "name": "Angelic Weapons",
-        "desc": "The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an extra 6d8 radiant damage (included in the attack)."
+        "desc": [
+          "The solar's weapon attacks are magical. When the solar hits with any weapon, the weapon deals an extra 6d8 radiant damage (included in the attack)."
+        ]
       },
       {
         "name": "Divine Awareness",
-        "desc": "The solar knows if it hears a lie."
+        "desc": [
+          "The solar knows if it hears a lie."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The solar's spell casting ability is Charisma (spell save DC 25). It can innately cast the following spells, requiring no material components:\nAt will: detect evil and good, invisibility (self only)\n3/day each: blade barrier, dispel evil and good, resurrection\n1/day each: commune, control weather"
+        "desc": [
+          "The solar's spell casting ability is Charisma (spell save DC 25). It can innately cast the following spells, requiring no material components:",
+          "At will: detect evil and good, invisibility (self only)",
+          "3/day each: blade barrier, dispel evil and good, resurrection",
+          "1/day each: commune, control weather"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The solar has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The solar has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The solar makes two greatsword attacks."
+        "desc": [
+          "The solar makes two greatsword attacks."
+        ]
       },
       {
         "name": "Greatsword",
-        "desc": "Melee Weapon Attack: +15 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) slashing damage plus 27 (6d8) radiant damage.",
+        "desc": [
+          "Melee Weapon Attack: +15 to hit, reach 5 ft., one target. Hit: 22 (4d6 + 8) slashing damage plus 27 (6d8) radiant damage."
+        ],
         "attack_bonus": 15,
         "damage": [
           {
@@ -22220,7 +24830,9 @@
       },
       {
         "name": "Slaying Longbow",
-        "desc": "Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 15 (2d8 + 6) piercing damage plus 27 (6d8) radiant damage. If the target is a creature that has 190 hit points or fewer, it must succeed on a DC 15 Constitution saving throw or die.",
+        "desc": [
+          "Ranged Weapon Attack: +13 to hit, range 150/600 ft., one target. Hit: 15 (2d8 + 6) piercing damage plus 27 (6d8) radiant damage. If the target is a creature that has 190 hit points or fewer, it must succeed on a DC 15 Constitution saving throw or die."
+        ],
         "attack_bonus": 13,
         "damage": [
           {
@@ -22243,21 +24855,29 @@
       },
       {
         "name": "Flying Sword",
-        "desc": "The solar releases its greatsword to hover magically in an unoccupied space within 5 ft. of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to 50 ft. and either make one attack against a target or return to the solar's hands. If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies."
+        "desc": [
+          "The solar releases its greatsword to hover magically in an unoccupied space within 5 ft. of it. If the solar can see the sword, the solar can mentally command it as a bonus action to fly up to 50 ft. and either make one attack against a target or return to the solar's hands. If the hovering sword is targeted by any effect, the solar is considered to be holding it. The hovering sword falls if the solar dies."
+        ]
       },
       {
         "name": "Healing Touch (4/Day)",
-        "desc": "The solar touches another creature. The target magically regains 40 (8d8 + 4) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        "desc": [
+          "The solar touches another creature. The target magically regains 40 (8d8 + 4) hit points and is freed from any curse, disease, poison, blindness, or deafness."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Teleport",
-        "desc": "The solar magically teleports, along with any equipment it is wearing or carrying, up to 120 ft. to an unoccupied space it can see."
+        "desc": [
+          "The solar magically teleports, along with any equipment it is wearing or carrying, up to 120 ft. to an unoccupied space it can see."
+        ]
       },
       {
         "name": "Searing Burst (Costs 2 Actions)",
-        "desc": "The solar emits magical, divine energy. Each creature of its choice in a 10 -foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The solar emits magical, divine energy. Each creature of its choice in a 10 -foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -22287,7 +24907,9 @@
       },
       {
         "name": "Blinding Gaze (Costs 3 Actions)",
-        "desc": "The solar targets one creature it can see within 30 ft. of it. If the target can see it, the target must succeed on a DC 15 Constitution saving throw or be blinded until magic such as the lesser restoration spell removes the blindness.",
+        "desc": [
+          "The solar targets one creature it can see within 30 ft. of it. If the target can see it, the target must succeed on a DC 15 Constitution saving throw or be blinded until magic such as the lesser restoration spell removes the blindness."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -22378,17 +25000,23 @@
     "special_abilities": [
       {
         "name": "Incorporeal Movement",
-        "desc": "The specter can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        "desc": [
+          "The specter can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        ]
       },
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the specter has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the specter has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Life Drain",
-        "desc": "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) necrotic damage. The target must succeed on a DC 10 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+        "desc": [
+          "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 10 (3d6) necrotic damage. The target must succeed on a DC 10 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the creature finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22435,21 +25063,29 @@
     "special_abilities": [
       {
         "name": "Spider Climb",
-        "desc": "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The spider can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Sense",
-        "desc": "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        "desc": [
+          "While in contact with a web, the spider knows the exact location of any other creature in contact with the same web."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The spider ignores movement restrictions caused by webbing."
+        "desc": [
+          "The spider ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 9 Constitution saving throw or take 2 (1d4) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 1 piercing damage, and the target must succeed on a DC 9 Constitution saving throw or take 2 (1d4) poison damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22509,17 +25145,29 @@
     "special_abilities": [
       {
         "name": "Rejuvenation",
-        "desc": "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        "desc": [
+          "If it dies, the naga returns to life in 1d6 days and regains all its hit points. Only a wish spell can prevent this trait from functioning."
+        ]
       },
       {
         "name": "Spellcasting",
-        "desc": "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, ray of frost\n- 1st level (4 slots): charm person, detect magic, sleep\n- 2nd level (3 slots): detect thoughts, hold person\n- 3rd level (3 slots): lightning bolt, water breathing\n- 4th level (3 slots): blight, dimension door\n- 5th level (2 slots): dominate person"
+        "desc": [
+          "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:",
+          "- Cantrips (at will): mage hand, minor illusion, ray of frost",
+          "- 1st level (4 slots): charm person, detect magic, sleep",
+          "- 2nd level (3 slots): detect thoughts, hold person",
+          "- 3rd level (3 slots): lightning bolt, water breathing",
+          "- 4th level (3 slots): blight, dimension door",
+          "- 5th level (2 slots): dominate person"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 7 (1d6 + 4) piercing damage, and the target must make a DC 13 Constitution saving throw, taking 31 (7d8) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 7 (1d6 + 4) piercing damage, and the target must make a DC 13 Constitution saving throw, taking 31 (7d8) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -22567,7 +25215,9 @@
     "actions": [
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -22582,7 +25232,9 @@
       },
       {
         "name": "Shortbow",
-        "desc": "Ranged Weapon Attack: +6 to hit, range 40/160 ft., one target. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or become poisoned for 1 minute. If its saving throw result is 5 or lower, the poisoned target falls unconscious for the same duration, or until it takes damage or another creature takes an action to shake it awake.",
+        "desc": [
+          "Ranged Weapon Attack: +6 to hit, range 40/160 ft., one target. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or become poisoned for 1 minute. If its saving throw result is 5 or lower, the poisoned target falls unconscious for the same duration, or until it takes damage or another creature takes an action to shake it awake."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -22597,7 +25249,9 @@
       },
       {
         "name": "Heart Sight",
-        "desc": "The sprite touches a creature and magically knows the creature's current emotional state. If the target fails a DC 10 Charisma saving throw, the sprite also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw.",
+        "desc": [
+          "The sprite touches a creature and magically knows the creature's current emotional state. If the target fails a DC 10 Charisma saving throw, the sprite also knows the creature's alignment. Celestials, fiends, and undead automatically fail the saving throw."
+        ],
         "dc": {
           "dc_type": {
             "name": "CHA",
@@ -22609,7 +25263,9 @@
       },
       {
         "name": "Invisibility",
-        "desc": "The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it."
+        "desc": [
+          "The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/264"
@@ -22649,21 +25305,29 @@
     "special_abilities": [
       {
         "name": "Cunning Action",
-        "desc": "On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+        "desc": [
+          "On each of its turns, the spy can use a bonus action to take the Dash, Disengage, or Hide action."
+        ]
       },
       {
         "name": "Sneak Attack (1/Turn)",
-        "desc": "The spy deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the spy that isn't incapacitated and the spy doesn't have disadvantage on the attack roll."
+        "desc": [
+          "The spy deals an extra 7 (2d6) damage when it hits a target with a weapon attack and has advantage on the attack roll, or when the target is within 5 ft. of an ally of the spy that isn't incapacitated and the spy doesn't have disadvantage on the attack roll."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The spy makes two melee attacks."
+        "desc": [
+          "The spy makes two melee attacks."
+        ]
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22678,7 +25342,9 @@
       },
       {
         "name": "Hand Crossbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -22732,7 +25398,9 @@
     "special_abilities": [
       {
         "name": "Death Burst",
-        "desc": "When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must succeed on a DC 10 Dexterity saving throw or take 4 (1d8) fire damage.",
+        "desc": [
+          "When the mephit dies, it explodes in a cloud of steam. Each creature within 5 ft. of the mephit must succeed on a DC 10 Dexterity saving throw or take 4 (1d8) fire damage."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -22754,13 +25422,17 @@
       },
       {
         "name": "Innate Spellcasting (1/Day)",
-        "desc": "The mephit can innately cast blur, requiring no material components. Its innate spellcasting ability is Charisma."
+        "desc": [
+          "The mephit can innately cast blur, requiring no material components. Its innate spellcasting ability is Charisma."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 2 (1d4) slashing damage plus 2 (1d4) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one creature. Hit: 2 (1d4) slashing damage plus 2 (1d4) fire damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -22783,7 +25455,9 @@
       },
       {
         "name": "Steam Breath (Recharge 6)",
-        "desc": "The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 4 (1d8) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 4 (1d8) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -22805,7 +25479,9 @@
       },
       {
         "name": "Variant: Summon Mephits (1/Day)",
-        "desc": "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The mephit has a 25 percent chance of summoning 1d4 mephits of its kind. A summoned mephit appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other mephits. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/266"
@@ -22840,7 +25516,10 @@
     "actions": [
       {
         "name": "Blood Drain",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 5 (1d4 + 3) piercing damage, and the stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.\nThe stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies. A creature, including the target, can use its action to detach the stirge.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 5 (1d4 + 3) piercing damage, and the stirge attaches to the target. While attached, the stirge doesn't attack. Instead, at the start of each of the stirge's turns, the target loses 5 (1d4 + 3) hit points due to blood loss.",
+          "The stirge can detach itself by spending 5 feet of its movement. It does so after it drains 10 hit points of blood from the target or the target dies. A creature, including the target, can use its action to detach the stirge."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -22890,17 +25569,23 @@
     "special_abilities": [
       {
         "name": "Stone Camouflage",
-        "desc": "The giant has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        "desc": [
+          "The giant has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatclub attacks."
+        "desc": [
+          "The giant makes two greatclub attacks."
+        ]
       },
       {
         "name": "Greatclub",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 15 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 15 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -22915,7 +25600,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage. If the target is a creature, it must succeed on a DC 17 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Ranged Weapon Attack: +9 to hit, range 60/240 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage. If the target is a creature, it must succeed on a DC 17 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -22932,7 +25619,9 @@
     "reactions": [
       {
         "name": "Rock Catching",
-        "desc": "If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no bludgeoning damage from it."
+        "desc": [
+          "If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no bludgeoning damage from it."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/268"
@@ -22995,25 +25684,35 @@
     "special_abilities": [
       {
         "name": "Immutable Form",
-        "desc": "The golem is immune to any spell or effect that would alter its form."
+        "desc": [
+          "The golem is immune to any spell or effect that would alter its form."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The golem has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The golem has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The golem's weapon attacks are magical."
+        "desc": [
+          "The golem's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": [
+          "The golem makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 19 (3d8 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -23028,7 +25727,9 @@
       },
       {
         "name": "Slow (Recharge 5-6)",
-        "desc": "The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a DC 17 Wisdom saving throw against this magic. On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The golem targets one or more creatures it can see within 10 ft. of it. Each target must make a DC 17 Wisdom saving throw against this magic. On a failed save, a target can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the target can take either an action or a bonus action on its turn, not both. These effects last for 1 minute. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -23084,21 +25785,31 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The giant can breathe air and water."
+        "desc": [
+          "The giant can breathe air and water."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The giant's innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:\n\nAt will: detect magic, feather fall, levitate, light\n3/day each: control weather, water breathing"
+        "desc": [
+          "The giant's innate spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:",
+          "At will: detect magic, feather fall, levitate, light",
+          "3/day each: control weather, water breathing"
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatsword attacks."
+        "desc": [
+          "The giant makes two greatsword attacks."
+        ]
       },
       {
         "name": "Greatsword",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 30 (6d6 + 9) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 30 (6d6 + 9) slashing damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -23113,7 +25824,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +14 to hit, range 60/240 ft., one target. Hit: 35 (4d12 + 9) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +14 to hit, range 60/240 ft., one target. Hit: 35 (4d12 + 9) bludgeoning damage."
+        ],
         "attack_bonus": 14,
         "damage": [
           {
@@ -23128,7 +25841,9 @@
       },
       {
         "name": "Lightning Strike (Recharge 5-6)",
-        "desc": "The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC 17 Dexterity saving throw, taking 54 (12d8) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The giant hurls a magical lightning bolt at a point it can see within 500 feet of it. Each creature within 10 feet of that point must make a DC 17 Dexterity saving throw, taking 54 (12d8) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -23192,17 +25907,23 @@
     "special_abilities": [
       {
         "name": "Telepathic Bond",
-        "desc": "The fiend ignores the range restriction on its telepathy when communicating with a creature it has charmed. The two don't even need to be on the same plane of existence."
+        "desc": [
+          "The fiend ignores the range restriction on its telepathy when communicating with a creature it has charmed. The two don't even need to be on the same plane of existence."
+        ]
       },
       {
         "name": "Shapechanger",
-        "desc": "The fiend can use its action to polymorph into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The fiend can use its action to polymorph into a Small or Medium humanoid, or back into its true form. Without wings, the fiend loses its flying speed. Other than its size and speed, its statistics are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Claw (Fiend Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -23217,7 +25938,10 @@
       },
       {
         "name": "Charm",
-        "desc": "One humanoid the fiend can see within 30 feet of it must succeed on a DC 15 Wisdom saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands. If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.\nThe fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends.",
+        "desc": [
+          "One humanoid the fiend can see within 30 feet of it must succeed on a DC 15 Wisdom saving throw or be magically charmed for 1 day. The charmed target obeys the fiend's verbal or telepathic commands. If the target suffers any harm or receives a suicidal command, it can repeat the saving throw, ending the effect on a success. If the target successfully saves against the effect, or if the effect on it ends, the target is immune to this fiend's Charm for the next 24 hours.",
+          "The fiend can have only one target charmed at a time. If it charms another, the effect on the previous target ends."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -23229,7 +25953,9 @@
       },
       {
         "name": "Draining Kiss",
-        "desc": "The fiend kisses a creature charmed by it or a willing creature. The target must make a DC 15 Constitution saving throw against this magic, taking 32 (5d10 + 5) psychic damage on a failed save, or half as much damage on a successful one. The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+        "desc": [
+          "The fiend kisses a creature charmed by it or a willing creature. The target must make a DC 15 Constitution saving throw against this magic, taking 32 (5d10 + 5) psychic damage on a failed save, or half as much damage on a successful one. The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        ],
         "attack_bonus": 0,
         "damage": [
           {
@@ -23244,7 +25970,9 @@
       },
       {
         "name": "Etherealness",
-        "desc": "The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa."
+        "desc": [
+          "The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/271"
@@ -23316,21 +26044,29 @@
     "special_abilities": [
       {
         "name": "Echolocation",
-        "desc": "The swarm can't use its blindsight while deafened."
+        "desc": [
+          "The swarm can't use its blindsight while deafened."
+        ]
       },
       {
         "name": "Keen Hearing",
-        "desc": "The swarm has advantage on Wisdom (Perception) checks that rely on hearing."
+        "desc": [
+          "The swarm has advantage on Wisdom (Perception) checks that rely on hearing."
+        ]
       },
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 0 ft., one creature in the swarm's space. Hit: 5 (2d4) piercing damage, or 2 (1d4) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 0 ft., one creature in the swarm's space. Hit: 5 (2d4) piercing damage, or 2 (1d4) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -23414,13 +26150,17 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -23503,13 +26243,18 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.\nA creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.",
+          "A creature reduced to 0 hit points by a swarm of centipedes is stable but poisoned for 1 hour, even after regaining hit points, and paralyzed while poisoned in this way."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -23592,13 +26337,17 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -23681,13 +26430,17 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 0 ft., one creature in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer. The target must make a DC 10 Constitution saving throw, taking 14 (4d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 0 ft., one creature in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer. The target must make a DC 10 Constitution saving throw, taking 14 (4d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -23770,21 +26523,29 @@
     "special_abilities": [
       {
         "name": "Blood Frenzy",
-        "desc": "The swarm has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        "desc": [
+          "The swarm has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+        ]
       },
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny quipper. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny quipper. The swarm can't regain hit points or gain temporary hit points."
+        ]
       },
       {
         "name": "Water Breathing",
-        "desc": "The swarm can breathe only underwater."
+        "desc": [
+          "The swarm can breathe only underwater."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 0 ft., one creature in the swarm's space. Hit: 14 (4d6) piercing damage, or 7 (2d6) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 0 ft., one creature in the swarm's space. Hit: 14 (4d6) piercing damage, or 7 (2d6) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -23866,17 +26627,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The swarm has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The swarm has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 0 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 0 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -23959,13 +26726,17 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Beaks",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target in the swarm's space. Hit: 7 (2d6) piercing damage, or 3 (1d6) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -24044,25 +26815,35 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The swarm can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The swarm can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Web Sense",
-        "desc": "While in contact with a web, the swarm knows the exact location of any other creature in contact with the same web."
+        "desc": [
+          "While in contact with a web, the swarm knows the exact location of any other creature in contact with the same web."
+        ]
       },
       {
         "name": "Web Walker",
-        "desc": "The swarm ignores movement restrictions caused by webbing."
+        "desc": [
+          "The swarm ignores movement restrictions caused by webbing."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -24145,13 +26926,17 @@
     "special_abilities": [
       {
         "name": "Swarm",
-        "desc": "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        "desc": [
+          "The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can't regain hit points or gain temporary hit points."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bites",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 0 ft., one target in the swarm's space. Hit: 10 (4d4) piercing damage, or 5 (2d4) piercing damage if the swarm has half of its hit points or fewer."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -24220,29 +27005,41 @@
     "special_abilities": [
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the tarrasque fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the tarrasque fails a saving throw, it can choose to succeed instead."
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The tarrasque has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The tarrasque has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Reflective Carapace",
-        "desc": "Any time the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target."
+        "desc": [
+          "Any time the tarrasque is targeted by a magic missile spell, a line spell, or a spell that requires a ranged attack roll, roll a d6. On a 1 to 5, the tarrasque is unaffected. On a 6, the tarrasque is unaffected, and the effect is reflected back at the caster as though it originated from the tarrasque, turning the caster into the target."
+        ]
       },
       {
         "name": "Siege Monster",
-        "desc": "The tarrasque deals double damage to objects and structures."
+        "desc": [
+          "The tarrasque deals double damage to objects and structures."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tai l. It can use its Swallow instead of its bite."
+        "desc": [
+          "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tai l. It can use its Swallow instead of its bite."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 36 (4d12 + 10) piercing damage. If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 36 (4d12 + 10) piercing damage. If the target is a creature, it is grappled (escape DC 20). Until this grapple ends, the target is restrained, and the tarrasque can't bite another target."
+        ],
         "attack_bonus": 19,
         "damage": [
           {
@@ -24257,7 +27054,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +19 to hit, reach 15 ft., one target. Hit: 28 (4d8 + 10) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +19 to hit, reach 15 ft., one target. Hit: 28 (4d8 + 10) slashing damage."
+        ],
         "attack_bonus": 19,
         "damage": [
           {
@@ -24272,7 +27071,9 @@
       },
       {
         "name": "Horns",
-        "desc": "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 32 (4d10 + 10) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +19 to hit, reach 10 ft., one target. Hit: 32 (4d10 + 10) piercing damage."
+        ],
         "attack_bonus": 19,
         "damage": [
           {
@@ -24287,7 +27088,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +19 to hit, reach 20 ft., one target. Hit: 24 (4d6 + 10) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +19 to hit, reach 20 ft., one target. Hit: 24 (4d6 + 10) bludgeoning damage. If the target is a creature, it must succeed on a DC 20 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 19,
         "damage": [
           {
@@ -24302,7 +27105,9 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "Each creature of the tarrasque's choice within 120 feet of it and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the tarrasque's Frightful Presence for the next 24 hours.",
+        "desc": [
+          "Each creature of the tarrasque's choice within 120 feet of it and aware of it must succeed on a DC 17 Wisdom saving throw or become frightened for 1 minute. A creature can repeat the saving throw at the end of each of its turns, with disadvantage if the tarrasque is within line of sight, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the tarrasque's Frightful Presence for the next 24 hours."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -24314,21 +27119,30 @@
       },
       {
         "name": "Swallow",
-        "desc": "The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite's damage, the target is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) acid damage at the start of each of the tarrasque's turns.\nIf the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the tarrasque. If the tarrasque dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 30 feet of movement, exiting prone."
+        "desc": [
+          "The tarrasque makes one bite attack against a Large or smaller creature it is grappling. If the attack hits, the target takes the bite's damage, the target is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) acid damage at the start of each of the tarrasque's turns.",
+          "If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must succeed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the tarrasque. If the tarrasque dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 30 feet of movement, exiting prone."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Attack",
-        "desc": "The tarrasque makes one claw attack or tail attack."
+        "desc": [
+          "The tarrasque makes one claw attack or tail attack."
+        ]
       },
       {
         "name": "Move",
-        "desc": "The tarrasque moves up to half its speed."
+        "desc": [
+          "The tarrasque moves up to half its speed."
+        ]
       },
       {
         "name": "Chomp (Costs 2 Actions)",
-        "desc": "The tarrasque makes one bite attack or uses its Swallow."
+        "desc": [
+          "The tarrasque makes one bite attack or uses its Swallow."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/282"
@@ -24363,17 +27177,23 @@
     "special_abilities": [
       {
         "name": "Pack Tactics",
-        "desc": "The thug has advantage on an attack roll against a creature if at least one of the thug's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The thug has advantage on an attack roll against a creature if at least one of the thug's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The thug makes two melee attacks."
+        "desc": [
+          "The thug makes two melee attacks."
+        ]
       },
       {
         "name": "Mace",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) bludgeoning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -24388,7 +27208,9 @@
       },
       {
         "name": "Heavy Crossbow",
-        "desc": "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +2 to hit, range 100/400 ft., one target. Hit: 5 (1d10) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -24435,17 +27257,23 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The tiger has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Pounce",
-        "desc": "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        "desc": [
+          "If the tiger moves at least 20 ft. straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the tiger can make one bite attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -24460,7 +27288,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -24510,21 +27340,29 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the treant remains motionless, it is indistinguishable from a normal tree."
+        "desc": [
+          "While the treant remains motionless, it is indistinguishable from a normal tree."
+        ]
       },
       {
         "name": "Siege Monster",
-        "desc": "The treant deals double damage to objects and structures."
+        "desc": [
+          "The treant deals double damage to objects and structures."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The treant makes two slam attacks."
+        "desc": [
+          "The treant makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 16 (3d6 + 6) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 16 (3d6 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -24539,7 +27377,9 @@
       },
       {
         "name": "Rock",
-        "desc": "Ranged Weapon Attack: +10 to hit, range 60/180 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage.",
+        "desc": [
+          "Ranged Weapon Attack: +10 to hit, range 60/180 ft., one target. Hit: 28 (4d10 + 6) bludgeoning damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -24554,7 +27394,9 @@
       },
       {
         "name": "Animate Trees (1/Day)",
-        "desc": "The treant magically animates one or two trees it can see within 60 feet of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can't speak, and they have only the Slam action option. An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible."
+        "desc": [
+          "The treant magically animates one or two trees it can see within 60 feet of it. These trees have the same statistics as a treant, except they have Intelligence and Charisma scores of 1, they can't speak, and they have only the Slam action option. An animated tree acts as an ally of the treant. The tree remains animate for 1 day or until it dies; until the treant dies or is more than 120 feet from the tree; or until the treant takes a bonus action to turn it back into an inanimate tree. The tree then takes root if possible."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/285"
@@ -24588,13 +27430,17 @@
     "special_abilities": [
       {
         "name": "Pack Tactics",
-        "desc": "The warrior has advantage on an attack roll against a creature if at least one of the warrior's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The warrior has advantage on an attack roll against a creature if at least one of the warrior's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +3 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 (1d6 + 1) piercing damage, or 5 (1d8 + 1) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -24653,13 +27499,17 @@
     "special_abilities": [
       {
         "name": "Trampling Charge",
-        "desc": "If the triceratops moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action."
+        "desc": [
+          "If the triceratops moves at least 20 ft. straight toward a creature and then hits it with a gore attack on the same turn, that target must succeed on a DC 13 Strength saving throw or be knocked prone. If the target is prone, the triceratops can make one stomp attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Gore",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 24 (4d8 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 24 (4d8 + 6) piercing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -24674,7 +27524,9 @@
       },
       {
         "name": "Stomp",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one prone creature. Hit: 22 (3d10 + 6) bludgeoning damage"
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -24720,25 +27572,44 @@
     "special_abilities": [
       {
         "name": "Keen Smell",
-        "desc": "The troll has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The troll has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       },
       {
         "name": "Regeneration",
-        "desc": "The troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with 0 hit points and doesn't regenerate."
+        "desc": [
+          "The troll regains 10 hit points at the start of its turn. If the troll takes acid or fire damage, this trait doesn't function at the start of the troll's next turn. The troll dies only if it starts its turn with 0 hit points and doesn't regenerate."
+        ]
       },
       {
         "name": "Variant: Loathsome Limbs",
-        "desc": "Whenever the troll takes at least 15 slashing damage at one time, roll a d20 to determine what else happens to it:\n1-10: Nothing else happens.\n11-14: One leg is severed from the troll if it has any legs left.\n15- 18: One arm is severed from the troll if it has any arms left.\n19-20: The troll is decapitated, but the troll dies only if it can't regenerate. If it dies, so does the severed head.\nIf the troll finishes a short or long rest without reattaching a severed limb or head, the part regrows. At that point, the severed part dies. Until then, a severed part acts on the troll's initiative and has its own action and movement. A severed part has AC 13, 10 hit points, and the troll's Regeneration trait.\nA severed leg is unable to attack and has a speed of 5 feet.\nA severed arm has a speed of 5 feet and can make one claw attack on its turn, with disadvantage on the attack roll unless the troll can see the arm and its target. Each time the troll loses an arm, it loses a claw attack.\nIf its head is severed, the troll loses its bite attack and its body is blinded unless the head can see it. The severed head has a speed of 0 feet and the troll's Keen Smell trait. It can make a bite attack but only against a target in its space.\nThe troll's speed is halved if it's missing a leg. If it loses both legs, it falls prone. If it has both arms, it can crawl. With only one arm, it can still crawl, but its speed is halved. With no arms or legs, its speed is 0, and it can't benefit from bonuses to speed."
+        "desc": [
+          "Whenever the troll takes at least 15 slashing damage at one time, roll a d20 to determine what else happens to it:",
+          "1-10: Nothing else happens.",
+          "11-14: One leg is severed from the troll if it has any legs left.",
+          "15- 18: One arm is severed from the troll if it has any arms left.",
+          "19-20: The troll is decapitated, but the troll dies only if it can't regenerate. If it dies, so does the severed head.",
+          "If the troll finishes a short or long rest without reattaching a severed limb or head, the part regrows. At that point, the severed part dies. Until then, a severed part acts on the troll's initiative and has its own action and movement. A severed part has AC 13, 10 hit points, and the troll's Regeneration trait.",
+          "A severed leg is unable to attack and has a speed of 5 feet.",
+          "A severed arm has a speed of 5 feet and can make one claw attack on its turn, with disadvantage on the attack roll unless the troll can see the arm and its target. Each time the troll loses an arm, it loses a claw attack.",
+          "If its head is severed, the troll loses its bite attack and its body is blinded unless the head can see it. The severed head has a speed of 0 feet and the troll's Keen Smell trait. It can make a bite attack but only against a target in its space.",
+          "The troll's speed is halved if it's missing a leg. If it loses both legs, it falls prone. If it has both arms, it can crawl. With only one arm, it can still crawl, but its speed is halved. With no arms or legs, its speed is 0, and it can't benefit from bonuses to speed."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The troll makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The troll makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 7 (1d6 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -24753,7 +27624,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -24799,11 +27672,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
+        "desc": [
+          "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 33 (4d12 + 7) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 33 (4d12 + 7) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the tyrannosaurus can't bite another target."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -24818,7 +27695,9 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 20 (3d8 + 7) bludgeoning damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -24878,29 +27757,43 @@
     "special_abilities": [
       {
         "name": "Charge",
-        "desc": "If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the unicorn moves at least 20 ft. straight toward a target and then hits it with a horn attack on the same turn, the target takes an extra 9 (2d8) piercing damage. If the target is a creature, it must succeed on a DC 15 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Innate Spellcasting",
-        "desc": "The unicorn's innate spellcasting ability is Charisma (spell save DC 14). The unicorn can innately cast the following spells, requiring no components:\n\nAt will: detect evil and good, druidcraft, pass without trace\n1/day each: calm emotions, dispel evil and good, entangle"
+        "desc": [
+          "The unicorn's innate spellcasting ability is Charisma (spell save DC 14). The unicorn can innately cast the following spells, requiring no components:",
+          "At will: detect evil and good, druidcraft, pass without trace",
+          "1/day each: calm emotions, dispel evil and good, entangle"
+        ]
       },
       {
         "name": "Magic Resistance",
-        "desc": "The unicorn has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The unicorn has advantage on saving throws against spells and other magical effects."
+        ]
       },
       {
         "name": "Magic Weapons",
-        "desc": "The unicorn's weapon attacks are magical."
+        "desc": [
+          "The unicorn's weapon attacks are magical."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The unicorn makes two attacks: one with its hooves and one with its horn."
+        "desc": [
+          "The unicorn makes two attacks: one with its hooves and one with its horn."
+        ]
       },
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -24915,7 +27808,9 @@
       },
       {
         "name": "Horn",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 8 (1d8 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft ., one target. Hit: 8 (1d8 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -24930,25 +27825,35 @@
       },
       {
         "name": "Healing Touch (3/Day)",
-        "desc": "The unicorn touches another creature with its horn. The target magically regains 11 (2d8 + 2) hit points. In addition, the touch removes all diseases and neutralizes all poisons afflicting the target."
+        "desc": [
+          "The unicorn touches another creature with its horn. The target magically regains 11 (2d8 + 2) hit points. In addition, the touch removes all diseases and neutralizes all poisons afflicting the target."
+        ]
       },
       {
         "name": "Teleport (1/Day)",
-        "desc": "The unicorn magically teleports itself and up to three willing creatures it can see within 5 ft. of it, along with any equipment they are wearing or carrying, to a location the unicorn is familiar with, up to 1 mile away."
+        "desc": [
+          "The unicorn magically teleports itself and up to three willing creatures it can see within 5 ft. of it, along with any equipment they are wearing or carrying, to a location the unicorn is familiar with, up to 1 mile away."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Hooves",
-        "desc": "The unicorn makes one attack with its hooves."
+        "desc": [
+          "The unicorn makes one attack with its hooves."
+        ]
       },
       {
         "name": "Shimmering Shield (Costs 2 Actions)",
-        "desc": "The unicorn creates a shimmering, magical field around itself or another creature it can see within 60 ft. of it. The target gains a +2 bonus to AC until the end of the unicorn's next turn."
+        "desc": [
+          "The unicorn creates a shimmering, magical field around itself or another creature it can see within 60 ft. of it. The target gains a +2 bonus to AC until the end of the unicorn's next turn."
+        ]
       },
       {
         "name": "Heal Self (Costs 3 Actions)",
-        "desc": "The unicorn magically regains 11 (2d8 + 2) hit points."
+        "desc": [
+          "The unicorn magically regains 11 (2d8 + 2) hit points."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/290"
@@ -24990,37 +27895,60 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.\nWhile in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.\nWhile in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+        "desc": [
+          "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.",
+          "While in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.",
+          "While in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+        ]
       },
       {
         "name": "Legendary Resistance (3/Day)",
-        "desc": "If the vampire fails a saving throw, it can choose to succeed instead."
+        "desc": [
+          "If the vampire fails a saving throw, it can choose to succeed instead."
+        ]
       },
       {
         "name": "Misty Escape",
-        "desc": "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.\nWhile it has 0 hit points in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least 1 hit point. After spending 1 hour in its resting place with 0 hit points, it regains 1 hit point."
+        "desc": [
+          "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.",
+          "While it has 0 hit points in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least 1 hit point. After spending 1 hour in its resting place with 0 hit points, it regains 1 hit point."
+        ]
       },
       {
         "name": "Regeneration",
-        "desc": "The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        "desc": [
+          "The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage if it ends its turn in running water.\nStake to the Heart. If a piercing weapon made of wood is driven into the vampire's heart while the vampire is incapacitated in its resting place, the vampire is paralyzed until the stake is removed.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        "desc": [
+          "The vampire has the following flaws:",
+          "Forbiddance. The vampire can't enter a residence without an invitation from one of the occupants.",
+          "Harmed by Running Water. The vampire takes 20 acid damage if it ends its turn in running water.",
+          "Stake to the Heart. If a piercing weapon made of wood is driven into the vampire's heart while the vampire is incapacitated in its resting place, the vampire is paralyzed until the stake is removed.",
+          "Sunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack (Vampire Form Only)",
-        "desc": "The vampire makes two attacks, only one of which can be a bite attack."
+        "desc": [
+          "The vampire makes two attacks, only one of which can be a bite attack."
+        ]
       },
       {
         "name": "Unarmed Strike (Vampire Form Only)",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 8 (1d8 + 4) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18).",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 8 (1d8 + 4) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18)."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -25035,7 +27963,9 @@
       },
       {
         "name": "Bite (Bat or Vampire Form Only)",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -25058,7 +27988,10 @@
       },
       {
         "name": "Charm",
-        "desc": "The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a DC 17 Wisdom saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bit attack.\nEach time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect.",
+        "desc": [
+          "The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a DC 17 Wisdom saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bit attack.",
+          "Each time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect."
+        ],
         "dc": {
           "dc_type": {
             "name": "WIS",
@@ -25070,23 +28003,31 @@
       },
       {
         "name": "Children of the Night (1/Day)",
-        "desc": "The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
+        "desc": [
+          "The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action."
+        ]
       }
     ],
     "legendary_actions": [
       {
         "name": "Move",
-        "desc": "The vampire moves up to its speed without provoking opportunity attacks.",
+        "desc": [
+          "The vampire moves up to its speed without provoking opportunity attacks."
+        ],
         "attack_bonus": 0
       },
       {
         "name": "Unarmed Strike",
-        "desc": "The vampire makes one unarmed strike.",
+        "desc": [
+          "The vampire makes one unarmed strike."
+        ],
         "attack_bonus": 0
       },
       {
         "name": "Bite (Costs 2 Actions)",
-        "desc": "The vampire makes one bite attack.",
+        "desc": [
+          "The vampire makes one bite attack."
+        ],
         "attack_bonus": 0
       }
     ],
@@ -25128,25 +28069,39 @@
     "special_abilities": [
       {
         "name": "Regeneration",
-        "desc": "The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        "desc": [
+          "The vampire regains 10 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+        ]
       },
       {
         "name": "Spider Climb",
-        "desc": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        "desc": [
+          "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+        ]
       },
       {
         "name": "Vampire Weaknesses",
-        "desc": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage when it ends its turn in running water.\nStake to the Heart. The vampire is destroyed if a piercing weapon made of wood is driven into its heart while it is incapacitated in its resting place.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        "desc": [
+          "The vampire has the following flaws:",
+          "Forbiddance. The vampire can't enter a residence without an invitation from one of the occupants.",
+          "Harmed by Running Water. The vampire takes 20 acid damage when it ends its turn in running water.",
+          "Stake to the Heart. The vampire is destroyed if a piercing weapon made of wood is driven into its heart while it is incapacitated in its resting place.",
+          "Sunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vampire makes two attacks, only one of which can be a bite attack."
+        "desc": [
+          "The vampire makes two attacks, only one of which can be a bite attack."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 6 (1d6 + 3) piercing damage plus 7 (2d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 6 (1d6 + 3) piercing damage plus 7 (2d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25169,7 +28124,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 8 (2d4 + 3) slashing damage. Instead of dealing damage, the vampire can grapple the target (escape DC 13).",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 8 (2d4 + 3) slashing damage. Instead of dealing damage, the vampire can grapple the target (escape DC 13)."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25216,11 +28173,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        "desc": [
+          "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        ]
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -25249,7 +28210,9 @@
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -25264,7 +28227,9 @@
       },
       {
         "name": "Heavy Crossbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +3 to hit, range 100/400 ft., one target. Hit: 6 (1d10 + 1) piercing damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {
@@ -25322,17 +28287,23 @@
     "special_abilities": [
       {
         "name": "False Appearance",
-        "desc": "While the violet fungus remains motionless, it is indistinguishable from an ordinary fungus."
+        "desc": [
+          "While the violet fungus remains motionless, it is indistinguishable from an ordinary fungus."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The fungus makes 1d4 Rotting Touch attacks."
+        "desc": [
+          "The fungus makes 1d4 Rotting Touch attacks."
+        ]
       },
       {
         "name": "Rotting Touch",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 10 ft., one creature. Hit: 4 (1d8) necrotic damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 10 ft., one creature. Hit: 4 (1d8) necrotic damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -25393,17 +28364,23 @@
     "special_abilities": [
       {
         "name": "Magic Resistance",
-        "desc": "The vrock has advantage on saving throws against spells and other magical effects."
+        "desc": [
+          "The vrock has advantage on saving throws against spells and other magical effects."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vrock makes two attacks: one with its beak and one with its talons."
+        "desc": [
+          "The vrock makes two attacks: one with its beak and one with its talons."
+        ]
       },
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25418,7 +28395,9 @@
       },
       {
         "name": "Talons",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 14 (2d10 + 3) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25433,7 +28412,9 @@
       },
       {
         "name": "Spores (Recharge 6)",
-        "desc": "A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a DC 14 Constitution saving throw or become poisoned. While poisoned in this way, a target takes 5 (1d10) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it.",
+        "desc": [
+          "A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a DC 14 Constitution saving throw or become poisoned. While poisoned in this way, a target takes 5 (1d10) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -25445,7 +28426,9 @@
       },
       {
         "name": "Stunning Screech (1/Day)",
-        "desc": "The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a DC 14 Constitution saving throw or be stunned until the end of the vrock's next turn .",
+        "desc": [
+          "The vrock emits a horrific screech. Each creature within 20 feet of it that can hear it and that isn't a demon must succeed on a DC 14 Constitution saving throw or be stunned until the end of the vrock's next turn ."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -25457,7 +28440,11 @@
       },
       {
         "name": "Variant: Summon Demon (1/Day)",
-        "desc": "The demon chooses what to summon and attempts a magical summoning.\nA vrock has a 30 percent chance of summoning 2d4 dretches or one vrock.\nA summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        "desc": [
+          "The demon chooses what to summon and attempts a magical summoning.",
+          "A vrock has a 30 percent chance of summoning 2d4 dretches or one vrock.",
+          "A summoned demon appears in an unoccupied space within 60 feet of its summoner, acts as an ally of its summoner, and can't summon other demons. It remains for 1 minute, until it or its summoner dies, or until its summoner dismisses it as an action."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/295"
@@ -25493,17 +28480,23 @@
     "special_abilities": [
       {
         "name": "Keen Sight and Smell",
-        "desc": "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        "desc": [
+          "The vulture has advantage on Wisdom (Perception) checks that rely on sight or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The vulture has advantage on an attack roll against a creature if at least one of the vulture's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Beak",
-        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 2 (1d4) piercing damage."
+        ],
         "attack_bonus": 2,
         "damage": [
           {
@@ -25548,13 +28541,17 @@
     "special_abilities": [
       {
         "name": "Trampling Charge",
-        "desc": "If the horse moves at least 20 ft. straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action."
+        "desc": [
+          "If the horse moves at least 20 ft. straight toward a creature and then hits it with a hooves attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the horse can make another attack with its hooves against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25612,7 +28609,9 @@
     "actions": [
       {
         "name": "Hooves",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -25696,21 +28695,29 @@
     "special_abilities": [
       {
         "name": "Water Form",
-        "desc": "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        "desc": [
+          "The elemental can enter a hostile creature's space and stop there. It can move through a space as narrow as 1 inch wide without squeezing."
+        ]
       },
       {
         "name": "Freeze",
-        "desc": "If the elemental takes cold damage, it partially freezes; its speed is reduced by 20 ft. until the end of its next turn."
+        "desc": [
+          "If the elemental takes cold damage, it partially freezes; its speed is reduced by 20 ft. until the end of its next turn."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": [
+          "The elemental makes two slam attacks."
+        ]
       },
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) bludgeoning damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -25725,7 +28732,10 @@
       },
       {
         "name": "Whelm (Recharge 4-6)",
-        "desc": "Each creature in the elemental's space must make a DC 15 Strength saving throw. On a failure, a target takes 13 (2d8 + 4) bludgeoning damage. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. If the saving throw is successful, the target is pushed out of the elemental's space.\nThe elemental can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the elemental's turns, each target grappled by it takes 13 (2d8 + 4) bludgeoning damage. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a DC 14 Strength and succeeding.",
+        "desc": [
+          "Each creature in the elemental's space must make a DC 15 Strength saving throw. On a failure, a target takes 13 (2d8 + 4) bludgeoning damage. If it is Large or smaller, it is also grappled (escape DC 14). Until this grapple ends, the target is restrained and unable to breathe unless it can breathe water. If the saving throw is successful, the target is pushed out of the elemental's space.",
+          "The elemental can grapple one Large creature or up to two Medium or smaller creatures at one time. At the start of each of the elemental's turns, each target grappled by it takes 13 (2d8 + 4) bludgeoning damage. A creature within 5 feet of the elemental can pull a creature or object out of it by taking an action to make a DC 14 Strength and succeeding."
+        ],
         "dc": {
           "dc_type": {
             "name": "STR",
@@ -25779,13 +28789,17 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The weasel has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one creature. Hit: 1 piercing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -25849,21 +28863,29 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The werebear can use its action to polymorph into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. Its statistics, other than its size and AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The werebear can use its action to polymorph into a Large bear-humanoid hybrid or into a Large bear, or back into its true form, which is humanoid. Its statistics, other than its size and AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Keen Smell",
-        "desc": "The werebear has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The werebear has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid."
+        "desc": [
+          "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid."
+        ]
       },
       {
         "name": "Bite (Bear or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage. If the target is a humanoid, it must succeed on a DC 14 Constitution saving throw or be cursed with werebear lycanthropy.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 15 (2d10 + 4) piercing damage. If the target is a humanoid, it must succeed on a DC 14 Constitution saving throw or be cursed with werebear lycanthropy."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -25878,7 +28900,9 @@
       },
       {
         "name": "Claw (Bear or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -25893,7 +28917,9 @@
       },
       {
         "name": "Greataxe (Humanoid or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 10 (1d12 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -25949,26 +28975,36 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The wereboar can use its action to polymorph into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The wereboar can use its action to polymorph into a boar-humanoid hybrid or into a boar, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Charge (Boar or Hybrid Form Only)",
-        "desc": "If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        "desc": [
+          "If the wereboar moves at least 15 feet straight toward a target and then hits it with its tusks on the same turn, the target takes an extra 7 (2d6) slashing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ]
       },
       {
         "name": "Relentless (Recharges after a Short or Long Rest)",
-        "desc": "If the wereboar takes 14 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead.",
+        "desc": [
+          "If the wereboar takes 14 damage or less that would reduce it to 0 hit points, it is reduced to 1 hit point instead."
+        ],
         "attack_bonus": 0
       }
     ],
     "actions": [
       {
         "name": "Multiattack (Humanoid or Hybrid Form Only)",
-        "desc": "The wereboar makes two attacks, only one of which can be with its tusks."
+        "desc": [
+          "The wereboar makes two attacks, only one of which can be with its tusks."
+        ]
       },
       {
         "name": "Maul (Humanoid or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) bludgeoning damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -25983,7 +29019,9 @@
       },
       {
         "name": "Tusks (Boar or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with wereboar lycanthropy.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) slashing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with wereboar lycanthropy."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -26032,21 +29070,29 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The wererat can use its action to polymorph into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The wererat can use its action to polymorph into a rat-humanoid hybrid or into a giant rat, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Keen Smell",
-        "desc": "The wererat has advantage on Wisdom (Perception) checks that rely on smell."
+        "desc": [
+          "The wererat has advantage on Wisdom (Perception) checks that rely on smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack (Humanoid or Hybrid Form Only)",
-        "desc": "The wererat makes two attacks, only one of which can be a bite."
+        "desc": [
+          "The wererat makes two attacks, only one of which can be a bite."
+        ]
       },
       {
         "name": "Bite (Rat or Hybrid Form Only).",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 11 Constitution saving throw or be cursed with wererat lycanthropy.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 4 (1d4 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 11 Constitution saving throw or be cursed with wererat lycanthropy."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26061,7 +29107,9 @@
       },
       {
         "name": "Shortsword (Humanoid or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26076,7 +29124,9 @@
       },
       {
         "name": "Hand Crossbow (Humanoid or Hybrid Form Only)",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 30/120 ft., one target. Hit: 5 (1d6 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26133,25 +29183,35 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The weretiger can use its action to polymorph into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The weretiger can use its action to polymorph into a tiger-humanoid hybrid or into a tiger, or back into its true form, which is humanoid. Its statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The weretiger has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The weretiger has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pounce (Tiger or Hybrid Form Only)",
-        "desc": "If the weretiger moves at least 15 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action."
+        "desc": [
+          "If the weretiger moves at least 15 feet straight toward a creature and then hits it with a claw attack on the same turn, that target must succeed on a DC 14 Strength saving throw or be knocked prone. If the target is prone, the weretiger can make one bite attack against it as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack (Humanoid or Hybrid Form Only)",
-        "desc": "In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks."
+        "desc": [
+          "In humanoid form, the weretiger makes two scimitar attacks or two longbow attacks. In hybrid form, it can attack like a humanoid or make two claw attacks."
+        ]
       },
       {
         "name": "Bite (Tiger or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage. If the target is a humanoid, it must succeed on a DC 13 Constitution saving throw or be cursed with weretiger lycanthropy.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d10 + 3) piercing damage. If the target is a humanoid, it must succeed on a DC 13 Constitution saving throw or be cursed with weretiger lycanthropy."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -26166,7 +29226,9 @@
       },
       {
         "name": "Claw (Tiger or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -26181,7 +29243,9 @@
       },
       {
         "name": "Scimitar (Humanoid or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -26196,7 +29260,9 @@
       },
       {
         "name": "Longbow (Humanoid or Hybrid Form Only)",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26252,21 +29318,29 @@
     "special_abilities": [
       {
         "name": "Shapechanger",
-        "desc": "The werewolf can use its action to polymorph into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        "desc": [
+          "The werewolf can use its action to polymorph into a wolf-humanoid hybrid or into a wolf, or back into its true form, which is humanoid. Its statistics, other than its AC, are the same in each form. Any equipment it is wearing or carrying isn't transformed. It reverts to its true form if it dies."
+        ]
       },
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The werewolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The werewolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack (Humanoid or Hybrid Form Only)",
-        "desc": "The werewolf makes two attacks: one with its bite and one with its claws or spear."
+        "desc": [
+          "The werewolf makes two attacks: one with its bite and one with its claws or spear."
+        ]
       },
       {
         "name": "Bite (Wolf or Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with werewolf lycanthropy.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) piercing damage. If the target is a humanoid, it must succeed on a DC 12 Constitution saving throw or be cursed with werewolf lycanthropy."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26281,7 +29355,9 @@
       },
       {
         "name": "Claws (Hybrid Form Only)",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (2d4 + 2) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 7 (2d4 + 2) slashing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26296,7 +29372,9 @@
       },
       {
         "name": "Spear (Humanoid Form Only)",
-        "desc": "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack.",
+        "desc": [
+          "Melee or Ranged Weapon Attack: +4 to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 5 (1d6 + 2) piercing damage, or 6 (1d8 + 2) piercing damage if used with two hands to make a melee attack."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26366,7 +29444,9 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (1d10 + 2) piercing damage plus 2 (1d4) cold damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26389,7 +29469,9 @@
       },
       {
         "name": "Cold Breath (Recharge 5-6)",
-        "desc": "The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 22 (5d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales an icy blast of hail in a 15-foot cone. Each creature in that area must make a DC 12 Constitution saving throw, taking 22 (5d8) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -26451,17 +29533,24 @@
     "special_abilities": [
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the wight has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the wight has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack."
+        "desc": [
+          "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack."
+        ]
       },
       {
         "name": "Life Drain",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) necrotic damage. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.\nA humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one creature. Hit: 5 (1d6 + 2) necrotic damage. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+          "A humanoid slain by this attack rises 24 hours later as a zombie under the wight's control, unless the humanoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at one time."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26476,7 +29565,9 @@
       },
       {
         "name": "Longsword",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage, or 7 (1d10 + 2) slashing damage if used with two hands.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 6 (1d8 + 2) slashing damage, or 7 (1d10 + 2) slashing damage if used with two hands."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26505,7 +29596,9 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": [
+          "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26591,7 +29684,9 @@
     "special_abilities": [
       {
         "name": "Consume Life",
-        "desc": "As a bonus action, the will-o'-wisp can target one creature it can see within 5 ft. of it that has 0 hit points and is still alive. The target must succeed on a DC 10 Constitution saving throw against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6) hit points.",
+        "desc": [
+          "As a bonus action, the will-o'-wisp can target one creature it can see within 5 ft. of it that has 0 hit points and is still alive. The target must succeed on a DC 10 Constitution saving throw against this magic or die. If the target dies, the will-o'-wisp regains 10 (3d6) hit points."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -26603,21 +29698,29 @@
       },
       {
         "name": "Ephemeral",
-        "desc": "The will-o'-wisp can't wear or carry anything."
+        "desc": [
+          "The will-o'-wisp can't wear or carry anything."
+        ]
       },
       {
         "name": "Incorporeal Movement",
-        "desc": "The will-o'-wisp can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        "desc": [
+          "The will-o'-wisp can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        ]
       },
       {
         "name": "Variable Illumination",
-        "desc": "The will-o'-wisp sheds bright light in a 5- to 20-foot radius and dim light for an additional number of ft. equal to the chosen radius. The will-o'-wisp can alter the radius as a bonus action."
+        "desc": [
+          "The will-o'-wisp sheds bright light in a 5- to 20-foot radius and dim light for an additional number of ft. equal to the chosen radius. The will-o'-wisp can alter the radius as a bonus action."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Shock",
-        "desc": "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d8) lightning damage.",
+        "desc": [
+          "Melee Spell Attack: +4 to hit, reach 5 ft., one creature. Hit: 9 (2d8) lightning damage."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26632,7 +29735,9 @@
       },
       {
         "name": "Invisibility",
-        "desc": "The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."
+        "desc": [
+          "The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/308"
@@ -26670,21 +29775,29 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       },
       {
         "name": "Snow Camouflage",
-        "desc": "The wolf has advantage on Dexterity (Stealth) checks made to hide in snowy terrain."
+        "desc": [
+          "The wolf has advantage on Dexterity (Stealth) checks made to hide in snowy terrain."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -26699,7 +29812,9 @@
       },
       {
         "name": "Cold Breath (Recharge 5-6)",
-        "desc": "The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The wolf exhales a blast of freezing wind in a 15-foot cone. Each creature in that area must make a DC 12 Dexterity saving throw, taking 18 (4d8) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -26753,17 +29868,23 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The wolf has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       },
       {
         "name": "Pack Tactics",
-        "desc": "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        "desc": [
+          "The wolf has advantage on an attack roll against a creature if at least one of the wolf's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +4 to hit, reach 5 ft., one target. Hit: 7 (2d4 + 2) piercing damage. If the target is a creature, it must succeed on a DC 11 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 4,
         "damage": [
           {
@@ -26809,13 +29930,17 @@
     "special_abilities": [
       {
         "name": "Keen Hearing and Smell",
-        "desc": "The worg has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        "desc": [
+          "The worg has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone.",
+        "desc": [
+          "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 10 (2d6 + 3) piercing damage. If the target is a creature, it must succeed on a DC 13 Strength saving throw or be knocked prone."
+        ],
         "attack_bonus": 5,
         "damage": [
           {
@@ -26905,17 +30030,23 @@
     "special_abilities": [
       {
         "name": "Incorporeal Movement",
-        "desc": "The wraith can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        "desc": [
+          "The wraith can move through other creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object."
+        ]
       },
       {
         "name": "Sunlight Sensitivity",
-        "desc": "While in sunlight, the wraith has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        "desc": [
+          "While in sunlight, the wraith has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Life Drain",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 21 (4d8 + 3) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one creature. Hit: 21 (4d8 + 3) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -26930,7 +30061,9 @@
       },
       {
         "name": "Create Specter",
-        "desc": "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time."
+        "desc": [
+          "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time."
+        ]
       }
     ],
     "url": "http://www.dnd5eapi.co/api/monsters/312"
@@ -26966,11 +30099,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."
+        "desc": [
+          "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -26985,7 +30122,9 @@
       },
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 13 (2d8 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27000,7 +30139,9 @@
       },
       {
         "name": "Stinger",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage. The target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one creature. Hit: 11 (2d6 + 4) piercing damage. The target must make a DC 15 Constitution saving throw, taking 24 (7d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27050,25 +30191,35 @@
     "special_abilities": [
       {
         "name": "Earth Glide",
-        "desc": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn't disturb the material it moves through."
+        "desc": [
+          "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn't disturb the material it moves through."
+        ]
       },
       {
         "name": "Stone Camouflage",
-        "desc": "The xorn has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        "desc": [
+          "The xorn has advantage on Dexterity (Stealth) checks made to hide in rocky terrain."
+        ]
       },
       {
         "name": "Treasure Sense",
-        "desc": "The xorn can pinpoint, by scent, the location of precious metals and stones, such as coins and gems, within 60 ft. of it."
+        "desc": [
+          "The xorn can pinpoint, by scent, the location of precious metals and stones, such as coins and gems, within 60 ft. of it."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The xorn makes three claw attacks and one bite attack."
+        "desc": [
+          "The xorn makes three claw attacks and one bite attack."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (3d6 + 3) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 13 (3d6 + 3) piercing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -27083,7 +30234,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +6 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) slashing damage."
+        ],
         "attack_bonus": 6,
         "damage": [
           {
@@ -27138,17 +30291,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) acid damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) acid damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27171,7 +30330,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27186,7 +30347,9 @@
       },
       {
         "name": "Acid Breath (Recharge 5-6)",
-        "desc": "The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 49 (11d8) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales acid in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 49 (11d8) acid damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -27248,11 +30411,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage plus 5 (1d10) lightning damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage plus 5 (1d10) lightning damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -27275,7 +30442,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        ],
         "attack_bonus": 9,
         "damage": [
           {
@@ -27290,7 +30459,9 @@
       },
       {
         "name": "Lightning Breath (Recharge 5-6)",
-        "desc": "The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -27353,11 +30524,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27372,7 +30547,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27387,7 +30564,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in a 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 42 (12d6) fire damage on a failed save, or half as much damage on a successful one.",
+          "Sleep Breath. The dragon exhales sleep gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw or fall unconscious for 5 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it."
+        ],
         "attack_bonus": 0,
         "attacks": [
           {
@@ -27467,17 +30648,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 16 (2d10 + 5) piercing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -27492,7 +30679,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +8 to hit, reach 5 ft., one target. Hit: 12 (2d6 + 5) slashing damage."
+        ],
         "attack_bonus": 8,
         "damage": [
           {
@@ -27507,7 +30696,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nLightning Breath. The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 15 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.\nRepulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 15 Strength saving throw. On a failed save, the creature is pushed 40 feet away from the dragon.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Lightning Breath. The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 15 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.",
+          "Repulsion Breath. The dragon exhales repulsion energy in a 30-foot cone. Each creature in that area must succeed on a DC 15 Strength saving throw. On a failed save, the creature is pushed 40 feet away from the dragon."
+        ],
         "attack_bonus": 0,
         "attacks": [
           {
@@ -27587,11 +30780,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27606,7 +30803,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27621,7 +30820,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nAcid Breath. The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 40 (9d8) acid damage on a failed save, or half as much damage on a successful one.\nSlowing Breath. The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Acid Breath. The dragon exhales acid in an 40-foot line that is 5 feet wide. Each creature in that line must make a DC 14 Dexterity saving throw, taking 40 (9d8) acid damage on a failed save, or half as much damage on a successful one.",
+          "Slowing Breath. The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 14 Constitution saving throw. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+        ],
         "attacks": [
           {
             "name": "Acid Breath",
@@ -27701,17 +30904,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -27726,7 +30935,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -27741,7 +30952,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 55 (10d10) fire damage on a failed save, or half as much damage on a successful one.\nWeakening Breath. The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Fire Breath. The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 55 (10d10) fire damage on a failed save, or half as much damage on a successful one.",
+          "Weakening Breath. The dragon exhales gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Strength saving throw or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Fire Breath",
@@ -27825,17 +31040,23 @@
     "special_abilities": [
       {
         "name": "Amphibious",
-        "desc": "The dragon can breathe air and water."
+        "desc": [
+          "The dragon can breathe air and water."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 7 (2d6) poison damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 7 (2d6) poison damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27858,7 +31079,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -27873,7 +31096,9 @@
       },
       {
         "name": "Poison Breath (Recharge 5-6)",
-        "desc": "The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales poisonous gas in a 30-foot cone. Each creature in that area must make a DC 14 Constitution saving throw, taking 42 (12d6) poison damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -27935,11 +31160,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 3 (1d6) fire damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage plus 3 (1d6) fire damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -27962,7 +31191,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -27977,7 +31208,9 @@
       },
       {
         "name": "Fire Breath (Recharge 5-6)",
-        "desc": "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales fire in a 30-foot cone. Each creature in that area must make a DC 17 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "DEX",
@@ -28040,11 +31273,15 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 10 ft., one target. Hit: 17 (2d10 + 6) piercing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -28059,7 +31296,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +10 to hit, reach 5 ft., one target. Hit: 13 (2d6 + 6) slashing damage."
+        ],
         "attack_bonus": 10,
         "damage": [
           {
@@ -28074,7 +31313,11 @@
       },
       {
         "name": "Breath Weapons (Recharge 5-6)",
-        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 17 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": [
+          "The dragon uses one of the following breath weapons.",
+          "Cold Breath. The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 17 Constitution saving throw, taking 54 (12d8) cold damage on a failed save, or half as much damage on a successful one.",
+          "Paralyzing Breath. The dragon exhales paralyzing gas in a 30-foot cone. Each creature in that area must succeed on a DC 17 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+        ],
         "attacks": [
           {
             "name": "Cold Breath",
@@ -28153,17 +31396,23 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": [
+          "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": [
+          "The dragon makes three attacks: one with its bite and two with its claws."
+        ]
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) cold damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 10 ft., one target. Hit: 15 (2d10 + 4) piercing damage plus 4 (1d8) cold damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -28186,7 +31435,9 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage.",
+        "desc": [
+          "Melee Weapon Attack: +7 to hit, reach 5 ft., one target. Hit: 11 (2d6 + 4) slashing damage."
+        ],
         "attack_bonus": 7,
         "damage": [
           {
@@ -28201,7 +31452,9 @@
       },
       {
         "name": "Cold Breath (Recharge 5-6)",
-        "desc": "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw, taking 45 (10d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": [
+          "The dragon exhales an icy blast in a 30-foot cone. Each creature in that area must make a DC 15 Constitution saving throw, taking 45 (10d8) cold damage on a failed save, or half as much damage on a successful one."
+        ],
         "dc": {
           "dc_type": {
             "name": "CON",
@@ -28259,13 +31512,17 @@
     "special_abilities": [
       {
         "name": "Undead Fortitude",
-        "desc": "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        "desc": [
+          "If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead."
+        ]
       }
     ],
     "actions": [
       {
         "name": "Slam",
-        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage.",
+        "desc": [
+          "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) bludgeoning damage."
+        ],
         "attack_bonus": 3,
         "damage": [
           {


### PR DESCRIPTION
## Overview

Instead of descriptions having newlines in them, convert them to lists of strings. This will also make the spellcasting changes easier.