### PR TITLE
Add higher_level to Hunter's Mark spell

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -6313,6 +6313,9 @@
     "desc": [
       "You choose a creature you can see within range and mystically mark it as your quarry. Until the spell ends, you deal an extra 1d6 damage to the target whenever you hit it with a weapon attack, and you have advantage on any Wisdom (Perception) or Wisdom (Survival) check you make to find it. If the target drops to 0 hit points before this spell ends, you can use a bonus action on a subsequent turn of yours to mark a new creature."
     ],
+    "higher_level": [
+      "When you cast this spell using a spell slot of 3rd or 4th level, you can maintain your concentration on the spell for up to 8 hours. When you use a spell slot of 5th level or higher, you can maintain your concentration on the spell for up to 24 hours."
+    ],
     "range": "90 feet",
     "components": ["V"],
     "ritual": false,


### PR DESCRIPTION
## What does this do?
It adds `higher_level` to the Hunter's Mark spell which was previously missing. Description pulled from [SRD.](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf)

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolves #172 

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/80407946-48aeed80-887b-11ea-89c9-d5358fe296a3.png)
