### PR TITLE
Switch Starting Equipment to string index

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -68,7 +68,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/1",
+      "url": "/api/starting-equipment/barbarian",
       "class": "Barbarian"
     },
     "class_levels": {
@@ -251,7 +251,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/2",
+      "url": "/api/starting-equipment/bard",
       "class": "Bard"
     },
     "class_levels": {
@@ -331,7 +331,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/3",
+      "url": "/api/starting-equipment/cleric",
       "class": "Cleric"
     },
     "class_levels": {
@@ -463,7 +463,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/4",
+      "url": "/api/starting-equipment/druid",
       "class": "Druid"
     },
     "class_levels": {
@@ -555,7 +555,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/5",
+      "url": "/api/starting-equipment/fighter",
       "class": "Fighter"
     },
     "class_levels": {
@@ -756,7 +756,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/6",
+      "url": "/api/starting-equipment/monk",
       "class": "Monk"
     },
     "class_levels": {
@@ -837,7 +837,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/7",
+      "url": "/api/starting-equipment/paladin",
       "class": "Paladin"
     },
     "class_levels": {
@@ -933,7 +933,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/8",
+      "url": "/api/starting-equipment/ranger",
       "class": "Ranger"
     },
     "class_levels": {
@@ -1049,7 +1049,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/9",
+      "url": "/api/starting-equipment/rogue",
       "class": "Rogue"
     },
     "class_levels": {
@@ -1130,7 +1130,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/10",
+      "url": "/api/starting-equipment/sorcerer",
       "class": "Sorcerer"
     },
     "class_levels": {
@@ -1210,7 +1210,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/11",
+      "url": "/api/starting-equipment/warlock",
       "class": "Warlock"
     },
     "class_levels": {
@@ -1294,7 +1294,7 @@
       }
     ],
     "starting_equipment": {
-      "url": "/api/starting-equipment/12",
+      "url": "/api/starting-equipment/wizard",
       "class": "Wizard"
     },
     "class_levels": {

--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -1,6 +1,6 @@
 [
   {
-    "index": 1,
+    "index": "barbarian",
     "class": {
       "url": "/api/classes/barbarian",
       "name": "Barbarian"
@@ -67,10 +67,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/1"
+    "url": "/api/starting-equipment/barbarian"
   },
   {
-    "index": 2,
+    "index": "bard",
     "class": {
       "url": "/api/classes/bard",
       "name": "Bard"
@@ -160,10 +160,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/2"
+    "url": "/api/starting-equipment/bard"
   },
   {
-    "index": 3,
+    "index": "cleric",
     "class": {
       "url": "/api/classes/cleric",
       "name": "Cleric"
@@ -299,10 +299,10 @@
         }
       }
     ],
-    "url": "/api/starting-equipment/3"
+    "url": "/api/starting-equipment/cleric"
   },
   {
-    "index": 4,
+    "index": "druid",
     "class": {
       "url": "/api/classes/druid",
       "name": "Druid"
@@ -379,10 +379,10 @@
         }
       }
     ],
-    "url": "/api/starting-equipment/4"
+    "url": "/api/starting-equipment/druid"
   },
   {
-    "index": 5,
+    "index": "fighter",
     "class": {
       "url": "/api/classes/fighter",
       "name": "Fighter"
@@ -505,10 +505,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/5"
+    "url": "/api/starting-equipment/fighter"
   },
   {
-    "index": 6,
+    "index": "monk",
     "class": {
       "url": "/api/classes/monk",
       "name": "Monk"
@@ -566,10 +566,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/6"
+    "url": "/api/starting-equipment/monk"
   },
   {
-    "index": 7,
+    "index": "paladin",
     "class": {
       "url": "/api/classes/paladin",
       "name": "Paladin"
@@ -657,10 +657,10 @@
         }
       }
     ],
-    "url": "/api/starting-equipment/7"
+    "url": "/api/starting-equipment/paladin"
   },
   {
-    "index": 8,
+    "index": "ranger",
     "class": {
       "url": "/api/classes/ranger",
       "name": "Ranger"
@@ -739,10 +739,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/8"
+    "url": "/api/starting-equipment/ranger"
   },
   {
-    "index": 9,
+    "index": "rogue",
     "class": {
       "url": "/api/classes/rogue",
       "name": "Rogue"
@@ -836,10 +836,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/9"
+    "url": "/api/starting-equipment/rogue"
   },
   {
-    "index": 10,
+    "index": "sorcerer",
     "class": {
       "url": "/api/classes/sorcerer",
       "name": "Sorcerer"
@@ -931,10 +931,10 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/10"
+    "url": "/api/starting-equipment/sorcerer"
   },
   {
-    "index": 11,
+    "index": "warlock",
     "class": {
       "url": "/api/classes/warlock",
       "name": "Warlock"
@@ -1040,10 +1040,10 @@
         }
       }
     ],
-    "url": "/api/starting-equipment/11"
+    "url": "/api/starting-equipment/warlock"
   },
   {
-    "index": 12,
+    "index": "wizard",
     "class": {
       "url": "/api/classes/wizard",
       "name": "Wizard"
@@ -1118,6 +1118,6 @@
         ]
       }
     ],
-    "url": "/api/starting-equipment/12"
+    "url": "/api/starting-equipment/wizard"
   }
 ]


### PR DESCRIPTION
## What does this do?
This switches the number index to a string index which is the just the class name as there is a 1:1 relationship between Class and Starting Equipment

This requires https://github.com/bagelbits/5e-srd-api/pull/78 to be merged immediately after this one for a clean cutover.

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolves #237 

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/90174104-4f923b00-dd5a-11ea-8c68-10b7b6847bd9.png)

