### PR TITLE
Non-distinct feature fix

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2295,7 +2295,7 @@
     "url": "/api/features/archdruid"
   },
   {
-    "index": "choose-fighting-style",
+    "index": "fighter-choose-fighting-style",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2336,7 +2336,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-fighting-style"
+    "url": "/api/features/fighter-choose-fighting-style"
   },
   {
     "index": "fighting-style-archery",
@@ -3278,7 +3278,7 @@
     "url": "/api/features/lay-on-hands"
   },
   {
-    "index": "choose-fighting-style",
+    "index": "paladin-choose-fighting-style",
     "class": {
       "url": "/api/classes/paladin",
       "name": "Paladin"
@@ -3311,7 +3311,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-fighting-style"
+    "url": "/api/features/paladin-choose-fighting-style"
   },
   {
     "index": "fighting-style-defense",
@@ -3746,7 +3746,7 @@
     "url": "/api/features/natural-explorer-1-terrain-type"
   },
   {
-    "index": "choose-fighting-style",
+    "index": "ranger-choose-fighting-style",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -3779,7 +3779,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-fighting-style"
+    "url": "/api/features/ranger-choose-fighting-style"
   },
   {
     "index": "fighting-style-archery",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -107,7 +107,7 @@
     "url": "/api/features/barbarian-ability-score-improvement-1"
   },
   {
-    "index": "extra-attack",
+    "index": "barbarian-extra-attack",
     "class": {
       "url": "/api/classes/barbarian",
       "name": "Barbarian"
@@ -118,7 +118,7 @@
     "desc": [
       "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."
     ],
-    "url": "/api/features/extra-attack"
+    "url": "/api/features/barbarian-extra-attack"
   },
   {
     "index": "fast-movement",
@@ -2967,7 +2967,7 @@
     "url": "/api/features/slow-fall"
   },
   {
-    "index": "extra-attack",
+    "index": "monk-extra-attack",
     "class": {
       "url": "/api/classes/monk",
       "name": "Monk"
@@ -2978,7 +2978,7 @@
     "desc": [
       "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."
     ],
-    "url": "/api/features/extra-attack"
+    "url": "/api/features/monk-extra-attack"
   },
   {
     "index": "stunning-strike",
@@ -3511,7 +3511,7 @@
     "url": "/api/features/paladin-ability-score-improvement-1"
   },
   {
-    "index": "extra-attack",
+    "index": "paladin-extra-attack",
     "class": {
       "url": "/api/classes/paladin",
       "name": "Paladin"
@@ -3522,7 +3522,7 @@
     "desc": [
       "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."
     ],
-    "url": "/api/features/extra-attack"
+    "url": "/api/features/paladin-extra-attack"
   },
   {
     "index": "aura-of-protection",
@@ -3989,7 +3989,7 @@
     "url": "/api/features/ranger-ability-score-improvement-1"
   },
   {
-    "index": "extra-attack",
+    "index": "ranger-extra-attack",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -4000,7 +4000,7 @@
     "desc": [
       "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn."
     ],
-    "url": "/api/features/extra-attack"
+    "url": "/api/features/ranger-extra-attack"
   },
   {
     "index": "favored-enemy-2-types",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -483,75 +483,75 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/expertise-survival",
+          "url": "/api/features/bard-expertise-survival",
           "name": "Expertise: Acrobatics"
         },
         {
-          "url": "/api/features/expertise-stealth",
+          "url": "/api/features/bard-expertise-stealth",
           "name": "Expertise: Animal Handling"
         },
         {
-          "url": "/api/features/expertise-acrobatics",
+          "url": "/api/features/bard-expertise-acrobatics",
           "name": "Expertise: Arcana"
         },
         {
-          "url": "/api/features/expertise-animal-handling",
+          "url": "/api/features/bard-expertise-animal-handling",
           "name": "Expertise: Athletics"
         },
         {
-          "url": "/api/features/expertise-arcana",
+          "url": "/api/features/bard-expertise-arcana",
           "name": "Expertise: Deception"
         },
         {
-          "url": "/api/features/expertise-athletics",
+          "url": "/api/features/bard-expertise-athletics",
           "name": "Expertise: History"
         },
         {
-          "url": "/api/features/expertise-deception",
+          "url": "/api/features/bard-expertise-deception",
           "name": "Expertise: Insight"
         },
         {
-          "url": "/api/features/expertise-history",
+          "url": "/api/features/bard-expertise-history",
           "name": "Expertise: Intimidation"
         },
         {
-          "url": "/api/features/expertise-insight",
+          "url": "/api/features/bard-expertise-insight",
           "name": "Expertise: Investigation"
         },
         {
-          "url": "/api/features/expertise-intimidation",
+          "url": "/api/features/bard-expertise-intimidation",
           "name": "Expertise: Medicine"
         },
         {
-          "url": "/api/features/expertise-investigation",
+          "url": "/api/features/bard-expertise-investigation",
           "name": "Expertise: Nature"
         },
         {
-          "url": "/api/features/expertise-medicine",
+          "url": "/api/features/bard-expertise-medicine",
           "name": "Expertise: Perception"
         },
         {
-          "url": "/api/features/expertise-nature",
+          "url": "/api/features/bard-expertise-nature",
           "name": "Expertise: Performance"
         },
         {
-          "url": "/api/features/expertise-perception",
+          "url": "/api/features/bard-expertise-perception",
           "name": "Expertise: Persuasion"
         },
         {
-          "url": "/api/features/expertise-performance",
+          "url": "/api/features/bard-expertise-performance",
           "name": "Expertise: Religion"
         },
         {
-          "url": "/api/features/expertise-persuasion",
+          "url": "/api/features/bard-expertise-persuasion",
           "name": "Expertise: Sleight of Hand"
         },
         {
-          "url": "/api/features/expertise-religion",
+          "url": "/api/features/bard-expertise-religion",
           "name": "Expertise: Stealth"
         },
         {
-          "url": "/api/features/expertise-sleight-of-hand",
+          "url": "/api/features/bard-expertise-sleight-of-hand",
           "name": "Expertise: Survival"
         }
       ]
@@ -559,7 +559,7 @@
     "url": "/api/features/bard-choose-expertise-1"
   },
   {
-    "index": "expertise-acrobatics",
+    "index": "bard-expertise-acrobatics",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -576,10 +576,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-acrobatics"
+    "url": "/api/features/bard-expertise-acrobatics"
   },
   {
-    "index": "expertise-animal-handling",
+    "index": "bard-expertise-animal-handling",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -596,10 +596,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-animal-handling"
+    "url": "/api/features/bard-expertise-animal-handling"
   },
   {
-    "index": "expertise-arcana",
+    "index": "bard-expertise-arcana",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -616,10 +616,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-arcana"
+    "url": "/api/features/bard-expertise-arcana"
   },
   {
-    "index": "expertise-athletics",
+    "index": "bard-expertise-athletics",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -636,10 +636,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-athletics"
+    "url": "/api/features/bard-expertise-athletics"
   },
   {
-    "index": "expertise-deception",
+    "index": "bard-expertise-deception",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -656,10 +656,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-deception"
+    "url": "/api/features/bard-expertise-deception"
   },
   {
-    "index": "expertise-history",
+    "index": "bard-expertise-history",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -676,10 +676,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-history"
+    "url": "/api/features/bard-expertise-history"
   },
   {
-    "index": "expertise-insight",
+    "index": "bard-expertise-insight",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -696,10 +696,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-insight"
+    "url": "/api/features/bard-expertise-insight"
   },
   {
-    "index": "expertise-intimidation",
+    "index": "bard-expertise-intimidation",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -716,10 +716,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-intimidation"
+    "url": "/api/features/bard-expertise-intimidation"
   },
   {
-    "index": "expertise-investigation",
+    "index": "bard-expertise-investigation",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -736,10 +736,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-investigation"
+    "url": "/api/features/bard-expertise-investigation"
   },
   {
-    "index": "expertise-medicine",
+    "index": "bard-expertise-medicine",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -756,10 +756,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-medicine"
+    "url": "/api/features/bard-expertise-medicine"
   },
   {
-    "index": "expertise-nature",
+    "index": "bard-expertise-nature",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -776,10 +776,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-nature"
+    "url": "/api/features/bard-expertise-nature"
   },
   {
-    "index": "expertise-perception",
+    "index": "bard-expertise-perception",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -796,10 +796,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-perception"
+    "url": "/api/features/bard-expertise-perception"
   },
   {
-    "index": "expertise-performance",
+    "index": "bard-expertise-performance",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -816,10 +816,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-performance"
+    "url": "/api/features/bard-expertise-performance"
   },
   {
-    "index": "expertise-persuasion",
+    "index": "bard-expertise-persuasion",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -836,10 +836,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-persuasion"
+    "url": "/api/features/bard-expertise-persuasion"
   },
   {
-    "index": "expertise-religion",
+    "index": "bard-expertise-religion",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -856,10 +856,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-religion"
+    "url": "/api/features/bard-expertise-religion"
   },
   {
-    "index": "expertise-sleight-of-hand",
+    "index": "bard-expertise-sleight-of-hand",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -876,10 +876,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-sleight-of-hand"
+    "url": "/api/features/bard-expertise-sleight-of-hand"
   },
   {
-    "index": "expertise-stealth",
+    "index": "bard-expertise-stealth",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -896,10 +896,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-stealth"
+    "url": "/api/features/bard-expertise-stealth"
   },
   {
-    "index": "expertise-survival",
+    "index": "bard-expertise-survival",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -916,7 +916,7 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Bard)",
-    "url": "/api/features/expertise-survival"
+    "url": "/api/features/bard-expertise-survival"
   },
   {
     "index": "bard-ability-score-improvement-1",
@@ -1055,75 +1055,75 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/expertise-survival",
+          "url": "/api/features/bard-expertise-survival",
           "name": "Expertise: Acrobatics"
         },
         {
-          "url": "/api/features/expertise-stealth",
+          "url": "/api/features/bard-expertise-stealth",
           "name": "Expertise: Animal Handling"
         },
         {
-          "url": "/api/features/expertise-acrobatics",
+          "url": "/api/features/bard-expertise-acrobatics",
           "name": "Expertise: Arcana"
         },
         {
-          "url": "/api/features/expertise-animal-handling",
+          "url": "/api/features/bard-expertise-animal-handling",
           "name": "Expertise: Athletics"
         },
         {
-          "url": "/api/features/expertise-arcana",
+          "url": "/api/features/bard-expertise-arcana",
           "name": "Expertise: Deception"
         },
         {
-          "url": "/api/features/expertise-athletics",
+          "url": "/api/features/bard-expertise-athletics",
           "name": "Expertise: History"
         },
         {
-          "url": "/api/features/expertise-deception",
+          "url": "/api/features/bard-expertise-deception",
           "name": "Expertise: Insight"
         },
         {
-          "url": "/api/features/expertise-history",
+          "url": "/api/features/bard-expertise-history",
           "name": "Expertise: Intimidation"
         },
         {
-          "url": "/api/features/expertise-insight",
+          "url": "/api/features/bard-expertise-insight",
           "name": "Expertise: Investigation"
         },
         {
-          "url": "/api/features/expertise-intimidation",
+          "url": "/api/features/bard-expertise-intimidation",
           "name": "Expertise: Medicine"
         },
         {
-          "url": "/api/features/expertise-investigation",
+          "url": "/api/features/bard-expertise-investigation",
           "name": "Expertise: Nature"
         },
         {
-          "url": "/api/features/expertise-medicine",
+          "url": "/api/features/bard-expertise-medicine",
           "name": "Expertise: Perception"
         },
         {
-          "url": "/api/features/expertise-nature",
+          "url": "/api/features/bard-expertise-nature",
           "name": "Expertise: Performance"
         },
         {
-          "url": "/api/features/expertise-perception",
+          "url": "/api/features/bard-expertise-perception",
           "name": "Expertise: Persuasion"
         },
         {
-          "url": "/api/features/expertise-performance",
+          "url": "/api/features/bard-expertise-performance",
           "name": "Expertise: Religion"
         },
         {
-          "url": "/api/features/expertise-persuasion",
+          "url": "/api/features/bard-expertise-persuasion",
           "name": "Expertise: Sleight of Hand"
         },
         {
-          "url": "/api/features/expertise-religion",
+          "url": "/api/features/bard-expertise-religion",
           "name": "Expertise: Stealth"
         },
         {
-          "url": "/api/features/expertise-sleight-of-hand",
+          "url": "/api/features/bard-expertise-sleight-of-hand",
           "name": "Expertise: Survival"
         }
       ]
@@ -4478,75 +4478,75 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/expertise-survival",
+          "url": "/api/features/rogue-expertise-survival",
           "name": "Expertise: Acrobatics"
         },
         {
-          "url": "/api/features/expertise-stealth",
+          "url": "/api/features/rogue-expertise-stealth",
           "name": "Expertise: Animal Handling"
         },
         {
-          "url": "/api/features/expertise-acrobatics",
+          "url": "/api/features/rogue-expertise-acrobatics",
           "name": "Expertise: Arcana"
         },
         {
-          "url": "/api/features/expertise-animal-handling",
+          "url": "/api/features/rogue-expertise-animal-handling",
           "name": "Expertise: Athletics"
         },
         {
-          "url": "/api/features/expertise-arcana",
+          "url": "/api/features/rogue-expertise-arcana",
           "name": "Expertise: Deception"
         },
         {
-          "url": "/api/features/expertise-athletics",
+          "url": "/api/features/rogue-expertise-athletics",
           "name": "Expertise: History"
         },
         {
-          "url": "/api/features/expertise-deception",
+          "url": "/api/features/rogue-expertise-deception",
           "name": "Expertise: Insight"
         },
         {
-          "url": "/api/features/expertise-history",
+          "url": "/api/features/rogue-expertise-history",
           "name": "Expertise: Intimidation"
         },
         {
-          "url": "/api/features/expertise-insight",
+          "url": "/api/features/rogue-expertise-insight",
           "name": "Expertise: Investigation"
         },
         {
-          "url": "/api/features/expertise-intimidation",
+          "url": "/api/features/rogue-expertise-intimidation",
           "name": "Expertise: Medicine"
         },
         {
-          "url": "/api/features/expertise-investigation",
+          "url": "/api/features/rogue-expertise-investigation",
           "name": "Expertise: Nature"
         },
         {
-          "url": "/api/features/expertise-medicine",
+          "url": "/api/features/rogue-expertise-medicine",
           "name": "Expertise: Perception"
         },
         {
-          "url": "/api/features/expertise-nature",
+          "url": "/api/features/rogue-expertise-nature",
           "name": "Expertise: Performance"
         },
         {
-          "url": "/api/features/expertise-perception",
+          "url": "/api/features/rogue-expertise-perception",
           "name": "Expertise: Persuasion"
         },
         {
-          "url": "/api/features/expertise-performance",
+          "url": "/api/features/rogue-expertise-performance",
           "name": "Expertise: Religion"
         },
         {
-          "url": "/api/features/expertise-persuasion",
+          "url": "/api/features/rogue-expertise-persuasion",
           "name": "Expertise: Sleight of Hand"
         },
         {
-          "url": "/api/features/expertise-religion",
+          "url": "/api/features/rogue-expertise-religion",
           "name": "Expertise: Stealth"
         },
         {
-          "url": "/api/features/expertise-sleight-of-hand",
+          "url": "/api/features/rogue-expertise-sleight-of-hand",
           "name": "Expertise: Survival"
         }
       ]
@@ -4554,7 +4554,7 @@
     "url": "/api/features/rogue-choose-expertise-1"
   },
   {
-    "index": "expertise-acrobatics",
+    "index": "rogue-expertise-acrobatics",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4571,10 +4571,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-acrobatics"
+    "url": "/api/features/rogue-expertise-acrobatics"
   },
   {
-    "index": "expertise-animal-handling",
+    "index": "rogue-expertise-animal-handling",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4591,10 +4591,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-animal-handling"
+    "url": "/api/features/rogue-expertise-animal-handling"
   },
   {
-    "index": "expertise-arcana",
+    "index": "rogue-expertise-arcana",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4611,10 +4611,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-arcana"
+    "url": "/api/features/rogue-expertise-arcana"
   },
   {
-    "index": "expertise-athletics",
+    "index": "rogue-expertise-athletics",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4631,10 +4631,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-athletics"
+    "url": "/api/features/rogue-expertise-athletics"
   },
   {
-    "index": "expertise-deception",
+    "index": "rogue-expertise-deception",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4651,10 +4651,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-deception"
+    "url": "/api/features/rogue-expertise-deception"
   },
   {
-    "index": "expertise-history",
+    "index": "rogue-expertise-history",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4671,10 +4671,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-history"
+    "url": "/api/features/rogue-expertise-history"
   },
   {
-    "index": "expertise-insight",
+    "index": "rogue-expertise-insight",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4691,10 +4691,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-insight"
+    "url": "/api/features/rogue-expertise-insight"
   },
   {
-    "index": "expertise-intimidation",
+    "index": "rogue-expertise-intimidation",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4711,10 +4711,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-intimidation"
+    "url": "/api/features/rogue-expertise-intimidation"
   },
   {
-    "index": "expertise-investigation",
+    "index": "rogue-expertise-investigation",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4731,10 +4731,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-investigation"
+    "url": "/api/features/rogue-expertise-investigation"
   },
   {
-    "index": "expertise-medicine",
+    "index": "rogue-expertise-medicine",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4751,10 +4751,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-medicine"
+    "url": "/api/features/rogue-expertise-medicine"
   },
   {
-    "index": "expertise-nature",
+    "index": "rogue-expertise-nature",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4771,10 +4771,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-nature"
+    "url": "/api/features/rogue-expertise-nature"
   },
   {
-    "index": "expertise-perception",
+    "index": "rogue-expertise-perception",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4791,10 +4791,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-perception"
+    "url": "/api/features/rogue-expertise-perception"
   },
   {
-    "index": "expertise-performance",
+    "index": "rogue-expertise-performance",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4811,10 +4811,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-performance"
+    "url": "/api/features/rogue-expertise-performance"
   },
   {
-    "index": "expertise-persuasion",
+    "index": "rogue-expertise-persuasion",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4831,10 +4831,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-persuasion"
+    "url": "/api/features/rogue-expertise-persuasion"
   },
   {
-    "index": "expertise-religion",
+    "index": "rogue-expertise-religion",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4851,10 +4851,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-religion"
+    "url": "/api/features/rogue-expertise-religion"
   },
   {
-    "index": "expertise-sleight-of-hand",
+    "index": "rogue-expertise-sleight-of-hand",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4871,10 +4871,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-sleight-of-hand"
+    "url": "/api/features/rogue-expertise-sleight-of-hand"
   },
   {
-    "index": "expertise-stealth",
+    "index": "rogue-expertise-stealth",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4891,10 +4891,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-stealth"
+    "url": "/api/features/rogue-expertise-stealth"
   },
   {
-    "index": "expertise-survival",
+    "index": "rogue-expertise-survival",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4911,10 +4911,10 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-survival"
+    "url": "/api/features/rogue-expertise-survival"
   },
   {
-    "index": "expertise-thieves-tools",
+    "index": "rogue-expertise-thieves-tools",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4931,7 +4931,7 @@
       "Your proficiency bonus is doubled for any ability check you make for this skill."
     ],
     "group": "Expertise (Rogue)",
-    "url": "/api/features/expertise-thieves-tools"
+    "url": "/api/features/rogue-expertise-thieves-tools"
   },
   {
     "index": "sneak-attack",
@@ -5073,75 +5073,75 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/expertise-survival",
+          "url": "/api/features/rogueexpertise-survival",
           "name": "Expertise: Acrobatics"
         },
         {
-          "url": "/api/features/expertise-stealth",
+          "url": "/api/features/rogueexpertise-stealth",
           "name": "Expertise: Animal Handling"
         },
         {
-          "url": "/api/features/expertise-acrobatics",
+          "url": "/api/features/rogueexpertise-acrobatics",
           "name": "Expertise: Arcana"
         },
         {
-          "url": "/api/features/expertise-animal-handling",
+          "url": "/api/features/rogueexpertise-animal-handling",
           "name": "Expertise: Athletics"
         },
         {
-          "url": "/api/features/expertise-arcana",
+          "url": "/api/features/rogueexpertise-arcana",
           "name": "Expertise: Deception"
         },
         {
-          "url": "/api/features/expertise-athletics",
+          "url": "/api/features/rogueexpertise-athletics",
           "name": "Expertise: History"
         },
         {
-          "url": "/api/features/expertise-deception",
+          "url": "/api/features/rogueexpertise-deception",
           "name": "Expertise: Insight"
         },
         {
-          "url": "/api/features/expertise-history",
+          "url": "/api/features/rogueexpertise-history",
           "name": "Expertise: Intimidation"
         },
         {
-          "url": "/api/features/expertise-insight",
+          "url": "/api/features/rogueexpertise-insight",
           "name": "Expertise: Investigation"
         },
         {
-          "url": "/api/features/expertise-intimidation",
+          "url": "/api/features/rogueexpertise-intimidation",
           "name": "Expertise: Medicine"
         },
         {
-          "url": "/api/features/expertise-investigation",
+          "url": "/api/features/rogueexpertise-investigation",
           "name": "Expertise: Nature"
         },
         {
-          "url": "/api/features/expertise-medicine",
+          "url": "/api/features/rogueexpertise-medicine",
           "name": "Expertise: Perception"
         },
         {
-          "url": "/api/features/expertise-nature",
+          "url": "/api/features/rogueexpertise-nature",
           "name": "Expertise: Performance"
         },
         {
-          "url": "/api/features/expertise-perception",
+          "url": "/api/features/rogueexpertise-perception",
           "name": "Expertise: Persuasion"
         },
         {
-          "url": "/api/features/expertise-performance",
+          "url": "/api/features/rogueexpertise-performance",
           "name": "Expertise: Religion"
         },
         {
-          "url": "/api/features/expertise-persuasion",
+          "url": "/api/features/rogueexpertise-persuasion",
           "name": "Expertise: Sleight of Hand"
         },
         {
-          "url": "/api/features/expertise-religion",
+          "url": "/api/features/rogueexpertise-religion",
           "name": "Expertise: Stealth"
         },
         {
-          "url": "/api/features/expertise-sleight-of-hand",
+          "url": "/api/features/rogueexpertise-sleight-of-hand",
           "name": "Expertise: Survival"
         }
       ]
@@ -6330,7 +6330,7 @@
     "prerequisites": [
       {
         "type": "feature",
-        "feature": "/api/features/expertise-medicine"
+        "feature": "/api/features/pact-of-the-tome"
       }
     ],
     "desc": [
@@ -6518,7 +6518,7 @@
     "prerequisites": [
       {
         "type": "feature",
-        "feature": "/api/features/expertise-intimidation"
+        "feature": "/api/features/pact-of-the-chain"
       }
     ],
     "desc": [
@@ -6607,7 +6607,7 @@
       },
       {
         "type": "feature",
-        "feature": "/api/features/expertise-investigation"
+        "feature": "/api/features/pact-of-the-blade"
       }
     ],
     "desc": [
@@ -6779,7 +6779,7 @@
       },
       {
         "type": "feature",
-        "feature": "/api/features/expertise-investigation"
+        "feature": "/api/features/pact-of-the-blade"
       }
     ],
     "desc": [
@@ -6804,7 +6804,7 @@
       },
       {
         "type": "feature",
-        "feature": "/api/features/expertise-intimidation"
+        "feature": "/api/features/pact-of-the-chain"
       }
     ],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -3026,7 +3026,7 @@
     "url": "/api/features/wholeness-of-body"
   },
   {
-    "index": "evasion",
+    "index": "monk-evasion",
     "class": {
       "url": "/api/classes/monk",
       "name": "Monk"
@@ -3037,7 +3037,7 @@
     "desc": [
       "At 7th level, your instinctive agility lets you dodge out of the way of certain area effects, such as a blue dragon's lightning breath or a fireball spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail."
     ],
-    "url": "/api/features/evasion"
+    "url": "/api/features/monk-evasion"
   },
   {
     "index": "stillness-of-mind",
@@ -5149,7 +5149,7 @@
     "url": "/api/features/rogue-choose-expertise-2"
   },
   {
-    "index": "evasion",
+    "index": "rogue-evasion",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -5160,7 +5160,7 @@
     "desc": [
       "Beginning at 7th level, you can nimbly dodge out of the way of certain area effects, such as a red dragon's fiery breath or an ice storm spell. When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail."
     ],
-    "url": "/api/features/evasion"
+    "url": "/api/features/rogue-evasion"
   },
   {
     "index": "rogue-ability-score-improvement-2",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2238,7 +2238,7 @@
     "url": "/api/features/druid-ability-score-improvement-4"
   },
   {
-    "index": "timeless-body",
+    "index": "druid-timeless-body",
     "class": {
       "url": "/api/classes/druid",
       "name": "Druid"
@@ -2249,7 +2249,7 @@
     "desc": [
       "Starting at 18th level, the primal magic that you wield causes you to age more slowly. For every 10 years that pass, your body ages only 1 year."
     ],
-    "url": "/api/features/timeless-body"
+    "url": "/api/features/druid-timeless-body"
   },
   {
     "index": "beast-spells",
@@ -3157,7 +3157,7 @@
     "url": "/api/features/diamond-soul"
   },
   {
-    "index": "timeless-body",
+    "index": "monk-timeless-body",
     "class": {
       "url": "/api/classes/monk",
       "name": "Monk"
@@ -3168,7 +3168,7 @@
     "desc": [
       "At 15th level, your ki sustains you so that you suffer none of the frailty of old age, and you can't be aged magically. You can still die of old age, however. In addition, you no longer need food or water."
     ],
-    "url": "/api/features/timeless-body"
+    "url": "/api/features/monk-timeless-body"
   },
   {
     "index": "monk-ability-score-improvement-4",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1306,9 +1306,7 @@
     "subclass": {},
     "name": "Spellcasting: Cleric",
     "level": 1,
-    "desc": [
-      "As a conduit for divine power, you can cast cleric spells."
-    ],
+    "desc": ["As a conduit for divine power, you can cast cleric spells."],
     "reference": "/api/spellcasting/cleric",
     "url": "/api/features/spellcasting-cleric"
   },
@@ -2364,9 +2362,7 @@
     "subclass": {},
     "name": "Fighting Style: Defense",
     "level": 1,
-    "desc": [
-      "While you are wearing armor, you gain a +1 bonus to AC."
-    ],
+    "desc": ["While you are wearing armor, you gain a +1 bonus to AC."],
     "group": "Fighting Style (Fighter)",
     "url": "/api/features/fighting-style-defense"
   },
@@ -3326,9 +3322,7 @@
     "subclass": {},
     "name": "Fighting Style: Defense",
     "level": 2,
-    "desc": [
-      "While you are wearing armor, you gain a +1 bonus to AC."
-    ],
+    "desc": ["While you are wearing armor, you gain a +1 bonus to AC."],
     "group": "Fighting Style (Paladin)",
     "url": "/api/features/fighting-style-defense"
   },
@@ -3675,9 +3669,7 @@
     "subclass": {},
     "name": "Aura improvements",
     "level": 18,
-    "desc": [
-      "At 18th level, the range of your auras increase to 30 feet."
-    ],
+    "desc": ["At 18th level, the range of your auras increase to 30 feet."],
     "url": "/api/features/aura-improvements"
   },
   {
@@ -3813,9 +3805,7 @@
     "subclass": {},
     "name": "Fighting Style: Defense",
     "level": 2,
-    "desc": [
-      "While you are wearing armor, you gain a +1 bonus to AC."
-    ],
+    "desc": ["While you are wearing armor, you gain a +1 bonus to AC."],
     "group": "Fighting Style (Ranger)",
     "url": "/api/features/fighting-style-defense"
   },
@@ -4102,9 +4092,7 @@
     },
     "name": "Defensive Tactics: Escape the Horde",
     "level": 7,
-    "desc": [
-      "Opportunity attacks against you are made with disadvantage."
-    ],
+    "desc": ["Opportunity attacks against you are made with disadvantage."],
     "group": "Defensive Tactics",
     "url": "/api/features/defensive-tactics-escape-the-horde"
   },
@@ -4138,9 +4126,7 @@
     },
     "name": "Defensive Tactics: Steel Will",
     "level": 7,
-    "desc": [
-      "You have advantage on saving throws against being frightened."
-    ],
+    "desc": ["You have advantage on saving throws against being frightened."],
     "group": "Defensive Tactics",
     "url": "/api/features/defensive-tactics-steel-will"
   },
@@ -6328,9 +6314,7 @@
     "name": "Eldritch Invocation: Beguiling Influence",
     "level": 2,
     "prerequisites": [],
-    "desc": [
-      "You gain proficiency in the Deception and Persuasion skills."
-    ],
+    "desc": ["You gain proficiency in the Deception and Persuasion skills."],
     "group": "Eldritch Invocations",
     "url": "/api/features/eldritch-invocation-beguiling-influence"
   },
@@ -6403,9 +6387,7 @@
         "spell": "/api/spells/dominate-monster"
       }
     ],
-    "desc": [
-      "When you cast eldritch blast, its range is 300 feet."
-    ],
+    "desc": ["When you cast eldritch blast, its range is 300 feet."],
     "group": "Eldritch Invocations",
     "url": "/api/features/eldritch-invocation-eldritch-spear"
   },
@@ -6419,9 +6401,7 @@
     "name": "Eldritch Invocation: Eyes of the Rune Keeper",
     "level": 2,
     "prerequisites": [],
-    "desc": [
-      "You can read all writing."
-    ],
+    "desc": ["You can read all writing."],
     "group": "Eldritch Invocations",
     "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
   },
@@ -6996,7 +6976,7 @@
     "url": "/api/features/warlock-ability-score-improvement-1"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-1",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7079,7 +7059,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-1"
   },
   {
     "index": "dark-ones-own-luck",
@@ -7100,7 +7080,7 @@
     "url": "/api/features/dark-ones-own-luck"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-2",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7183,7 +7163,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-2"
   },
   {
     "index": "warlock-ability-score-improvement-2",
@@ -7200,7 +7180,7 @@
     "url": "/api/features/warlock-ability-score-improvement-2"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-3",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7283,7 +7263,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-3"
   },
   {
     "index": "fiendish-resilience",
@@ -7333,7 +7313,7 @@
     "url": "/api/features/warlock-ability-score-improvement-3"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-4",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7416,7 +7396,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-4"
   },
   {
     "index": "mystic-arcanum-7th-level",
@@ -7470,7 +7450,7 @@
     "url": "/api/features/mystic-arcanum-8th-level"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-5",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7553,7 +7533,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-5"
   },
   {
     "index": "warlock-ability-score-improvement-5",
@@ -7586,7 +7566,7 @@
     "url": "/api/features/mystic-arcanum-9th-level"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-6",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7669,7 +7649,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-6"
   },
   {
     "index": "warlock-ability-score-improvement-6",
@@ -7701,7 +7681,7 @@
     "url": "/api/features/eldritch-master"
   },
   {
-    "index": "choose-additional-eldritch-invocation",
+    "index": "choose-additional-eldritch-invocation-7",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -7784,7 +7764,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-eldritch-invocation"
+    "url": "/api/features/choose-additional-eldritch-invocation-7"
   },
   {
     "index": "spellcasting-wizard",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5923,7 +5923,7 @@
     "url": "/api/features/sorcerer-ability-score-improvement-2"
   },
   {
-    "index": "choose-additional-metamagic",
+    "index": "choose-additional-metamagic-1",
     "class": {
       "url": "/api/classes/sorcerer",
       "name": "Sorcerer"
@@ -5973,7 +5973,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-metamagic"
+    "url": "/api/features/choose-additional-metamagic-1"
   },
   {
     "index": "sorcerer-ability-score-improvement-3",
@@ -6022,7 +6022,7 @@
     "url": "/api/features/sorcerer-ability-score-improvement-4"
   },
   {
-    "index": "choose-additional-metamagic",
+    "index": "choose-additional-metamagic-2",
     "class": {
       "url": "/api/classes/sorcerer",
       "name": "Sorcerer"
@@ -6072,7 +6072,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-additional-metamagic"
+    "url": "/api/features/choose-additional-metamagic-2"
   },
   {
     "index": "draconic-presence",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1039,7 +1039,7 @@
     "url": "/api/features/bardic-inspiration-d10"
   },
   {
-    "index": "choose-expertise-2",
+    "index": "bard-choose-expertise-2",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -1128,7 +1128,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-expertise-2"
+    "url": "/api/features/bard-choose-expertise-2"
   },
   {
     "index": "magical-secrets-1",
@@ -5056,7 +5056,7 @@
     "url": "/api/features/uncanny-dodge"
   },
   {
-    "index": "choose-expertise-2",
+    "index": "rogue-choose-expertise-2",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -5146,7 +5146,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-expertise-2"
+    "url": "/api/features/rogue-choose-expertise-2"
   },
   {
     "index": "evasion",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -20,7 +20,7 @@
     "url": "/api/features/rage"
   },
   {
-    "index": "unarmored-defense",
+    "index": "barbarian-unarmored-defense",
     "class": {
       "url": "/api/classes/barbarian",
       "name": "Barbarian"
@@ -31,7 +31,7 @@
     "desc": [
       "While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier. You can use a shield and still gain this benefit."
     ],
-    "url": "/api/features/unarmored-defense"
+    "url": "/api/features/barbarian-unarmored-defense"
   },
   {
     "index": "reckless-attack",
@@ -2782,7 +2782,7 @@
     "url": "/api/features/extra-attack-3"
   },
   {
-    "index": "unarmored-defense",
+    "index": "monk-unarmored-defense",
     "class": {
       "url": "/api/classes/monk",
       "name": "Monk"
@@ -2793,7 +2793,7 @@
     "desc": [
       "Beginning at 1st level, while you are wearing no armor and not wielding a shield, your AC equals 10 + your Dexterity modifier + your Wisdom modifier."
     ],
-    "url": "/api/features/unarmored-defense"
+    "url": "/api/features/monk-unarmored-defense"
   },
   {
     "index": "martial-arts",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2311,27 +2311,27 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/fighting-style-archery",
+          "url": "/api/features/fighter-fighting-style-archery",
           "name": "Fighting Style: Archery"
         },
         {
-          "url": "/api/features/fighting-style-defense",
+          "url": "/api/features/fighter-fighting-style-defense",
           "name": "Fighting Style: Defense"
         },
         {
-          "url": "/api/features/fighting-style-dueling",
+          "url": "/api/features/fighter-fighting-style-dueling",
           "name": "Fighting Style: Dueling"
         },
         {
-          "url": "/api/features/fighting-style-great-weapon-fighting",
+          "url": "/api/features/fighter-fighting-style-great-weapon-fighting",
           "name": "Fighting Style: Great Weapon Fighting"
         },
         {
-          "url": "/api/features/fighting-style-protection",
+          "url": "/api/features/fighter-fighting-style-protection",
           "name": "Fighting Style: Protection"
         },
         {
-          "url": "/api/features/fighting-style-two-weapon-fighting",
+          "url": "/api/features/fighter-fighting-style-two-weapon-fighting",
           "name": "Fighting Style: Two-Weapon Fighting"
         }
       ]
@@ -2339,7 +2339,7 @@
     "url": "/api/features/fighter-choose-fighting-style"
   },
   {
-    "index": "fighting-style-archery",
+    "index": "fighter-fighting-style-archery",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2351,10 +2351,10 @@
       "You gain a +2 bonus to attack rolls you make with ranged weapons."
     ],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-archery"
+    "url": "/api/features/fighter-fighting-style-archery"
   },
   {
-    "index": "fighting-style-defense",
+    "index": "fighter-fighting-style-defense",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2364,10 +2364,10 @@
     "level": 1,
     "desc": ["While you are wearing armor, you gain a +1 bonus to AC."],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-defense"
+    "url": "/api/features/fighter-fighting-style-defense"
   },
   {
-    "index": "fighting-style-dueling",
+    "index": "fighter-fighting-style-dueling",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2379,10 +2379,10 @@
       "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon."
     ],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-dueling"
+    "url": "/api/features/fighter-fighting-style-dueling"
   },
   {
-    "index": "fighting-style-great-weapon-fighting",
+    "index": "fighter-fighting-style-great-weapon-fighting",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2394,10 +2394,10 @@
       "When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2. The weapon must have the two-handed or versatile property for you to gain this benefit."
     ],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-great-weapon-fighting"
+    "url": "/api/features/fighter-fighting-style-great-weapon-fighting"
   },
   {
-    "index": "fighting-style-protection",
+    "index": "fighter-fighting-style-protection",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2409,10 +2409,10 @@
       "When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield."
     ],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-protection"
+    "url": "/api/features/fighter-fighting-style-protection"
   },
   {
-    "index": "fighting-style-two-weapon-fighting",
+    "index": "fighter-fighting-style-two-weapon-fighting",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -2424,7 +2424,7 @@
       "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack."
     ],
     "group": "Fighting Style (Fighter)",
-    "url": "/api/features/fighting-style-two-weapon-fighting"
+    "url": "/api/features/fighter-fighting-style-two-weapon-fighting"
   },
   {
     "index": "second-wind",
@@ -2593,27 +2593,27 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/fighting-style-archery",
+          "url": "/api/features/fighter-fighting-style-archery",
           "name": "Fighting Style: Archery"
         },
         {
-          "url": "/api/features/fighting-style-defense",
+          "url": "/api/features/fighter-fighting-style-defense",
           "name": "Fighting Style: Defense"
         },
         {
-          "url": "/api/features/fighting-style-dueling",
+          "url": "/api/features/fighter-fighting-style-dueling",
           "name": "Fighting Style: Dueling"
         },
         {
-          "url": "/api/features/fighting-style-great-weapon-fighting",
+          "url": "/api/features/fighter-fighting-style-great-weapon-fighting",
           "name": "Fighting Style: Great Weapon Fighting"
         },
         {
-          "url": "/api/features/fighting-style-protection",
+          "url": "/api/features/fighter-fighting-style-protection",
           "name": "Fighting Style: Protection"
         },
         {
-          "url": "/api/features/fighting-style-two-weapon-fighting",
+          "url": "/api/features/fighter-fighting-style-two-weapon-fighting",
           "name": "Fighting Style: Two-Weapon Fighting"
         }
       ]
@@ -3762,19 +3762,19 @@
       "type": "feature",
       "from": [
         {
-          "url": "/api/features/fighting-style-archery",
+          "url": "/api/features/ranger-fighting-style-archery",
           "name": "Fighting Style: Archery"
         },
         {
-          "url": "/api/features/fighting-style-defense",
+          "url": "/api/features/ranger-fighting-style-defense",
           "name": "Fighting Style: Defense"
         },
         {
-          "url": "/api/features/fighting-style-dueling",
+          "url": "/api/features/ranger-fighting-style-dueling",
           "name": "Fighting Style: Dueling"
         },
         {
-          "url": "/api/features/fighting-style-two-weapon-fighting",
+          "url": "/api/features/ranger-fighting-style-two-weapon-fighting",
           "name": "Fighting Style: Two-Weapon Fighting"
         }
       ]
@@ -3782,7 +3782,7 @@
     "url": "/api/features/ranger-choose-fighting-style"
   },
   {
-    "index": "fighting-style-archery",
+    "index": "ranger-fighting-style-archery",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -3794,10 +3794,10 @@
       "You gain a +2 bonus to attack rolls you make with ranged weapons."
     ],
     "group": "Fighting Style (Ranger)",
-    "url": "/api/features/fighting-style-archery"
+    "url": "/api/features/ranger-fighting-style-archery"
   },
   {
-    "index": "fighting-style-defense",
+    "index": "ranger-fighting-style-defense",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -3807,10 +3807,10 @@
     "level": 2,
     "desc": ["While you are wearing armor, you gain a +1 bonus to AC."],
     "group": "Fighting Style (Ranger)",
-    "url": "/api/features/fighting-style-defense"
+    "url": "/api/features/ranger-fighting-style-defense"
   },
   {
-    "index": "fighting-style-dueling",
+    "index": "ranger-fighting-style-dueling",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -3822,10 +3822,10 @@
       "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon."
     ],
     "group": "Fighting Style (Ranger)",
-    "url": "/api/features/fighting-style-dueling"
+    "url": "/api/features/ranger-fighting-style-dueling"
   },
   {
-    "index": "fighting-style-two-weapon-fighting",
+    "index": "ranger-fighting-style-two-weapon-fighting",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -3837,7 +3837,7 @@
       "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack."
     ],
     "group": "Fighting Style (Ranger)",
-    "url": "/api/features/fighting-style-two-weapon-fighting"
+    "url": "/api/features/ranger-fighting-style-two-weapon-fighting"
   },
   {
     "index": "spellcasting-ranger",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2084,7 +2084,7 @@
     "url": "/api/features/circle-spells-2"
   },
   {
-    "index": "lands-stride",
+    "index": "druid-lands-stride",
     "class": {
       "url": "/api/classes/druid",
       "name": "Druid"
@@ -2099,7 +2099,7 @@
       "Starting at 6th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.",
       "In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell."
     ],
-    "url": "/api/features/lands-stride"
+    "url": "/api/features/druid-lands-stride"
   },
   {
     "index": "circle-spells-3",
@@ -4145,7 +4145,7 @@
     "url": "/api/features/ranger-ability-score-improvement-2"
   },
   {
-    "index": "lands-stride",
+    "index": "ranger-lands-stride",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -4157,7 +4157,7 @@
       "Starting at 8th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.",
       "In addition, you have advantage on saving throws against plants that are magically created or manipulated to impede movement, such those created by the entangle spell."
     ],
-    "url": "/api/features/lands-stride"
+    "url": "/api/features/ranger-lands-stride"
   },
   {
     "index": "natural-explorer-3-terrain-types",
@@ -4266,18 +4266,18 @@
     "url": "/api/features/multiattack-whirlwind-attack"
   },
   {
-    "index": "ranger-ability-score-improvement-4",
+    "index": "ranger-ability-score-improvement-3",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
     },
     "subclass": {},
-    "name": "Ranger: Ability Score Improvement 4",
+    "name": "Ranger: Ability Score Improvement 3",
     "level": 12,
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/ranger-ability-score-improvement-4"
+    "url": "/api/features/ranger-ability-score-improvement-3"
   },
   {
     "index": "favored-enemy-3-enemies",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -467,7 +467,7 @@
     "url": "/api/features/cutting-words"
   },
   {
-    "index": "choose-expertise-1",
+    "index": "bard-choose-expertise-1",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -556,7 +556,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-expertise-1"
+    "url": "/api/features/bard-choose-expertise-1"
   },
   {
     "index": "expertise-acrobatics",
@@ -4461,7 +4461,7 @@
     "url": "/api/features/foe-slayer"
   },
   {
-    "index": "choose-expertise-1",
+    "index": "rogue-choose-expertise-1",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -4551,7 +4551,7 @@
         }
       ]
     },
-    "url": "/api/features/choose-expertise-1"
+    "url": "/api/features/rogue-choose-expertise-1"
   },
   {
     "index": "expertise-acrobatics",

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -3390,7 +3390,7 @@
     "features": [
       {
         "name": "Evasion",
-        "url": "/api/features/evasion"
+        "url": "/api/features/monk-evasion"
       },
       {
         "name": "Stillness of Mind",
@@ -5107,7 +5107,7 @@
     "features": [
       {
         "name": "Evasion",
-        "url": "/api/features/evasion"
+        "url": "/api/features/rogue-evasion"
       }
     ],
     "spellcasting": {},

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -11,7 +11,7 @@
       },
       {
         "name": "Unarmored Defense",
-        "url": "/api/features/unarmored-defense"
+        "url": "/api/features/barbarian-unarmored-defense"
       }
     ],
     "class_specific": {
@@ -3190,7 +3190,7 @@
     "features": [
       {
         "name": "Unarmored Defense",
-        "url": "/api/features/unarmored-defense"
+        "url": "/api/features/monk-unarmored-defense"
       },
       {
         "name": "Martial Arts",

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -2700,7 +2700,7 @@
     "feature_choices": [
       {
         "name": "Choose: Fighting Style",
-        "url": "/api/features/choose-fighting-style"
+        "url": "/api/features/fighter-choose-fighting-style"
       }
     ],
     "features": [
@@ -3808,7 +3808,7 @@
     "feature_choices": [
       {
         "name": "Choose: Fighting Style",
-        "url": "/api/features/choose-fighting-style"
+        "url": "/api/features/paladin-choose-fighting-style"
       }
     ],
     "features": [
@@ -4357,7 +4357,7 @@
     "feature_choices": [
       {
         "name": "Choose: Fighting Style",
-        "url": "/api/features/choose-fighting-style"
+        "url": "/api/features/ranger-choose-fighting-style"
       }
     ],
     "features": [

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -4556,7 +4556,7 @@
       },
       {
         "name": "Land's Stride",
-        "url": "/api/features/lands-stride"
+        "url": "/api/features/ranger-lands-stride"
       }
     ],
     "spellcasting": {

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -111,7 +111,7 @@
     "features": [
       {
         "name": "Extra Attack",
-        "url": "/api/features/extra-attack"
+        "url": "/api/features/barbarian-extra-attack"
       },
       {
         "name": "Fast Movement",
@@ -3330,7 +3330,7 @@
     "features": [
       {
         "name": "Extra Attack",
-        "url": "/api/features/extra-attack"
+        "url": "/api/features/monk-extra-attack"
       },
       {
         "name": "Stunning Strike",
@@ -3917,7 +3917,7 @@
     "features": [
       {
         "name": "Extra Attack",
-        "url": "/api/features/extra-attack"
+        "url": "/api/features/paladin-extra-attack"
       }
     ],
     "spellcasting": {
@@ -4460,7 +4460,7 @@
     "features": [
       {
         "name": "Extra Attack",
-        "url": "/api/features/extra-attack"
+        "url": "/api/features/ranger-extra-attack"
       }
     ],
     "spellcasting": {

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -6721,7 +6721,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-1"
       }
     ],
     "features": [],
@@ -6794,7 +6794,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-2"
       }
     ],
     "features": [],
@@ -6872,7 +6872,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-3"
       }
     ],
     "features": [],
@@ -6984,7 +6984,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-4"
       }
     ],
     "features": [
@@ -7101,7 +7101,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-5"
       }
     ],
     "features": [
@@ -7223,7 +7223,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-6"
       }
     ],
     "features": [],
@@ -7301,7 +7301,7 @@
     "feature_choices": [
       {
         "name": "Choose: Additional Eldritch Invocation",
-        "url": "/api/features/choose-additional-eldritch-invocation"
+        "url": "/api/features/choose-additional-eldritch-invocation-7"
       }
     ],
     "features": [

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -852,7 +852,7 @@
     "feature_choices": [
       {
         "name": "Choose: Expertise 2",
-        "url": "/api/features/choose-expertise-2"
+        "url": "/api/features/bard-choose-expertise-2"
       }
     ],
     "features": [
@@ -5080,7 +5080,7 @@
     "feature_choices": [
       {
         "name": "Expertise 2",
-        "url": "/api/features/choose-expertise-2"
+        "url": "/api/features/rogue-choose-expertise-2"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -5948,7 +5948,7 @@
     "feature_choices": [
       {
         "name": "Choose: Metamagic, Third",
-        "url": "/api/features/choose-additional-metamagic"
+        "url": "/api/features/choose-additional-metamagic-1"
       }
     ],
     "features": [],
@@ -6334,7 +6334,7 @@
     "feature_choices": [
       {
         "name": "Choose: Metamagic, Fourth",
-        "url": "/api/features/choose-additional-metamagic"
+        "url": "/api/features/choose-additional-metamagic-2"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -2589,7 +2589,7 @@
     "features": [
       {
         "name": "Timeless Body",
-        "url": "/api/features/timeless-body"
+        "url": "/api/features/druid-timeless-body"
       },
       {
         "name": "Beast Spells",
@@ -3613,7 +3613,7 @@
     "features": [
       {
         "name": "Timeless Body",
-        "url": "/api/features/timeless-body"
+        "url": "/api/features/monk-timeless-body"
       }
     ],
     "spellcasting": {},

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -575,7 +575,7 @@
     "feature_choices": [
       {
         "name": "Choose: Expertise 1",
-        "url": "/api/features/choose-expertise-1"
+        "url": "/api/features/bard-choose-expertise-1"
       }
     ],
     "features": [
@@ -4941,7 +4941,7 @@
     "feature_choices": [
       {
         "name": "Expertise 1",
-        "url": "/api/features/choose-expertise-1"
+        "url": "/api/features/rogue-choose-expertise-1"
       }
     ],
     "features": [

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -421,8 +421,8 @@
     "feature_choices": [],
     "features": [
       {
-        "name": "Fast Movement",
-        "url": "/api/features/fast-movement"
+        "name": "Primal Champion",
+        "url": "/api/features/primal-champion"
       }
     ],
     "rage_count": 9999,

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -3970,7 +3970,7 @@
     "features": [
       {
         "name": "Evasion",
-        "url": "/api/features/evasion"
+        "url": "/api/features/rogue-evasion"
       }
     ],
     "sneak_attack": {

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -11,7 +11,7 @@
       },
       {
         "name": "Unarmored Defense",
-        "url": "/api/features/unarmored-defense"
+        "url": "/api/features/barbarian-unarmored-defense"
       }
     ],
     "rage_count": 2,

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -779,7 +779,7 @@
       },
       {
         "name": "Choose: Expertise 2",
-        "url": "/api/features/choose-expertise-2"
+        "url": "/api/features/bard-choose-expertise-2"
       },
       {
         "name": "Magical Secrets 1",
@@ -3946,7 +3946,7 @@
     "feature_choices": [
       {
         "name": "Expertise 2",
-        "url": "/api/features/choose-expertise-2"
+        "url": "/api/features/rogue-choose-expertise-2"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -525,7 +525,7 @@
     "feature_choices": [
       {
         "name": "Choose: Expertise 1",
-        "url": "/api/features/choose-expertise-1"
+        "url": "/api/features/bard-choose-expertise-1"
       }
     ],
     "features": [
@@ -3822,7 +3822,7 @@
     "feature_choices": [
       {
         "name": "Expertise 1",
-        "url": "/api/features/choose-expertise-1"
+        "url": "/api/features/rogue-choose-expertise-1"
       }
     ],
     "features": [

--- a/src/5e-SRD-Test.json
+++ b/src/5e-SRD-Test.json
@@ -103,7 +103,7 @@
     "features": [
       {
         "name": "Extra Attack",
-        "url": "/api/features/extra-attack"
+        "url": "/api/features/barbarian-extra-attack"
       },
       {
         "name": "Fast Movement",


### PR DESCRIPTION
## What does this do?
This fixes a bunch of Feature indices that are non distinct.
```
choose-additional-eldritch-invocation
choose-additional-metamagic
choose-expertise-1
choose-expertise-2
choose-fighting-style
evasion
expertise-acrobatics
expertise-animal-handling
expertise-arcana
expertise-athletics
expertise-deception
expertise-history
expertise-insight
expertise-intimidation
expertise-investigation
expertise-medicine
expertise-nature
expertise-perception
expertise-performance
expertise-persuasion
expertise-religion
expertise-sleight-of-hand
expertise-stealth
expertise-survival
extra-attack
fast-movement
fighting-style-archery
fighting-style-defense
fighting-style-dueling
fighting-style-great-weapon-fighting
fighting-style-protection
fighting-style-two-weapon-fighting
lands-stride
ranger-ability-score-improvement-4
timeless-body
unarmored-defense
```

## How was it tested?
CR

## Is there a Github issue this is resolving?
This resolves #149.

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/80617791-61441280-89f7-11ea-9820-4e39472d97bd.png)

