### PR TITLE
Classic Spellcasting

### DIFF
--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -5206,7 +5206,11 @@
           },
           "dc": 17,
           "modifier": 9,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "wizard",
           "slots": {
             "1": 4,
@@ -9678,7 +9682,11 @@
           },
           "dc": 11,
           "modifier": 3,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "cleric",
           "slots": {
             "1": 4,
@@ -11309,7 +11317,11 @@
           },
           "dc": 12,
           "modifier": 4,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "druid",
           "slots": {
             "1": 4,
@@ -17236,7 +17248,9 @@
           },
           "dc": 16,
           "modifier": 8,
-          "components_required": ["V"],
+          "components_required": [
+            "V"
+          ],
           "school": "cleric",
           "slots": {
             "1": 4,
@@ -17435,7 +17449,10 @@
           },
           "dc": 16,
           "modifier": 8,
-          "components_required": ["V", "S"],
+          "components_required": [
+            "V",
+            "S"
+          ],
           "school": "wizard",
           "slots": {
             "1": 4,
@@ -20116,7 +20133,11 @@
           },
           "dc": 20,
           "modifier": 12,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "wizard",
           "slots": {
             "1": 4,
@@ -20655,7 +20676,11 @@
           },
           "dc": 14,
           "modifier": 6,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "wizard",
           "slots": {
             "1": 4,
@@ -22171,7 +22196,11 @@
           },
           "dc": 17,
           "modifier": 9,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "cleric",
           "slots": {
             "1": 4,
@@ -24526,7 +24555,11 @@
           },
           "dc": 13,
           "modifier": 5,
-          "components_required": ["V", "S", "M"],
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
           "school": "cleric",
           "slots": {
             "1": 4,
@@ -27721,7 +27754,9 @@
           },
           "dc": 14,
           "modifier": 6,
-          "components_required": ["V"],
+          "components_required": [
+            "V"
+          ],
           "school": "wizard",
           "slots": {
             "1": 4,

--- a/5e-SRD-Monsters.json
+++ b/5e-SRD-Monsters.json
@@ -204,7 +204,57 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (3 slots): bless, cure wounds, sanctuary"
+        "desc": "The acolyte is a 1st-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). The acolyte has following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (3 slots): bless, cure wounds, sanctuary",
+        "spellcasting": {
+          "level": 1,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 12,
+          "modifier": 4,
+          "components_required": [
+            "V",
+            "S",
+            "M"
+          ],
+          "school": "cleric",
+          "slots": {
+            "1": 3
+          },
+          "spells": [
+            {
+              "name": "Light",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Bless",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/29"
+            },
+            {
+              "name": "Cure Wounds",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/70"
+            },
+            {
+              "name": "Sanctuary",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/251"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -4640,7 +4690,106 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, spare the dying, thaumaturgy\n- 1st level (4 slots): command, detect evil and good, detect magic\n- 2nd level (3 slots): lesser restoration, zone of truth\n- 3rd level (3 slots): dispel magic, tongues\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, greater restoration\n- 6th level (1 slot): heroes' feast"
+        "desc": "The sphinx is a 12th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 18, +10 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, spare the dying, thaumaturgy\n- 1st level (4 slots): command, detect evil and good, detect magic\n- 2nd level (3 slots): lesser restoration, zone of truth\n- 3rd level (3 slots): dispel magic, tongues\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, greater restoration\n- 6th level (1 slot): heroes' feast",
+        "spellcasting": {
+          "level": 12,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 18,
+          "modifier": 10,
+          "components_required": [
+            "V",
+            "S"
+          ],
+          "school": "cleric",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 2,
+            "6": 1
+          },
+          "spells": [
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Spare the Dying",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/271"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Command",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/46"
+            },
+            {
+              "name": "Detect Evil and Good",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/78"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/79"
+            },
+            {
+              "name": "Lesser Restoration",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/178"
+            },
+            {
+              "name": "Zone of Truth",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/319"
+            },
+            {
+              "name": "Dispel Magic",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/86"
+            },
+            {
+              "name": "Tongues",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/295"
+            },
+            {
+              "name": "Banishment",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/23"
+            },
+            {
+              "name": "Freedom of Movement",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/130"
+            },
+            {
+              "name": "Flame Strike",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/121"
+            },
+            {
+              "name": "Greater Restoration",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/143"
+            },
+            {
+              "name": "Heroes' Feast",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/157"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -5048,7 +5197,173 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp\n- 1st level (4 slots): detect magic, identify, mage armor*, magic missile\n- 2nd level (3 slots): detect thoughts, mirror image, misty step\n- 3rd level (3 slots): counterspell, fly, lightning bolt\n- 4th level (3 slots): banishment, fire shield, stoneskin*\n- 5th level (3 slots): cone of cold, scrying, wall of force\n- 6th level (1 slot): globe of invulnerability\n- 7th level (1 slot): teleport\n- 8th level (1 slot): mind blank*\n- 9th level (1 slot): time stop\n* The archmage casts these spells on itself before combat."
+        "desc": "The archmage is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 17, +9 to hit with spell attacks). The archmage can cast disguise self and invisibility at will and has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation, shocking grasp\n- 1st level (4 slots): detect magic, identify, mage armor*, magic missile\n- 2nd level (3 slots): detect thoughts, mirror image, misty step\n- 3rd level (3 slots): counterspell, fly, lightning bolt\n- 4th level (3 slots): banishment, fire shield, stoneskin*\n- 5th level (3 slots): cone of cold, scrying, wall of force\n- 6th level (1 slot): globe of invulnerability\n- 7th level (1 slot): teleport\n- 8th level (1 slot): mind blank*\n- 9th level (1 slot): time stop\n* The archmage casts these spells on itself before combat.",
+        "spellcasting": {
+          "level": 18,
+          "ability": {
+            "name": "INT",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/4"
+          },
+          "dc": 17,
+          "modifier": 9,
+          "components_required": ["V", "S", "M"],
+          "school": "wizard",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 3,
+            "6": 1,
+            "7": 1,
+            "8": 1,
+            "9": 1
+          },
+          "spells": [
+            {
+              "name": "Disguise Self",
+              "url": "http://www.dnd5eapi.co/api/spells/83",
+              "usage": {
+                "type": "at will"
+              }
+            },
+            {
+              "name": "Invisibility",
+              "url": "http://www.dnd5eapi.co/api/spells/173",
+              "usage": {
+                "type": "at will"
+              }
+            },
+            {
+              "name": "Fire Bolt",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/116"
+            },
+            {
+              "name": "Light",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Mage Hand",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/187"
+            },
+            {
+              "name": "Prestidigitation",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/227"
+            },
+            {
+              "name": "Shocking Grasp",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/264"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/79"
+            },
+            {
+              "name": "Identify",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/166"
+            },
+            {
+              "name": "Mage Armor",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/186",
+              "note": "Cast on self before combat"
+            },
+            {
+              "name": "Magic Missile",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/190"
+            },
+            {
+              "name": "Detect Thoughts",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/81"
+            },
+            {
+              "name": "Mirror Image",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/207"
+            },
+            {
+              "name": "Misty Step",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/209"
+            },
+            {
+              "name": "Counterspell",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/65"
+            },
+            {
+              "name": "Fly",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/125"
+            },
+            {
+              "name": "Lightning Bolt",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/181"
+            },
+            {
+              "name": "Banishment",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/23"
+            },
+            {
+              "name": "Fire Shield",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/117"
+            },
+            {
+              "name": "Stoneskin",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/281",
+              "note": "Cast on self before combat"
+            },
+            {
+              "name": "Cone of Cold",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/51"
+            },
+            {
+              "name": "Scrying",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/253"
+            },
+            {
+              "name": "Wall of Force",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/306"
+            },
+            {
+              "name": "Globe of Invulnerability",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/138"
+            },
+            {
+              "name": "Teleport",
+              "level": 7,
+              "url": "http://www.dnd5eapi.co/api/spells/289"
+            },
+            {
+              "name": "Mind Blank",
+              "level": 8,
+              "url": "http://www.dnd5eapi.co/api/spells/204",
+              "note": "Cast on self before combat"
+            },
+            {
+              "name": "Time Stop",
+              "level": 9,
+              "url": "http://www.dnd5eapi.co/api/spells/293"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -9354,7 +9669,64 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:\n\nCantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): command, inflict wounds, shield of faith\n- 2nd level (3 slots): hold person, spiritual weapon"
+        "desc": "The fanatic is a 4th-level spellcaster. Its spell casting ability is Wisdom (spell save DC 11, +3 to hit with spell attacks). The fanatic has the following cleric spells prepared:\n\nCantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): command, inflict wounds, shield of faith\n- 2nd level (3 slots): hold person, spiritual weapon",
+        "spellcasting": {
+          "level": 4,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 11,
+          "modifier": 3,
+          "components_required": ["V", "S", "M"],
+          "school": "cleric",
+          "slots": {
+            "1": 4,
+            "2": 3
+          },
+          "spells": [
+            {
+              "name": "Light",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Command",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/46"
+            },
+            {
+              "name": "Inflict Wounds",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/170"
+            },
+            {
+              "name": "Shield of Faith",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/262"
+            },
+            {
+              "name": "Hold Person",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/161"
+            },
+            {
+              "name": "Spiritual Weapon",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/278"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -10928,7 +11300,69 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared:\n\n- Cantrips (at will): druidcraft, produce flame, shillelagh\n- 1st level (4 slots): entangle, longstrider, speak with animals, thunderwave\n- 2nd level (3 slots): animal messenger, barkskin"
+        "desc": "The druid is a 4th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 12, +4 to hit with spell attacks). It has the following druid spells prepared:\n\n- Cantrips (at will): druidcraft, produce flame, shillelagh\n- 1st level (4 slots): entangle, longstrider, speak with animals, thunderwave\n- 2nd level (3 slots): animal messenger, barkskin",
+        "spellcasting": {
+          "level": 4,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 12,
+          "modifier": 4,
+          "components_required": ["V", "S", "M"],
+          "school": "druid",
+          "slots": {
+            "1": 4,
+            "2": 3
+          },
+          "spells": [
+            {
+              "name": "Druidcraft",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/94"
+            },
+            {
+              "name": "Produce Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/231"
+            },
+            {
+              "name": "Shillelagh",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/263"
+            },
+            {
+              "name": "Entangle",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/99"
+            },
+            {
+              "name": "Longstrider",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/185"
+            },
+            {
+              "name": "Speak with Animals",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/272"
+            },
+            {
+              "name": "Thunderwave",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/292"
+            },
+            {
+              "name": "Animal Messenger",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/7"
+            },
+            {
+              "name": "Barkskin",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/24"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -16793,7 +17227,103 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:\n\n- Cantrips (at will): mending, sacred flame, thaumaturgy\n- 1st level (4 slots): command, cure wounds, shield of faith\n- 2nd level (3 slots): calm emotions, hold person\n- 3rd level (3 slots): bestow curse, clairvoyance\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, geas\n- 6th level (1 slot): true seeing"
+        "desc": "The naga is an 11th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 16, +8 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following cleric spells prepared:\n\n- Cantrips (at will): mending, sacred flame, thaumaturgy\n- 1st level (4 slots): command, cure wounds, shield of faith\n- 2nd level (3 slots): calm emotions, hold person\n- 3rd level (3 slots): bestow curse, clairvoyance\n- 4th level (3 slots): banishment, freedom of movement\n- 5th level (2 slots): flame strike, geas\n- 6th level (1 slot): true seeing",
+        "spellcasting": {
+          "level": 11,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 16,
+          "modifier": 8,
+          "components_required": ["V"],
+          "school": "cleric",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 2,
+            "6": 1
+          },
+          "spells": [
+            {
+              "name": "Mending",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/201"
+            },
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Command",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/46"
+            },
+            {
+              "name": "Cure Wounds",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/70"
+            },
+            {
+              "name": "Shield of Faith",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/262"
+            },
+            {
+              "name": "Calm Emotions",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/37"
+            },
+            {
+              "name": "Hold Person",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/161"
+            },
+            {
+              "name": "Bestow Curse",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/26"
+            },
+            {
+              "name": "Clairvoyance",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/42"
+            },
+            {
+              "name": "Banishment",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/23"
+            },
+            {
+              "name": "Freedom of Movement",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/130"
+            },
+            {
+              "name": "Flame Strike",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/121"
+            },
+            {
+              "name": "Geas",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/134"
+            },
+            {
+              "name": "True Seeing",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/300"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -16896,7 +17426,102 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, prestidigitation\n- 1st level (4 slots): detect magic, identify, shield\n- 2nd level (3 slots): darkness, locate object, suggestion\n- 3rd level (3 slots): dispel magic, remove curse, tongues\n- 4th level (3 slots): banishment, greater invisibility\n- 5th level (1 slot): legend lore"
+        "desc": "The sphinx is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 16, +8 to hit with spell attacks). It requires no material components to cast its spells. The sphinx has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, prestidigitation\n- 1st level (4 slots): detect magic, identify, shield\n- 2nd level (3 slots): darkness, locate object, suggestion\n- 3rd level (3 slots): dispel magic, remove curse, tongues\n- 4th level (3 slots): banishment, greater invisibility\n- 5th level (1 slot): legend lore",
+        "spellcasting": {
+          "level": 9,
+          "ability": {
+            "name": "INT",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/4"
+          },
+          "dc": 16,
+          "modifier": 8,
+          "components_required": ["V", "S"],
+          "school": "wizard",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 1
+          },
+          "spells": [
+            {
+              "name": "Mage Hand",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/187"
+            },
+            {
+              "name": "Minor Illusion",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/205"
+            },
+            {
+              "name": "Prestidigitation",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/227"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/79"
+            },
+            {
+              "name": "Identify",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/166"
+            },
+            {
+              "name": "Shield",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/261"
+            },
+            {
+              "name": "Darkness",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/72"
+            },
+            {
+              "name": "Locate Object",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/184"
+            },
+            {
+              "name": "Suggestion",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/198"
+            },
+            {
+              "name": "Dispel Magic",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/86"
+            },
+            {
+              "name": "Remove Curse",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/243"
+            },
+            {
+              "name": "Tongues",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/295"
+            },
+            {
+              "name": "Banishment",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/23"
+            },
+            {
+              "name": "Greater Invisibility",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/142"
+            },
+            {
+              "name": "Legend Lore",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/177"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -19482,7 +20107,161 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, prestidigitation, ray of frost\n- 1st level (4 slots): detect magic, magic missile, shield, thunderwave\n- 2nd level (3 slots): detect thoughts, invisibility, Melf's acid arrow, mirror image\n- 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball\n- 4th level (3 slots): blight, dimension door\n- 5th level (3 slots): cloudkill, scrying\n- 6th level (1 slot): disintegrate, globe of invulnerability\n- 7th level (1 slot): finger of death, plane shift\n- 8th level (1 slot): dominate monster, power word stun\n- 9th level (1 slot): power word kill"
+        "desc": "The lich is an 18th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 20, +12 to hit with spell attacks). The lich has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, prestidigitation, ray of frost\n- 1st level (4 slots): detect magic, magic missile, shield, thunderwave\n- 2nd level (3 slots): acid arrow, detect thoughts, invisibility, mirror image\n- 3rd level (3 slots): animate dead, counterspell, dispel magic, fireball\n- 4th level (3 slots): blight, dimension door\n- 5th level (3 slots): cloudkill, scrying\n- 6th level (1 slot): disintegrate, globe of invulnerability\n- 7th level (1 slot): finger of death, plane shift\n- 8th level (1 slot): dominate monster, power word stun\n- 9th level (1 slot): power word kill",
+        "spellcasting": {
+          "level": 18,
+          "ability": {
+            "name": "INT",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/4"
+          },
+          "dc": 20,
+          "modifier": 12,
+          "components_required": ["V", "S", "M"],
+          "school": "wizard",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 3,
+            "6": 1,
+            "7": 1,
+            "8": 1,
+            "9": 1
+          },
+          "spells": [
+            {
+              "name": "Mage Hand",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/187"
+            },
+            {
+              "name": "Prestidigitation",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/227"
+            },
+            {
+              "name": "Ray of Frost",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/240"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/179"
+            },
+            {
+              "name": "Magic Missile",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/190"
+            },
+            {
+              "name": "Shield",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/261"
+            },
+            {
+              "name": "Thunderwave",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/292"
+            },
+            {
+              "name": "Acid Arrow",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/1"
+            },
+            {
+              "name": "Detect Thoughts",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/81"
+            },
+            {
+              "name": "Invisibility",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/172"
+            },
+            {
+              "name": "Mirror Image",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/207"
+            },
+            {
+              "name": "Animate Dead",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/9"
+            },
+            {
+              "name": "Counterspell",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/65"
+            },
+            {
+              "name": "Dispel Magic",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/86"
+            },
+            {
+              "name": "Fireball",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/119"
+            },
+            {
+              "name": "Blight",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/30"
+            },
+            {
+              "name": "Dimension Door",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/82"
+            },
+            {
+              "name": "Cloudkill",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/44"
+            },
+            {
+              "name": "Scrying",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/253"
+            },
+            {
+              "name": "Disintegrate",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/84"
+            },
+            {
+              "name": "Globe of Invulnerability",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/138"
+            },
+            {
+              "name": "Finger of Death",
+              "level": 7,
+              "url": "http://www.dnd5eapi.co/api/spells/115"
+            },
+            {
+              "name": "Plane Shift",
+              "level": 7,
+              "url": "http://www.dnd5eapi.co/api/spells/220"
+            },
+            {
+              "name": "Dominate Monster",
+              "level": 8,
+              "url": "http://www.dnd5eapi.co/api/spells/91"
+            },
+            {
+              "name": "Power Word Stun",
+              "level": 8,
+              "url": "http://www.dnd5eapi.co/api/spells/225"
+            },
+            {
+              "name": "Power Word Kill",
+              "level": 9,
+              "url": "http://www.dnd5eapi.co/api/spells/224"
+            }
+          ]
+        }
       },
       {
         "name": "Turn Resistance",
@@ -19867,7 +20646,107 @@
     "special_abilities": [
       {
         "name": "Spellcasting",
-        "desc": "The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n- 1st level (4 slots): detect magic, mage armor, magic missile, shield\n- 2nd level (3 slots): misty step, suggestion\n- 3rd level (3 slots): counterspell, fireball, fly\n- 4th level (3 slots): greater invisibility, ice storm\n- 5th level (1 slot): cone of cold"
+        "desc": "The mage is a 9th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks). The mage has the following wizard spells prepared:\n\n- Cantrips (at will): fire bolt, light, mage hand, prestidigitation\n- 1st level (4 slots): detect magic, mage armor, magic missile, shield\n- 2nd level (3 slots): misty step, suggestion\n- 3rd level (3 slots): counterspell, fireball, fly\n- 4th level (3 slots): greater invisibility, ice storm\n- 5th level (1 slot): cone of cold",
+        "spellcasting": {
+          "level": 9,
+          "ability": {
+            "name": "INT",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/4"
+          },
+          "dc": 14,
+          "modifier": 6,
+          "components_required": ["V", "S", "M"],
+          "school": "wizard",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 1
+          },
+          "spells": [
+            {
+              "name": "Fire Bolt",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/116"
+            },
+            {
+              "name": "Light",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Mage Hand",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/187"
+            },
+            {
+              "name": "Prestidigitation",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/227"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/79"
+            },
+            {
+              "name": "Mage Armor",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/186"
+            },
+            {
+              "name": "Magic Missile",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/190"
+            },
+            {
+              "name": "Shield",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/261"
+            },
+            {
+              "name": "Misty Step",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/209"
+            },
+            {
+              "name": "Suggestion",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/283"
+            },
+            {
+              "name": "Counterspell",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/65"
+            },
+            {
+              "name": "Fireball",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/119"
+            },
+            {
+              "name": "Fly",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/125"
+            },
+            {
+              "name": "Greater Invisibility",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/142"
+            },
+            {
+              "name": "Ice Storm",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/165"
+            },
+            {
+              "name": "Cone of Cold",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/51"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -21283,7 +22162,103 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, thaumaturgy\n- 1st level (4 slots): command, guiding bolt, shield of faith\n- 2nd level (3 slots): hold person, silence, spiritual weapon\n- 3rd level (3 slots): animate dead, dispel magic\n- 4th level (3 slots): divination, guardian of faith\n- 5th level (2 slots): contagion, insect plague\n- 6th level (1 slot): harm"
+        "desc": "The mummy lord is a 10th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 17, +9 to hit with spell attacks). The mummy lord has the following cleric spells prepared:\n\n- Cantrips (at will): sacred flame, thaumaturgy\n- 1st level (4 slots): command, guiding bolt, shield of faith\n- 2nd level (3 slots): hold person, silence, spiritual weapon\n- 3rd level (3 slots): animate dead, dispel magic\n- 4th level (3 slots): divination, guardian of faith\n- 5th level (2 slots): contagion, insect plague\n- 6th level (1 slot): harm",
+        "spellcasting": {
+          "level": 10,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 17,
+          "modifier": 9,
+          "components_required": ["V", "S", "M"],
+          "school": "cleric",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 2,
+            "6": 1
+          },
+          "spells": [
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Command",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/46"
+            },
+            {
+              "name": "Guiding Bolt",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/147"
+            },
+            {
+              "name": "Shield of Faith",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/262"
+            },
+            {
+              "name": "Hold Person",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/161"
+            },
+            {
+              "name": "Silence",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/265"
+            },
+            {
+              "name": "Spiritual Weapon",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/278"
+            },
+            {
+              "name": "Animate Dead",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/9"
+            },
+            {
+              "name": "Dispel Magic",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/86"
+            },
+            {
+              "name": "Divination",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/87"
+            },
+            {
+              "name": "Guardian of Faith",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/144"
+            },
+            {
+              "name": "Contagion",
+              "level": 60,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Insect Plague",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/171"
+            },
+            {
+              "name": "Harm",
+              "level": 6,
+              "url": "http://www.dnd5eapi.co/api/spells/151"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -23542,7 +24517,75 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): cure wounds, guiding bolt, sanctuary\n- 2nd level (3 slots): lesser restoration, spiritual weapon\n- 3rd level (2 slots): dispel magic, spirit guardians"
+        "desc": "The priest is a 5th-level spellcaster. Its spellcasting ability is Wisdom (spell save DC 13, +5 to hit with spell attacks). The priest has the following cleric spells prepared:\n\n- Cantrips (at will): light, sacred flame, thaumaturgy\n- 1st level (4 slots): cure wounds, guiding bolt, sanctuary\n- 2nd level (3 slots): lesser restoration, spiritual weapon\n- 3rd level (2 slots): dispel magic, spirit guardians",
+        "spellcasting": {
+          "level": 5,
+          "ability": {
+            "name": "WIS",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/5"
+          },
+          "dc": 13,
+          "modifier": 5,
+          "components_required": ["V", "S", "M"],
+          "school": "cleric",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 2
+          },
+          "spells": [
+            {
+              "name": "Light",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Sacred Flame",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/250"
+            },
+            {
+              "name": "Thaumaturgy",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/291"
+            },
+            {
+              "name": "Cure Wounds",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/70"
+            },
+            {
+              "name": "Guiding Bolt",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/147"
+            },
+            {
+              "name": "Sanctuary",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/251"
+            },
+            {
+              "name": "Lesser Restoration",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/178"
+            },
+            {
+              "name": "Spiritual Weapon",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/278"
+            },
+            {
+              "name": "Dispel Magic",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/86"
+            },
+            {
+              "name": "Spirit Guardians",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/277"
+            }
+          ]
+        }
       }
     ],
     "actions": [
@@ -26669,7 +27712,92 @@
       },
       {
         "name": "Spellcasting",
-        "desc": "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, ray of frost\n- 1st level (4 slots): charm person, detect magic, sleep\n- 2nd level (3 slots): detect thoughts, hold person\n- 3rd level (3 slots): lightning bolt, water breathing\n- 4th level (3 slots): blight, dimension door\n- 5th level (2 slots): dominate person"
+        "desc": "The naga is a 10th-level spellcaster. Its spellcasting ability is Intelligence (spell save DC 14, +6 to hit with spell attacks), and it needs only verbal components to cast its spells. It has the following wizard spells prepared:\n\n- Cantrips (at will): mage hand, minor illusion, ray of frost\n- 1st level (4 slots): charm person, detect magic, sleep\n- 2nd level (3 slots): detect thoughts, hold person\n- 3rd level (3 slots): lightning bolt, water breathing\n- 4th level (3 slots): blight, dimension door\n- 5th level (2 slots): dominate person",
+        "spellcasting": {
+          "level": 10,
+          "ability": {
+            "name": "INT",
+            "url": "http://www.dnd5eapi.co/api/ability-scores/4"
+          },
+          "dc": 14,
+          "modifier": 6,
+          "components_required": ["V"],
+          "school": "wizard",
+          "slots": {
+            "1": 4,
+            "2": 3,
+            "3": 3,
+            "4": 3,
+            "5": 2
+          },
+          "spells": [
+            {
+              "name": "Mage Hand",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/180"
+            },
+            {
+              "name": "Minor Illusion",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/205"
+            },
+            {
+              "name": "Ray of Frost",
+              "level": 0,
+              "url": "http://www.dnd5eapi.co/api/spells/240"
+            },
+            {
+              "name": "Charm Person",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/39"
+            },
+            {
+              "name": "Detect Magic",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/79"
+            },
+            {
+              "name": "Sleep",
+              "level": 1,
+              "url": "http://www.dnd5eapi.co/api/spells/268"
+            },
+            {
+              "name": "Detect Thoughts",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/81"
+            },
+            {
+              "name": "Hold Person",
+              "level": 2,
+              "url": "http://www.dnd5eapi.co/api/spells/161"
+            },
+            {
+              "name": "Lightning Bolt",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/181"
+            },
+            {
+              "name": "Water Breathing",
+              "level": 3,
+              "url": "http://www.dnd5eapi.co/api/spells/311"
+            },
+            {
+              "name": "Blight",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/30"
+            },
+            {
+              "name": "Dimension Door",
+              "level": 4,
+              "url": "http://www.dnd5eapi.co/api/spells/82"
+            },
+            {
+              "name": "Dominate Person",
+              "level": 5,
+              "url": "http://www.dnd5eapi.co/api/spells/92"
+            }
+          ]
+        }
       }
     ],
     "actions": [


### PR DESCRIPTION
## Overview
This adds in data for Regular Spellcasting as was discussed in #4 
The base structure I used was:
```json
{
  "spellcasting": {
    "level": 1,
    "ability": {
      "name": "WIS",
      "url": "http://www.dnd5eapi.co/api/ability-scores/5"
    },
    "dc": 12,
    "modifier": 4,
    "components_required": [
      "V",
      "S",
      "M"
    ],
    "school": "cleric",
    "slots": {
      "1": 3
    },
    "spells": [
      {
        "name": "Light",
        "level": 0,
        "url": "http://www.dnd5eapi.co/api/spells/180"
      },
      {
        "name": "Sacred Flame",
        "level": 0,
        "url": "http://www.dnd5eapi.co/api/spells/250"
      },
      {
        "name": "Thaumaturgy",
        "level": 0,
        "url": "http://www.dnd5eapi.co/api/spells/291"
      },
      {
        "name": "Bless",
        "level": 1,
        "url": "http://www.dnd5eapi.co/api/spells/29"
      },
      {
        "name": "Cure Wounds",
        "level": 1,
        "url": "http://www.dnd5eapi.co/api/spells/70"
      },
      {
        "name": "Sanctuary",
        "level": 1,
        "url": "http://www.dnd5eapi.co/api/spells/251"
      }
    ]
  }
}
```

In one case  I added in some of the Innate Spellcasting structure, as it had At Will spells. Additionally, some monsters ignore some components, so that's why I added the `components_required` field.

Additionally, Lich had `Melf's Acid Arrow`, which is  not in SRD, so I exchanged  it for regular  `Acid Arrow`