### PR TITLE
Change monsters' proficiencies to a list of proficiencies

### DIFF
--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -19,11 +19,33 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 18,
-    "constitution_save": 6,
-    "intelligence_save": 8,
-    "wisdom_save": 6,
-    "history": 12,
-    "perception": 10,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 12
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 10
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -158,8 +180,18 @@
     "intelligence": 10,
     "wisdom": 14,
     "charisma": 11,
-    "medicine": 4,
-    "religion": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Medicine",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/114",
+        "value": 4
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -215,12 +247,38 @@
     "intelligence": 14,
     "wisdom": 13,
     "charisma": 17,
-    "dexterity_save": 7,
-    "constitution_save": 10,
-    "wisdom_save": 6,
-    "charisma_save": 8,
-    "perception": 11,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 11
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -389,7 +447,13 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 19,
-    "perception": 12,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 12
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "necrotic"
@@ -582,12 +646,38 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 19,
-    "dexterity_save": 5,
-    "constitution_save": 11,
-    "wisdom_save": 7,
-    "charisma_save": 9,
-    "perception": 12,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 12
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -752,14 +842,48 @@
     "intelligence": 14,
     "wisdom": 13,
     "charisma": 17,
-    "dexterity_save": 5,
-    "constitution_save": 10,
-    "wisdom_save": 6,
-    "charisma_save": 8,
-    "history": 7,
-    "perception": 11,
-    "persuasion": 8,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 7
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 11
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 8
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -903,13 +1027,43 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 19,
-    "dexterity_save": 5,
-    "constitution_save": 11,
-    "wisdom_save": 7,
-    "charisma_save": 9,
-    "insight": 7,
-    "perception": 12,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 7
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 12
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -1089,13 +1243,43 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 17,
-    "dexterity_save": 6,
-    "constitution_save": 10,
-    "wisdom_save": 7,
-    "charisma_save": 8,
-    "deception": 8,
-    "perception": 12,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 12
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -1271,14 +1455,48 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 24,
-    "dexterity_save": 8,
-    "constitution_save": 13,
-    "wisdom_save": 8,
-    "charisma_save": 13,
-    "insight": 8,
-    "perception": 14,
-    "persuasion": 13,
-    "stealth": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 13
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 13
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 14
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 13
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -1458,15 +1676,53 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 17,
-    "dexterity_save": 6,
-    "constitution_save": 10,
-    "wisdom_save": 7,
-    "charisma_save": 8,
-    "deception": 8,
-    "insight": 7,
-    "perception": 12,
-    "persuasion": 8,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 8
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 7
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 12
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 8
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -1640,12 +1896,38 @@
     "intelligence": 16,
     "wisdom": 13,
     "charisma": 21,
-    "dexterity_save": 6,
-    "constitution_save": 13,
-    "wisdom_save": 7,
-    "charisma_save": 11,
-    "perception": 13,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 13
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 11
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 13
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -1858,14 +2140,48 @@
     "intelligence": 16,
     "wisdom": 13,
     "charisma": 21,
-    "dexterity_save": 5,
-    "constitution_save": 12,
-    "wisdom_save": 6,
-    "charisma_save": 10,
-    "arcana": 8,
-    "history": 8,
-    "perception": 11,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 12
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 10
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 8
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 11
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -2042,12 +2358,38 @@
     "intelligence": 8,
     "wisdom": 12,
     "charisma": 12,
-    "dexterity_save": 5,
-    "constitution_save": 11,
-    "wisdom_save": 6,
-    "charisma_save": 6,
-    "perception": 11,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 6
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 11
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -2215,6 +2557,7 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "lightning",
@@ -2318,12 +2661,38 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 19,
-    "dexterity_save": 9,
-    "constitution_save": 14,
-    "wisdom_save": 9,
-    "charisma_save": 11,
-    "perception": 16,
-    "stealth": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 11
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 16
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -2492,12 +2861,38 @@
     "intelligence": 18,
     "wisdom": 17,
     "charisma": 21,
-    "dexterity_save": 7,
-    "constitution_save": 15,
-    "wisdom_save": 10,
-    "charisma_save": 12,
-    "perception": 17,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 15
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 12
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 17
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -2647,14 +3042,48 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 19,
-    "dexterity_save": 6,
-    "constitution_save": 13,
-    "wisdom_save": 8,
-    "charisma_save": 10,
-    "history": 9,
-    "perception": 14,
-    "persuasion": 10,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 13
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 10
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 14
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 10
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -2834,13 +3263,43 @@
     "intelligence": 18,
     "wisdom": 17,
     "charisma": 21,
-    "dexterity_save": 7,
-    "constitution_save": 15,
-    "wisdom_save": 10,
-    "charisma_save": 12,
-    "insight": 10,
-    "perception": 17,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 15
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 12
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 10
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 17
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3024,13 +3483,43 @@
     "intelligence": 20,
     "wisdom": 17,
     "charisma": 19,
-    "dexterity_save": 8,
-    "constitution_save": 14,
-    "wisdom_save": 10,
-    "charisma_save": 11,
-    "deception": 11,
-    "perception": 17,
-    "stealth": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 11
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 11
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 17
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3210,14 +3699,48 @@
     "intelligence": 18,
     "wisdom": 17,
     "charisma": 28,
-    "dexterity_save": 9,
-    "constitution_save": 16,
-    "wisdom_save": 10,
-    "charisma_save": 16,
-    "insight": 10,
-    "perception": 17,
-    "persuasion": 16,
-    "stealth": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 16
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 16
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 10
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 17
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 16
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3401,15 +3924,53 @@
     "intelligence": 20,
     "wisdom": 17,
     "charisma": 19,
-    "dexterity_save": 8,
-    "constitution_save": 14,
-    "wisdom_save": 10,
-    "charisma_save": 11,
-    "deception": 11,
-    "insight": 10,
-    "perception": 17,
-    "persuasion": 11,
-    "stealth": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 11
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 11
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 10
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 17
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 11
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3586,12 +4147,38 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 23,
-    "dexterity_save": 7,
-    "constitution_save": 16,
-    "wisdom_save": 9,
-    "charisma_save": 13,
-    "perception": 16,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 16
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 13
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 16
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3758,14 +4345,48 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 23,
-    "dexterity_save": 7,
-    "constitution_save": 16,
-    "wisdom_save": 9,
-    "charisma_save": 13,
-    "arcana": 11,
-    "history": 11,
-    "perception": 16,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 16
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 13
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 11
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 11
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 16
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -3946,12 +4567,38 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 14,
-    "dexterity_save": 6,
-    "constitution_save": 14,
-    "wisdom_save": 7,
-    "charisma_save": 8,
-    "perception": 13,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 13
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -4122,13 +4769,43 @@
     "intelligence": 16,
     "wisdom": 18,
     "charisma": 23,
-    "dexterity_save": 6,
-    "constitution_save": 11,
-    "intelligence_save": 9,
-    "wisdom_save": 10,
-    "arcana": 9,
-    "perception": 10,
-    "religion": 15,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 10
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 15
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -4270,6 +4947,7 @@
     "intelligence": 1,
     "wisdom": 3,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -4369,6 +5047,7 @@
     "intelligence": 1,
     "wisdom": 13,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -4449,8 +5128,18 @@
     "intelligence": 6,
     "wisdom": 12,
     "charisma": 7,
-    "athletics": 5,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -4517,10 +5206,28 @@
     "intelligence": 20,
     "wisdom": 15,
     "charisma": 16,
-    "intelligence_save": 9,
-    "wisdom_save": 6,
-    "arcana": 13,
-    "history": 13,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 13
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 13
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "damage from spells",
@@ -4581,12 +5288,38 @@
     "intelligence": 13,
     "wisdom": 11,
     "charisma": 10,
-    "dexterity_save": 6,
-    "intelligence_save": 4,
-    "acrobatics": 6,
-    "deception": 3,
-    "perception": 3,
-    "stealth": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 4
+      },
+      {
+        "name": "Skill: Acrobatics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/105",
+        "value": 6
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "poison"
@@ -4701,6 +5434,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "fire"
     ],
@@ -4758,6 +5492,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "fire"
     ],
@@ -4816,6 +5551,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -4863,7 +5599,13 @@
     "intelligence": 12,
     "wisdom": 13,
     "charisma": 10,
-    "constitution_save": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -4962,6 +5704,7 @@
     "intelligence": 4,
     "wisdom": 12,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5016,6 +5759,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5071,10 +5815,28 @@
     "intelligence": 20,
     "wisdom": 16,
     "charisma": 22,
-    "strength_save": 14,
-    "constitution_save": 12,
-    "wisdom_save": 9,
-    "charisma_save": 12,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 12
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 12
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -5224,6 +5986,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 10,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5286,11 +6049,33 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 14,
-    "strength_save": 4,
-    "dexterity_save": 5,
-    "wisdom_save": 2,
-    "athletics": 4,
-    "deception": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 4
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5363,13 +6148,43 @@
     "intelligence": 12,
     "wisdom": 14,
     "charisma": 14,
-    "strength_save": 6,
-    "constitution_save": 7,
-    "wisdom_save": 5,
-    "charisma_save": 5,
-    "deception": 5,
-    "insight": 5,
-    "perception": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -5488,6 +6303,7 @@
     "intelligence": 2,
     "wisdom": 8,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5559,6 +6375,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 4,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5617,9 +6434,23 @@
     "intelligence": 9,
     "wisdom": 11,
     "charisma": 11,
-    "strength_save": 5,
-    "constitution_save": 4,
-    "wisdom_save": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -5713,8 +6544,18 @@
     "intelligence": 7,
     "wisdom": 14,
     "charisma": 12,
-    "perception": 6,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -5829,6 +6670,7 @@
     "intelligence": 9,
     "wisdom": 11,
     "charisma": 9,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5883,6 +6725,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -5957,12 +6800,38 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 13,
-    "dexterity_save": 4,
-    "constitution_save": 3,
-    "wisdom_save": 2,
-    "charisma_save": 3,
-    "perception": 4,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -6051,6 +6920,7 @@
     "intelligence": 1,
     "wisdom": 6,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -6167,8 +7037,18 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 11,
-    "perception": 3,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6227,7 +7107,13 @@
     "intelligence": 3,
     "wisdom": 14,
     "charisma": 5,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6287,12 +7173,38 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 2,
-    "constitution_save": 4,
-    "wisdom_save": 2,
-    "charisma_save": 4,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -6374,6 +7286,7 @@
     "intelligence": 2,
     "wisdom": 9,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6442,11 +7355,33 @@
     "intelligence": 13,
     "wisdom": 14,
     "charisma": 16,
-    "intelligence_save": 5,
-    "wisdom_save": 6,
-    "charisma_save": 7,
-    "deception": 7,
-    "insight": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 7
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -6545,12 +7480,38 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 13,
-    "dexterity_save": 2,
-    "constitution_save": 3,
-    "wisdom_save": 2,
-    "charisma_save": 3,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -6642,12 +7603,38 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 2,
-    "constitution_save": 4,
-    "wisdom_save": 2,
-    "charisma_save": 4,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -6744,7 +7731,13 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6817,8 +7810,18 @@
     "intelligence": 8,
     "wisdom": 11,
     "charisma": 9,
-    "stealth": 6,
-    "survival": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      },
+      {
+        "name": "Skill: Survival",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/122",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6893,7 +7896,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
-    "perception": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -6953,6 +7962,7 @@
     "intelligence": 2,
     "wisdom": 8,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7001,7 +8011,13 @@
     "intelligence": 1,
     "wisdom": 12,
     "charisma": 5,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7080,8 +8096,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7136,7 +8162,13 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7210,9 +8242,23 @@
     "intelligence": 9,
     "wisdom": 13,
     "charisma": 11,
-    "athletics": 6,
-    "perception": 3,
-    "survival": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 6
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Survival",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/122",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7310,9 +8356,23 @@
     "intelligence": 11,
     "wisdom": 12,
     "charisma": 14,
-    "constitution_save": 7,
-    "wisdom_save": 4,
-    "charisma_save": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -7405,7 +8465,13 @@
     "intelligence": 3,
     "wisdom": 14,
     "charisma": 10,
-    "perception": 8,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7511,7 +8577,13 @@
     "intelligence": 5,
     "wisdom": 11,
     "charisma": 5,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -7593,6 +8665,7 @@
     "intelligence": 3,
     "wisdom": 8,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -7702,7 +8775,13 @@
     "intelligence": 13,
     "wisdom": 12,
     "charisma": 14,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7800,11 +8879,33 @@
     "intelligence": 12,
     "wisdom": 16,
     "charisma": 16,
-    "constitution_save": 10,
-    "wisdom_save": 7,
-    "charisma_save": 7,
-    "insight": 7,
-    "perception": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 7
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7882,6 +8983,7 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7930,6 +9032,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 10,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -7978,6 +9081,7 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8043,12 +9147,38 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 13,
-    "dexterity_save": 3,
-    "constitution_save": 3,
-    "wisdom_save": 2,
-    "charisma_save": 3,
-    "perception": 4,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -8139,9 +9269,23 @@
     "intelligence": 18,
     "wisdom": 20,
     "charisma": 18,
-    "constitution_save": 5,
-    "wisdom_save": 7,
-    "charisma_save": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "radiant"
@@ -8229,7 +9373,13 @@
     "intelligence": 1,
     "wisdom": 8,
     "charisma": 2,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8285,7 +9435,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8339,9 +9495,23 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 14,
-    "deception": 4,
-    "persuasion": 4,
-    "religion": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 4
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 4
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8403,8 +9573,18 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 10,
-    "deception": 2,
-    "religion": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 2
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8459,7 +9639,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8522,8 +9708,18 @@
     "intelligence": 3,
     "wisdom": 13,
     "charisma": 6,
-    "perception": 5,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8582,9 +9778,23 @@
     "intelligence": 12,
     "wisdom": 10,
     "charisma": 9,
-    "investigation": 3,
-    "perception": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Investigation",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/113",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8662,6 +9872,7 @@
     "intelligence": 2,
     "wisdom": 14,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8710,10 +9921,28 @@
     "intelligence": 17,
     "wisdom": 20,
     "charisma": 20,
-    "wisdom_save": 9,
-    "charisma_save": 9,
-    "insight": 9,
-    "perception": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "radiant",
@@ -8812,8 +10041,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -8872,9 +10111,23 @@
     "intelligence": 15,
     "wisdom": 16,
     "charisma": 20,
-    "dexterity_save": 6,
-    "wisdom_save": 7,
-    "charisma_save": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -8978,8 +10231,18 @@
     "intelligence": 11,
     "wisdom": 12,
     "charisma": 14,
-    "deception": 6,
-    "insight": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 6
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9055,6 +10318,7 @@
     "intelligence": 2,
     "wisdom": 11,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9103,9 +10367,23 @@
     "intelligence": 10,
     "wisdom": 12,
     "charisma": 12,
-    "dexterity_save": 6,
-    "constitution_save": 11,
-    "wisdom_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "fire"
@@ -9218,6 +10496,7 @@
     "intelligence": 5,
     "wisdom": 8,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -9309,8 +10588,18 @@
     "intelligence": 13,
     "wisdom": 14,
     "charisma": 12,
-    "perception": 5,
-    "stealth": 9,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9445,8 +10734,18 @@
     "intelligence": 11,
     "wisdom": 11,
     "charisma": 12,
-    "perception": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9524,9 +10823,23 @@
     "intelligence": 12,
     "wisdom": 15,
     "charisma": 11,
-    "medicine": 4,
-    "nature": 3,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Medicine",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/114",
+        "value": 4
+      },
+      {
+        "name": "Skill: Nature",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/115",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9594,8 +10907,18 @@
     "intelligence": 14,
     "wisdom": 15,
     "charisma": 18,
-    "perception": 4,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9674,6 +10997,7 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 9,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "poison"
@@ -9758,8 +11082,18 @@
     "intelligence": 9,
     "wisdom": 11,
     "charisma": 10,
-    "perception": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [
       "fire"
     ],
@@ -9852,7 +11186,13 @@
     "intelligence": 2,
     "wisdom": 14,
     "charisma": 7,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -9907,6 +11247,7 @@
     "intelligence": 5,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "thunder"
     ],
@@ -9998,9 +11339,23 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 16,
-    "intelligence_save": 7,
-    "wisdom_save": 6,
-    "charisma_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -10092,6 +11447,7 @@
     "intelligence": 3,
     "wisdom": 11,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -10160,6 +11516,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -10229,10 +11586,28 @@
     "intelligence": 14,
     "wisdom": 14,
     "charisma": 18,
-    "dexterity_save": 7,
-    "constitution_save": 8,
-    "wisdom_save": 6,
-    "charisma_save": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -10362,9 +11737,23 @@
     "intelligence": 7,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 3,
-    "stealth": 4,
-    "survival": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      },
+      {
+        "name": "Skill: Survival",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/122",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -10474,7 +11863,13 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 8,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -10552,6 +11947,7 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons"
@@ -10666,11 +12062,33 @@
     "intelligence": 10,
     "wisdom": 14,
     "charisma": 13,
-    "dexterity_save": 3,
-    "constitution_save": 10,
-    "charisma_save": 5,
-    "athletics": 11,
-    "perception": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 11
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -10739,6 +12157,7 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -10848,6 +12267,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -10912,7 +12332,13 @@
     "intelligence": 1,
     "wisdom": 5,
     "charisma": 1,
-    "dexterity_save": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -11004,8 +12430,18 @@
     "intelligence": 1,
     "wisdom": 8,
     "charisma": 3,
-    "perception": 1,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 1
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11047,11 +12483,33 @@
     "intelligence": 9,
     "wisdom": 10,
     "charisma": 12,
-    "constitution_save": 8,
-    "wisdom_save": 3,
-    "charisma_save": 4,
-    "athletics": 9,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -11121,6 +12579,7 @@
     "intelligence": 6,
     "wisdom": 11,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons that aren't adamantine"
@@ -11211,6 +12670,7 @@
     "intelligence": 1,
     "wisdom": 6,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11316,6 +12776,7 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 8,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -11406,6 +12867,7 @@
     "intelligence": 10,
     "wisdom": 12,
     "charisma": 17,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -11539,6 +13001,7 @@
     "intelligence": 7,
     "wisdom": 10,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11608,8 +13071,18 @@
     "intelligence": 7,
     "wisdom": 12,
     "charisma": 7,
-    "athletics": 9,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11677,6 +13150,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11751,6 +13225,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11809,6 +13284,7 @@
     "intelligence": 2,
     "wisdom": 7,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11867,6 +13343,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11916,7 +13393,13 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 3,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -11981,7 +13464,13 @@
     "intelligence": 1,
     "wisdom": 9,
     "charisma": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12037,7 +13526,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 7,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12111,7 +13606,13 @@
     "intelligence": 8,
     "wisdom": 14,
     "charisma": 10,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12184,7 +13685,13 @@
     "intelligence": 7,
     "wisdom": 14,
     "charisma": 10,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12253,6 +13760,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12308,8 +13816,18 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 3,
-    "perception": 2,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12372,6 +13890,7 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12429,7 +13948,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12484,6 +14009,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12543,8 +14069,18 @@
     "intelligence": 4,
     "wisdom": 10,
     "charisma": 4,
-    "perception": 4,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12612,8 +14148,18 @@
     "intelligence": 8,
     "wisdom": 13,
     "charisma": 10,
-    "perception": 5,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12673,7 +14219,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 3,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12722,6 +14274,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 4,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12780,6 +14333,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 4,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12828,6 +14382,7 @@
     "intelligence": 1,
     "wisdom": 9,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12896,6 +14451,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -12953,7 +14509,13 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 5,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13013,7 +14575,13 @@
     "intelligence": 2,
     "wisdom": 11,
     "charisma": 4,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13083,6 +14651,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13154,7 +14723,13 @@
     "intelligence": 6,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13233,6 +14808,7 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13280,8 +14856,18 @@
     "intelligence": 4,
     "wisdom": 12,
     "charisma": 5,
-    "perception": 3,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13337,8 +14923,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 4,
-    "perception": 3,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13403,6 +14999,7 @@
     "intelligence": 3,
     "wisdom": 10,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13490,10 +15087,28 @@
     "intelligence": 19,
     "wisdom": 17,
     "charisma": 16,
-    "strength_save": 9,
-    "constitution_save": 9,
-    "wisdom_save": 7,
-    "charisma_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -13587,11 +15202,33 @@
     "intelligence": 10,
     "wisdom": 12,
     "charisma": 15,
-    "strength_save": 7,
-    "dexterity_save": 5,
-    "constitution_save": 6,
-    "athletics": 10,
-    "intimidation": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 10
+      },
+      {
+        "name": "Skill: Intimidation",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/112",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13689,6 +15326,7 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13787,6 +15425,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13844,7 +15483,13 @@
     "intelligence": 10,
     "wisdom": 8,
     "charisma": 8,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -13916,12 +15561,38 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 16,
-    "dexterity_save": 4,
-    "constitution_save": 5,
-    "wisdom_save": 2,
-    "charisma_save": 5,
-    "perception": 4,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -14017,7 +15688,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -14105,7 +15782,13 @@
     "intelligence": 1,
     "wisdom": 6,
     "charisma": 2,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -14207,12 +15890,38 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 13,
-    "dexterity_save": 3,
-    "constitution_save": 3,
-    "wisdom_save": 2,
-    "charisma_save": 3,
-    "perception": 4,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -14305,10 +16014,28 @@
     "intelligence": 13,
     "wisdom": 14,
     "charisma": 14,
-    "arcana": 3,
-    "deception": 4,
-    "perception": 4,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 3
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -14392,6 +16119,7 @@
     "intelligence": 3,
     "wisdom": 14,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing damage from nonmagical weapons"
@@ -14468,7 +16196,13 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 8,
-    "perception": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -14542,9 +16276,23 @@
     "intelligence": 9,
     "wisdom": 8,
     "charisma": 6,
-    "athletics": 5,
-    "perception": 3,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -14620,7 +16368,13 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 10,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -14682,11 +16436,33 @@
     "intelligence": 16,
     "wisdom": 19,
     "charisma": 18,
-    "dexterity_save": 8,
-    "constitution_save": 7,
-    "intelligence_save": 7,
-    "wisdom_save": 8,
-    "charisma_save": 8,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -14762,10 +16538,28 @@
     "intelligence": 18,
     "wisdom": 18,
     "charisma": 18,
-    "arcana": 12,
-    "history": 12,
-    "perception": 8,
-    "religion": 8,
+    "proficiencies": [
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 12
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 12
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons"
@@ -14859,6 +16653,7 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 10,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "fire"
@@ -14981,6 +16776,7 @@
     "intelligence": 7,
     "wisdom": 10,
     "charisma": 13,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15052,7 +16848,13 @@
     "intelligence": 2,
     "wisdom": 14,
     "charisma": 6,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15106,7 +16908,13 @@
     "intelligence": 6,
     "wisdom": 13,
     "charisma": 6,
-    "perception": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -15197,9 +17005,23 @@
     "intelligence": 5,
     "wisdom": 12,
     "charisma": 13,
-    "strength_save": 7,
-    "constitution_save": 8,
-    "wisdom_save": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -15301,7 +17123,13 @@
     "intelligence": 5,
     "wisdom": 9,
     "charisma": 6,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15369,7 +17197,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15442,6 +17276,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 9,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15526,6 +17361,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -15592,10 +17428,28 @@
     "intelligence": 12,
     "wisdom": 16,
     "charisma": 17,
-    "strength_save": 10,
-    "dexterity_save": 7,
-    "wisdom_save": 7,
-    "charisma_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -15699,7 +17553,13 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 4,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15759,7 +17619,13 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 7,
-    "perception": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15830,7 +17696,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -15884,10 +17756,28 @@
     "intelligence": 18,
     "wisdom": 15,
     "charisma": 18,
-    "dexterity_save": 7,
-    "constitution_save": 9,
-    "wisdom_save": 7,
-    "charisma_save": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
@@ -16020,8 +17910,18 @@
     "intelligence": 9,
     "wisdom": 11,
     "charisma": 12,
-    "perception": 2,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [
       "bludgeoning",
       "fire"
@@ -16148,10 +18048,28 @@
     "intelligence": 11,
     "wisdom": 12,
     "charisma": 14,
-    "deception": 4,
-    "insight": 3,
-    "persuasion": 4,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 4
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 3
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -16233,8 +18151,18 @@
     "intelligence": 10,
     "wisdom": 15,
     "charisma": 11,
-    "perception": 8,
-    "stealth": 10,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 10
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons"
@@ -16334,6 +18262,7 @@
     "intelligence": 3,
     "wisdom": 11,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -16471,7 +18400,13 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 6,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -16529,7 +18464,13 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -16592,8 +18533,18 @@
     "intelligence": 11,
     "wisdom": 11,
     "charisma": 15,
-    "constitution_save": 4,
-    "wisdom_save": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -16676,6 +18627,7 @@
     "intelligence": 8,
     "wisdom": 7,
     "charisma": 8,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -16750,11 +18702,33 @@
     "intelligence": 22,
     "wisdom": 18,
     "charisma": 20,
-    "strength_save": 17,
-    "dexterity_save": 7,
-    "constitution_save": 14,
-    "intelligence_save": 13,
-    "wisdom_save": 11,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 17
+      },
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 13
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 11
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -16891,9 +18865,23 @@
     "intelligence": 14,
     "wisdom": 15,
     "charisma": 16,
-    "deception": 7,
-    "insight": 4,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 7
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -16971,6 +18959,7 @@
     "intelligence": 1,
     "wisdom": 11,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold"
@@ -17047,13 +19036,43 @@
     "intelligence": 20,
     "wisdom": 14,
     "charisma": 16,
-    "constitution_save": 10,
-    "intelligence_save": 12,
-    "wisdom_save": 9,
-    "arcana": 18,
-    "history": 12,
-    "insight": 9,
-    "perception": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 12
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 18
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 12
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -17192,8 +19211,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 3,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17275,6 +19304,7 @@
     "intelligence": 1,
     "wisdom": 8,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17324,9 +19354,23 @@
     "intelligence": 7,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
-    "stealth": 4,
-    "survival": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      },
+      {
+        "name": "Skill: Survival",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/122",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17429,10 +19473,28 @@
     "intelligence": 17,
     "wisdom": 12,
     "charisma": 11,
-    "intelligence_save": 6,
-    "wisdom_save": 4,
-    "arcana": 6,
-    "history": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 6
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17487,7 +19549,13 @@
     "intelligence": 7,
     "wisdom": 10,
     "charisma": 10,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [
       "cold"
     ],
@@ -17612,6 +19680,7 @@
     "intelligence": 8,
     "wisdom": 11,
     "charisma": 10,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning, piercing, and slashing from nonmagical weapons"
@@ -17692,6 +19761,7 @@
     "intelligence": 3,
     "wisdom": 11,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17761,6 +19831,7 @@
     "intelligence": 7,
     "wisdom": 12,
     "charisma": 8,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -17849,10 +19920,28 @@
     "intelligence": 18,
     "wisdom": 16,
     "charisma": 20,
-    "strength_save": 9,
-    "constitution_save": 10,
-    "wisdom_save": 8,
-    "charisma_save": 10,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 10
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -17960,7 +20049,13 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18014,10 +20109,28 @@
     "intelligence": 12,
     "wisdom": 13,
     "charisma": 15,
-    "deception": 5,
-    "insight": 4,
-    "perception": 4,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18131,7 +20244,13 @@
     "intelligence": 11,
     "wisdom": 11,
     "charisma": 12,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18200,6 +20319,7 @@
     "intelligence": 8,
     "wisdom": 10,
     "charisma": 9,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18288,7 +20408,13 @@
     "intelligence": 5,
     "wisdom": 13,
     "charisma": 8,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -18385,7 +20511,13 @@
     "intelligence": 6,
     "wisdom": 16,
     "charisma": 9,
-    "perception": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18463,6 +20595,7 @@
     "intelligence": 6,
     "wisdom": 8,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "bludgeoning"
     ],
@@ -18545,6 +20678,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -18602,7 +20736,13 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 12,
-    "wisdom_save": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [
       "fire"
     ],
@@ -18703,12 +20843,38 @@
     "intelligence": 11,
     "wisdom": 18,
     "charisma": 16,
-    "constitution_save": 8,
-    "intelligence_save": 5,
-    "wisdom_save": 9,
-    "charisma_save": 8,
-    "history": 5,
-    "religion": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 5
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [
       "bludgeoning"
     ],
@@ -18861,10 +21027,28 @@
     "intelligence": 19,
     "wisdom": 12,
     "charisma": 15,
-    "constitution_save": 11,
-    "intelligence_save": 9,
-    "wisdom_save": 6,
-    "charisma_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -18970,10 +21154,28 @@
     "intelligence": 16,
     "wisdom": 14,
     "charisma": 16,
-    "deception": 7,
-    "insight": 6,
-    "perception": 6,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 7
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 6
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -19070,6 +21272,7 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 15,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -19141,9 +21344,23 @@
     "intelligence": 12,
     "wisdom": 14,
     "charisma": 16,
-    "deception": 5,
-    "insight": 4,
-    "persuasion": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 4
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19198,6 +21415,7 @@
     "intelligence": 2,
     "wisdom": 6,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid"
@@ -19301,8 +21519,18 @@
     "intelligence": 3,
     "wisdom": 10,
     "charisma": 4,
-    "perception": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19370,6 +21598,7 @@
     "intelligence": 5,
     "wisdom": 7,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19433,7 +21662,13 @@
     "intelligence": 3,
     "wisdom": 6,
     "charisma": 5,
-    "wisdom_save": 0,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 0
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -19496,13 +21731,43 @@
     "intelligence": 14,
     "wisdom": 12,
     "charisma": 15,
-    "dexterity_save": 3,
-    "constitution_save": 6,
-    "wisdom_save": 4,
-    "charisma_save": 5,
-    "arcana": 5,
-    "deception": 8,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 5
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19588,7 +21853,13 @@
     "intelligence": 7,
     "wisdom": 11,
     "charisma": 10,
-    "intimidation": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Intimidation",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/112",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19658,7 +21929,13 @@
     "intelligence": 6,
     "wisdom": 13,
     "charisma": 6,
-    "constitution_save": 7,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19753,8 +22030,18 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19813,7 +22100,13 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19888,8 +22181,18 @@
     "intelligence": 3,
     "wisdom": 14,
     "charisma": 7,
-    "perception": 4,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -19963,10 +22266,28 @@
     "intelligence": 10,
     "wisdom": 15,
     "charisma": 13,
-    "dexterity_save": 4,
-    "wisdom_save": 4,
-    "charisma_save": 3,
-    "perception": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20015,7 +22336,13 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 6,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20079,9 +22406,23 @@
     "intelligence": 22,
     "wisdom": 18,
     "charisma": 24,
-    "dexterity_save": 8,
-    "constitution_save": 13,
-    "wisdom_save": 10,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 13
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 10
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -20217,10 +22558,28 @@
     "intelligence": 19,
     "wisdom": 22,
     "charisma": 25,
-    "constitution_save": 12,
-    "wisdom_save": 11,
-    "charisma_save": 12,
-    "perception": 11,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 12
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 12
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 11
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "radiant",
@@ -20320,8 +22679,18 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 5,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20376,6 +22745,7 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20425,7 +22795,13 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 7,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20498,6 +22874,7 @@
     "intelligence": 2,
     "wisdom": 11,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20545,9 +22922,23 @@
     "intelligence": 13,
     "wisdom": 16,
     "charisma": 13,
-    "medicine": 7,
-    "persuasion": 3,
-    "religion": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Medicine",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/114",
+        "value": 7
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 3
+      },
+      {
+        "name": "Skill: Religion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/119",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20606,8 +22997,18 @@
     "intelligence": 10,
     "wisdom": 12,
     "charisma": 10,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20691,8 +23092,18 @@
     "intelligence": 1,
     "wisdom": 8,
     "charisma": 4,
-    "constitution_save": 11,
-    "wisdom_save": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 11
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20767,7 +23178,13 @@
     "intelligence": 7,
     "wisdom": 10,
     "charisma": 10,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -20858,6 +23275,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 2,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -20916,8 +23334,18 @@
     "intelligence": 13,
     "wisdom": 16,
     "charisma": 20,
-    "deception": 10,
-    "insight": 8,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 10
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [
       "piercing from magic weapons wielded by good creatures"
     ],
@@ -20984,6 +23412,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 4,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21039,7 +23468,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 6,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21095,12 +23530,38 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 2,
-    "constitution_save": 5,
-    "wisdom_save": 2,
-    "charisma_save": 4,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -21182,7 +23643,13 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 4,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21242,6 +23709,7 @@
     "intelligence": 4,
     "wisdom": 10,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -21322,6 +23790,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21375,6 +23844,7 @@
     "intelligence": 2,
     "wisdom": 11,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21423,11 +23893,33 @@
     "intelligence": 3,
     "wisdom": 10,
     "charisma": 9,
-    "dexterity_save": 4,
-    "constitution_save": 9,
-    "wisdom_save": 4,
-    "charisma_save": 3,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21501,8 +23993,18 @@
     "intelligence": 7,
     "wisdom": 16,
     "charisma": 6,
-    "perception": 6,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21578,6 +24080,7 @@
     "intelligence": 1,
     "wisdom": 3,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -21662,6 +24165,7 @@
     "intelligence": 2,
     "wisdom": 13,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21724,8 +24228,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 3,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21799,7 +24313,13 @@
     "intelligence": 12,
     "wisdom": 13,
     "charisma": 9,
-    "perception": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -21910,6 +24430,7 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 12,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "cold"
     ],
@@ -22033,9 +24554,23 @@
     "intelligence": 12,
     "wisdom": 10,
     "charisma": 14,
-    "perception": 2,
-    "performance": 6,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Performance",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/117",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22123,6 +24658,7 @@
     "intelligence": 1,
     "wisdom": 8,
     "charisma": 2,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22171,10 +24707,28 @@
     "intelligence": 11,
     "wisdom": 13,
     "charisma": 11,
-    "nature": 4,
-    "perception": 5,
-    "stealth": 6,
-    "survival": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Nature",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/115",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      },
+      {
+        "name": "Skill: Survival",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/122",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22248,6 +24802,7 @@
     "intelligence": 12,
     "wisdom": 12,
     "charisma": 13,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22334,6 +24889,7 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 2,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22370,7 +24926,13 @@
     "intelligence": 6,
     "wisdom": 10,
     "charisma": 8,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [
       "radiant"
     ],
@@ -22479,7 +25041,13 @@
     "intelligence": 5,
     "wisdom": 10,
     "charisma": 5,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -22560,6 +25128,7 @@
     "intelligence": 7,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -22656,6 +25225,7 @@
     "intelligence": 1,
     "wisdom": 3,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -22713,12 +25283,38 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 2,
-    "constitution_save": 5,
-    "wisdom_save": 2,
-    "charisma_save": 4,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -22808,6 +25404,7 @@
     "intelligence": 6,
     "wisdom": 8,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "bludgeoning"
     ],
@@ -22879,10 +25476,28 @@
     "intelligence": 25,
     "wisdom": 25,
     "charisma": 30,
-    "intelligence_save": 14,
-    "wisdom_save": 14,
-    "charisma_save": 17,
-    "perception": 14,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 17
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 14
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "radiant",
@@ -23065,6 +25680,7 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 11,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -23171,7 +25787,13 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -23234,10 +25856,28 @@
     "intelligence": 16,
     "wisdom": 15,
     "charisma": 16,
-    "dexterity_save": 6,
-    "constitution_save": 5,
-    "wisdom_save": 5,
-    "charisma_save": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -23308,8 +25948,18 @@
     "intelligence": 14,
     "wisdom": 13,
     "charisma": 11,
-    "perception": 3,
-    "stealth": 8,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 8
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -23388,12 +26038,38 @@
     "intelligence": 12,
     "wisdom": 14,
     "charisma": 16,
-    "deception": 5,
-    "insight": 4,
-    "investigation": 5,
-    "perception": 6,
-    "persuasion": 5,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 4
+      },
+      {
+        "name": "Skill: Investigation",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/113",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -23471,6 +26147,7 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 12,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -23590,6 +26267,7 @@
     "intelligence": 2,
     "wisdom": 8,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -23638,11 +26316,33 @@
     "intelligence": 10,
     "wisdom": 12,
     "charisma": 9,
-    "dexterity_save": 5,
-    "constitution_save": 8,
-    "wisdom_save": 4,
-    "athletics": 12,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 12
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -23722,6 +26422,7 @@
     "intelligence": 3,
     "wisdom": 11,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -23830,14 +26531,48 @@
     "intelligence": 16,
     "wisdom": 18,
     "charisma": 18,
-    "strength_save": 14,
-    "constitution_save": 10,
-    "wisdom_save": 9,
-    "charisma_save": 9,
-    "arcana": 8,
-    "athletics": 14,
-    "history": 8,
-    "perception": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: STR",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/99",
+        "value": 14
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 10
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 8
+      },
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 14
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold"
@@ -23942,11 +26677,33 @@
     "intelligence": 15,
     "wisdom": 12,
     "charisma": 20,
-    "deception": 9,
-    "insight": 5,
-    "perception": 5,
-    "persuasion": 9,
-    "stealth": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 9
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 9
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -24043,6 +26800,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 4,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24144,6 +26902,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24236,6 +26995,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24328,6 +27088,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24420,6 +27181,7 @@
     "intelligence": 1,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24512,6 +27274,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 2,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24611,6 +27374,7 @@
     "intelligence": 2,
     "wisdom": 10,
     "charisma": 3,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24707,6 +27471,7 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 6,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24798,6 +27563,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24898,6 +27664,7 @@
     "intelligence": 1,
     "wisdom": 7,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "bludgeoning",
@@ -24989,9 +27756,23 @@
     "intelligence": 3,
     "wisdom": 11,
     "charisma": 11,
-    "intelligence_save": 5,
-    "wisdom_save": 9,
-    "charisma_save": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: INT",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/102",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -25158,7 +27939,13 @@
     "intelligence": 10,
     "wisdom": 10,
     "charisma": 11,
-    "intimidation": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Intimidation",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/112",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25231,8 +28018,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 3,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25306,6 +28103,7 @@
     "intelligence": 12,
     "wisdom": 16,
     "charisma": 12,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "fire"
     ],
@@ -25391,6 +28189,7 @@
     "intelligence": 8,
     "wisdom": 11,
     "charisma": 8,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25458,6 +28257,7 @@
     "intelligence": 2,
     "wisdom": 11,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25526,7 +28326,13 @@
     "intelligence": 7,
     "wisdom": 9,
     "charisma": 7,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25608,7 +28414,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 9,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -25675,6 +28487,7 @@
     "intelligence": 11,
     "wisdom": 17,
     "charisma": 16,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -25797,11 +28610,33 @@
     "intelligence": 17,
     "wisdom": 15,
     "charisma": 18,
-    "dexterity_save": 9,
-    "wisdom_save": 7,
-    "charisma_save": 9,
-    "perception": 7,
-    "stealth": 9,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 9
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "necrotic",
@@ -25939,10 +28774,28 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 12,
-    "dexterity_save": 6,
-    "wisdom_save": 3,
-    "perception": 3,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 3
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "necrotic",
@@ -26035,8 +28888,18 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 10,
-    "athletics": 5,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Athletics",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/108",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -26132,6 +28995,7 @@
     "intelligence": 1,
     "wisdom": 3,
     "charisma": 1,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -26204,9 +29068,23 @@
     "intelligence": 8,
     "wisdom": 13,
     "charisma": 8,
-    "dexterity_save": 5,
-    "wisdom_save": 4,
-    "charisma_save": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
@@ -26321,7 +29199,13 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 4,
-    "perception": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -26379,6 +29263,7 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 7,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -26432,6 +29317,7 @@
     "intelligence": 2,
     "wisdom": 8,
     "charisma": 5,
+    "proficiencies": [],
     "damage_vulnerabilities": [
       "bludgeoning"
     ],
@@ -26494,6 +29380,7 @@
     "intelligence": 5,
     "wisdom": 10,
     "charisma": 8,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -26616,8 +29503,18 @@
     "intelligence": 2,
     "wisdom": 12,
     "charisma": 3,
-    "perception": 3,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -26687,7 +29584,13 @@
     "intelligence": 11,
     "wisdom": 12,
     "charisma": 12,
-    "perception": 7,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -26789,7 +29692,13 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 8,
-    "perception": 2,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -26873,8 +29782,18 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 8,
-    "perception": 2,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 2
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -26977,8 +29896,18 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 11,
-    "perception": 5,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -27100,7 +30029,13 @@
     "intelligence": 10,
     "wisdom": 11,
     "charisma": 10,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -27211,12 +30146,38 @@
     "intelligence": 5,
     "wisdom": 10,
     "charisma": 11,
-    "dexterity_save": 2,
-    "constitution_save": 4,
-    "wisdom_save": 2,
-    "charisma_save": 2,
-    "perception": 4,
-    "stealth": 2,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 2
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 2
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 2
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -27298,8 +30259,18 @@
     "intelligence": 10,
     "wisdom": 13,
     "charisma": 15,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -27412,6 +30383,7 @@
     "intelligence": 13,
     "wisdom": 14,
     "charisma": 11,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -27529,8 +30501,18 @@
     "intelligence": 7,
     "wisdom": 12,
     "charisma": 8,
-    "perception": 5,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -27616,8 +30598,18 @@
     "intelligence": 3,
     "wisdom": 12,
     "charisma": 6,
-    "perception": 3,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 3
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -27675,7 +30667,13 @@
     "intelligence": 7,
     "wisdom": 11,
     "charisma": 8,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -27732,6 +30730,7 @@
     "intelligence": 12,
     "wisdom": 14,
     "charisma": 15,
+    "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "acid",
@@ -27838,7 +30837,13 @@
     "intelligence": 5,
     "wisdom": 12,
     "charisma": 6,
-    "perception": 4,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],
@@ -27922,8 +30927,18 @@
     "intelligence": 11,
     "wisdom": 10,
     "charisma": 11,
-    "perception": 6,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "piercing and slashing from nonmagical weapons that aren't adamantine"
@@ -28010,12 +31025,38 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 5,
-    "constitution_save": 6,
-    "wisdom_save": 3,
-    "charisma_save": 5,
-    "perception": 6,
-    "stealth": 5,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 5
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28124,12 +31165,38 @@
     "intelligence": 14,
     "wisdom": 13,
     "charisma": 17,
-    "dexterity_save": 4,
-    "constitution_save": 8,
-    "wisdom_save": 5,
-    "charisma_save": 7,
-    "perception": 9,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 8
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 7
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 9
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28232,13 +31299,43 @@
     "intelligence": 12,
     "wisdom": 11,
     "charisma": 15,
-    "dexterity_save": 3,
-    "constitution_save": 6,
-    "wisdom_save": 3,
-    "charisma_save": 5,
-    "perception": 6,
-    "persuasion": 5,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 5
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28350,13 +31447,43 @@
     "intelligence": 14,
     "wisdom": 13,
     "charisma": 17,
-    "dexterity_save": 3,
-    "constitution_save": 7,
-    "wisdom_save": 4,
-    "charisma_save": 6,
-    "insight": 4,
-    "perception": 7,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 6
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28474,13 +31601,43 @@
     "intelligence": 16,
     "wisdom": 13,
     "charisma": 15,
-    "dexterity_save": 4,
-    "constitution_save": 6,
-    "wisdom_save": 4,
-    "charisma_save": 5,
-    "deception": 5,
-    "perception": 7,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28591,14 +31748,48 @@
     "intelligence": 16,
     "wisdom": 13,
     "charisma": 20,
-    "dexterity_save": 6,
-    "constitution_save": 9,
-    "wisdom_save": 5,
-    "charisma_save": 9,
-    "insight": 5,
-    "perception": 9,
-    "persuasion": 9,
-    "stealth": 6,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 5
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 9
+      },
+      {
+        "name": "Skill: Insight",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/111",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 9
+      },
+      {
+        "name": "Skill: Persuasion",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/118",
+        "value": 9
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 6
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28715,13 +31906,43 @@
     "intelligence": 16,
     "wisdom": 13,
     "charisma": 15,
-    "dexterity_save": 4,
-    "constitution_save": 6,
-    "wisdom_save": 4,
-    "charisma_save": 5,
-    "deception": 5,
-    "perception": 7,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 6
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 5
+      },
+      {
+        "name": "Skill: Deception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/109",
+        "value": 5
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 7
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28835,12 +32056,38 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 19,
-    "dexterity_save": 4,
-    "constitution_save": 9,
-    "wisdom_save": 4,
-    "charisma_save": 8,
-    "perception": 8,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -28942,14 +32189,48 @@
     "intelligence": 14,
     "wisdom": 11,
     "charisma": 19,
-    "dexterity_save": 4,
-    "constitution_save": 9,
-    "wisdom_save": 4,
-    "charisma_save": 8,
-    "arcana": 6,
-    "history": 6,
-    "perception": 8,
-    "stealth": 4,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 9
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 4
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 8
+      },
+      {
+        "name": "Skill: Arcana",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/107",
+        "value": 6
+      },
+      {
+        "name": "Skill: History",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/110",
+        "value": 6
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 8
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 4
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -29061,12 +32342,38 @@
     "intelligence": 6,
     "wisdom": 11,
     "charisma": 12,
-    "dexterity_save": 3,
-    "constitution_save": 7,
-    "wisdom_save": 3,
-    "charisma_save": 4,
-    "perception": 6,
-    "stealth": 3,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: DEX",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/100",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CON",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/101",
+        "value": 7
+      },
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 3
+      },
+      {
+        "name": "Saving Throw: CHA",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/104",
+        "value": 4
+      },
+      {
+        "name": "Skill: Perception",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/116",
+        "value": 6
+      },
+      {
+        "name": "Skill: Stealth",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/121",
+        "value": 3
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
@@ -29173,7 +32480,13 @@
     "intelligence": 3,
     "wisdom": 6,
     "charisma": 5,
-    "wisdom_save": 0,
+    "proficiencies": [
+      {
+        "name": "Saving Throw: WIS",
+        "url": "http://www.dnd5eapi.co/api/proficiencies/103",
+        "value": 0
+      }
+    ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [],


### PR DESCRIPTION
This is a much needed change. So many proficiencies and no reference to the ones in `5e-SRD-Proficiencies.json`. Well, now there is one!