### PR TITLE
Fixed Eldritch blast

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -3752,10 +3752,8 @@
     "index": "eldritch-blast",
     "name": "Eldritch Blast",
     "desc": [
-      "A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage."
-    ],
-    "higher_level": [
-      "The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam."
+      "A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage. The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam."
+
     ],
     "range": "120 feet",
     "components": ["V", "S"],


### PR DESCRIPTION
## What does this do?
Eldritch blast was formatted incorrectly, this fixes that

## How was it tested?
Compared to other cantrips and formatted the same way

## Is there a Github issue this is resolving?
Yes, issue#iforgot that I opened this week

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
