### PR TITLE
Infernal, not Internal

### DIFF
--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -474,7 +474,7 @@
     "url": "/api/traits/hellish-resistance"
   },
   {
-    "index": "internal-legacy",
+    "index": "infernal-legacy",
     "races": [
       {
         "name": "Tiefling",
@@ -482,10 +482,10 @@
       }
     ],
     "subraces": [],
-    "name": "Internal Legacy",
+    "name": "Infernal Legacy",
     "desc": [
       "You know the thaumaturgy cantrip. When you reach 3rd level, you can cast the hellish rebuke spell as a 2nd-level spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5h level, you can cast the darkness spell once with this trait and regain the ability to do so when you finish a long rest. Charisma is your spellcasting ability for these spells."
     ],
-    "url": "/api/traits/internal-legacy"
+    "url": "/api/traits/infernal-legacy"
   }
 ]


### PR DESCRIPTION
This resolves [this issue.](https://github.com/bagelbits/5e-srd-api/issues/63)