### PR TITLE
Removed duplicate proficiencies

### DIFF
--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -830,20 +830,6 @@
 	"races": [],
 	"url": "/api/proficiencies/viol"
 }, {
-	"index": "disguise-kit",
-	"type": "Other",
-	"name": "Disguise Kit",
-	"classes": [],
-	"races": [],
-	"url": "/api/proficiencies/disguise-kit"
-}, {
-	"index": "forgery-kit",
-	"type": "Other",
-	"name": "Forgery Kit",
-	"classes": [],
-	"races": [],
-	"url": "/api/proficiencies/forgery-kit"
-}, {
 	"index": "herbalism-kit",
 	"type": "Other",
 	"name": "Herbalism Kit",


### PR DESCRIPTION
## What does this do?

Removed duplicate proficiencies

Disguise and forgery kits were listed in proficiencies twice

https://github.com/bagelbits/5e-database/blob/ddcc6c09445bc402fef84de9875fa3ed057aa86d/src/5e-SRD-Proficiencies.json#L720-L734

https://github.com/bagelbits/5e-database/blob/ddcc6c09445bc402fef84de9875fa3ed057aa86d/src/5e-SRD-Proficiencies.json#L832-L846