### PR TITLE
Tidy up subclasses spells prerequisites

### DIFF
--- a/src/5e-SRD-Subclasses.json
+++ b/src/5e-SRD-Subclasses.json
@@ -45,8 +45,9 @@
 	],
 	"spells": [{
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/1",
-			"type": "level"
+			"name": "Cleric 1",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/bless",
@@ -54,8 +55,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/1",
-			"type": "level"
+			"name": "Cleric 1",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/cure-wounds",
@@ -63,8 +65,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/3",
-			"type": "level"
+			"name": "Cleric 3",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/3"
 		}],
 		"spell": {
 			"url": "/api/spells/lesser-restoration",
@@ -72,8 +75,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/3",
-			"type": "level"
+			"name": "Cleric 3",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/3"
 		}],
 		"spell": {
 			"url": "/api/spells/spiritual-weapon",
@@ -81,8 +85,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/5",
-			"type": "level"
+			"name": "Cleric 5",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/5"
 		}],
 		"spell": {
 			"url": "/api/spells/beacon-of-hope",
@@ -90,8 +95,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/5",
-			"type": "level"
+			"name": "Cleric 5",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/5"
 		}],
 		"spell": {
 			"url": "/api/spells/revivify",
@@ -99,8 +105,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/7",
-			"type": "level"
+			"name": "Cleric 7",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/7"
 		}],
 		"spell": {
 			"url": "/api/spells/death-ward",
@@ -108,8 +115,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/9",
-			"type": "level"
+			"name": "Cleric 9",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/9"
 		}],
 		"spell": {
 			"url": "/api/spells/mass-cure-wounds",
@@ -117,8 +125,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/cleric/levels/9",
-			"type": "level"
+			"name": "Cleric 9",
+			"type": "level",
+			"url": "/api/classes/cleric/levels/9"
 		}],
 		"spell": {
 			"url": "/api/spells/raise-dead",
@@ -140,10 +149,12 @@
 	],
 	"spells": [{
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -152,10 +163,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -164,10 +177,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -176,10 +191,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -188,10 +205,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -200,10 +219,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -212,10 +233,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -224,10 +247,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Arctic",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-arctic"
 		}],
 		"spell": {
@@ -236,10 +261,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -248,10 +275,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -260,10 +289,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -272,10 +303,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -284,10 +317,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -296,10 +331,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -308,10 +345,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -320,10 +359,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Coast",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-coast"
 		}],
 		"spell": {
@@ -332,10 +373,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -344,10 +387,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -356,10 +401,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -368,10 +415,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -380,10 +429,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -392,10 +443,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -404,10 +457,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -416,10 +471,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Desert",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-desert"
 		}],
 		"spell": {
@@ -428,10 +485,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -440,10 +499,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -452,10 +513,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -464,10 +527,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -476,10 +541,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -488,10 +555,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -500,10 +569,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -512,10 +583,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Forest",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-forest"
 		}],
 		"spell": {
@@ -524,10 +597,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -536,10 +611,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -548,10 +625,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -560,10 +639,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -572,10 +653,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -584,10 +667,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -596,10 +681,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -608,10 +695,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Grassland",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-grassland"
 		}],
 		"spell": {
@@ -620,10 +709,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -632,10 +723,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -644,10 +737,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -656,10 +751,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -668,10 +765,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -680,10 +779,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -692,10 +793,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -704,10 +807,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Mountain",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-mountain"
 		}],
 		"spell": {
@@ -716,10 +821,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -728,10 +835,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/3",
-			"type": "level"
+			"name": "Druid 3",
+			"type": "level",
+			"url": "/api/classes/druid/levels/3"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -740,10 +849,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -752,10 +863,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/5",
-			"type": "level"
+			"name": "Druid 5",
+			"type": "level",
+			"url": "/api/classes/druid/levels/5"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -764,10 +877,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -776,10 +891,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/7",
-			"type": "level"
+			"name": "Druid 7",
+			"type": "level",
+			"url": "/api/classes/druid/levels/7"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -788,10 +905,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -800,10 +919,12 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/druid/levels/9",
-			"type": "level"
+			"name": "Druid 9",
+			"type": "level",
+			"url": "/api/classes/druid/levels/9"
 		}, {
 			"name": "Circle of the Land: Swamp",
+			"type": "feature",
 			"url": "/api/features/circle-of-the-land-swamp"
 		}],
 		"spell": {
@@ -852,8 +973,9 @@
 	],
 	"spells": [{
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/3",
-			"type": "level"
+			"name": "Paladin 3",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/3"
 		}],
 		"spell": {
 			"url": "/api/spells/protection-from-evil-and-good",
@@ -861,8 +983,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/3",
-			"type": "level"
+			"name": "Paladin 3",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/3"
 		}],
 		"spell": {
 			"url": "/api/spells/sanctuary",
@@ -870,8 +993,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/5",
-			"type": "level"
+			"name": "Paladin 5",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/5"
 		}],
 		"spell": {
 			"url": "/api/spells/lesser-restoration",
@@ -879,8 +1003,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/5",
-			"type": "level"
+			"name": "Paladin 5",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/5"
 		}],
 		"spell": {
 			"url": "/api/spells/zone-of-truth",
@@ -888,8 +1013,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/9",
-			"type": "level"
+			"name": "Paladin 9",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/9"
 		}],
 		"spell": {
 			"url": "/api/spells/beacon-of-hope",
@@ -897,8 +1023,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/9",
-			"type": "level"
+			"name": "Paladin 9",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/9"
 		}],
 		"spell": {
 			"url": "/api/spells/dispel-magic",
@@ -906,8 +1033,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/13",
-			"type": "level"
+			"name": "Paladin 13",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/13"
 		}],
 		"spell": {
 			"url": "/api/spells/freedom-of-movement",
@@ -915,8 +1043,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/17",
-			"type": "level"
+			"name": "Paladin 17",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/17"
 		}],
 		"spell": {
 			"url": "/api/spells/commune",
@@ -924,8 +1053,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/paladin/levels/17",
-			"type": "level"
+			"name": "Paladin 17",
+			"type": "level",
+			"url": "/api/classes/paladin/levels/17"
 		}],
 		"spell": {
 			"url": "/api/spells/flame-strike",
@@ -986,8 +1116,9 @@
 	],
 	"spells": [{
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/burning-hands",
@@ -995,8 +1126,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/command",
@@ -1004,8 +1136,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/blindness-deafness",
@@ -1013,8 +1146,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/scorching-ray",
@@ -1022,8 +1156,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/fireball",
@@ -1031,8 +1166,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/stinking-cloud",
@@ -1040,8 +1176,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/fire-shield",
@@ -1049,8 +1186,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/wall-of-fire",
@@ -1058,8 +1196,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/flame-strike",
@@ -1067,8 +1206,9 @@
 		}
 	}, {
 		"prerequisites": [{
-			"url": "/api/classes/warlock/levels/1",
-			"type": "level"
+			"name": "Warlock 1",
+			"type": "level",
+			"url": "/api/classes/warlock/levels/1"
 		}],
 		"spell": {
 			"url": "/api/spells/hallow",


### PR DESCRIPTION
## What does this do?
Make prerequisites more consistent
```
		"prerequisites": [{
			"url": "/api/classes/druid/levels/3",
			"type": "level"
		}, {
			"name": "Circle of the Land: Arctic",
			"url": "/api/features/circle-of-the-land-arctic"
		}],
```
To
```
		"prerequisites": [{
			"name": "Druid 3",
			"type": "level",
			"url": "/api/classes/druid/levels/3"
		}, {
			"name": "Circle of the Land: Arctic",
			"type": "feature",
			"url": "/api/features/circle-of-the-land-arctic"
		}],
```

## How was it tested?
GraphQL Type

## Is there a Github issue this is resolving?
Not to my knowledge 

## Here's a fun image for your troubles
![random photo - update me](https://i.picsum.photos/id/1070/200/200.jpg?hmac=ulNtCwg9etYpYD_RxTGBFNLAbCqxJ0cj1L0WI7Ezcr4)
