### PR TITLE
Add missing exhaustion description, addressing issue #150

### DIFF
--- a/src/5e-SRD-Conditions.json
+++ b/src/5e-SRD-Conditions.json
@@ -136,7 +136,19 @@
   {
     "index": "exhaustion",
     "name": "Exhaustion",
-    "desc": ["- Exhaustion is measured in six levels."],
+    "desc": [
+      "Some special abilities and environmental hazards, such as starvation and the long-term effects of freezing or scorching temperatures, can lead to a special condition called exhaustion. Exhaustion is measured in six levels. An effect can give a creature one or more levels of exhaustion, as specified in the effect's description.",
+      "1 - Disadvantage on ability checks",
+      "2 - Speed halved",
+      "3 - Disadvantage on attack rolls and saving throws",
+      "4 - Hit point maximum halved",
+      "5 - Speed reduced to 0",
+      "6 - Death",
+      "If an already exhausted creature suffers another effect that causes exhaustion, its current level of exhaustion increases by the amount specified in the effect's description.",
+      "A creature suffers the effect of its current level of exhaustion as well as all lower levels. For example, a creature suffering level 2 exhaustion has its speed halved and has disadvantage on ability checks.",
+      "An effect that removes exhaustion reduces its level as specified in the effect's description, with all exhaustion effects ending if a creature's exhaustion level is reduced below 1.",
+      "Finishing a long rest reduces a creature's exhaustion level by 1, provided that the creature has also ingested some food and drink."
+    ],
     "url": "/api/conditions/exhaustion"
   }
 ]


### PR DESCRIPTION
I've updated exhaustion with a proposal for the response.

Given exhaustion's unique format (paragraphs of prose separated by a table), the description format is up for debate.