### PR TITLE
Monster multiattack V1

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -25973,7 +25973,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The owlbear makes two attacks: one with its beak and one with its claws."
+        "desc": "The owlbear makes two attacks: one with its beak and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -26360,7 +26377,34 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail."
+        "desc": "The pit fiend makes four attacks: one with its bite, one with its claw, one with its mace, and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Mace",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -26595,7 +26639,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The planetar makes two melee attacks."
+        "desc": "The planetar makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -26792,7 +26848,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": "The bear makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -27168,7 +27241,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The worm makes two attacks: one with its bite and one with its stinger."
+        "desc": "The worm makes two attacks: one with its bite and one with its stinger.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail Stinger",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -27532,7 +27622,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The rakshasa makes two claw attacks"
+        "desc": "The rakshasa makes two claw attacks",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -28102,7 +28204,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The roc makes two attacks: one with its beak and one with its talons."
+        "desc": "The roc makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -28196,7 +28315,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite."
+        "desc": "The roper makes four attacks with its tendrils, uses Reel, and makes one attack with its bite.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tendril",
+                "count": 4,
+                "type": "melee"
+              },
+              {
+                "name": "Reel",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -28511,7 +28652,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear."
+        "desc": "The sahuagin makes two melee attacks: one with its bite and one with its claws or spear.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Spear",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -28634,7 +28804,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The salamander makes two attacks: one with its spear and one with its tail."
+        "desc": "The salamander makes two attacks: one with its spear and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Spear",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Spear",
@@ -28911,7 +29098,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The scout makes two melee attacks or two ranged attacks."
+        "desc": "The scout makes two melee attacks or two ranged attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Shortsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Shortsword",
@@ -29249,7 +29455,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it."
+        "desc": "The shambling mound makes two slam attacks. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "note": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Engulf",
+                "note": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -29344,7 +29569,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The guardian makes two fist attacks."
+        "desc": "The guardian makes two fist attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fist",
@@ -29786,7 +30023,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The solar makes two greatsword attacks."
+        "desc": "The solar makes two greatsword attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -30417,7 +30666,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The spy makes two melee attacks."
+        "desc": "The spy makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Shortsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Shortsword",
@@ -30695,7 +30956,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatclub attacks."
+        "desc": "The giant makes two greatclub attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatclub",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatclub",
@@ -30812,7 +31085,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": "The golem makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -30992,7 +31277,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatsword attacks."
+        "desc": "The giant makes two greatsword attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -32226,7 +32523,67 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tai l. It can use its Swallow instead of its bite."
+        "desc": "The tarrasque can use its Frightful Presence. It then makes five attacks: one with its bite, two with its claws, one with its horns, and one with its tail. It can use its Swallow instead of its bite.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Horns",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Swallow",
+                "note": "If the target is grappled",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Horns",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -32365,7 +32722,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The thug makes two melee attacks."
+        "desc": "The thug makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Mace",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Mace",
@@ -32532,7 +32901,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The treant makes two slam attacks."
+        "desc": "The treant makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -32765,7 +33146,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The troll makes three attacks: one with its bite and two with its claws."
+        "desc": "The troll makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -32838,7 +33236,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
+        "desc": "The tyrannosaurus makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "note": "It can't make both attacks against the same target",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "note": "It can't make both attacks against the same target",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -32994,7 +33411,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The unicorn makes two attacks: one with its hooves and one with its horn."
+        "desc": "The unicorn makes two attacks: one with its hooves and one with its horn.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Hooves",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Horn",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Hooves",
@@ -33302,7 +33736,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vampire makes two attacks, only one of which can be a bite attack."
+        "desc": "The vampire makes two attacks, only one of which can be a bite attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claws",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -33388,7 +33846,25 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Shortsword",
+                "note": "If shortsword is drawn",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -33504,7 +33980,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The fungus makes 1d4 Rotting Touch attacks."
+        "desc": "The fungus makes 1d4 Rotting Touch attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Rotting Touch",
+                "count": "1d4",
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Rotting Touch",
@@ -33592,7 +34080,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vrock makes two attacks: one with its beak and one with its talons."
+        "desc": "The vrock makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -33926,7 +34431,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": "The elemental makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -34104,7 +34621,42 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid."
+        "desc": "In bear form, the werebear makes two claw attacks. In humanoid form, it makes two greataxe attacks. In hybrid form, it can attack like a bear or a humanoid.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "note": "Bear or Hybrid Form Only",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Greataxe",
+                "note": "Humanoid or Hybrid Form Only",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Greataxe",
+                "note": "Hybrid Form Only",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "note": "Hybrid Form Only",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite (Bear or Hybrid Form Only)",
@@ -34799,7 +35351,38 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack."
+        "desc": "The wight makes two longsword attacks or two longbow attacks. It can use its Life Drain in place of one longsword attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Life Drain",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Longsword",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Life Drain",
@@ -35363,7 +35946,52 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack."
+        "desc": "The wyvern makes two attacks: one with its bite and one with its stinger. While flying, it can use its claws in place of one other attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Stinger",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "note": "If flying",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "note": "If flying",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Stinger",
+                "note": "If flying",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "note": "If flying",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -35475,7 +36103,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The xorn makes three claw attacks and one bite attack."
+        "desc": "The xorn makes three claw attacks and one bite attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 3,
+                "type": "melee"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -35585,7 +36230,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -35724,7 +36386,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -35868,7 +36547,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36027,7 +36723,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36180,7 +36893,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36343,7 +37073,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36506,7 +37253,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36645,7 +37409,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36793,7 +37574,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -36947,7 +37745,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -14716,7 +14716,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gargoyle makes two attacks: one with its bite and one with its claws."
+        "desc": "The gargoyle makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -15195,7 +15212,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ape makes two fist attacks."
+        "desc": "The ape makes two fist attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fist",
@@ -15270,7 +15299,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The badger makes two attacks: one with its bite and one with its claws."
+        "desc": "The badger makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -15658,7 +15704,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The crocodile makes two attacks: one with its bite and one with its tail."
+        "desc": "The crocodile makes two attacks: one with its bite and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -15738,7 +15801,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The eagle makes two attacks: one with its beak and one with its talons."
+        "desc": "The eagle makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -16525,7 +16605,24 @@
       },
       {
         "name": "Multiattack",
-        "desc": "The scorpion makes three attacks: two with its claws and one with its sting."
+        "desc": "The scorpion makes three attacks: two with its claws and one with its sting.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Sting",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Sting",
@@ -16871,7 +16968,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The vulture makes two attacks: one with its beak and one with its talons."
+        "desc": "The vulture makes two attacks: one with its beak and one with its talons.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Talons",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -17155,7 +17269,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle."
+        "desc": "The gibbering mouther makes one bite attack and, if it can, uses its Blinding Spittle.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bites",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Blinding Spittle",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bites",
@@ -17323,7 +17454,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell."
+        "desc": "The glabrezu makes four attacks: two with its pincers and two with its fists. Alternatively, it makes two attacks with its pincers and casts one spell.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Pincer",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Pincer",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Innate Spellcasting",
+                "count": 1,
+                "type": "magic"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Pincer",
@@ -17434,7 +17594,57 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The gladiator makes three melee attacks or two ranged attacks."
+        "desc": "The gladiator makes three melee attacks or two ranged attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Spear",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Shield Bash",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spear",
+                "count": 2,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Spear",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Shield Bash",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Shield Bash",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Spear",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Spear",
@@ -18370,7 +18580,25 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target."
+        "desc": "The grick makes one attack with its tentacles. If that attack hits, the grick can make one beak attack against the same target.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tentacles",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Beak",
+                "note": "If tentacles attack hits",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Tentacles",
@@ -18451,7 +18679,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The griffon makes two attacks: one with its beak and one with its claws."
+        "desc": "The griffon makes two attacks: one with its beak and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -19025,7 +19270,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sphinx makes two claw attacks."
+        "desc": "The sphinx makes two claw attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -19095,7 +19352,25 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack."
+        "desc": "The veteran makes two longsword attacks. If it has a shortsword drawn, it can also make a shortsword attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Shortsword",
+                "note": "If shortsword is drawn",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -19219,7 +19494,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The harpy makes two attacks: one with its claws and one with its club."
+        "desc": "The harpy makes two attacks: one with its claws and one with its club.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claws",
@@ -19500,7 +19792,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hezrou makes three attacks: one with its bite and two with its claws."
+        "desc": "The hezrou makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -19581,7 +19890,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatclub attacks."
+        "desc": "The giant makes two greatclub attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatclub",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatclub",
@@ -19661,7 +19982,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hippogriff makes two attacks: one with its beak and one with its claws."
+        "desc": "The hippogriff makes two attacks: one with its beak and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beak",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beak",
@@ -19923,7 +20261,53 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack."
+        "desc": "The devil makes three melee attacks: two with its fork and one with its tail. It can use Hurl Flame in place of any melee attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fork",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Fork",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Hurl Flame",
+                "count": 1,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Fork",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Hurl Flame",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fork",
@@ -20096,7 +20480,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The hydra makes as many bite attacks as it has heads."
+        "desc": "The hydra makes as many bite attacks as it has heads.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": "Number of Heads",
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -20251,7 +20647,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail."
+        "desc": "The devil makes three attacks: one with its bite, one with its claws, and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -20672,7 +21090,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The stalker makes two slam attacks."
+        "desc": "The stalker makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -20773,7 +21203,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two melee attacks."
+        "desc": "The golem makes two melee attacks.",
+        "options": {
+          "choose": 2,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Sword",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -21017,7 +21466,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The knight makes two melee attacks."
+        "desc": "The knight makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -21229,7 +21690,50 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling."
+        "desc": "The kraken makes three tentacle attacks, each of which it can replace with one use of Fling.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tentacle",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tentacle",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Fling",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tentacle",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Fling",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Fling",
+                "count": 3,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -21420,7 +21924,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch."
+        "desc": "The lamia makes two attacks: one with its claws and one with its dagger or Intoxicating Touch.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Dagger",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Intoxicating Touch",
+                "count": 1,
+                "type": "ability"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claws",
@@ -22070,7 +22603,84 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The lizardfolk makes two melee attacks, each one with a different weapon."
+        "desc": "The lizardfolk makes two melee attacks, each one with a different weapon.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Javelin",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Spiked Shield",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Heavy Club",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -22644,7 +23254,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes."
+        "desc": "The manticore makes three attacks: one with its bite and two with its claws or three with its tail spikes.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Tail Spike",
+                "count": 3,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -22774,7 +23408,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The marilith can make seven attacks: six with its longswords and one with its tail."
+        "desc": "The marilith can make seven attacks: six with its longswords and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 6,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -22955,7 +23606,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow."
+        "desc": "The medusa makes either three melee attacks--one with its snake hair and two with its shortsword--or two ranged attacks with its longbow.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Snake Hair",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Shortsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Snake Hair",
@@ -23136,7 +23811,48 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The merrow makes two attacks: one with its bite and one with its claws or harpoon."
+        "desc": "The merrow makes two attacks: one with its bite and one with its claws or harpoon.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Harpoon",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Harpoon",
+                "count": 1,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -23581,7 +24297,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Dreadful Glare",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Rotting Fist",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Rotting Fist",
@@ -23826,7 +24559,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist."
+        "desc": "The mummy can use its Dreadful Glare and makes one attack with its rotting fist.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Dreadful Glare",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Rotting Fist",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Rotting Fist",
@@ -23977,7 +24727,30 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Horror Nimbus",
+                "note": "If it can use Horror Nimbus",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -24818,7 +25591,41 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The oni makes two attacks, either with its claws or its glaive."
+        "desc": "The oni makes two attacks, either with its claws or its glaive.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Glaive",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Claw",
+                "note": "If in Oni form",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Glaive",
+                "note": "If in Oni form",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "note": "If in Oni form",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw (Oni Form Only)",
@@ -24978,7 +25785,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The otyugh makes three attacks: one with its bite and two with its tentacles."
+        "desc": "The otyugh makes three attacks: one with its bite and two with its tentacles.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tentacle",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -81,7 +81,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The aboleth makes three tentacle attacks."
+        "desc": "The aboleth makes three tentacle attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tentacle",
+                "count": 3,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Tentacle",
@@ -363,7 +375,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -571,7 +605,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -789,7 +845,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -982,7 +1060,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -1203,7 +1303,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -1433,7 +1555,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -1673,7 +1817,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -1881,7 +2047,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -2147,7 +2335,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -2368,7 +2578,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -2576,7 +2808,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": "The elemental makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -2688,7 +2932,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -2886,7 +3152,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -3095,7 +3383,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -3324,7 +3634,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -3549,7 +3881,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -3783,7 +4137,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -4027,7 +4403,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -4235,7 +4633,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -4452,7 +4872,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -4677,7 +5119,29 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws."
+        "desc": "The dragon can use its Frightful Presence. It then makes three attacks: one with its bite and two with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Frightful Presence",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -5001,7 +5465,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The sphinx makes two claw attacks."
+        "desc": "The sphinx makes two claw attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -5167,7 +5643,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The armor makes two melee attacks."
+        "desc": "The armor makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -5312,7 +5800,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ape makes two fist attacks."
+        "desc": "The ape makes two fist attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Fist",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Fist",
@@ -5678,7 +6178,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The assassin makes two shortsword attacks."
+        "desc": "The assassin makes two shortsword attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Shortsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Shortsword",
@@ -6238,7 +6750,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The balor makes two attacks: one with its longsword and one with its whip."
+        "desc": "The balor makes two attacks: one with its longsword and one with its whip.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Whip",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -6422,7 +6951,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers."
+        "desc": "The captain makes three melee attacks: two with its scimitar and one with its dagger. Or the captain makes two ranged attacks with its daggers.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Scimitar",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Dagger",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Dagger",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Scimitar",
@@ -6568,7 +7121,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice."
+        "desc": "The devil makes three melee attacks: one with its tail and two with its claws. Alternatively, it can use Hurl Flame twice.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Hurl Flame",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -6823,7 +7400,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes two attacks: one with its beard and one with its glaive."
+        "desc": "The devil makes two attacks: one with its beard and one with its glaive.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Beard",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Glaive",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Beard",
@@ -6906,7 +7500,23 @@
       {
         "name": "Multiattack",
         "desc": "The behir makes two attacks: one with its bite and one to constrict.",
-        "attack_bonus": 0
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Constrict",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -7083,7 +7693,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": "The bear makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -7777,7 +8404,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes three attacks: two with its claws and one with its sting."
+        "desc": "The devil makes three attacks: two with its claws and one with its sting.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Claw",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Sting",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Claw",
@@ -8127,7 +8771,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The bear makes two attacks: one with its bite and one with its claws."
+        "desc": "The bear makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -8492,7 +9153,31 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow."
+        "desc": "The centaur makes two attacks: one with its pike and one with its hooves or two with its longbow.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Pike",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Hooves",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Pike",
@@ -8612,7 +9297,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The devil makes two attacks with its chains."
+        "desc": "The devil makes two attacks with its chains.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Chain",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Chain",
@@ -8697,7 +9394,69 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns."
+        "desc": "The chimera makes three attacks: one with its bite, one with its horns, and one with its claws. When its fire breath is available, it can use the breath in place of its bite or horns.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Horns",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Fire Breath",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Horns",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Fire Breath",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "ability"
+              },
+              {
+                "name": "Claws",
+                "note": "When Fire Breath is available",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -8831,7 +9590,33 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once."
+        "desc": "The chuul makes two pincer attacks. If the chuul is grappling a creature, the chuul can also use its tentacles once.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Pincer",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Pincer",
+                "note": "When chuul is grappling",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Tentacles",
+                "note": "When chuul is grappling",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Pincer",
@@ -8948,7 +9733,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": "The golem makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -9031,7 +9828,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The cloaker makes two attacks: one with its bite and one with its tail."
+        "desc": "The cloaker makes two attacks: one with its bite and one with its tail.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -9235,7 +10049,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two morningstar attacks."
+        "desc": "The giant makes two morningstar attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Morningstar",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Morningstar",
@@ -10020,7 +10846,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The fanatic makes two melee attacks."
+        "desc": "The fanatic makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Dagger",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Dagger",
@@ -10229,7 +11067,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dog makes two bite attacks."
+        "desc": "The dog makes two bite attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -10553,7 +11403,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The deva makes two melee attacks."
+        "desc": "The deva makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Mace",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Mace",
@@ -10835,7 +11697,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The djinni makes three scimitar attacks."
+        "desc": "The djinni makes three scimitar attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Scimitar",
+                "count": 3,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Scimitar",
@@ -10952,7 +11826,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The doppelganger makes two melee attacks."
+        "desc": "The doppelganger makes two melee attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -11082,7 +11968,36 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks."
+        "desc": "The dragon turtle makes three attacks: one with its bite and two with its claws. It can make one tail attack in place of its two claw attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Tail",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -11203,7 +12118,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The dretch makes two attacks: one with its bite and one with its claws."
+        "desc": "The dretch makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -11354,7 +12286,50 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack."
+        "desc": "The drider makes three attacks, either with its longsword or its longbow. It can replace one of those attacks with a bite attack.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 3,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 3,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Longsword",
+                "count": 2,
+                "type": "melee"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 2,
+                "type": "ranged"
+              },
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -12197,7 +13172,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two slam attacks."
+        "desc": "The elemental makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -12366,7 +13353,26 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The efreeti makes two scimitar attacks or uses its Hurl Flame twice."
+        "desc": "The efreeti makes two scimitar attacks or uses its Hurl Flame twice.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Scimitar",
+                "count": 2,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Hurl Flame",
+                "count": 2,
+                "type": "ranged"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Scimitar",
@@ -12623,7 +13629,33 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The erinyes makes three attacks"
+        "desc": "The erinyes makes three attacks",
+        "options": {
+          "choose": 3,
+          "from": [
+            [
+              {
+                "name": "Longsword",
+                "count": 1,
+                "type": "melee"
+              }
+            ],
+            [
+              {
+                "name": "Longbow",
+                "count": 1,
+                "type": "ranged"
+              }
+            ],
+            [
+              {
+                "name": "Variant: Rope of Entanglement",
+                "count": 2,
+                "type": "ability"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Longsword",
@@ -12762,7 +13794,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ettercap makes two attacks: one with its bite and one with its claws."
+        "desc": "The ettercap makes two attacks: one with its bite and one with its claws.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Bite",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Claws",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Bite",
@@ -12879,7 +13928,24 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The ettin makes two attacks: one with its battleaxe and one with its morningstar."
+        "desc": "The ettin makes two attacks: one with its battleaxe and one with its morningstar.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Battleaxe",
+                "count": 1,
+                "type": "melee"
+              },
+              {
+                "name": "Morningstar",
+                "count": 1,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Battleaxe",
@@ -13009,7 +14075,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The elemental makes two touch attacks."
+        "desc": "The elemental makes two touch attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Touch",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Touch",
@@ -13089,7 +14167,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greatsword attacks."
+        "desc": "The giant makes two greatsword attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greatsword",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greatsword",
@@ -13212,7 +14302,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The golem makes two slam attacks."
+        "desc": "The golem makes two slam attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Slam",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Slam",
@@ -13510,7 +14612,19 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The giant makes two greataxe attacks."
+        "desc": "The giant makes two greataxe attacks.",
+        "options": {
+          "choose": 1,
+          "from": [
+            [
+              {
+                "name": "Greataxe",
+                "count": 2,
+                "type": "melee"
+              }
+            ]
+          ]
+        }
       },
       {
         "name": "Greataxe",


### PR DESCRIPTION
## What does this do?
This merges in the changes from #168, #169, and #170 into master in one branch. This based on the work that @caldane and @jbhaywood have done to get this over the line. Currently, complicated uses of multiattacks are added to a human readable `notes` field.

## How was it tested?
CI and previous PR review.

## Is there a Github issue this is resolving?
This is a first stab at #116. There is still some more work that will have to be done though. Namely, converting the `notes` field into something properly parseable and not just human readable.

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/80430437-760f9180-88a3-11ea-9687-09e117a80776.png)
