### PR TITLE
Change monsters' senses to be an object

### DIFF
--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -28,7 +28,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 20",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 20
+    },
     "languages": "Deep Speech, telepathy 120 ft.",
     "challenge_rating": 10,
     "special_abilities": [
@@ -161,7 +164,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -222,7 +227,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 21
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 14,
     "special_abilities": [
@@ -411,7 +420,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 22
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 17,
     "special_abilities": [
@@ -581,7 +594,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 22
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 16,
     "special_abilities": [
@@ -749,7 +766,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 21
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 13,
     "special_abilities": [
@@ -895,7 +916,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 22
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 15,
     "special_abilities": [
@@ -1077,7 +1102,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 22
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 14,
     "special_abilities": [
@@ -1256,7 +1285,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 24",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 24
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 17,
     "special_abilities": [
@@ -1445,7 +1478,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 22",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 22
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 15,
     "special_abilities": [
@@ -1615,7 +1652,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 23",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 23
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 17,
     "special_abilities": [
@@ -1831,7 +1872,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 21
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 16,
     "special_abilities": [
@@ -2009,7 +2054,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 21",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 21
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 13,
     "special_abilities": [
@@ -2209,7 +2258,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Auran",
     "challenge_rating": 5,
     "special_abilities": [
@@ -2278,7 +2330,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 26
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 21,
     "special_abilities": [
@@ -2448,7 +2504,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 27
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 23,
     "actions": [
@@ -2601,7 +2661,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 24",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 24
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 20,
     "special_abilities": [
@@ -2783,7 +2847,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 27
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 22,
     "special_abilities": [
@@ -2969,7 +3037,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 27
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 21,
     "special_abilities": [
@@ -3152,7 +3224,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 27
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 24,
     "special_abilities": [
@@ -3345,7 +3421,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 27",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 27
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 22,
     "special_abilities": [
@@ -3518,7 +3598,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 26
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 24,
     "special_abilities": [
@@ -3688,7 +3772,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 26",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 26
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 23,
     "special_abilities": [
@@ -3870,7 +3958,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 23",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 23
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 20,
     "special_abilities": [
@@ -4053,7 +4145,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 20",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 20
+    },
     "languages": "Common, Sphinx",
     "challenge_rating": 17,
     "special_abilities": [
@@ -4215,7 +4310,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 6
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -4275,7 +4373,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 2,
     "actions": [
@@ -4353,7 +4455,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "actions": [
@@ -4424,7 +4528,9 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "any six languages",
     "challenge_rating": 12,
     "special_abilities": [
@@ -4487,7 +4593,9 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Thieves' cant plus any two languages",
     "challenge_rating": 8,
     "special_abilities": [
@@ -4601,7 +4709,9 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "one language known by its creator",
     "challenge_rating": 0,
     "special_abilities": [
@@ -4657,7 +4767,9 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "one language known by its creator",
     "challenge_rating": 2,
     "special_abilities": [
@@ -4708,7 +4820,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -4762,7 +4876,9 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "Ignan",
     "challenge_rating": 2,
     "special_abilities": [
@@ -4850,7 +4966,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -4902,7 +5020,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -4970,7 +5091,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 13",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 19,
     "special_abilities": [
@@ -5104,7 +5228,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
     "actions": [
@@ -5169,7 +5295,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any two languages",
     "challenge_rating": 2,
     "actions": [
@@ -5257,7 +5385,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 18",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 18
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 5,
     "special_abilities": [
@@ -5361,7 +5492,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 3,
     "special_abilities": [
@@ -5429,7 +5563,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., passive Perception 11",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -5498,7 +5635,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 3,
     "special_abilities": [
@@ -5581,7 +5721,10 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 90 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "90 ft.",
+      "passive_perception": 16
+    },
     "languages": "Draconic",
     "challenge_rating": 11,
     "actions": [
@@ -5690,7 +5833,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 2,
     "special_abilities": [
@@ -5742,7 +5887,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -5822,7 +5969,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 2,
     "special_abilities": [
@@ -5934,7 +6085,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 4,
     "special_abilities": [
@@ -6019,7 +6173,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "Blink Dog, understands Sylvan but can't speak it",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -6076,7 +6232,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -6141,7 +6299,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 3,
     "actions": [
@@ -6216,7 +6378,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 9",
+    "senses": {
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -6298,7 +6462,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 9
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 12,
     "special_abilities": [
@@ -6390,7 +6557,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 1,
     "actions": [
@@ -6483,7 +6654,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 2,
     "special_abilities": [
@@ -6574,7 +6749,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -6646,7 +6823,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Common, Goblin",
     "challenge_rating": 1,
     "special_abilities": [
@@ -6718,7 +6898,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 16
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -6773,7 +6957,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 9",
+    "senses": {
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "actions": [
@@ -6820,7 +7006,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -6897,7 +7086,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -6950,7 +7141,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -7023,7 +7217,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Elvish, Sylvan",
     "challenge_rating": 2,
     "special_abilities": [
@@ -7132,7 +7328,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 8,
     "special_abilities": [
@@ -7211,7 +7410,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 18",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 18
+    },
     "languages": "understands Draconic but can't speak",
     "challenge_rating": 6,
     "actions": [
@@ -7321,7 +7523,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "understands Deep Speech but can't speak",
     "challenge_rating": 4,
     "special_abilities": [
@@ -7422,7 +7627,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 9,
     "special_abilities": [
@@ -7499,7 +7707,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "Deep Speech, Undercommon",
     "challenge_rating": 8,
     "special_abilities": [
@@ -7598,7 +7809,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 17",
+    "senses": {
+      "passive_perception": 17
+    },
     "languages": "Common, Giant",
     "challenge_rating": 9,
     "special_abilities": [
@@ -7673,7 +7886,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "actions": [
@@ -7718,7 +7934,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0,
     "actions": [
@@ -7764,7 +7982,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -7834,7 +8055,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 1,
     "actions": [
@@ -7926,7 +8151,10 @@
       "bludgeoning, piercing, and slashing from nonmagical weapons"
     ],
     "condition_immunities": [],
-    "senses": "truesight 120 ft., passive Perception 15",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 15
+    },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 4,
     "special_abilities": [
@@ -8006,7 +8234,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., passive Perception 9",
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -8059,7 +8290,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -8113,7 +8346,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 2,
     "special_abilities": [
@@ -8174,7 +8409,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -8227,7 +8464,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -8288,7 +8528,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -8346,7 +8589,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "Gnomish, Terran, Undercommon",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -8420,7 +8666,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0,
     "actions": [
@@ -8486,7 +8734,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 19",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 19
+    },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 10,
     "special_abilities": [
@@ -8567,7 +8818,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -8629,7 +8882,10 @@
       "thunder"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "Auran",
     "challenge_rating": 11,
     "special_abilities": [
@@ -8733,7 +8989,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/2"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "Common",
     "challenge_rating": 3,
     "special_abilities": [
@@ -8800,7 +9059,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -8851,7 +9112,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Aquan, Draconic",
     "challenge_rating": 17,
     "special_abilities": [
@@ -8969,7 +9233,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "Abyssal, telepathy 60 ft. (works only with creatures that understand Abyssal)",
     "challenge_rating": 0.25,
     "actions": [
@@ -9048,7 +9315,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
     "languages": "Elvish, Undercommon",
     "challenge_rating": 6,
     "special_abilities": [
@@ -9181,7 +9451,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "Elvish, Undercommon",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -9258,7 +9531,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "Druidic plus any two languages",
     "challenge_rating": 2,
     "special_abilities": [
@@ -9325,7 +9600,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Elvish, Sylvan",
     "challenge_rating": 1,
     "special_abilities": [
@@ -9402,7 +9680,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "Dwarvish, Undercommon",
     "challenge_rating": 1,
     "special_abilities": [
@@ -9492,7 +9773,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Auran, Terran",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -9573,7 +9857,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -9652,7 +9938,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Terran",
     "challenge_rating": 5,
     "special_abilities": [
@@ -9717,7 +10007,10 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "Ignan",
     "challenge_rating": 11,
     "special_abilities": [
@@ -9803,7 +10096,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 4,
     "special_abilities": [
@@ -9869,7 +10164,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -9951,7 +10248,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 12",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 12,
     "special_abilities": [
@@ -10069,7 +10369,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -10176,7 +10479,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Giant, Orc",
     "challenge_rating": 4,
     "special_abilities": [
@@ -10288,7 +10594,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Ignan",
     "challenge_rating": 5,
     "special_abilities": [
@@ -10368,7 +10677,9 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 16",
+    "senses": {
+      "passive_perception": 16
+    },
     "languages": "Giant",
     "challenge_rating": 9,
     "actions": [
@@ -10461,7 +10772,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 5,
     "special_abilities": [
@@ -10538,7 +10852,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 11",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -10632,7 +10949,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 7",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 7
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -10690,7 +11010,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -10735,7 +11058,9 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Giant",
     "challenge_rating": 8,
     "actions": [
@@ -10817,7 +11142,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Terran",
     "challenge_rating": 2,
     "special_abilities": [
@@ -10912,7 +11240,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -10996,7 +11327,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Common",
     "challenge_rating": 2,
     "special_abilities": [
@@ -11123,7 +11457,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/12"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "any languages it knew in life",
     "challenge_rating": 4,
     "special_abilities": [
@@ -11211,7 +11548,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Common",
     "challenge_rating": 1,
     "actions": [
@@ -11274,7 +11614,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 7,
     "actions": [
@@ -11339,7 +11681,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -11410,7 +11755,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., passive Perception 11",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -11465,7 +11813,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 8",
+    "senses": {
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -11521,7 +11871,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -11568,7 +11921,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 12",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 2,
     "actions": [
@@ -11630,7 +11986,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., passive Perception 9",
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -11683,7 +12042,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -11755,7 +12116,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "Giant Eagle, understands Common and Auran but can't speak",
     "challenge_rating": 1,
     "special_abilities": [
@@ -11826,7 +12189,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "Giant Elk, understands Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 2,
     "special_abilities": [
@@ -11892,7 +12257,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -11946,7 +12314,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -12005,7 +12376,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -12061,7 +12434,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -12113,7 +12488,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -12171,7 +12549,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -12237,7 +12618,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
     "languages": "Giant Owl, understands Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -12294,7 +12678,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 12",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -12339,7 +12726,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -12394,7 +12784,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "actions": [
@@ -12439,7 +12832,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., passive Perception 9",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 3,
     "actions": [
@@ -12504,7 +12900,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -12560,7 +12958,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 60 ft., passive Perception 13",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -12617,7 +13018,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -12682,7 +13087,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -12751,7 +13159,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "understands Common but can't speak",
     "challenge_rating": 1,
     "special_abilities": [
@@ -12827,7 +13237,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "actions": [
@@ -12874,7 +13286,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -12928,7 +13343,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -12993,7 +13412,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -13088,7 +13510,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 13",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 9,
     "special_abilities": [
@@ -13171,7 +13596,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 5,
     "special_abilities": [
@@ -13266,7 +13693,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Gnoll",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -13361,7 +13791,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -13417,7 +13849,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "Common, Goblin",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -13493,7 +13928,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 3,
     "special_abilities": [
@@ -13588,7 +14027,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/9"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -13697,7 +14139,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -13779,7 +14224,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 2,
     "special_abilities": [
@@ -13864,7 +14313,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Common, Draconic, Sylvan",
     "challenge_rating": 3,
     "special_abilities": [
@@ -13946,7 +14398,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -14018,7 +14473,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -14096,7 +14554,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/1"
       }
     ],
-    "senses": "blindsight 30 ft. or 10 ft. while deafened (blind beyond this radius), passive Perception 13",
+    "senses": {
+      "blindsight": "30 ft. or 10 ft. while deafened (blind beyond this radius)",
+      "passive_perception": 13
+    },
     "languages": "Undercommon",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -14164,7 +14625,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
     "actions": [
@@ -14239,7 +14702,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Celestial, Common",
     "challenge_rating": 10,
     "special_abilities": [
@@ -14317,7 +14783,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 18",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 18
+    },
     "languages": "Common, Sphinx",
     "challenge_rating": 11,
     "special_abilities": [
@@ -14396,7 +14865,11 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 5,
     "actions": [
@@ -14512,7 +14985,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "Common",
     "challenge_rating": 1,
     "actions": [
@@ -14582,7 +15057,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -14636,7 +15113,10 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
     "languages": "understands Infernal but can't speak it",
     "challenge_rating": 3,
     "special_abilities": [
@@ -14736,7 +15216,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 8,
     "special_abilities": [
@@ -14823,7 +15306,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "Giant",
     "challenge_rating": 5,
     "actions": [
@@ -14889,7 +15374,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 15",
+    "senses": {
+      "passive_perception": 15
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -14959,7 +15446,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Common, Goblin",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -15051,7 +15541,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 0,
     "special_abilities": [
@@ -15118,7 +15611,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 11,
     "special_abilities": [
@@ -15208,7 +15704,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -15265,7 +15764,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 16
+    },
     "languages": "",
     "challenge_rating": 8,
     "special_abilities": [
@@ -15333,7 +15835,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -15398,7 +15902,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft., darkvision 120 ft., passive Perception 12",
+    "senses": {
+      "blindsight": "60 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 14,
     "special_abilities": [
@@ -15529,7 +16037,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Aquan, Auran",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -15656,7 +16167,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Infernal, Common",
     "challenge_rating": 1,
     "special_abilities": [
@@ -15762,7 +16276,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 18",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 18
+    },
     "languages": "Auran, understands Common but doesn't speak it",
     "challenge_rating": 6,
     "special_abilities": [
@@ -15851,7 +16368,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 16,
     "special_abilities": [
@@ -15956,7 +16476,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -16012,7 +16534,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 120 ft., passive Perception 13",
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 3,
     "special_abilities": [
@@ -16073,7 +16598,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 3,
     "special_abilities": [
@@ -16153,7 +16680,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -16241,7 +16771,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/8"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 14",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 14
+    },
     "languages": "understands Abyssal, Celestial, Infernal, and Primordial but can't speak, telepathy 120 ft.",
     "challenge_rating": 23,
     "special_abilities": [
@@ -16365,7 +16898,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Abyssal, Common",
     "challenge_rating": 4,
     "special_abilities": [
@@ -16457,7 +16993,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands infernal but can't speak",
     "challenge_rating": 0,
     "special_abilities": [
@@ -16547,7 +17086,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 19",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 19
+    },
     "languages": "Common plus up to five other languages",
     "challenge_rating": 21,
     "special_abilities": [
@@ -16656,7 +17198,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -16735,7 +17279,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0,
     "actions": [
@@ -16784,7 +17331,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Draconic",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -16888,7 +17437,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "any four languages",
     "challenge_rating": 6,
     "special_abilities": [
@@ -16951,7 +17502,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Ignan, Terran",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -17066,7 +17620,10 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Ignan",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -17139,7 +17696,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 6,
     "special_abilities": [
@@ -17206,7 +17765,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 3,
     "special_abilities": [
@@ -17307,7 +17869,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 13",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 16,
     "special_abilities": [
@@ -17400,7 +17965,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -17455,7 +18022,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Common",
     "challenge_rating": 6,
     "special_abilities": [
@@ -17566,7 +18136,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "Aquan, Common",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -17632,7 +18204,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Abyssal, Aquan",
     "challenge_rating": 2,
     "special_abilities": [
@@ -17725,7 +18300,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -17812,7 +18390,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 17",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 17
+    },
     "languages": "Abyssal",
     "challenge_rating": 3,
     "special_abilities": [
@@ -17899,7 +18480,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "understands Abyssal but can't speak",
     "challenge_rating": 2,
     "special_abilities": [
@@ -17965,7 +18549,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -18049,7 +18635,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 3,
     "actions": [
@@ -18151,7 +18740,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 15,
     "special_abilities": [
@@ -18289,7 +18881,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 11",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 13,
     "special_abilities": [
@@ -18392,7 +18987,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/2"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
     "languages": "Abyssal, Common, Infernal, Primordial",
     "challenge_rating": 5,
     "special_abilities": [
@@ -18478,7 +19076,9 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "understands Abyssal, Common, and Infernal but can't speak",
     "challenge_rating": 3,
     "special_abilities": [
@@ -18548,7 +19148,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "any two languages",
     "challenge_rating": 0.125,
     "actions": [
@@ -18630,7 +19232,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/11"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 8",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -18702,7 +19307,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -18766,7 +19374,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "Common, Giant",
     "challenge_rating": 2,
     "actions": [
@@ -18834,7 +19445,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "understands Common and Giant but can't speak",
     "challenge_rating": 2,
     "special_abilities": [
@@ -18893,7 +19507,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Common, Giant",
     "challenge_rating": 7,
     "special_abilities": [
@@ -18976,7 +19593,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Common, Orc",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -19043,7 +19663,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Otyugh",
     "challenge_rating": 5,
     "special_abilities": [
@@ -19136,7 +19759,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -19192,7 +19818,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 3,
     "special_abilities": [
@@ -19265,7 +19894,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -19340,7 +19971,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 16",
+    "senses": {
+      "passive_perception": 16
+    },
     "languages": "understands Celestial, Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 2,
     "actions": [
@@ -19387,7 +20020,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 3,
     "special_abilities": [
@@ -19461,7 +20097,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 14",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 14
+    },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 20,
     "special_abilities": [
@@ -19602,7 +20241,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 21",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 21
+    },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 16,
     "special_abilities": [
@@ -19684,7 +20326,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -19736,7 +20380,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "actions": [
@@ -19783,7 +20430,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -19853,7 +20502,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "actions": [
@@ -19901,7 +20552,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "any two languages",
     "challenge_rating": 2,
     "special_abilities": [
@@ -19959,7 +20612,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "understands Common and Draconic but can't speak",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -20040,7 +20697,11 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., tremorsense 60 ft., passive Perception 9",
+    "senses": {
+      "blindsight": "30 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 15,
     "special_abilities": [
@@ -20123,7 +20784,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "Abyssal, Common",
     "challenge_rating": 1,
     "special_abilities": [
@@ -20198,7 +20862,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -20259,7 +20926,10 @@
       "bludgeoning, piercing, and slashing from nonmagical weapons"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "Common, Infernal",
     "challenge_rating": 13,
     "special_abilities": [
@@ -20318,7 +20988,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -20371,7 +21044,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -20432,7 +21107,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 4,
     "actions": [
@@ -20508,7 +21187,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., passive Perception 12",
+    "senses": {
+      "blindsight": "30 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -20567,7 +21249,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 11,
     "special_abilities": [
@@ -20640,7 +21326,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -20691,7 +21379,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "actions": [
@@ -20742,7 +21432,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 11,
     "special_abilities": [
@@ -20815,7 +21507,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 16
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -20919,7 +21614,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 6",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 6
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -20968,7 +21666,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -21029,7 +21730,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -21101,7 +21804,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 15
+    },
     "languages": "Sahuagin",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -21214,7 +21920,10 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Ignan",
     "challenge_rating": 5,
     "special_abilities": [
@@ -21331,7 +22040,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "Common, Elvish, Sylvan",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -21416,7 +22127,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., passive Perception 9",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0,
     "actions": [
@@ -21465,7 +22179,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 15",
+    "senses": {
+      "passive_perception": 15
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -21536,7 +22252,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "Aquan, Common, Giant",
     "challenge_rating": 2,
     "special_abilities": [
@@ -21619,7 +22338,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -21699,7 +22420,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/12"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -21778,7 +22502,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/15"
       }
     ],
-    "senses": "blindsight 60 ft. (blind beyond this radius), passive Perception 10",
+    "senses": {
+      "blindsight": "60 ft. (blind beyond this radius)",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -21860,7 +22587,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands commands given in any language but can't speak",
     "challenge_rating": 7,
     "special_abilities": [
@@ -21942,7 +22673,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "blindsight 30 ft. (blind beyond this radius), passive Perception 6",
+    "senses": {
+      "blindsight": "30 ft. (blind beyond this radius)",
+      "passive_perception": 6
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -21991,7 +22725,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 2,
     "actions": [
@@ -22081,7 +22819,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "understands all languages it spoke in life but can't speak",
     "challenge_rating": 0.25,
     "actions": [
@@ -22169,7 +22910,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "truesight 120 ft., passive Perception 24",
+    "senses": {
+      "truesight": "120 ft.",
+      "passive_perception": 24
+    },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 21,
     "special_abilities": [
@@ -22372,7 +23116,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands all languages it knew in life but can't speak",
     "challenge_rating": 1,
     "special_abilities": [
@@ -22429,7 +23176,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 30 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 12
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -22503,7 +23253,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Abyssal, Common",
     "challenge_rating": 8,
     "special_abilities": [
@@ -22561,7 +23314,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Common, Elvish, Sylvan",
     "challenge_rating": 0.25,
     "actions": [
@@ -22643,7 +23398,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 16",
+    "senses": {
+      "passive_perception": 16
+    },
     "languages": "any two languages",
     "challenge_rating": 1,
     "special_abilities": [
@@ -22726,7 +23483,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Aquan, Ignan",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -22834,7 +23594,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0.125,
     "actions": [
@@ -22884,7 +23647,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Giant",
     "challenge_rating": 7,
     "special_abilities": [
@@ -22989,7 +23755,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 10,
     "special_abilities": [
@@ -23078,7 +23847,9 @@
       "thunder"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 19",
+    "senses": {
+      "passive_perception": 19
+    },
     "languages": "Common, Giant",
     "challenge_rating": 13,
     "special_abilities": [
@@ -23186,7 +23957,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
     "languages": "Abyssal, Common, Infernal, telepathy 60 ft.",
     "challenge_rating": 4,
     "special_abilities": [
@@ -23310,7 +24084,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 60 ft., passive Perception 11",
+    "senses": {
+      "blindsight": "60 ft.",
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -23408,7 +24185,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -23497,7 +24277,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -23586,7 +24369,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -23675,7 +24461,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 2,
     "special_abilities": [
@@ -23764,7 +24553,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -23860,7 +24652,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "darkvision 30 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "30 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -23953,7 +24748,9 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "passive Perception 15",
+    "senses": {
+      "passive_perception": 15
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -24038,7 +24835,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -24139,7 +24939,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/13"
       }
     ],
-    "senses": "blindsight 10 ft., passive Perception 8",
+    "senses": {
+      "blindsight": "10 ft.",
+      "passive_perception": 8
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -24214,7 +25017,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 120 ft., passive Perception 10",
+    "senses": {
+      "blindsight": "120 ft.",
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 30,
     "special_abilities": [
@@ -24357,7 +25163,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -24429,7 +25237,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 1,
     "special_abilities": [
@@ -24504,7 +25315,9 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "Common, Druidic, Elvish, Sylvan",
     "challenge_rating": 9,
     "special_abilities": [
@@ -24582,7 +25395,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "any one language",
     "challenge_rating": 0.125,
     "special_abilities": [
@@ -24647,7 +25462,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 10",
+    "senses": {
+      "passive_perception": 10
+    },
     "languages": "",
     "challenge_rating": 5,
     "special_abilities": [
@@ -24714,7 +25531,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "Giant",
     "challenge_rating": 5,
     "special_abilities": [
@@ -24793,7 +25613,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 8,
     "actions": [
@@ -24872,7 +25694,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "Celestial, Elvish, Sylvan, telepathy 60 ft.",
     "challenge_rating": 5,
     "special_abilities": [
@@ -24984,7 +25809,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 120 ft., passive Perception 17",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 13,
     "special_abilities": [
@@ -25122,7 +25950,10 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 5,
     "special_abilities": [
@@ -25210,7 +26041,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "any one language (usually Common)",
     "challenge_rating": 3,
     "actions": [
@@ -25316,7 +26149,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/4"
       }
     ],
-    "senses": "blindsight 30 ft. (blind beyond this radius), passive Perception 6",
+    "senses": {
+      "blindsight": "30 ft. (blind beyond this radius)",
+      "passive_perception": 6
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -25387,7 +26223,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 11",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 11
+    },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 6,
     "special_abilities": [
@@ -25487,7 +26326,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -25542,7 +26383,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 11",
+    "senses": {
+      "passive_perception": 11
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -25606,7 +26449,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 9",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 9
+    },
     "languages": "",
     "challenge_rating": 0.5,
     "actions": [
@@ -25690,7 +26536,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 10",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 10
+    },
     "languages": "Aquan",
     "challenge_rating": 5,
     "special_abilities": [
@@ -25773,7 +26622,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0,
     "special_abilities": [
@@ -25843,7 +26694,9 @@
       "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 17",
+    "senses": {
+      "passive_perception": 17
+    },
     "languages": "Common (can't speak in bear form)",
     "challenge_rating": 5,
     "special_abilities": [
@@ -25943,7 +26796,9 @@
       "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 12",
+    "senses": {
+      "passive_perception": 12
+    },
     "languages": "Common (can't speak in boar form)",
     "challenge_rating": 4,
     "special_abilities": [
@@ -26026,7 +26881,10 @@
       "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft. (rat form only), passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft. (rat form only)",
+      "passive_perception": 12
+    },
     "languages": "Common (can't speak in rat form)",
     "challenge_rating": 2,
     "special_abilities": [
@@ -26127,7 +26985,10 @@
       "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 15",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 15
+    },
     "languages": "Common (can't speak in tiger form)",
     "challenge_rating": 4,
     "special_abilities": [
@@ -26246,7 +27107,9 @@
       "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 14",
+    "senses": {
+      "passive_perception": 14
+    },
     "languages": "Common (can't speak in wolf form)",
     "challenge_rating": 3,
     "special_abilities": [
@@ -26360,7 +27223,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 10 ft., darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "blindsight": "10 ft.",
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Draconic",
     "challenge_rating": 2,
     "actions": [
@@ -26445,7 +27312,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 13",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 13
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 3,
     "special_abilities": [
@@ -26585,7 +27455,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/14"
       }
     ],
-    "senses": "darkvision 120 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 12
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 2,
     "special_abilities": [
@@ -26664,7 +27537,9 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "passive Perception 15",
+    "senses": {
+      "passive_perception": 15
+    },
     "languages": "Common, Giant, Winter Wolf",
     "challenge_rating": 3,
     "special_abilities": [
@@ -26747,7 +27622,9 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "passive Perception 13",
+    "senses": {
+      "passive_perception": 13
+    },
     "languages": "",
     "challenge_rating": 0.25,
     "special_abilities": [
@@ -26803,7 +27680,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "Goblin, Worg",
     "challenge_rating": 0.5,
     "special_abilities": [
@@ -26899,7 +27779,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/12"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 12",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 12
+    },
     "languages": "the languages it knew in life",
     "challenge_rating": 5,
     "special_abilities": [
@@ -26960,7 +27843,10 @@
     "damage_resistances": [],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., passive Perception 14",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 14
+    },
     "languages": "",
     "challenge_rating": 6,
     "actions": [
@@ -27044,7 +27930,11 @@
     ],
     "damage_immunities": [],
     "condition_immunities": [],
-    "senses": "darkvision 60 ft., tremorsense 60 ft., passive Perception 16",
+    "senses": {
+      "darkvision": "60 ft.",
+      "tremorsense": "60 ft.",
+      "passive_perception": 16
+    },
     "languages": "Terran",
     "challenge_rating": 5,
     "special_abilities": [
@@ -27132,7 +28022,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 7,
     "special_abilities": [
@@ -27242,7 +28136,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 19",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 19
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 9,
     "actions": [
@@ -27347,7 +28245,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 6,
     "actions": [
@@ -27461,7 +28363,11 @@
       "lightning"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 8,
     "special_abilities": [
@@ -27581,7 +28487,11 @@
       "acid"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 7,
     "actions": [
@@ -27695,7 +28605,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 19",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 19
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 10,
     "special_abilities": [
@@ -27819,7 +28733,11 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 17",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 8,
     "special_abilities": [
@@ -27929,7 +28847,11 @@
       "fire"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 18",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 18
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 10,
     "actions": [
@@ -28034,7 +28956,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 18",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 18
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 9,
     "actions": [
@@ -28147,7 +29073,11 @@
       "cold"
     ],
     "condition_immunities": [],
-    "senses": "blindsight 30 ft., darkvision 120 ft., passive Perception 16",
+    "senses": {
+      "blindsight": "30 ft.",
+      "darkvision": "120 ft.",
+      "passive_perception": 16
+    },
     "languages": "Common, Draconic",
     "challenge_rating": 6,
     "special_abilities": [
@@ -28253,7 +29183,10 @@
         "url": "http://www.dnd5eapi.co/api/conditions/10"
       }
     ],
-    "senses": "darkvision 60 ft., passive Perception 8",
+    "senses": {
+      "darkvision": "60 ft.",
+      "passive_perception": 8
+    },
     "languages": "understands all languages it spoke in life but can't speak",
     "challenge_rating": 0.25,
     "special_abilities": [


### PR DESCRIPTION
Changes the senses so that it's an object instead of a simple string.

A distinction was made between "blindsight", "darkvision", "truesight" and "tremorsight" and "passive_perception": the four first map to strings to indicate a distance, while the latter maps to a score.