### PR TITLE
Add Deafened immunity to Gray Ooze

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -18209,8 +18209,8 @@
         "url": "/api/conditions/charmed"
       },
       {
-        "name": "Blinded",
-        "url": "/api/conditions/blinded"
+        "name": "Deafened",
+        "url": "/api/conditions/deafened"
       },
       {
         "name": "Exhaustion",


### PR DESCRIPTION
## What does this do?
Fixes the ooze's incorrect condition immunities list. There was 

## How was it tested?
CI

## Is there a Github issue this is resolving?
https://github.com/bagelbits/5e-database/issues/205

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
