### PR TITLE
Add quantity and fix price for ammo

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1715,9 +1715,10 @@
     "name": "Arrow",
     "equipment_category": "Adventuring Gear",
     "gear_category": "Ammunition",
+    "quantity": 20,
     "cost": {
-      "quantity": 5,
-      "unit": "cp"
+      "quantity": 1,
+      "unit": "gp"
     },
     "weight": 1,
     "url": "/api/equipment/arrow"
@@ -1727,9 +1728,10 @@
     "name": "Blowgun needle",
     "equipment_category": "Adventuring Gear",
     "gear_category": "Ammunition",
+    "quantity": 50,
     "cost": {
-      "quantity": 2,
-      "unit": "cp"
+      "quantity": 1,
+      "unit": "gp"
     },
     "weight": 1,
     "url": "/api/equipment/blowgun-needle"
@@ -1739,9 +1741,10 @@
     "name": "Crossbow bolt",
     "equipment_category": "Adventuring Gear",
     "gear_category": "Ammunition",
+    "quantity": 20,
     "cost": {
-      "quantity": 5,
-      "unit": "cp"
+      "quantity": 1,
+      "unit": "gp"
     },
     "weight": 1.5,
     "url": "/api/equipment/crossbow-bolt"
@@ -1751,8 +1754,9 @@
     "name": "Sling bullet",
     "equipment_category": "Adventuring Gear",
     "gear_category": "Ammunition",
+    "quantity": 20,
     "cost": {
-      "quantity": 1,
+      "quantity": 4,
       "unit": "cp"
     },
     "weight": 1.5,


### PR DESCRIPTION
## What does this do?
Fixes ammo to show quantity and price for quantity so that it matches weight.

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolved #189 

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/84436963-241f9280-abe9-11ea-9da7-2089a6bd0f3d.png)
