### PR TITLE
Fix #213: change Drow's darkness and faerie fire usage to 1 per day

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -12479,7 +12479,7 @@
               "url": "/api/spells/entangle",
               "usage": {
                 "type": "per day",
-                "times": 72
+                "times": 1
               }
             },
             {
@@ -12487,7 +12487,7 @@
               "url": "/api/spells/faerie-fire",
               "usage": {
                 "type": "per day",
-                "times": 3
+                "times": 1
               }
             }
           ]


### PR DESCRIPTION
## What does this do?

Change the Drow monster's Darkness and Faerie Fire usage to 1 per day

## How was it tested?

Standard CI

## Is there a Github issue this is resolving?

#213 

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
