### PR TITLE
Moonbeam typo fix

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -8251,7 +8251,7 @@
       "On each of your turns after you cast this spell, you can use an action to move the beam 60 feet in any direction."
     ],
     "higher_level": [
-      "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1dlO for each slot level above 2nd."
+      "When you cast this spell using a spell slot of 3rd level or higher, the damage increases by 1dl0 for each slot level above 2nd."
     ],
     "range": "120 feet",
     "components": ["V", "S", "M"],

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -3752,10 +3752,8 @@
     "index": "eldritch-blast",
     "name": "Eldritch Blast",
     "desc": [
-      "A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage."
-    ],
-    "higher_level": [
-      "The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam."
+      "A beam of crackling energy streaks toward a creature within range. Make a ranged spell attack against the target. On a hit, the target takes 1d10 force damage. The spell creates more than one beam when you reach higher levels: two beams at 5th level, three beams at 11th level, and four beams at 17th level. You can direct the beams at the same target or at different ones. Make a separate attack roll for each beam."
+
     ],
     "range": "120 feet",
     "components": ["V", "S"],


### PR DESCRIPTION
## What does this do?
Fix the typo in moonbeam

## How was it tested?
I changed one character, dont see how that will break anything

## Is there a Github issue this is resolving?
issue#201

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
