### PR TITLE
Update incorrect damage type,dice,bonus for attacks with secondary rolls

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -379,9 +379,12 @@
             "damage_bonus": 6
           },
           {
-            "type": "acid",
-            "dice": "1d8",
-            "bonus": 0
+            "damage_type": {
+              "name": "Acid",
+              "url": "/api/damage-types/acid"
+            },
+            "damage_dice": "1d8",
+            "damage_bonus": 0
           }
         ]
       },
@@ -584,9 +587,12 @@
             "damage_bonus": 7
           },
           {
-            "type": "lightning",
-            "dice": "1d10",
-            "bonus": 0
+            "damage_type": {
+              "name": "Lightning",
+              "url": "/api/damage-types/lightning"
+            },
+            "damage_dice": "1d10",
+            "damage_bonus": 0
           }
         ]
       },
@@ -1683,9 +1689,12 @@
             "damage_bonus": 6
           },
           {
-            "type": "poison",
-            "dice": "2d6",
-            "bonus": 0
+            "damage_type": {
+              "name": "Poison",
+              "url": "/api/damage-types/poison"
+            },
+            "damage_dice": "2d6",
+            "damage_bonus": 0
           }
         ]
       },
@@ -1888,9 +1897,12 @@
             "damage_bonus": 8
           },
           {
-            "type": "fire",
-            "dice": "2d6",
-            "bonus": 0
+            "damage_type": {
+              "name": "Fire",
+              "url": "/api/damage-types/fire"
+            },
+            "damage_dice": "2d6",
+            "damage_bonus": 0
           }
         ]
       },
@@ -2372,9 +2384,12 @@
             "damage_bonus": 6
           },
           {
-            "type": "cold",
-            "dice": "1d8",
-            "bonus": 0
+            "damage_type": {
+              "name": "Cold",
+              "url": "/api/damage-types/cold"
+            },
+            "damage_dice": "1d8",
+            "damage_bonus": 0
           }
         ]
       },
@@ -2689,9 +2704,12 @@
             "damage_bonus": 8
           },
           {
-            "type": "acid",
-            "dice": "2d8",
-            "bonus": 0
+            "damage_type": {
+              "name": "Acid",
+              "url": "/api/damage-types/acid"
+            },
+            "damage_dice": "2d8",
+            "damage_bonus": 0
           }
         ]
       },
@@ -2884,9 +2902,12 @@
             "damage_bonus": 9
           },
           {
-            "type": "lightning",
-            "dice": "2d10",
-            "bonus": 0
+            "damage_type": {
+              "name": "Lightning",
+              "url": "/api/damage-types/lightning"
+            },
+            "damage_dice": "2d10",
+            "damage_bonus": 0
           }
         ]
       },

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -3845,12 +3845,12 @@
     "index": "enlarge-reduce",
     "name": "Enlarge/Reduce",
     "desc": [
-      "Enlarging or reducing in size a creature or object that you can see and is within range for the duration of the spell. Choose a creature or object that is not worn or carried. If the target does not consent, it can make a constitution saving throw. If successful, the spell has no effect.",
-      "If the target is a creature, everything she wears and carries with it change size. Any item dropped by the affected creature returns to its normal size.",
-      "Magnification.",
-      " The double target in all dimensions, and its weight is multiplied by eight. This increases the size of a class of M to G for example. If there is not enough space in the room for the double target size, the creature or object reaches the maximum size possible in the available space. Until the end of the spell, the target also has the advantage of its jets Force and Force saves. Weapons to the target also grow. As long as these weapons are enlarged, the target's attacks cause additional 1d4 damage.",
-      "Reduction.",
-      " The size of the target is reduced by half in all dimensions, and its weight is divided by eight. This reduction decreases the size of a class from M to P for example. Until the end of the spell, the target has a disadvantage to its jets Force and its Force saves. The weapons of the target shrink too. As long as these weapons are reduced, target attacks cause less damage 1d4 (minimum 1 point of damage)."
+      "You cause a creature or an object you can see within range to grow larger or smaller for the duration. Choose either a creature or an object that is neither worn nor carried. If the target is unwilling, it can make a Constitution saving throw. On a success, the spell has no effect.",
+      "If the target is a creature, everything it is wearing and carrying changes size with it. Any item dropped by an affected creature returns to normal size at once.",
+      "Enlarge.",
+      "The target’s size doubles in all dimensions, and its weight is multiplied by eight. This growth increases its size by one category—from Medium to Large, for example. If there isn’t enough room for the target to double its size, the creature or object attains the maximum possible size in the space available. Until the spell ends, the target also has advantage on Strength checks and Strength saving throws. The target’s weapons also grow to match its new size. While these weapons are enlarged, the target’s attacks with them deal 1d4 extra damage.",
+      "Reduce.",
+      "The target’s size is halved in all dimensions, and its weight is reduced to one-eighth of normal. This reduction decreases its size by one category—from Medium to Small, for example. Until the spell ends, the target also has disadvantage on Strength checks and Strength saving throws. The target’s weapons also shrink to match its new size. While these weapons are reduced, the target’s attacks with them deal 1d4 less damage (this can’t reduce the damage below 1)."
     ],
     "range": "30 feet",
     "components": ["V", "S", "M"],


### PR DESCRIPTION
Update the damage type,dice,bonus for attacks with secondary rolls for the following monsters:

- Adult Black Dragon
- Adult Blue Dragon
- Adult Green Dragon
- Adult Red Dragon
- Adult White Dragon
- Ancient Black Dragon
- Ancient Blue Dragon