### PR TITLE
Fix url for starting-equipment

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -68,7 +68,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/1",
+			"url": "/api/starting-equipment/1",
 			"class": "Barbarian"
 		},
 		"class_levels": {
@@ -253,7 +253,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/2",
+			"url": "/api/starting-equipment/2",
 			"class": "Bard"
 		},
 		"class_levels": {
@@ -333,7 +333,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/3",
+			"url": "/api/starting-equipment/3",
 			"class": "Cleric"
 		},
 		"class_levels": {
@@ -465,7 +465,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/4",
+			"url": "/api/starting-equipment/4",
 			"class": "Druid"
 		},
 		"class_levels": {
@@ -557,7 +557,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/5",
+			"url": "/api/starting-equipment/5",
 			"class": "Fighter"
 		},
 		"class_levels": {
@@ -760,7 +760,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/6",
+			"url": "/api/starting-equipment/6",
 			"class": "Monk"
 		},
 		"class_levels": {
@@ -843,7 +843,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/7",
+			"url": "/api/starting-equipment/7",
 			"class": "Paladin"
 		},
 		"class_levels": {
@@ -939,7 +939,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/8",
+			"url": "/api/starting-equipment/8",
 			"class": "Ranger"
 		},
 		"class_levels": {
@@ -1055,7 +1055,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/9",
+			"url": "/api/starting-equipment/9",
 			"class": "Rogue"
 		},
 		"class_levels": {
@@ -1138,7 +1138,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/10",
+			"url": "/api/starting-equipment/10",
 			"class": "Sorcerer"
 		},
 		"class_levels": {
@@ -1218,7 +1218,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/11",
+			"url": "/api/starting-equipment/11",
 			"class": "Warlock"
 		},
 		"class_levels": {
@@ -1302,7 +1302,7 @@
 			}
 		],
 		"starting_equipment": {
-			"url": "/api/startingequipment/12",
+			"url": "/api/starting-equipment/12",
 			"class": "Wizard"
 		},
 		"class_levels": {

--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -60,7 +60,7 @@
 			"item": { "url": "/api/equipment/shortbow", "name": "Shortbow"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/sling", "name": "Sling"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/1"
+	"url": "/api/starting-equipment/1"
 }, {
 	"index": 2,
 	"class": {
@@ -131,7 +131,7 @@
 			"item": { "url": "/api/equipment/shawm", "name": "Shawm"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/viol", "name": "Viol"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/2"
+	"url": "/api/starting-equipment/2"
 }, {
 	"index": 3,
 	"class": {
@@ -221,7 +221,7 @@
 			"item": { "url": "/api/equipment/emblem", "name": "Emblem"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/reliquary", "name": "Reliquary"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/3"
+	"url": "/api/starting-equipment/3"
 }, {
 	"index": 4,
 	"class": {
@@ -285,7 +285,7 @@
 			"item": { "url": "/api/equipment/wooden-staff", "name": "Wooden staff"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/yew-wand", "name": "Yew wand"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/4"
+	"url": "/api/starting-equipment/4"
 }, {
 	"index": 5,
 	"class": {
@@ -391,7 +391,7 @@
 			"item": { "url": "/api/equipment/longbow", "name": "Longbow"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/net", "name": "Net"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/5"
+	"url": "/api/starting-equipment/5"
 }, {
 	"index": 6,
 	"class": {
@@ -436,7 +436,7 @@
 		"from": [{
 			"item": { "url": "/api/equipment/explorers-pack", "name": "Explorer's Pack"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/6"
+	"url": "/api/starting-equipment/6"
 }, {
 	"index": 7,
 	"class": {
@@ -550,7 +550,7 @@
 			"item": { "url": "/api/equipment/longbow", "name": "Longbow"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/net", "name": "Net"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/7"
+	"url": "/api/starting-equipment/7"
 }, {
 	"index": 8,
 	"class": {
@@ -603,7 +603,7 @@
 		"from": [{
 			"item": { "url": "/api/equipment/explorers-pack", "name": "Explorer's Pack"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/8"
+	"url": "/api/starting-equipment/8"
 }, {
 	"index": 9,
 	"class": {
@@ -654,7 +654,7 @@
 		"from": [{
 			"item": { "url": "/api/equipment/explorers-pack", "name": "Explorer's Pack"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/9"
+	"url": "/api/starting-equipment/9"
 }, {
 	"index": 10,
 	"class": {
@@ -715,7 +715,7 @@
 		"from": [{
 			"item": { "url": "/api/equipment/explorers-pack", "name": "Explorer's Pack"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/10"
+	"url": "/api/starting-equipment/10"
 }, {
 	"index": 11,
 	"class": {
@@ -796,7 +796,7 @@
 			"item": { "url": "/api/equipment/shortbow", "name": "Shortbow"}, "quantity": 1}, {
 			"item": { "url": "/api/equipment/sling", "name": "Sling"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/11"
+	"url": "/api/starting-equipment/11"
 }, {
 	"index": 12,
 	"class": {
@@ -843,5 +843,5 @@
 		"from": [{
 			"item": { "url": "/api/equipment/dungeoneers-pack", "name": "Dungeoneer's Pack"}, "quantity": 1}]
 	}],
-	"url": "/api/startingequipment/12"
+	"url": "/api/starting-equipment/12"
 }]


### PR DESCRIPTION
## Overview
Fixes urls from `startingequipment` to `starting-equipment` which reflects the actual API.

At some point, I'll need to fix the table name but I can shave that yak later.