### PR TITLE
Removing redundant traits from Gnome Subrace

### DIFF
--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -242,14 +242,6 @@
     "language_options": {},
     "racial_traits": [
       {
-        "name": "Darkvision",
-        "url": "/api/traits/darkvision"
-      },
-      {
-        "name": "Gnome Cunning",
-        "url": "/api/traits/gnome-cunning"
-      },
-      {
         "name": "Artificer's Lore",
         "url": "/api/traits/artificers-lore"
       },


### PR DESCRIPTION
## What does this do?
Removes Darkvision and Gnome Cunning from Rock Gnome as it's already in the Gnome race.

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolves #184 

## Here's a fun image for your troubles
![image](https://i.kym-cdn.com/photos/images/newsfeed/001/185/519/64c.gif)

