### PR TITLE
Switching to singular reference names in proficiency

### DIFF
--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -330,7 +330,7 @@
       {
         "url": "/api/equipment/shield",
         "type": "equipment",
-        "name": "Shields"
+        "name": "Shield"
       }
     ]
   },
@@ -434,7 +434,7 @@
       {
         "url": "/api/equipment/club",
         "type": "equipment",
-        "name": "Clubs"
+        "name": "Club"
       }
     ]
   },
@@ -462,7 +462,7 @@
       {
         "url": "/api/equipment/dagger",
         "type": "equipment",
-        "name": "Daggers"
+        "name": "Dagger"
       }
     ]
   },
@@ -477,7 +477,7 @@
       {
         "url": "/api/equipment/greatclub",
         "type": "equipment",
-        "name": "Greatclubs"
+        "name": "Greatclub"
       }
     ]
   },
@@ -497,7 +497,7 @@
       {
         "url": "/api/equipment/handaxe",
         "type": "equipment",
-        "name": "Handaxes"
+        "name": "Handaxe"
       }
     ]
   },
@@ -517,7 +517,7 @@
       {
         "url": "/api/equipment/javelin",
         "type": "equipment",
-        "name": "Javelins"
+        "name": "Javelin"
       }
     ]
   },
@@ -537,7 +537,7 @@
       {
         "url": "/api/equipment/light-hammer",
         "type": "equipment",
-        "name": "Light hammers"
+        "name": "Light hammer"
       }
     ]
   },
@@ -557,7 +557,7 @@
       {
         "url": "/api/equipment/mace",
         "type": "equipment",
-        "name": "Maces"
+        "name": "Mace"
       }
     ]
   },
@@ -585,7 +585,7 @@
       {
         "url": "/api/equipment/quarterstaff",
         "type": "equipment",
-        "name": "Quarterstaffs"
+        "name": "Quarterstaff"
       }
     ]
   },
@@ -605,7 +605,7 @@
       {
         "url": "/api/equipment/sickle",
         "type": "equipment",
-        "name": "Sickles"
+        "name": "Sickle"
       }
     ]
   },
@@ -625,7 +625,7 @@
       {
         "url": "/api/equipment/spear",
         "type": "equipment",
-        "name": "Spears"
+        "name": "Spear"
       }
     ]
   },
@@ -640,7 +640,7 @@
       {
         "url": "/api/equipment/crossbow-light",
         "type": "equipment",
-        "name": "Crossbows, light"
+        "name": "Crossbow, light"
       }
     ]
   },
@@ -668,7 +668,7 @@
       {
         "url": "/api/equipment/dart",
         "type": "equipment",
-        "name": "Darts"
+        "name": "Dart"
       }
     ]
   },
@@ -688,7 +688,7 @@
       {
         "url": "/api/equipment/shortbow",
         "type": "equipment",
-        "name": "Shortbows"
+        "name": "Shortbow"
       }
     ]
   },
@@ -716,7 +716,7 @@
       {
         "url": "/api/equipment/sling",
         "type": "equipment",
-        "name": "Slings"
+        "name": "Sling"
       }
     ]
   },
@@ -736,7 +736,7 @@
       {
         "url": "/api/equipment/battleaxe",
         "type": "equipment",
-        "name": "Battleaxes"
+        "name": "Battleaxe"
       }
     ]
   },
@@ -751,7 +751,7 @@
       {
         "url": "/api/equipment/flail",
         "type": "equipment",
-        "name": "Flails"
+        "name": "Flail"
       }
     ]
   },
@@ -766,7 +766,7 @@
       {
         "url": "/api/equipment/glaive",
         "type": "equipment",
-        "name": "Glaives"
+        "name": "Glaive"
       }
     ]
   },
@@ -781,7 +781,7 @@
       {
         "url": "/api/equipment/greataxe",
         "type": "equipment",
-        "name": "Greataxes"
+        "name": "Greataxe"
       }
     ]
   },
@@ -796,7 +796,7 @@
       {
         "url": "/api/equipment/greatsword",
         "type": "equipment",
-        "name": "Greatswords"
+        "name": "Greatsword"
       }
     ]
   },
@@ -811,7 +811,7 @@
       {
         "url": "/api/equipment/halberd",
         "type": "equipment",
-        "name": "Halberds"
+        "name": "Halberd"
       }
     ]
   },
@@ -826,7 +826,7 @@
       {
         "url": "/api/equipment/lance",
         "type": "equipment",
-        "name": "Lances"
+        "name": "Lance"
       }
     ]
   },
@@ -855,7 +855,7 @@
       {
         "url": "/api/equipment/longsword",
         "type": "equipment",
-        "name": "Longswords"
+        "name": "Longsword"
       }
     ]
   },
@@ -870,7 +870,7 @@
       {
         "url": "/api/equipment/maul",
         "type": "equipment",
-        "name": "Mauls"
+        "name": "Maul"
       }
     ]
   },
@@ -885,7 +885,7 @@
       {
         "url": "/api/equipment/morningstar",
         "type": "equipment",
-        "name": "Morningstars"
+        "name": "Morningstar"
       }
     ]
   },
@@ -900,7 +900,7 @@
       {
         "url": "/api/equipment/pike",
         "type": "equipment",
-        "name": "Pikes"
+        "name": "Pike"
       }
     ]
   },
@@ -924,7 +924,7 @@
       {
         "url": "/api/equipment/rapier",
         "type": "equipment",
-        "name": "Rapiers"
+        "name": "Rapier"
       }
     ]
   },
@@ -944,7 +944,7 @@
       {
         "url": "/api/equipment/scimitar",
         "type": "equipment",
-        "name": "Scimitars"
+        "name": "Scimitar"
       }
     ]
   },
@@ -977,7 +977,7 @@
       {
         "url": "/api/equipment/shortsword",
         "type": "equipment",
-        "name": "Shortswords"
+        "name": "Shortsword"
       }
     ]
   },
@@ -992,7 +992,7 @@
       {
         "url": "/api/equipment/trident",
         "type": "equipment",
-        "name": "Tridents"
+        "name": "Trident"
       }
     ]
   },
@@ -1007,7 +1007,7 @@
       {
         "url": "/api/equipment/war-pick",
         "type": "equipment",
-        "name": "War picks"
+        "name": "War pick"
       }
     ]
   },
@@ -1027,7 +1027,7 @@
       {
         "url": "/api/equipment/warhammer",
         "type": "equipment",
-        "name": "Warhammers"
+        "name": "Warhammer"
       }
     ]
   },
@@ -1042,7 +1042,7 @@
       {
         "url": "/api/equipment/whip",
         "type": "equipment",
-        "name": "Whips"
+        "name": "Whip"
       }
     ]
   },
@@ -1057,7 +1057,7 @@
       {
         "url": "/api/equipment/blowgun",
         "type": "equipment",
-        "name": "Blowguns"
+        "name": "Blowgun"
       }
     ]
   },
@@ -1081,7 +1081,7 @@
       {
         "url": "/api/equipment/crossbow-hand",
         "type": "equipment",
-        "name": "Crossbows, hand"
+        "name": "Crossbow, hand"
       }
     ]
   },
@@ -1096,7 +1096,7 @@
       {
         "url": "/api/equipment/crossbow-heavy",
         "type": "equipment",
-        "name": "Crossbows, heavy"
+        "name": "Crossbow, heavy"
       }
     ]
   },
@@ -1116,7 +1116,7 @@
       {
         "url": "/api/equipment/longbow",
         "type": "equipment",
-        "name": "Longbows"
+        "name": "Longbow"
       }
     ]
   },
@@ -1131,7 +1131,7 @@
       {
         "url": "/api/equipment/net",
         "type": "equipment",
-        "name": "Nets"
+        "name": "Net"
       }
     ]
   },


### PR DESCRIPTION
## What does this do?
Switches plural to singular for equipment reference names in the proficiency table.

## How was it tested?
CI

## Is there a Github issue this is resolving?
Nope. Raised in Discord.

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/89462882-f6575580-d722-11ea-8be7-1a91ddac22fe.png)
