### PR TITLE
Use dice notation for damage

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -15,7 +15,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -54,7 +53,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -105,7 +103,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -140,7 +137,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -187,7 +183,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -230,7 +225,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -277,7 +271,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -312,7 +305,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -335,7 +327,6 @@
     ],
     "2h_damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -359,7 +350,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -398,7 +388,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -429,7 +418,6 @@
     },
     "2h_damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -453,7 +441,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -496,7 +483,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -539,7 +525,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -578,7 +563,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -613,7 +597,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -632,7 +615,6 @@
     ],
     "2h_damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -656,7 +638,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -686,7 +667,6 @@
     },
     "damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -729,7 +709,6 @@
     },
     "damage": {
       "damage_dice": "1d12",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -768,7 +747,6 @@
     },
     "damage": {
       "damage_dice": "2d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -807,7 +785,6 @@
     },
     "damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -850,7 +827,6 @@
     },
     "damage": {
       "damage_dice": "1d12",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -892,7 +868,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -911,7 +886,6 @@
     ],
     "2h_damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -935,7 +909,6 @@
     },
     "damage": {
       "damage_dice": "2d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -974,7 +947,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1004,7 +976,6 @@
     },
     "damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1047,7 +1018,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1082,7 +1052,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -1121,7 +1090,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1164,7 +1132,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -1191,7 +1158,6 @@
     },
     "2h_damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1215,7 +1181,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1245,7 +1210,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -1264,7 +1228,6 @@
     ],
     "2h_damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/bludgeoning",
         "name": "Bludgeoning"
@@ -1288,7 +1251,6 @@
     },
     "damage": {
       "damage_dice": "1d4",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"
@@ -1327,7 +1289,6 @@
     },
     "damage": {
       "damage_dice": "1d1",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1366,7 +1327,6 @@
     },
     "damage": {
       "damage_dice": "1d6",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1409,7 +1369,6 @@
     },
     "damage": {
       "damage_dice": "1d10",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1456,7 +1415,6 @@
     },
     "damage": {
       "damage_dice": "1d8",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/piercing",
         "name": "Piercing"
@@ -1499,7 +1457,6 @@
     },
     "damage": {
       "damage_dice": "1d0",
-      "damage_bonus": 0,
       "damage_type": {
         "url": "/api/damage-types/slashing",
         "name": "Slashing"

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1455,13 +1455,6 @@
       "quantity": 1,
       "unit": "gp"
     },
-    "damage": {
-      "damage_dice": "1d0",
-      "damage_type": {
-        "url": "/api/damage-types/slashing",
-        "name": "Slashing"
-      }
-    },
     "range": {
       "normal": 5,
       "long": 15

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6494,7 +6494,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -7158,7 +7158,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -7166,7 +7166,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -8884,7 +8884,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -8892,7 +8892,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -10437,7 +10437,7 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage.",
+        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -10445,7 +10445,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -14108,7 +14108,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           },
           {
             "damage_type": {
@@ -19236,7 +19236,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -19797,7 +19797,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -22114,7 +22114,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -22122,7 +22122,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -24267,7 +24267,7 @@
     "actions": [
       {
         "name": "Multiattack",
-        "desc": "The nalfeshnee uses Horror Nimbus if it can.  It then makes three attacks: one with its bite and two with its claws.",
+        "desc": "The nalfeshnee uses Horror Nimbus if it can. It then makes three attacks: one with its bite and two with its claws.",
         "options": {
           "choose": 1,
           "from": [
@@ -24831,7 +24831,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       },
@@ -25441,7 +25441,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -26302,7 +26302,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -26942,7 +26942,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -27188,7 +27188,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -27196,7 +27196,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -27256,7 +27256,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -27989,7 +27989,7 @@
       },
       {
         "name": "Antennae",
-        "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a  bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
+        "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
       }
     ],
     "url": "/api/monsters/rust-monster"
@@ -28496,7 +28496,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -29763,7 +29763,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }
@@ -29999,7 +29999,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       },
@@ -30013,7 +30013,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       },
@@ -33927,7 +33927,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4+1"
+            "damage_dice": "1"
           }
         ]
       }

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -113,8 +113,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           }
         ]
       },
@@ -128,8 +127,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 5
+            "damage_dice": "3d6+5"
           }
         ]
       },
@@ -169,8 +167,7 @@
               "name": "Psychic",
               "url": "/api/damage-types/psychic"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -284,8 +281,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -409,16 +405,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -432,8 +426,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -447,8 +440,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -486,8 +478,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "12d8",
-            "damage_bonus": 0
+            "damage_dice": "12d8"
           }
         ]
       }
@@ -518,8 +509,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       }
@@ -639,16 +629,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 7
+            "damage_dice": "2d10+7"
           },
           {
             "damage_type": {
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -662,8 +650,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 7
+            "damage_dice": "2d6+7"
           }
         ]
       },
@@ -677,8 +664,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 7
+            "damage_dice": "2d8+7"
           }
         ]
       },
@@ -716,8 +702,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "12d10",
-            "damage_bonus": 0
+            "damage_dice": "12d10"
           }
         ]
       }
@@ -748,8 +733,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       }
@@ -879,8 +863,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -894,8 +877,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -909,8 +891,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -951,8 +932,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "13d6",
-                "damage_bonus": 0
+                "damage_dice": "13d6"
               }
             ]
           },
@@ -1094,8 +1074,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 7
+            "damage_dice": "2d10+7"
           }
         ]
       },
@@ -1109,8 +1088,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 7
+            "damage_dice": "2d6+7"
           }
         ]
       },
@@ -1124,8 +1102,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 7
+            "damage_dice": "2d8+7"
           }
         ]
       },
@@ -1166,8 +1143,7 @@
                   "name": "Lightning",
                   "url": "/api/damage-types/lightning"
                 },
-                "damage_dice": "12d10",
-                "damage_bonus": 0
+                "damage_dice": "12d10"
               }
             ]
           },
@@ -1211,8 +1187,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 7
+            "damage_dice": "2d6+7"
           }
         ]
       }
@@ -1337,8 +1312,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -1352,8 +1326,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -1367,8 +1340,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -1409,8 +1381,7 @@
                   "name": "Acid",
                   "url": "/api/damage-types/acid"
                 },
-                "damage_dice": "12d8",
-                "damage_bonus": 0
+                "damage_dice": "12d8"
               }
             ]
           },
@@ -1454,8 +1425,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "13d6",
-            "damage_bonus": 6
+            "damage_dice": "13d6+6"
           }
         ]
       }
@@ -1589,8 +1559,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           }
         ]
       },
@@ -1604,8 +1573,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -1619,8 +1587,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -1661,8 +1628,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "12d10",
-                "damage_bonus": 0
+                "damage_dice": "12d10"
               }
             ]
           },
@@ -1706,8 +1672,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -1851,16 +1816,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -1874,8 +1837,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -1889,8 +1851,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -1928,8 +1889,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "16d6",
-            "damage_bonus": 0
+            "damage_dice": "16d6"
           }
         ]
       }
@@ -1960,8 +1920,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       }
@@ -2081,16 +2040,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -2104,8 +2061,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -2119,8 +2075,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -2158,8 +2113,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "18d6",
-            "damage_bonus": 0
+            "damage_dice": "18d6"
           }
         ]
       },
@@ -2183,8 +2137,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "6d6",
-                "damage_bonus": 0
+                "damage_dice": "6d6"
               }
             ]
           },
@@ -2239,8 +2192,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -2369,8 +2321,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           }
         ]
       },
@@ -2384,8 +2335,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -2399,8 +2349,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -2441,8 +2390,7 @@
                   "name": "Cold",
                   "url": "/api/damage-types/cold"
                 },
-                "damage_dice": "13d8",
-                "damage_bonus": 0
+                "damage_dice": "13d8"
               }
             ]
           },
@@ -2486,8 +2434,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -2612,16 +2559,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -2635,8 +2580,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -2650,8 +2594,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -2689,8 +2632,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "12d8",
-            "damage_bonus": 0
+            "damage_dice": "12d8"
           }
         ]
       }
@@ -2721,8 +2663,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       }
@@ -2832,8 +2773,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       },
@@ -2966,16 +2906,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 0
+            "damage_dice": "2d8"
           }
         ]
       },
@@ -2989,8 +2927,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -3004,8 +2941,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -3043,8 +2979,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "15d8",
-            "damage_bonus": 0
+            "damage_dice": "15d8"
           }
         ]
       }
@@ -3075,8 +3010,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -3186,16 +3120,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 9
+            "damage_dice": "2d10+9"
           },
           {
             "damage_type": {
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 0
+            "damage_dice": "2d10"
           }
         ]
       },
@@ -3209,8 +3141,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 9
+            "damage_dice": "2d6+9"
           }
         ]
       },
@@ -3224,8 +3155,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 9
+            "damage_dice": "2d8+9"
           }
         ]
       },
@@ -3286,8 +3216,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 9
+            "damage_dice": "2d6+9"
           }
         ]
       }
@@ -3417,8 +3346,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           }
         ]
       },
@@ -3432,8 +3360,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -3447,8 +3374,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -3489,8 +3415,7 @@
                   "name": "Bludgeoning",
                   "url": "/api/damage-types/bludgeoning"
                 },
-                "damage_dice": "2d6",
-                "damage_bonus": 8
+                "damage_dice": "2d6+8"
               }
             ]
           },
@@ -3538,8 +3463,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -3668,8 +3592,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 9
+            "damage_dice": "2d10+9"
           }
         ]
       },
@@ -3683,8 +3606,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 9
+            "damage_dice": "2d6+9"
           }
         ]
       },
@@ -3698,8 +3620,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 9
+            "damage_dice": "2d8+9"
           }
         ]
       },
@@ -3740,8 +3661,7 @@
                   "name": "Lightning",
                   "url": "/api/damage-types/lightning"
                 },
-                "damage_dice": "16d10",
-                "damage_bonus": 0
+                "damage_dice": "16d10"
               }
             ]
           },
@@ -3789,8 +3709,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 9
+            "damage_dice": "2d6+9"
           }
         ]
       }
@@ -3915,8 +3834,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           }
         ]
       },
@@ -3930,8 +3848,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -3945,8 +3862,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -3987,8 +3903,7 @@
                   "name": "Acid",
                   "url": "/api/damage-types/acid"
                 },
-                "damage_dice": "14d8",
-                "damage_bonus": 0
+                "damage_dice": "14d8"
               }
             ]
           },
@@ -4036,8 +3951,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -4171,8 +4085,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 10
+            "damage_dice": "2d10+10"
           }
         ]
       },
@@ -4186,8 +4099,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       },
@@ -4201,8 +4113,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 10
+            "damage_dice": "2d8+10"
           }
         ]
       },
@@ -4243,8 +4154,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "13d10",
-                "damage_bonus": 0
+                "damage_dice": "13d10"
               }
             ]
           },
@@ -4292,8 +4202,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       }
@@ -4437,16 +4346,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -4460,8 +4367,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 8
+            "damage_dice": "4d6+8"
           }
         ]
       },
@@ -4475,8 +4381,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -4514,8 +4419,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "22d6",
-            "damage_bonus": 0
+            "damage_dice": "22d6"
           }
         ]
       }
@@ -4546,8 +4450,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -4667,16 +4570,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 10
+            "damage_dice": "2d10+10"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           }
         ]
       },
@@ -4690,8 +4591,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       },
@@ -4705,8 +4605,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 10
+            "damage_dice": "2d8+10"
           }
         ]
       },
@@ -4744,8 +4643,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "26d6",
-            "damage_bonus": 0
+            "damage_dice": "26d6"
           }
         ]
       }
@@ -4776,8 +4674,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       }
@@ -4906,8 +4803,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 10
+            "damage_dice": "2d10+10"
           }
         ]
       },
@@ -4921,8 +4817,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       },
@@ -4936,8 +4831,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 10
+            "damage_dice": "2d8+10"
           }
         ]
       },
@@ -4978,8 +4872,7 @@
                   "name": "Cold",
                   "url": "/api/damage-types/cold"
                 },
-                "damage_dice": "15d8",
-                "damage_bonus": 0
+                "damage_dice": "15d8"
               }
             ]
           },
@@ -5027,8 +4920,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 10
+            "damage_dice": "2d6+10"
           }
         ]
       }
@@ -5153,16 +5045,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 8
+            "damage_dice": "2d10+8"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 0
+            "damage_dice": "2d8"
           }
         ]
       },
@@ -5176,8 +5066,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -5191,8 +5080,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -5230,8 +5118,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "16d8",
-            "damage_bonus": 0
+            "damage_dice": "16d8"
           }
         ]
       }
@@ -5262,8 +5149,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       }
@@ -5489,8 +5375,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -5540,8 +5425,7 @@
                   "name": "Thunder",
                   "url": "/api/damage-types/thunder"
                 },
-                "damage_dice": "8d10",
-                "damage_bonus": 0
+                "damage_dice": "8d10"
               }
             ]
           }
@@ -5667,8 +5551,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -5718,16 +5601,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -5748,8 +5629,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -5824,8 +5704,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -5839,8 +5718,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       }
@@ -6091,8 +5969,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -6202,8 +6079,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           },
           {
             "dc": {
@@ -6218,8 +6094,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "7d6",
-            "damage_bonus": 0
+            "damage_dice": "7d6"
           }
         ]
       },
@@ -6233,8 +6108,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "dc": {
@@ -6249,8 +6123,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "7d6",
-            "damage_bonus": 0
+            "damage_dice": "7d6"
           }
         ]
       }
@@ -6307,8 +6180,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": -1
+            "damage_dice": "1d4-1"
           }
         ]
       }
@@ -6366,8 +6238,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 4
+            "damage_dice": "3d6+4"
           }
         ]
       }
@@ -6414,8 +6285,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -6475,8 +6345,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -6489,8 +6358,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -6510,16 +6378,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       }
@@ -6573,8 +6439,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": -1
+            "damage_dice": "1d4-1"
           }
         ]
       }
@@ -6629,8 +6494,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -6719,8 +6583,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "20d6",
-            "damage_bonus": 0
+            "damage_dice": "20d6"
           }
         ]
       },
@@ -6733,8 +6596,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -6779,16 +6641,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 8
+            "damage_dice": "3d8+8"
           },
           {
             "damage_type": {
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 0
+            "damage_dice": "3d8"
           }
         ]
       },
@@ -6802,16 +6662,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -6870,8 +6728,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       },
@@ -6885,8 +6742,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       }
@@ -6987,8 +6843,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -7002,8 +6857,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       }
@@ -7104,8 +6958,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -7157,8 +7010,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -7172,8 +7024,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -7187,8 +7038,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -7250,16 +7100,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -7310,7 +7158,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one creature. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -7318,8 +7166,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -7429,8 +7276,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       },
@@ -7444,8 +7290,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           }
         ]
       }
@@ -7528,8 +7373,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 6
+            "damage_dice": "3d10+6"
           }
         ]
       },
@@ -7543,16 +7387,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           },
           {
             "damage_type": {
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -7578,8 +7420,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "12d10",
-            "damage_bonus": 0
+            "damage_dice": "12d10"
           }
         ]
       },
@@ -7592,8 +7433,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 0
+            "damage_dice": "6d6"
           }
         ]
       }
@@ -7646,8 +7486,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d12",
-            "damage_bonus": 3
+            "damage_dice": "1d12+3"
           }
         ]
       }
@@ -7722,8 +7561,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -7737,8 +7575,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       }
@@ -7828,16 +7665,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -7863,8 +7698,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "5d8",
-            "damage_bonus": 0
+            "damage_dice": "5d8"
           }
         ]
       }
@@ -7946,8 +7780,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 8
+            "damage_dice": "1d8+8"
           }
         ]
       },
@@ -7967,16 +7800,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 0
+            "damage_dice": "4d8"
           }
         ]
       }
@@ -8046,8 +7877,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       },
@@ -8120,8 +7950,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -8205,16 +8034,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           },
           {
             "damage_type": {
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -8240,8 +8067,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 0
+            "damage_dice": "4d10"
           }
         ]
       }
@@ -8287,8 +8113,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -8315,8 +8140,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -8433,8 +8257,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -8448,16 +8271,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "5d6",
-            "damage_bonus": 0
+            "damage_dice": "5d6"
           }
         ]
       }
@@ -8541,8 +8362,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           }
         ]
       },
@@ -8571,8 +8391,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "4d6",
-                "damage_bonus": 0
+                "damage_dice": "4d6"
               }
             ]
           },
@@ -8675,8 +8494,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           }
         ]
       },
@@ -8705,8 +8523,7 @@
                   "name": "Lightning",
                   "url": "/api/damage-types/lightning"
                 },
-                "damage_dice": "3d10",
-                "damage_bonus": 0
+                "damage_dice": "3d10"
               }
             ]
           },
@@ -8800,8 +8617,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -8815,8 +8631,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -8885,8 +8700,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 2
+            "damage_dice": "2d8+2"
           }
         ]
       },
@@ -8900,8 +8714,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       }
@@ -8963,8 +8776,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d12",
-            "damage_bonus": 4
+            "damage_dice": "4d12+4"
           }
         ]
       },
@@ -9015,8 +8827,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -9073,7 +8884,7 @@
     "actions": [
       {
         "name": "Claws",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
+        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 slashing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -9081,8 +8892,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -9144,8 +8954,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -9189,8 +8998,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 4
+            "damage_dice": "1d10+4"
           }
         ]
       },
@@ -9204,8 +9012,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -9219,8 +9026,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -9321,8 +9127,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -9468,8 +9273,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -9483,8 +9287,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d12",
-            "damage_bonus": 4
+            "damage_dice": "1d12+4"
           }
         ]
       },
@@ -9498,8 +9301,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -9525,8 +9327,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "7d8",
-            "damage_bonus": 0
+            "damage_dice": "7d8"
           }
         ]
       }
@@ -9628,8 +9429,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -9757,8 +9557,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 5
+            "damage_dice": "2d10+5"
           }
         ]
       },
@@ -9857,8 +9656,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -9872,8 +9670,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -10073,8 +9870,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 8
+            "damage_dice": "3d8+8"
           }
         ]
       },
@@ -10088,8 +9884,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 8
+            "damage_dice": "4d10+8"
           }
         ]
       }
@@ -10138,8 +9933,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           }
         ]
       }
@@ -10186,8 +9980,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -10236,8 +10029,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -10251,8 +10043,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -10336,8 +10127,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           }
         ]
       },
@@ -10366,8 +10156,7 @@
                   "name": "Acid",
                   "url": "/api/damage-types/acid"
                 },
-                "damage_dice": "4d8",
-                "damage_bonus": 0
+                "damage_dice": "4d8"
               }
             ]
           },
@@ -10577,8 +10366,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 5
+            "damage_dice": "1d6+5"
           }
         ]
       },
@@ -10592,8 +10380,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -10650,7 +10437,7 @@
     "actions": [
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage.",
+        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -10658,8 +10445,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -10719,8 +10505,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           }
         ]
       }
@@ -10870,8 +10655,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -10935,8 +10719,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -11001,8 +10784,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -11091,8 +10873,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -11212,8 +10993,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       },
@@ -11227,8 +11007,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -11275,8 +11054,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -11427,16 +11205,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 4
+            "damage_dice": "1d6+4"
           },
           {
             "damage_type": {
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 0
+            "damage_dice": "4d8"
           }
         ]
       },
@@ -11516,8 +11292,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -11721,8 +11496,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           },
           {
             "choose": 1,
@@ -11733,16 +11507,14 @@
                   "name": "Lightning",
                   "url": "/api/damage-types/lightning"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 0
+                "damage_dice": "1d6"
               },
               {
                 "damage_type": {
                   "name": "Thunder",
                   "url": "/api/damage-types/thunder"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 0
+                "damage_dice": "1d6"
               }
             ]
           }
@@ -11850,8 +11622,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 4
+            "damage_dice": "1d6+4"
           }
         ]
       },
@@ -11902,8 +11673,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 4
+            "damage_dice": "2d4+4"
           }
         ]
       }
@@ -12009,8 +11779,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d12",
-            "damage_bonus": 7
+            "damage_dice": "3d12+7"
           }
         ]
       },
@@ -12024,8 +11793,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 7
+            "damage_dice": "2d8+7"
           }
         ]
       },
@@ -12039,8 +11807,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d12",
-            "damage_bonus": 7
+            "damage_dice": "3d12+7"
           }
         ]
       },
@@ -12066,8 +11833,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "15d6",
-            "damage_bonus": 0
+            "damage_dice": "15d6"
           }
         ]
       }
@@ -12147,8 +11913,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -12162,8 +11927,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 0
+            "damage_dice": "2d4"
           }
         ]
       },
@@ -12341,16 +12105,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 0
+            "damage_dice": "2d8"
           }
         ]
       },
@@ -12368,16 +12130,14 @@
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 3
+                "damage_dice": "1d8+3"
               },
               {
                 "damage_type": {
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 3
+                "damage_dice": "1d10+3"
               }
             ]
           }
@@ -12393,16 +12153,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       }
@@ -12509,8 +12267,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -12524,8 +12281,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -12664,16 +12420,14 @@
                   "name": "Bludgeoning",
                   "url": "/api/damage-types/bludgeoning"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 0
+                "damage_dice": "1d6"
               },
               {
                 "damage_type": {
                   "name": "Bludgeoning",
                   "url": "/api/damage-types/bludgeoning"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 2
+                "damage_dice": "1d8+2"
               }
             ]
           }
@@ -12809,8 +12563,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -12893,8 +12646,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       },
@@ -12908,8 +12660,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -13011,8 +12762,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       },
@@ -13092,8 +12842,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -13196,8 +12945,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       }
@@ -13384,16 +13132,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -13407,8 +13153,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "5d6",
-            "damage_bonus": 0
+            "damage_dice": "5d6"
           }
         ]
       }
@@ -13461,8 +13206,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 6
+            "damage_dice": "3d8+6"
           }
         ]
       },
@@ -13476,8 +13220,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 6
+            "damage_dice": "3d10+6"
           }
         ]
       }
@@ -13530,8 +13273,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -13545,8 +13287,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 3
+            "damage_dice": "2d4+3"
           }
         ]
       }
@@ -13671,16 +13412,14 @@
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 4
+                "damage_dice": "1d8+4"
               },
               {
                 "damage_type": {
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 4
+                "damage_dice": "1d10+4"
               }
             ]
           },
@@ -13689,8 +13428,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 0
+            "damage_dice": "3d8"
           }
         ]
       },
@@ -13704,16 +13442,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 0
+            "damage_dice": "3d8"
           }
         ]
       },
@@ -13823,16 +13559,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -13846,8 +13580,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       },
@@ -13871,8 +13604,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -13957,8 +13689,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       },
@@ -13972,8 +13703,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       }
@@ -14058,8 +13788,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "5d10",
-            "damage_bonus": 0
+            "damage_dice": "5d10"
           }
         ]
       },
@@ -14099,8 +13828,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -14191,8 +13919,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 7
+            "damage_dice": "6d6+7"
           }
         ]
       },
@@ -14206,8 +13933,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 7
+            "damage_dice": "4d10+7"
           }
         ]
       }
@@ -14326,8 +14052,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -14383,16 +14108,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "3d4",
-            "damage_bonus": 0
+            "damage_dice": "3d4"
           }
         ]
       }
@@ -14490,8 +14213,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       }
@@ -14636,8 +14358,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "3d12",
-            "damage_bonus": 6
+            "damage_dice": "3d12+6"
           }
         ]
       },
@@ -14651,8 +14372,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 6
+            "damage_dice": "4d10+6"
           }
         ]
       }
@@ -14745,8 +14465,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -14760,8 +14479,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -14844,8 +14562,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -14866,8 +14583,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -14940,8 +14656,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 3
+            "damage_dice": "2d8+3"
           }
         ]
       },
@@ -14955,8 +14670,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -15063,8 +14777,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 3
+            "damage_dice": "4d6+3"
           }
         ]
       },
@@ -15145,8 +14858,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       },
@@ -15160,8 +14872,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       }
@@ -15236,8 +14947,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 6
+            "damage_dice": "3d10+6"
           }
         ]
       },
@@ -15251,8 +14961,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "7d6",
-            "damage_bonus": 6
+            "damage_dice": "7d6+6"
           }
         ]
       }
@@ -15328,8 +15037,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       },
@@ -15343,8 +15051,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 1
+            "damage_dice": "2d4+1"
           }
         ]
       }
@@ -15403,8 +15110,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -15468,8 +15174,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -15518,8 +15223,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -15574,8 +15278,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -15589,8 +15292,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -15651,8 +15353,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -15733,8 +15434,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 5
+            "damage_dice": "3d10+5"
           }
         ]
       },
@@ -15748,8 +15448,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       }
@@ -15830,8 +15529,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -15845,8 +15543,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -15905,8 +15602,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -15920,8 +15616,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 4
+            "damage_dice": "4d8+4"
           }
         ]
       }
@@ -15975,8 +15670,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": -1
+            "damage_dice": "1d6-1"
           }
         ]
       }
@@ -16046,8 +15740,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       },
@@ -16108,8 +15801,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 3
+            "damage_dice": "2d4+3"
           }
         ]
       }
@@ -16168,8 +15860,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -16228,8 +15919,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -16303,8 +15993,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -16385,8 +16074,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 1
+            "damage_dice": "2d6+1"
           }
         ]
       }
@@ -16441,8 +16129,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 4
+            "damage_dice": "1d4+4"
           }
         ]
       }
@@ -16500,8 +16187,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -16549,8 +16235,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -16598,8 +16283,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       },
@@ -16634,8 +16318,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           }
         ]
       }
@@ -16693,8 +16376,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -16758,8 +16440,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 6
+            "damage_dice": "3d10+6"
           }
         ]
       }
@@ -16829,8 +16510,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -16899,16 +16579,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 8
+            "damage_dice": "1d10+8"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -16997,8 +16675,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       },
@@ -17012,8 +16689,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       }
@@ -17062,8 +16738,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -17128,8 +16803,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       }
@@ -17204,8 +16878,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -17298,8 +16971,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "5d6",
-            "damage_bonus": 0
+            "damage_dice": "5d6"
           }
         ]
       },
@@ -17495,8 +17167,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 5
+            "damage_dice": "2d10+5"
           }
         ]
       },
@@ -17510,8 +17181,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       },
@@ -17660,16 +17330,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "2d6",
-                "damage_bonus": 4
+                "damage_dice": "2d6+4"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "2d8",
-                "damage_bonus": 4
+                "damage_dice": "2d8+4"
               }
             ]
           }
@@ -17685,8 +17353,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 4
+            "damage_dice": "2d4+4"
           }
         ]
       }
@@ -17747,8 +17414,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       },
@@ -17766,16 +17432,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 2
+                "damage_dice": "1d6+2"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 2
+                "damage_dice": "1d8+2"
               }
             ]
           }
@@ -17791,8 +17455,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       }
@@ -17849,8 +17512,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           }
         ]
       }
@@ -17910,8 +17572,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -17925,8 +17586,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -18016,8 +17676,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 4
+            "damage_dice": "1d10+4"
           }
         ]
       },
@@ -18046,8 +17705,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "4d10",
-                "damage_bonus": 0
+                "damage_dice": "4d10"
               }
             ]
           },
@@ -18125,8 +17783,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d12",
-            "damage_bonus": 5
+            "damage_dice": "2d12+5"
           }
         ]
       },
@@ -18140,8 +17797,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 5
+            "damage_dice": "2d10+5"
           }
         ]
       },
@@ -18256,16 +17912,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -18360,16 +18014,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -18395,8 +18047,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 0
+            "damage_dice": "6d6"
           }
         ]
       }
@@ -18522,8 +18173,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -18610,8 +18260,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       },
@@ -18625,8 +18274,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -18708,8 +18356,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -18723,8 +18370,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -18807,16 +18453,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           },
           {
             "damage_type": {
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -18873,16 +18517,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 1
+                "damage_dice": "1d6+1"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 1
+                "damage_dice": "1d8+1"
               }
             ]
           }
@@ -19077,8 +18719,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -19294,8 +18935,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -19386,16 +19026,14 @@
                   "name": "Bludgeoning",
                   "url": "/api/damage-types/bludgeoning"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 3
+                "damage_dice": "1d8+3"
               },
               {
                 "damage_type": {
                   "name": "Bludgeoning",
                   "url": "/api/damage-types/bludgeoning"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 3
+                "damage_dice": "1d10+3"
               }
             ]
           }
@@ -19411,8 +19049,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -19426,8 +19063,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 1
+            "damage_dice": "1d10+1"
           }
         ]
       },
@@ -19453,8 +19089,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "7d6",
-            "damage_bonus": 0
+            "damage_dice": "7d6"
           }
         ]
       }
@@ -19523,8 +19158,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 1
+            "damage_dice": "2d4+1"
           }
         ]
       },
@@ -19538,8 +19172,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           }
         ]
       },
@@ -19603,8 +19236,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -19670,16 +19302,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -19705,8 +19335,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 0
+            "damage_dice": "6d6"
           }
         ]
       }
@@ -19821,8 +19450,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -19836,8 +19464,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -19914,8 +19541,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 5
+            "damage_dice": "3d8+5"
           }
         ]
       },
@@ -19929,8 +19555,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 5
+            "damage_dice": "3d10+5"
           }
         ]
       }
@@ -20011,8 +19636,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           }
         ]
       },
@@ -20026,8 +19650,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -20085,16 +19708,14 @@
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 1
+                "damage_dice": "1d8+1"
               },
               {
                 "damage_type": {
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 1
+                "damage_dice": "1d10+1"
               }
             ]
           }
@@ -20110,8 +19731,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       }
@@ -20177,8 +19797,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -20319,8 +19938,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           }
         ]
       },
@@ -20334,8 +19952,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 6
+            "damage_dice": "1d8+6"
           }
         ]
       },
@@ -20349,8 +19966,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           }
         ]
       }
@@ -20414,8 +20030,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -20504,8 +20119,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 5
+            "damage_dice": "1d10+5"
           }
         ]
       }
@@ -20564,8 +20178,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       }
@@ -20681,16 +20294,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -20704,16 +20315,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 5
+            "damage_dice": "2d4+5"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -20727,16 +20336,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -20818,8 +20425,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -20847,16 +20453,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -20877,8 +20481,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 0
+            "damage_dice": "2d4"
           }
         ]
       },
@@ -20985,8 +20588,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       },
@@ -21114,8 +20716,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -21234,8 +20835,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 7
+            "damage_dice": "3d8+7"
           }
         ]
       },
@@ -21249,8 +20849,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 7
+            "damage_dice": "3d10+7"
           }
         ]
       },
@@ -21276,8 +20875,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "10d8",
-            "damage_bonus": 0
+            "damage_dice": "10d8"
           }
         ]
       }
@@ -21340,8 +20938,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": -1
+            "damage_dice": "1d4-1"
           }
         ]
       }
@@ -21409,8 +21006,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "5d6",
-            "damage_bonus": 4
+            "damage_dice": "5d6+4"
           }
         ]
       }
@@ -21490,8 +21086,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -21505,8 +21100,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -21581,8 +21175,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       },
@@ -21596,8 +21189,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -21745,8 +21337,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 10
+            "damage_dice": "3d8+10"
           }
         ]
       },
@@ -21760,8 +21351,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 10
+            "damage_dice": "3d6+10"
           }
         ]
       },
@@ -21786,8 +21376,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 0
+            "damage_dice": "4d10"
           }
         ]
       }
@@ -21965,8 +21554,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 3
+            "damage_dice": "2d10+3"
           }
         ]
       },
@@ -21980,8 +21568,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       },
@@ -22061,8 +21648,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -22354,8 +21940,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -22398,8 +21983,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 0
+            "damage_dice": "6d6"
           }
         ]
       }
@@ -22475,8 +22059,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -22490,8 +22073,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       }
@@ -22532,7 +22114,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -22540,8 +22122,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -22692,8 +22273,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -22707,8 +22287,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -22722,8 +22301,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -22737,8 +22315,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -22916,8 +22493,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -22989,8 +22565,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -23018,16 +22593,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -23048,8 +22621,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -23116,8 +22688,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -23137,8 +22708,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -23191,8 +22761,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 7
+            "damage_dice": "4d8+7"
           }
         ]
       },
@@ -23206,8 +22775,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 7
+            "damage_dice": "4d10+7"
           }
         ]
       }
@@ -23290,8 +22858,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -23305,8 +22872,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -23320,8 +22886,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       }
@@ -23437,8 +23002,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -23452,8 +23016,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -23530,8 +23093,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }
@@ -23642,16 +23204,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           }
         ]
       },
@@ -23665,8 +23225,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -23680,16 +23239,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -23753,16 +23310,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 0
+                "damage_dice": "1d6"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 0
+                "damage_dice": "1d8"
               }
             ]
           }
@@ -23864,8 +23419,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -23879,8 +23433,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 4
+            "damage_dice": "2d4+4"
           }
         ]
       },
@@ -23894,8 +23447,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -23974,8 +23526,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -23989,16 +23540,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       }
@@ -24066,8 +23615,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d12",
-            "damage_bonus": 4
+            "damage_dice": "2d12+4"
           }
         ]
       },
@@ -24081,8 +23629,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -24149,8 +23696,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d12",
-            "damage_bonus": 4
+            "damage_dice": "2d12+4"
           }
         ]
       },
@@ -24164,8 +23710,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -24222,8 +23767,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -24326,16 +23870,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           },
           {
             "damage_type": {
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -24588,16 +24130,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 4
+            "damage_dice": "3d6+4"
           },
           {
             "damage_type": {
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 0
+            "damage_dice": "6d6"
           }
         ]
       },
@@ -24762,8 +24302,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "5d10",
-            "damage_bonus": 5
+            "damage_dice": "5d10+5"
           }
         ]
       },
@@ -24777,8 +24316,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 5
+            "damage_dice": "3d6+5"
           }
         ]
       },
@@ -24961,8 +24499,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -25038,16 +24575,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -25114,8 +24649,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       }
@@ -25210,16 +24744,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       }
@@ -25299,8 +24831,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       },
@@ -25360,8 +24891,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -25375,8 +24905,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -25443,8 +24972,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -25637,8 +25165,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -25652,8 +25179,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -25717,8 +25243,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d12",
-            "damage_bonus": 3
+            "damage_dice": "1d12+3"
           }
         ]
       },
@@ -25732,8 +25257,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       }
@@ -25814,8 +25338,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 3
+            "damage_dice": "2d8+3"
           }
         ]
       },
@@ -25829,16 +25352,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           },
           {
             "damage_type": {
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -25920,8 +25441,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -26002,8 +25522,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 5
+            "damage_dice": "1d10+5"
           }
         ]
       },
@@ -26017,8 +25536,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       }
@@ -26087,8 +25605,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -26102,8 +25619,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -26172,8 +25688,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -26242,8 +25757,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           }
         ]
       }
@@ -26416,8 +25930,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 8
+            "damage_dice": "4d6+8"
           }
         ]
       },
@@ -26431,8 +25944,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 8
+            "damage_dice": "2d8+8"
           }
         ]
       },
@@ -26446,8 +25958,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 8
+            "damage_dice": "2d6+8"
           }
         ]
       },
@@ -26461,8 +25972,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 8
+            "damage_dice": "3d10+8"
           }
         ]
       }
@@ -26663,16 +26173,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 7
+            "damage_dice": "4d6+7"
           },
           {
             "damage_type": {
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "5d8",
-            "damage_bonus": 0
+            "damage_dice": "5d8"
           }
         ]
       },
@@ -26745,8 +26253,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 4
+            "damage_dice": "3d6+4"
           }
         ]
       }
@@ -26795,8 +26302,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -26877,8 +26383,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 5
+            "damage_dice": "1d8+5"
           }
         ]
       },
@@ -26892,8 +26397,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           }
         ]
       }
@@ -26940,8 +26444,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       }
@@ -27086,8 +26589,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       }
@@ -27166,8 +26668,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       },
@@ -27181,8 +26682,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       }
@@ -27270,8 +26770,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 9
+            "damage_dice": "3d8+9"
           }
         ]
       },
@@ -27285,8 +26784,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 9
+            "damage_dice": "3d6+9"
           }
         ]
       }
@@ -27366,8 +26864,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       },
@@ -27445,8 +26942,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -27646,8 +27142,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       }
@@ -27693,7 +27188,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack: +0 to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
+        "desc": "Melee Weapon Attack:  to hit, reach 5 ft., one target. Hit: 1 piercing damage.",
         "attack_bonus": 0,
         "damage": [
           {
@@ -27701,8 +27196,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -27762,8 +27256,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -27847,16 +27340,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 4
+            "damage_dice": "1d10+4"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -27882,8 +27373,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "7d6",
-            "damage_bonus": 0
+            "damage_dice": "7d6"
           }
         ]
       }
@@ -27947,8 +27437,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -28000,8 +27489,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -28017,16 +27505,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "6d10",
-            "damage_bonus": 7
+            "damage_dice": "6d10+7"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -28083,8 +27569,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 5
+            "damage_dice": "2d8+5"
           }
         ]
       }
@@ -28131,8 +27616,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 3
+            "damage_dice": "2d4+3"
           }
         ]
       }
@@ -28233,8 +27717,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 9
+            "damage_dice": "4d8+9"
           }
         ]
       },
@@ -28248,8 +27731,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 9
+            "damage_dice": "4d6+9"
           }
         ]
       }
@@ -28349,8 +27831,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 4
+            "damage_dice": "4d8+4"
           }
         ]
       },
@@ -28502,14 +27983,13 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 1
+            "damage_dice": "1d8+1"
           }
         ]
       },
       {
         "name": "Antennae",
-        "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
+        "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a  bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
       }
     ],
     "url": "/api/monsters/rust-monster"
@@ -28575,8 +28055,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 5
+            "damage_dice": "1d10+5"
           }
         ]
       },
@@ -28590,8 +28069,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           }
         ]
       }
@@ -28693,8 +28171,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           }
         ]
       },
@@ -28708,8 +28185,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 1
+            "damage_dice": "1d4+1"
           }
         ]
       },
@@ -28727,16 +28203,14 @@
                   "name": "Psychic",
                   "url": "/api/damage-types/psychic"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 1
+                "damage_dice": "1d6+1"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 1
+                "damage_dice": "1d8+1"
               }
             ]
           }
@@ -28791,8 +28265,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -28837,16 +28310,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "2d6",
-                "damage_bonus": 4
+                "damage_dice": "2d6+4"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "2d8",
-                "damage_bonus": 4
+                "damage_dice": "2d8+4"
               }
             ]
           },
@@ -28855,8 +28326,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -28870,16 +28340,14 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -28948,8 +28416,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 1
+            "damage_dice": "2d4+1"
           }
         ]
       },
@@ -28963,8 +28430,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -28978,8 +28444,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -29031,8 +28496,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -29129,8 +28593,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -29144,8 +28607,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -29216,8 +28678,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -29383,8 +28844,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 2
+            "damage_dice": "2d6+2"
           }
         ]
       }
@@ -29486,8 +28946,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -29593,8 +29052,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -29740,8 +29198,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 4
+            "damage_dice": "1d10+4"
           }
         ]
       },
@@ -29770,8 +29227,7 @@
                   "name": "Cold",
                   "url": "/api/damage-types/cold"
                 },
-                "damage_dice": "4d8",
-                "damage_bonus": 0
+                "damage_dice": "4d8"
               }
             ]
           },
@@ -29839,8 +29295,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -29854,8 +29309,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -30047,16 +29501,14 @@
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 8
+            "damage_dice": "4d6+8"
           },
           {
             "damage_type": {
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "6d8",
-            "damage_bonus": 0
+            "damage_dice": "6d8"
           }
         ]
       },
@@ -30070,16 +29522,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 6
+            "damage_dice": "2d8+6"
           },
           {
             "damage_type": {
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "6d8",
-            "damage_bonus": 0
+            "damage_dice": "6d8"
           }
         ]
       },
@@ -30118,16 +29568,14 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           },
           {
             "damage_type": {
               "name": "Radiant",
               "url": "/api/damage-types/radiant"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           }
         ]
       },
@@ -30246,8 +29694,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       }
@@ -30316,8 +29763,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -30494,8 +29940,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 4
+            "damage_dice": "1d6+4"
           }
         ]
       }
@@ -30554,8 +29999,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       },
@@ -30569,8 +30013,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       },
@@ -30690,8 +30133,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -30705,8 +30147,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -30770,8 +30211,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -30795,16 +30235,14 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -30825,8 +30263,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -30883,8 +30320,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 3
+            "damage_dice": "1d4+3"
           }
         ]
       }
@@ -30980,8 +30416,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 6
+            "damage_dice": "3d8+6"
           }
         ]
       },
@@ -30995,8 +30430,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 6
+            "damage_dice": "4d10+6"
           }
         ]
       }
@@ -31109,8 +30543,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 6
+            "damage_dice": "3d8+6"
           }
         ]
       },
@@ -31301,8 +30734,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "6d6",
-            "damage_bonus": 9
+            "damage_dice": "6d6+9"
           }
         ]
       },
@@ -31316,8 +30748,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d12",
-            "damage_bonus": 9
+            "damage_dice": "4d12+9"
           }
         ]
       },
@@ -31343,8 +30774,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "12d8",
-            "damage_bonus": 0
+            "damage_dice": "12d8"
           }
         ]
       }
@@ -31435,8 +30865,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -31462,8 +30891,7 @@
               "name": "Psychic",
               "url": "/api/damage-types/psychic"
             },
-            "damage_dice": "5d10",
-            "damage_bonus": 5
+            "damage_dice": "5d10+5"
           }
         ]
       },
@@ -31567,8 +30995,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 0
+            "damage_dice": "2d4"
           }
         ]
       }
@@ -31661,8 +31088,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d4",
-            "damage_bonus": 0
+            "damage_dice": "4d4"
           }
         ]
       }
@@ -31754,8 +31180,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d4",
-            "damage_bonus": 0
+            "damage_dice": "4d4"
           }
         ]
       }
@@ -31847,8 +31272,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d4",
-            "damage_bonus": 0
+            "damage_dice": "4d4"
           }
         ]
       }
@@ -31940,8 +31364,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -32041,8 +31464,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 0
+            "damage_dice": "4d6"
           }
         ]
       }
@@ -32137,8 +31559,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -32229,8 +31650,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       }
@@ -32330,8 +31750,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d4",
-            "damage_bonus": 0
+            "damage_dice": "4d4"
           }
         ]
       }
@@ -32423,8 +31842,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d4",
-            "damage_bonus": 0
+            "damage_dice": "4d4"
           }
         ]
       }
@@ -32595,8 +32013,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d12",
-            "damage_bonus": 10
+            "damage_dice": "4d12+10"
           }
         ]
       },
@@ -32610,8 +32027,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 10
+            "damage_dice": "4d8+10"
           }
         ]
       },
@@ -32625,8 +32041,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 10
+            "damage_dice": "4d10+10"
           }
         ]
       },
@@ -32640,8 +32055,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d6",
-            "damage_bonus": 10
+            "damage_dice": "4d6+10"
           }
         ]
       },
@@ -32746,8 +32160,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -32761,8 +32174,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       }
@@ -32831,8 +32243,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           }
         ]
       },
@@ -32846,8 +32257,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       }
@@ -32925,8 +32335,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 6
+            "damage_dice": "3d6+6"
           }
         ]
       },
@@ -32940,8 +32349,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "4d10",
-            "damage_bonus": 6
+            "damage_dice": "4d10+6"
           }
         ]
       },
@@ -33006,16 +32414,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 1
+                "damage_dice": "1d6+1"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 1
+                "damage_dice": "1d8+1"
               }
             ]
           }
@@ -33070,8 +32476,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 6
+            "damage_dice": "4d8+6"
           }
         ]
       },
@@ -33085,8 +32490,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d10",
-            "damage_bonus": 6
+            "damage_dice": "3d10+6"
           }
         ]
       }
@@ -33175,8 +32579,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 4
+            "damage_dice": "1d6+4"
           }
         ]
       },
@@ -33190,8 +32593,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -33267,8 +32669,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "4d12",
-            "damage_bonus": 7
+            "damage_dice": "4d12+7"
           }
         ]
       },
@@ -33282,8 +32683,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "3d8",
-            "damage_bonus": 7
+            "damage_dice": "3d8+7"
           }
         ]
       }
@@ -33440,8 +32840,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -33455,8 +32854,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -33597,8 +32995,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 4
+            "damage_dice": "1d8+4"
           }
         ]
       },
@@ -33612,16 +33009,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 4
+            "damage_dice": "1d6+4"
           },
           {
             "damage_type": {
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 0
+            "damage_dice": "3d6"
           }
         ]
       },
@@ -33772,16 +33167,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           },
           {
             "damage_type": {
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -33795,8 +33188,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 3
+            "damage_dice": "2d4+3"
           }
         ]
       }
@@ -33880,16 +33272,14 @@
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 3
+                "damage_dice": "1d8+3"
               },
               {
                 "damage_type": {
                   "name": "Thunder",
                   "url": "/api/damage-types/thunder"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 3
+                "damage_dice": "1d10+3"
               }
             ]
           }
@@ -33905,8 +33295,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -33920,8 +33309,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 1
+            "damage_dice": "1d10+1"
           }
         ]
       }
@@ -34004,8 +33392,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       }
@@ -34109,8 +33496,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -34124,8 +33510,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 3
+            "damage_dice": "2d10+3"
           }
         ]
       },
@@ -34225,8 +33610,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       }
@@ -34279,8 +33663,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -34341,8 +33724,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -34455,8 +33837,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -34482,8 +33863,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       }
@@ -34547,8 +33927,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "0d4",
-            "damage_bonus": 1
+            "damage_dice": "0d4+1"
           }
         ]
       }
@@ -34668,8 +34047,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -34683,8 +34061,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -34698,8 +34075,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d12",
-            "damage_bonus": 4
+            "damage_dice": "1d12+4"
           }
         ]
       }
@@ -34788,8 +34164,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       },
@@ -34803,8 +34178,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -34879,8 +34253,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 2
+            "damage_dice": "1d4+2"
           }
         ]
       },
@@ -34894,8 +34267,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -34909,8 +34281,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       }
@@ -34997,8 +34368,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 3
+            "damage_dice": "1d10+3"
           }
         ]
       },
@@ -35012,8 +34382,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 3
+            "damage_dice": "1d8+3"
           }
         ]
       },
@@ -35027,8 +34396,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       },
@@ -35042,8 +34410,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -35120,8 +34487,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       },
@@ -35135,8 +34501,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       },
@@ -35154,16 +34519,14 @@
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d6",
-                "damage_bonus": 2
+                "damage_dice": "1d6+2"
               },
               {
                 "damage_type": {
                   "name": "Piercing",
                   "url": "/api/damage-types/piercing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 2
+                "damage_dice": "1d8+2"
               }
             ]
           }
@@ -35250,16 +34613,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 2
+            "damage_dice": "1d10+2"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "1d4",
-            "damage_bonus": 0
+            "damage_dice": "1d4"
           }
         ]
       },
@@ -35285,8 +34646,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "5d8",
-            "damage_bonus": 0
+            "damage_dice": "5d8"
           }
         ]
       }
@@ -35394,8 +34754,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 2
+            "damage_dice": "1d6+2"
           }
         ]
       },
@@ -35413,16 +34772,14 @@
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d8",
-                "damage_bonus": 2
+                "damage_dice": "1d8+2"
               },
               {
                 "damage_type": {
                   "name": "Slashing",
                   "url": "/api/damage-types/slashing"
                 },
-                "damage_dice": "1d10",
-                "damage_bonus": 2
+                "damage_dice": "1d10+2"
               }
             ]
           }
@@ -35438,8 +34795,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 2
+            "damage_dice": "1d8+2"
           }
         ]
       }
@@ -35554,8 +34910,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 0
+            "damage_dice": "2d8"
           }
         ]
       },
@@ -35633,8 +34988,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -35660,8 +35014,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 0
+            "damage_dice": "4d8"
           }
         ]
       }
@@ -35729,8 +35082,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d4",
-            "damage_bonus": 2
+            "damage_dice": "2d4+2"
           }
         ]
       }
@@ -35790,8 +35142,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 3
+            "damage_dice": "2d6+3"
           }
         ]
       }
@@ -35894,8 +35245,7 @@
               "name": "Necrotic",
               "url": "/api/damage-types/necrotic"
             },
-            "damage_dice": "4d8",
-            "damage_bonus": 3
+            "damage_dice": "4d8+3"
           }
         ]
       },
@@ -36003,8 +35353,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -36018,8 +35367,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d8",
-            "damage_bonus": 4
+            "damage_dice": "2d8+4"
           }
         ]
       },
@@ -36033,8 +35381,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       }
@@ -36132,8 +35479,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "3d6",
-            "damage_bonus": 3
+            "damage_dice": "3d6+3"
           }
         ]
       },
@@ -36147,8 +35493,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 3
+            "damage_dice": "1d6+3"
           }
         ]
       }
@@ -36259,16 +35604,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           },
           {
             "damage_type": {
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -36282,8 +35625,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -36309,8 +35651,7 @@
               "name": "Acid",
               "url": "/api/damage-types/acid"
             },
-            "damage_dice": "11d8",
-            "damage_bonus": 0
+            "damage_dice": "11d8"
           }
         ]
       }
@@ -36415,16 +35756,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 5
+            "damage_dice": "2d10+5"
           },
           {
             "damage_type": {
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "1d10",
-            "damage_bonus": 0
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -36438,8 +35777,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           }
         ]
       },
@@ -36465,8 +35803,7 @@
               "name": "Lightning",
               "url": "/api/damage-types/lightning"
             },
-            "damage_dice": "10d10",
-            "damage_bonus": 0
+            "damage_dice": "10d10"
           }
         ]
       }
@@ -36576,8 +35913,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -36591,8 +35927,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -36622,8 +35957,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "12d6",
-                "damage_bonus": 0
+                "damage_dice": "12d6"
               }
             ]
           },
@@ -36752,8 +36086,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 5
+            "damage_dice": "2d10+5"
           }
         ]
       },
@@ -36767,8 +36100,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 5
+            "damage_dice": "2d6+5"
           }
         ]
       },
@@ -36798,8 +36130,7 @@
                   "name": "Lightning",
                   "url": "/api/damage-types/lightning"
                 },
-                "damage_dice": "10d10",
-                "damage_bonus": 0
+                "damage_dice": "10d10"
               }
             ]
           },
@@ -36922,8 +36253,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           }
         ]
       },
@@ -36937,8 +36267,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -36967,8 +36296,7 @@
                   "name": "Acid",
                   "url": "/api/damage-types/acid"
                 },
-                "damage_dice": "9d8",
-                "damage_bonus": 0
+                "damage_dice": "9d8"
               }
             ]
           },
@@ -37102,8 +36430,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -37117,8 +36444,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -37147,8 +36473,7 @@
                   "name": "Fire",
                   "url": "/api/damage-types/fire"
                 },
-                "damage_dice": "10d10",
-                "damage_bonus": 0
+                "damage_dice": "10d10"
               }
             ]
           },
@@ -37282,16 +36607,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           },
           {
             "damage_type": {
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 0
+            "damage_dice": "2d6"
           }
         ]
       },
@@ -37305,8 +36628,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -37332,8 +36654,7 @@
               "name": "Poison",
               "url": "/api/damage-types/poison"
             },
-            "damage_dice": "12d6",
-            "damage_bonus": 0
+            "damage_dice": "12d6"
           }
         ]
       }
@@ -37438,16 +36759,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           },
           {
             "damage_type": {
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 0
+            "damage_dice": "1d6"
           }
         ]
       },
@@ -37461,8 +36780,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -37488,8 +36806,7 @@
               "name": "Fire",
               "url": "/api/damage-types/fire"
             },
-            "damage_dice": "16d6",
-            "damage_bonus": 0
+            "damage_dice": "16d6"
           }
         ]
       }
@@ -37603,8 +36920,7 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 6
+            "damage_dice": "2d10+6"
           }
         ]
       },
@@ -37618,8 +36934,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 6
+            "damage_dice": "2d6+6"
           }
         ]
       },
@@ -37648,8 +36963,7 @@
                   "name": "Cold",
                   "url": "/api/damage-types/cold"
                 },
-                "damage_dice": "12d8",
-                "damage_bonus": 0
+                "damage_dice": "12d8"
               }
             ]
           },
@@ -37774,16 +37088,14 @@
               "name": "Piercing",
               "url": "/api/damage-types/piercing"
             },
-            "damage_dice": "2d10",
-            "damage_bonus": 4
+            "damage_dice": "2d10+4"
           },
           {
             "damage_type": {
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "1d8",
-            "damage_bonus": 0
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -37797,8 +37109,7 @@
               "name": "Slashing",
               "url": "/api/damage-types/slashing"
             },
-            "damage_dice": "2d6",
-            "damage_bonus": 4
+            "damage_dice": "2d6+4"
           }
         ]
       },
@@ -37824,8 +37135,7 @@
               "name": "Cold",
               "url": "/api/damage-types/cold"
             },
-            "damage_dice": "10d8",
-            "damage_bonus": 0
+            "damage_dice": "10d8"
           }
         ]
       }
@@ -37890,8 +37200,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "1d6",
-            "damage_bonus": 1
+            "damage_dice": "1d6+1"
           }
         ]
       }


### PR DESCRIPTION
## What does this do?
1. Merge the `"damage_dice"` and `"damage_bonus"` fields into one `"damage_dice"` field with [standard dice notation](https://en.wikipedia.org/wiki/Dice_notation).
2. Remove the damage for the net, since its damage is stroked through in the SRD.

## Is there a Github issue this is resolving?
No, not yet

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
