### PR TITLE
Update 5e-SRD-Equipment-Categories.json

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -988,7 +988,7 @@
 				"name": "Chariot"
 			},
 			{
-				"url": "/api/equipment/animal-feed-1 day",
+				"url": "/api/equipment/animal-feed-1-day",
 				"name": "Animal Feed (1 day)"
 			},
 			{
@@ -1016,7 +1016,7 @@
 				"name": "Sled"
 			},
 			{
-				"url": "/api/equipment/stabling-1 day",
+				"url": "/api/equipment/stabling-1-day",
 				"name": "Stabling (1 day)"
 			},
 			{
@@ -2185,7 +2185,7 @@
 				"name": "Chariot"
 			},
 			{
-				"url": "/api/equipment/animal-feed-1 day",
+				"url": "/api/equipment/animal-feed-1-day",
 				"name": "Animal Feed (1 day)"
 			},
 			{
@@ -2213,7 +2213,7 @@
 				"name": "Sled"
 			},
 			{
-				"url": "/api/equipment/stabling-1 day",
+				"url": "/api/equipment/stabling-1-day",
 				"name": "Stabling (1 day)"
 			},
 			{


### PR DESCRIPTION
Missing hyphens on several urls

## What does this do?
Fixes url references to equipment

## How was it tested?
Via api web app to ensure fixed urls exist and old urls do not

## Is there a Github issue this is resolving?
No

## Here's a fun image for your troubles
![random photo - update me](https://i.imgur.com/lYTsVSF.jpg)
