### PR TITLE
Add Multiattack Improvements for Monsters.json (Part 2 of 3)

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -13581,7 +13581,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gargoyle makes two attacks: one with its bite and one with its claws."
+        "desc": "The gargoyle makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -14060,7 +14077,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ape makes two fist attacks."
+        "desc": "The ape makes two fist attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fist",
@@ -14135,7 +14164,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The badger makes two attacks: one with its bite and one with its claws."
+        "desc": "The badger makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -14523,7 +14569,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The crocodile makes two attacks: one with its bite and one with its tail."
+        "desc": "The crocodile makes two attacks: one with its bite and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -14603,7 +14666,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The eagle makes two attacks: one with its beak and one with its talons."
+        "desc": "The eagle makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -15390,7 +15470,24 @@
       },
       {
         "name": "Multiattack",
-        "desc": "The scorpion makes three attacks: two with its claws and one with its sting."
+        "desc": "The scorpion makes three attacks: two with its claws and one with its sting.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Sting",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Sting",
@@ -15736,7 +15833,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vulture makes two attacks: one with its beak and one with its talons."
+        "desc": "The vulture makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -16020,7 +16134,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."
+        "desc": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bites",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Blinding Spittle",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bites",
@@ -16188,7 +16319,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."
+        "desc": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Pincer",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Pincer",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Innate Spellcasting",
+                "count": 1,
+                "type": "magic"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Pincer",
@@ -16299,7 +16459,57 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gladiator makes three melee attacks or two ranged attacks."
+        "desc": "The gladiator makes three melee attacks or two ranged attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Spear",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Shield Bash",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spear",
+                "count": 2,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Spear",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Shield Bash",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Shield Bash",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Spear",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Spear",
@@ -17235,7 +17445,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."
+        "desc": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tentacles",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Tentacles",
@@ -17316,7 +17545,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The griffon makes two attacks: one with its beak and one with its claws."
+        "desc": "The griffon makes two attacks: one with its beak and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -17890,7 +18136,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sphinx makes two claw attacks."
+        "desc": "The sphinx makes two claw attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -17960,7 +18218,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -18084,7 +18354,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The harpy makes two attacks: one with its claws and one with its club."
+        "desc": "The harpy makes two attacks: one with its claws and one with its club.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claws",
@@ -18365,7 +18652,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hezrou makes three attacks: one with its bite and two with its claws."
+        "desc": "The hezrou makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -18446,7 +18750,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatclub attacks."
+        "desc": "The giant makes two greatclub attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatclub",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatclub",
@@ -18526,7 +18842,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hippogriff makes two attacks: one with its beak and one with its claws."
+        "desc": "The hippogriff makes two attacks: one with its beak and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -18788,7 +19121,53 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."
+        "desc": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fork",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Fork",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Hurl Flame",
+                "count": 1,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Fork",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Hurl Flame",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fork",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -17454,11 +17454,10 @@
                 "name": "Tentacles",
                 "count": 1,
                 "type": "melee"
-              }
-            ],
-            [
+              },
               {
                 "name": "Beak",
+                "note": "If tentacles attack hits",
                 "count": 1,
                 "type": "melee"
               }
@@ -18226,6 +18225,12 @@
               {
                 "name": "Longsword",
                 "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Shortsword",
+                "note": "If shortsword is drawn",
+                "count": 1,
                 "type": "melee"
               }
             ]
@@ -20065,28 +20070,16 @@
         "name": "Multiattack",
         "desc": "The golem makes two melee attacks.",
         "options": {
-          "choose": 1,
+          "choose": 2,
           "from": [
-            [
-              {
-                "name": "Slam",
-                "count": 2,
-                "type": "melee"
-              }
-            ],
-            [
-              {
-                "name": "Sword",
-                "count": 2,
-                "type": "melee"
-              }
-            ],
             [
               {
                 "name": "Slam",
                 "count": 1,
                 "type": "melee"
-              },
+              }
+            ],
+            [
               {
                 "name": "Sword",
                 "count": 1,
@@ -23606,6 +23599,7 @@
             [
               {
                 "name": "Horror Nimbus",
+                "note": "If it can use Horror Nimbus",
                 "count": 1,
                 "type": "ability"
               },
@@ -24476,6 +24470,7 @@
             [
               {
                 "name": "Claw",
+                "note": "If in Oni form",
                 "count": 2,
                 "type": "melee"
               }
@@ -24483,11 +24478,13 @@
             [
               {
                 "name": "Glaive",
+                "note": "If in Oni form",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claw",
+                "note": "If in Oni form",
                 "count": 1,
                 "type": "melee"
               }

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -19340,7 +19340,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hydra makes as many bite attacks as it has heads."
+        "desc": "The hydra makes as many bite attacks as it has heads.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": "Number of Heads",
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -19495,7 +19507,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."
+        "desc": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -19916,7 +19950,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The stalker makes two slam attacks."
+        "desc": "The stalker makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -20017,7 +20063,38 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two melee attacks."
+        "desc": "The golem makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Sword",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Slam",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Sword",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -20261,7 +20338,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The knight makes two melee attacks."
+        "desc": "The knight makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -20473,7 +20562,50 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling."
+        "desc": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tentacle",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tentacle",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Fling",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tentacle",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Fling",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Fling",
+                "count": 3,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -20664,7 +20796,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."
+        "desc": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Dagger",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Intoxicating Touch",
+                "count": 1,
+                "type": "ability"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claws",
@@ -21314,7 +21475,84 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lizardfolk makes two melee attacks, each one with a different weapon."
+        "desc": "The lizardfolk makes two melee attacks, each one with a different weapon.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -21888,7 +22126,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."
+        "desc": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tail Spike",
+                "count": 3,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -22018,7 +22280,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The marilith can make seven attacks: six with its longswords and one with its tail."
+        "desc": "The marilith can make seven attacks: six with its longswords and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 6,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -22199,7 +22478,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow."
+        "desc": "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Snake Hair",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Shortsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Snake Hair",
@@ -22380,7 +22683,48 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The merrow makes two attacks: one with its bite and one with its claws or harpoon."
+        "desc": "The merrow makes two attacks: one with its bite and one with its claws or harpoon.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Harpoon",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Harpoon",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -22825,7 +23169,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Dreadful Glare",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Rotting Fist",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Rotting Fist",
@@ -23070,7 +23431,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Dreadful Glare",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Rotting Fist",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Rotting Fist",
@@ -23221,7 +23599,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Horror Nimbus",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -24062,7 +24462,38 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The oni makes two attacks, either with its claws or its glaive."
+        "desc": "The oni makes two attacks, either with its claws or its glaive.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Glaive",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Glaive",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw (Oni Form Only)",
@@ -24222,7 +24653,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The otyugh makes three attacks: one with its bite and two with its tentacles."
+        "desc": "The otyugh makes three attacks: one with its bite and two with its tentacles.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tentacle",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",


### PR DESCRIPTION
This is the isolated code from PR #144 pertaining only to multiattack options only for **Gargoyle** to **Otyugh**

This will be split up into 3 PR's to keep the lines of code down.