### PR TITLE
New equipment categories for spellcasting foci and holy symbols

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -254,26 +254,6 @@
 				"name": "Antitoxin (vial)"
 			},
 			{
-				"url": "/api/equipment/crystal",
-				"name": "Crystal"
-			},
-			{
-				"url": "/api/equipment/orb",
-				"name": "Orb"
-			},
-			{
-				"url": "/api/equipment/rod",
-				"name": "Rod"
-			},
-			{
-				"url": "/api/equipment/staff",
-				"name": "Staff"
-			},
-			{
-				"url": "/api/equipment/wand",
-				"name": "Wand"
-			},
-			{
 				"url": "/api/equipment/backpack",
 				"name": "Backpack"
 			},
@@ -368,22 +348,6 @@
 			{
 				"url": "/api/equipment/crowbar",
 				"name": "Crowbar"
-			},
-			{
-				"url": "/api/equipment/sprig-of-mistletoe",
-				"name": "Sprig of mistletoe"
-			},
-			{
-				"url": "/api/equipment/totem",
-				"name": "Totem"
-			},
-			{
-				"url": "/api/equipment/wooden-staff",
-				"name": "Wooden staff"
-			},
-			{
-				"url": "/api/equipment/yew-wand",
-				"name": "Yew wand"
 			},
 			{
 				"url": "/api/equipment/emblem",
@@ -656,6 +620,42 @@
 			{
 				"url": "/api/equipment/scholars-pack",
 				"name": "Scholar's Pack"
+			},
+			{
+				"url": "/api/equipment/crystal",
+				"name": "Crystal"
+			},
+			{
+				"url": "/api/equipment/orb",
+				"name": "Orb"
+			},
+			{
+				"url": "/api/equipment/rod",
+				"name": "Rod"
+			},
+			{
+				"url": "/api/equipment/staff",
+				"name": "Staff"
+			},
+			{
+				"url": "/api/equipment/wand",
+				"name": "Wand"
+			},
+			{
+				"url": "/api/equipment/sprig-of-mistletoe",
+				"name": "Sprig of mistletoe"
+			},
+			{
+				"url": "/api/equipment/totem",
+				"name": "Totem"
+			},
+			{
+				"url": "/api/equipment/wooden-staff",
+				"name": "Wooden staff"
+			},
+			{
+				"url": "/api/equipment/yew-wand",
+				"name": "Yew wand"
 			}
 		],
 		"url": "/api/equipment-categories/adventuring-gear"
@@ -1485,32 +1485,8 @@
 				"name": "Sling bullet"
 			},
 			{
-				"url": "/api/equipment/amulet",
-				"name": "Amulet"
-			},
-			{
 				"url": "/api/equipment/antitoxin-vial",
 				"name": "Antitoxin (vial)"
-			},
-			{
-				"url": "/api/equipment/crystal",
-				"name": "Crystal"
-			},
-			{
-				"url": "/api/equipment/orb",
-				"name": "Orb"
-			},
-			{
-				"url": "/api/equipment/rod",
-				"name": "Rod"
-			},
-			{
-				"url": "/api/equipment/staff",
-				"name": "Staff"
-			},
-			{
-				"url": "/api/equipment/wand",
-				"name": "Wand"
 			},
 			{
 				"url": "/api/equipment/backpack",
@@ -1607,26 +1583,6 @@
 			{
 				"url": "/api/equipment/crowbar",
 				"name": "Crowbar"
-			},
-			{
-				"url": "/api/equipment/sprig-of-mistletoe",
-				"name": "Sprig of mistletoe"
-			},
-			{
-				"url": "/api/equipment/totem",
-				"name": "Totem"
-			},
-			{
-				"url": "/api/equipment/wooden-staff",
-				"name": "Wooden staff"
-			},
-			{
-				"url": "/api/equipment/yew-wand",
-				"name": "Yew wand"
-			},
-			{
-				"url": "/api/equipment/emblem",
-				"name": "Emblem"
 			},
 			{
 				"url": "/api/equipment/fishing-tackle",
@@ -1775,10 +1731,6 @@
 			{
 				"url": "/api/equipment/rations-1-day",
 				"name": "Rations (1 day)"
-			},
-			{
-				"url": "/api/equipment/reliquary",
-				"name": "Reliquary"
 			},
 			{
 				"url": "/api/equipment/robes",
@@ -2280,5 +2232,72 @@
 			}
 		],
 		"url": "/api/equipment-categories/waterborne-vehicles"
+	},
+	{
+		"index": "arcane-foci",
+		"name": "Arcane Foci",
+		"equipment": [
+			{
+				"url": "/api/equipment/crystal",
+				"name": "Crystal"
+			},
+			{
+				"url": "/api/equipment/orb",
+				"name": "Orb"
+			},
+			{
+				"url": "/api/equipment/rod",
+				"name": "Rod"
+			},
+			{
+				"url": "/api/equipment/staff",
+				"name": "Staff"
+			},
+			{
+				"url": "/api/equipment/wand",
+				"name": "Wand"
+			}
+			
+		]
+	},
+	{
+		"index": "druidic-foci",
+		"name": "Druidic Foci",
+		"equipment": [
+			{
+				"url": "/api/equipment/sprig-of-mistletoe",
+				"name": "Sprig of mistletoe"
+			},
+			{
+				"url": "/api/equipment/totem",
+				"name": "Totem"
+			},
+			{
+				"url": "/api/equipment/wooden-staff",
+				"name": "Wooden staff"
+			},
+			{
+				"url": "/api/equipment/yew-wand",
+				"name": "Yew wand"
+			}
+		]
+	},
+	{
+		"index": "holy-symbols",
+		"name": "Holy Symbols",
+		"equipment": [
+			{
+				"url": "/api/equipment/amulet",
+				"name": "Amulet"
+			},
+			{
+				"url": "/api/equipment/emblem",
+				"name": "Emblem"
+			},
+			{
+				"url": "/api/equipment/reliquary",
+				"name": "Reliquary"
+			}
+		]
 	}
 ]

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1890,7 +1890,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Holy Symbol",
+    "gear_category": "Holy Symbols",
     "cost": {
       "quantity": 5,
       "unit": "gp"
@@ -1927,7 +1927,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Arcane focus",
+    "gear_category": "Arcane Foci",
     "cost": {
       "quantity": 10,
       "unit": "gp"
@@ -1945,7 +1945,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Arcane focus",
+    "gear_category": "Arcane Foci",
     "cost": {
       "quantity": 20,
       "unit": "gp"
@@ -1963,7 +1963,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Arcane focus",
+    "gear_category": "Arcane Foci",
     "cost": {
       "quantity": 10,
       "unit": "gp"
@@ -1981,7 +1981,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Arcane focus",
+    "gear_category": "Arcane Foci",
     "cost": {
       "quantity": 5,
       "unit": "gp"
@@ -1999,7 +1999,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Arcane focus",
+    "gear_category": "Arcane Foci",
     "cost": {
       "quantity": 10,
       "unit": "gp"
@@ -2410,7 +2410,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Druidic focus",
+    "gear_category": "Druidic Foci",
     "cost": {
       "quantity": 1,
       "unit": "gp"
@@ -2428,7 +2428,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Druidic focus",
+    "gear_category": "Druidic Foci",
     "cost": {
       "quantity": 1,
       "unit": "gp"
@@ -2446,7 +2446,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Druidic focus",
+    "gear_category": "Druidic Foci",
     "cost": {
       "quantity": 5,
       "unit": "gp"
@@ -2464,7 +2464,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Druidic focus",
+    "gear_category": "Druidic Foci",
     "cost": {
       "quantity": 10,
       "unit": "gp"
@@ -2482,7 +2482,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Holy Symbol",
+    "gear_category": "Holy Symbols",
     "cost": {
       "quantity": 5,
       "unit": "gp"
@@ -3179,7 +3179,7 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
-    "gear_category": "Holy Symbol",
+    "gear_category": "Holy Symbols",
     "cost": {
       "quantity": 5,
       "unit": "gp"

--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -179,11 +179,12 @@
 		}, {
 			"choose": 1,
 			"type": "equipment",
-			"from": [
-				{ "equipment": { "url": "/api/equipment/amulet", "name": "Amulet" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/emblem", "name": "Emblem" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/reliquary", "name": "Reliquary" }, "quantity": 1 }
-			]
+			"from": {
+				"equipment_category": {
+					"name": "Holy Symbols",
+					"url": "/api/equipment-categories/holy-symbols"
+				}
+			}
 		}
 	],
 	"url": "/api/starting-equipment/3"
@@ -237,12 +238,12 @@
 		}, {
 			"choose": 1,
 			"type": "equipment",
-			"from": [
-				{ "equipment": { "url": "/api/equipment/sprig-of-mistletoe", "name": "Sprig of mistletoe" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/totem", "name": "Totem" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/wooden-staff", "name": "Wooden staff" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/yew-wand", "name": "Yew wand" }, "quantity": 1 }
-			]
+			"from": {
+				"equipment_category": {
+					"name": "Druidic Foci",
+					"url": "/api/equipment-categories/druidic-foci"
+				}
+			}
 		}
 	],
 	"url": "/api/starting-equipment/4"
@@ -408,11 +409,12 @@
 		}, {
 			"choose": 1,
 			"type": "equipment",
-			"from": [
-				{ "equipment": { "url": "/api/equipment/amulet", "name": "Amulet" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/emblem", "name": "Emblem" }, "quantity": 1 },
-				{ "equipment": { "url": "/api/equipment/reliquary", "name": "Reliquary" }, "quantity": 1 }
-			]
+			"from": {
+				"equipment_category": {
+					"name": "Holy Symbols",
+					"url": "/api/equipment-categories/holy-symbols"
+				}
+			}
 		}
 	],
 	"url": "/api/starting-equipment/7"
@@ -543,13 +545,12 @@
 					"equipment_option": {
 						"choose": 1,
 						"type": "equipment",
-						"from": [
-							{ "equipment": { "url": "/api/equipment/crystal", "name": "Crystal" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/orb", "name": "Orb" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/rod", "name": "Rod" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/staff", "name": "Staff" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/wand", "name": "Wand" }, "quantity": 1 }
-						]
+						"from": {
+							"equipment_category": {
+								"name": "Arcane Foci",
+								"url": "/api/equipment-categories/arcane-foci"
+							}
+						}
 					}
 				}
 			]
@@ -603,13 +604,12 @@
 					"equipment_option": {
 						"choose": 1,
 						"type": "equipment",
-						"from": [
-							{ "equipment": { "url": "/api/equipment/crystal", "name": "Crystal"}, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/orb", "name": "Orb"}, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/rod", "name": "Rod"}, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/staff", "name": "Staff"}, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/wand", "name": "Wand"}, "quantity": 1 }
-						]
+						"from": {
+							"equipment_category": {
+								"name": "Arcane foci",
+								"url": "/api/equipment-categories/arcane-foci"
+							}
+						}
 					}
 				}
 			]
@@ -658,13 +658,12 @@
 					"equipment_option": {
 						"choose": 1,
 						"type": "equipment",
-						"from": [
-							{ "equipment": { "url": "/api/equipment/crystal", "name": "Crystal "}, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/orb", "name": "Orb" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/rod", "name": "Rod" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/staff", "name": "Staff" }, "quantity": 1 },
-							{ "equipment": { "url": "/api/equipment/wand", "name": "Wand" }, "quantity": 1 }
-						]
+						"from": {
+							"equipment_category": {
+								"name": "Arcane Foci",
+								"url": "/api/equipment-categories/arcane-foci"
+							}
+						}
 					}
 				}
 			]


### PR DESCRIPTION
## What does this do?
- Creates three new equipment categories, "Arcane Foci", "Druidic Foci" and "Holy Symbols", containing the suggested equipment items that may be used for each purpose, according to the SRD.
- Removes arcane foci, druidic foci and holy symbols from the "Standard Gear" category (though they remain in the "Adventuring Gear" category).
- Replaces the lists of foci equipment items included in starting equipment choices with references to the appropriate equipment category, to match similar references to weapon categories.

## How was it tested?
JSON validated with ESLint.

## Is there a Github issue this is resolving?
Resolves #234

## Here's a fun image for your troubles
![arcane focus](https://64.media.tumblr.com/0f5aadacdd3656854d8362129ce5efcb/tumblr_ophkqxxXJ61w7ibmjo1_400.jpg)
