### PR TITLE
Switch to string indices in Level objects

### DIFF
--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -19,7 +19,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 1,
+    "index": "barbarian-1",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -47,7 +47,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 2,
+    "index": "barbarian-2",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -71,7 +71,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 3,
+    "index": "barbarian-3",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -95,7 +95,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 4,
+    "index": "barbarian-4",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -123,7 +123,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 5,
+    "index": "barbarian-5",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -143,7 +143,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 6,
+    "index": "barbarian-6",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -168,7 +168,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 7,
+    "index": "barbarian-7",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -193,7 +193,7 @@
       "rage_damage_bonus": 2,
       "brutal_critical_dice": 0
     },
-    "index": 8,
+    "index": "barbarian-8",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -218,7 +218,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 1
     },
-    "index": 9,
+    "index": "barbarian-9",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -238,7 +238,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 1
     },
-    "index": 10,
+    "index": "barbarian-10",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -263,7 +263,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 1
     },
-    "index": 11,
+    "index": "barbarian-11",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -287,7 +287,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 1
     },
-    "index": 12,
+    "index": "barbarian-12",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -311,7 +311,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 2
     },
-    "index": 13,
+    "index": "barbarian-13",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -330,7 +330,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 2
     },
-    "index": 14,
+    "index": "barbarian-14",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -354,7 +354,7 @@
       "rage_damage_bonus": 3,
       "brutal_critical_dice": 2
     },
-    "index": 15,
+    "index": "barbarian-15",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -378,7 +378,7 @@
       "rage_damage_bonus": 4,
       "brutal_critical_dice": 2
     },
-    "index": 16,
+    "index": "barbarian-16",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -402,7 +402,7 @@
       "rage_damage_bonus": 4,
       "brutal_critical_dice": 3
     },
-    "index": 17,
+    "index": "barbarian-17",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -426,7 +426,7 @@
       "rage_damage_bonus": 4,
       "brutal_critical_dice": 3
     },
-    "index": 18,
+    "index": "barbarian-18",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -450,7 +450,7 @@
       "rage_damage_bonus": 4,
       "brutal_critical_dice": 3
     },
-    "index": 19,
+    "index": "barbarian-19",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -474,7 +474,7 @@
       "rage_damage_bonus": 4,
       "brutal_critical_dice": 3
     },
-    "index": 20,
+    "index": "barbarian-20",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -517,7 +517,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 21,
+    "index": "bard-1",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -560,7 +560,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 22,
+    "index": "bard-2",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -604,7 +604,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 23,
+    "index": "bard-3",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -643,7 +643,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 24,
+    "index": "bard-4",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -686,7 +686,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 25,
+    "index": "bard-5",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -725,7 +725,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 26,
+    "index": "bard-6",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -759,7 +759,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 27,
+    "index": "bard-7",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -798,7 +798,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 28,
+    "index": "bard-8",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -837,7 +837,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 29,
+    "index": "bard-9",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -885,7 +885,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 30,
+    "index": "bard-10",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -919,7 +919,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 31,
+    "index": "bard-11",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -958,7 +958,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 32,
+    "index": "bard-12",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -997,7 +997,7 @@
       "magical_secrets_max_7": 0,
       "magical_secrets_max_9": 0
     },
-    "index": 33,
+    "index": "bard-13",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1036,7 +1036,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 0
     },
-    "index": 34,
+    "index": "bard-14",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1075,7 +1075,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 0
     },
-    "index": 35,
+    "index": "bard-15",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1114,7 +1114,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 0
     },
-    "index": 36,
+    "index": "bard-16",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1153,7 +1153,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 0
     },
-    "index": 37,
+    "index": "bard-17",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1192,7 +1192,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 2
     },
-    "index": 38,
+    "index": "bard-18",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1231,7 +1231,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 2
     },
-    "index": 39,
+    "index": "bard-19",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1270,7 +1270,7 @@
       "magical_secrets_max_7": 2,
       "magical_secrets_max_9": 2
     },
-    "index": 40,
+    "index": "bard-20",
     "class": {
       "name": "Bard",
       "url": "/api/classes/bard"
@@ -1314,7 +1314,7 @@
       "channel_divinity_charges": 0,
       "destroy_undead_cr": 0
     },
-    "index": 41,
+    "index": "cleric-1",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1354,7 +1354,7 @@
       "channel_divinity_charges": 1,
       "destroy_undead_cr": 0
     },
-    "index": 42,
+    "index": "cleric-2",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1390,7 +1390,7 @@
       "channel_divinity_charges": 1,
       "destroy_undead_cr": 0
     },
-    "index": 43,
+    "index": "cleric-3",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1426,7 +1426,7 @@
       "channel_divinity_charges": 1,
       "destroy_undead_cr": 0
     },
-    "index": 44,
+    "index": "cleric-4",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1466,7 +1466,7 @@
       "channel_divinity_charges": 1,
       "destroy_undead_cr": 0.5
     },
-    "index": 45,
+    "index": "cleric-5",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1502,7 +1502,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 0.5
     },
-    "index": 46,
+    "index": "cleric-6",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1538,7 +1538,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 0.5
     },
-    "index": 47,
+    "index": "cleric-7",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1578,7 +1578,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 1
     },
-    "index": 48,
+    "index": "cleric-8",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1614,7 +1614,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 1
     },
-    "index": 49,
+    "index": "cleric-9",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1650,7 +1650,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 1
     },
-    "index": 50,
+    "index": "cleric-10",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1686,7 +1686,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 2
     },
-    "index": 51,
+    "index": "cleric-11",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1722,7 +1722,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 2
     },
-    "index": 52,
+    "index": "cleric-12",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1753,7 +1753,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 2
     },
-    "index": 53,
+    "index": "cleric-13",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1789,7 +1789,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 3
     },
-    "index": 54,
+    "index": "cleric-14",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1820,7 +1820,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 3
     },
-    "index": 55,
+    "index": "cleric-15",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1856,7 +1856,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 3
     },
-    "index": 56,
+    "index": "cleric-16",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1892,7 +1892,7 @@
       "channel_divinity_charges": 2,
       "destroy_undead_cr": 4
     },
-    "index": 57,
+    "index": "cleric-17",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1928,7 +1928,7 @@
       "channel_divinity_charges": 3,
       "destroy_undead_cr": 4
     },
-    "index": 58,
+    "index": "cleric-18",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -1964,7 +1964,7 @@
       "channel_divinity_charges": 3,
       "destroy_undead_cr": 4
     },
-    "index": 59,
+    "index": "cleric-19",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -2000,7 +2000,7 @@
       "channel_divinity_charges": 3,
       "destroy_undead_cr": 4
     },
-    "index": 60,
+    "index": "cleric-20",
     "class": {
       "name": "Cleric",
       "url": "/api/classes/cleric"
@@ -2040,7 +2040,7 @@
       "wild_shape_swim": false,
       "wild_shape_fly": false
     },
-    "index": 61,
+    "index": "druid-1",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2080,7 +2080,7 @@
       "wild_shape_swim": false,
       "wild_shape_fly": false
     },
-    "index": 62,
+    "index": "druid-2",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2111,7 +2111,7 @@
       "wild_shape_swim": false,
       "wild_shape_fly": false
     },
-    "index": 63,
+    "index": "druid-3",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2151,7 +2151,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": false
     },
-    "index": 64,
+    "index": "druid-4",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2182,7 +2182,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": false
     },
-    "index": 65,
+    "index": "druid-5",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2213,7 +2213,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": false
     },
-    "index": 66,
+    "index": "druid-6",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2244,7 +2244,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": false
     },
-    "index": 67,
+    "index": "druid-7",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2284,7 +2284,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 68,
+    "index": "druid-8",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2315,7 +2315,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 69,
+    "index": "druid-9",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2346,7 +2346,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 70,
+    "index": "druid-10",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2377,7 +2377,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 71,
+    "index": "druid-11",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2413,7 +2413,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 72,
+    "index": "druid-12",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2444,7 +2444,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 73,
+    "index": "druid-13",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2475,7 +2475,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 74,
+    "index": "druid-14",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2506,7 +2506,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 75,
+    "index": "druid-15",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2542,7 +2542,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 76,
+    "index": "druid-16",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2573,7 +2573,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 77,
+    "index": "druid-17",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2613,7 +2613,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 78,
+    "index": "druid-18",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2649,7 +2649,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 79,
+    "index": "druid-19",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2685,7 +2685,7 @@
       "wild_shape_swim": true,
       "wild_shape_fly": true
     },
-    "index": 80,
+    "index": "druid-20",
     "class": {
       "name": "Druid",
       "url": "/api/classes/druid"
@@ -2715,7 +2715,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 0
     },
-    "index": 81,
+    "index": "fighter-1",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2740,7 +2740,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 0
     },
-    "index": 82,
+    "index": "fighter-2",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2765,7 +2765,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 0
     },
-    "index": 83,
+    "index": "fighter-3",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2790,7 +2790,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 0
     },
-    "index": 84,
+    "index": "fighter-4",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2815,7 +2815,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 1
     },
-    "index": 85,
+    "index": "fighter-5",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2840,7 +2840,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 1
     },
-    "index": 86,
+    "index": "fighter-6",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2860,7 +2860,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 1
     },
-    "index": 87,
+    "index": "fighter-7",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2885,7 +2885,7 @@
       "indomitable_uses": 0,
       "extra_attacks": 1
     },
-    "index": 88,
+    "index": "fighter-8",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2910,7 +2910,7 @@
       "indomitable_uses": 1,
       "extra_attacks": 1
     },
-    "index": 89,
+    "index": "fighter-9",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2930,7 +2930,7 @@
       "indomitable_uses": 1,
       "extra_attacks": 1
     },
-    "index": 90,
+    "index": "fighter-10",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2955,7 +2955,7 @@
       "indomitable_uses": 1,
       "extra_attacks": 2
     },
-    "index": 91,
+    "index": "fighter-11",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -2980,7 +2980,7 @@
       "indomitable_uses": 1,
       "extra_attacks": 2
     },
-    "index": 92,
+    "index": "fighter-12",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3005,7 +3005,7 @@
       "indomitable_uses": 2,
       "extra_attacks": 2
     },
-    "index": 93,
+    "index": "fighter-13",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3030,7 +3030,7 @@
       "indomitable_uses": 2,
       "extra_attacks": 2
     },
-    "index": 94,
+    "index": "fighter-14",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3050,7 +3050,7 @@
       "indomitable_uses": 2,
       "extra_attacks": 2
     },
-    "index": 95,
+    "index": "fighter-15",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3075,7 +3075,7 @@
       "indomitable_uses": 2,
       "extra_attacks": 2
     },
-    "index": 96,
+    "index": "fighter-16",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3104,7 +3104,7 @@
       "indomitable_uses": 3,
       "extra_attacks": 2
     },
-    "index": 97,
+    "index": "fighter-17",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3124,7 +3124,7 @@
       "indomitable_uses": 3,
       "extra_attacks": 2
     },
-    "index": 98,
+    "index": "fighter-18",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3149,7 +3149,7 @@
       "indomitable_uses": 3,
       "extra_attacks": 2
     },
-    "index": 99,
+    "index": "fighter-19",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3174,7 +3174,7 @@
       "indomitable_uses": 3,
       "extra_attacks": 3
     },
-    "index": 100,
+    "index": "fighter-20",
     "class": {
       "name": "Fighter",
       "url": "/api/classes/fighter"
@@ -3206,7 +3206,7 @@
       "ki_points": 0,
       "unarmored_movement": 0
     },
-    "index": 101,
+    "index": "monk-1",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3250,7 +3250,7 @@
       "ki_points": 2,
       "unarmored_movement": 10
     },
-    "index": 102,
+    "index": "monk-2",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3282,7 +3282,7 @@
       "ki_points": 3,
       "unarmored_movement": 10
     },
-    "index": 103,
+    "index": "monk-3",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3314,7 +3314,7 @@
       "ki_points": 4,
       "unarmored_movement": 10
     },
-    "index": 104,
+    "index": "monk-4",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3346,7 +3346,7 @@
       "ki_points": 5,
       "unarmored_movement": 10
     },
-    "index": 105,
+    "index": "monk-5",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3374,7 +3374,7 @@
       "ki_points": 6,
       "unarmored_movement": 15
     },
-    "index": 106,
+    "index": "monk-6",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3406,7 +3406,7 @@
       "ki_points": 7,
       "unarmored_movement": 15
     },
-    "index": 107,
+    "index": "monk-7",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3434,7 +3434,7 @@
       "ki_points": 8,
       "unarmored_movement": 15
     },
-    "index": 108,
+    "index": "monk-8",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3462,7 +3462,7 @@
       "ki_points": 9,
       "unarmored_movement": 15
     },
-    "index": 109,
+    "index": "monk-9",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3490,7 +3490,7 @@
       "ki_points": 10,
       "unarmored_movement": 20
     },
-    "index": 110,
+    "index": "monk-10",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3513,7 +3513,7 @@
       "ki_points": 11,
       "unarmored_movement": 20
     },
-    "index": 111,
+    "index": "monk-11",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3541,7 +3541,7 @@
       "ki_points": 12,
       "unarmored_movement": 20
     },
-    "index": 112,
+    "index": "monk-12",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3569,7 +3569,7 @@
       "ki_points": 13,
       "unarmored_movement": 20
     },
-    "index": 113,
+    "index": "monk-13",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3597,7 +3597,7 @@
       "ki_points": 14,
       "unarmored_movement": 25
     },
-    "index": 114,
+    "index": "monk-14",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3625,7 +3625,7 @@
       "ki_points": 15,
       "unarmored_movement": 25
     },
-    "index": 115,
+    "index": "monk-15",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3653,7 +3653,7 @@
       "ki_points": 16,
       "unarmored_movement": 25
     },
-    "index": 116,
+    "index": "monk-16",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3676,7 +3676,7 @@
       "ki_points": 17,
       "unarmored_movement": 25
     },
-    "index": 117,
+    "index": "monk-17",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3704,7 +3704,7 @@
       "ki_points": 18,
       "unarmored_movement": 30
     },
-    "index": 118,
+    "index": "monk-18",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3732,7 +3732,7 @@
       "ki_points": 19,
       "unarmored_movement": 30
     },
-    "index": 119,
+    "index": "monk-19",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3760,7 +3760,7 @@
       "ki_points": 20,
       "unarmored_movement": 30
     },
-    "index": 120,
+    "index": "monk-20",
     "class": {
       "name": "Monk",
       "url": "/api/classes/monk"
@@ -3793,7 +3793,7 @@
     "class_specific": {
       "aura_range": 0
     },
-    "index": 121,
+    "index": "paladin-1",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3831,7 +3831,7 @@
     "class_specific": {
       "aura_range": 0
     },
-    "index": 122,
+    "index": "paladin-2",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3872,7 +3872,7 @@
     "class_specific": {
       "aura_range": 0
     },
-    "index": 123,
+    "index": "paladin-3",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3901,7 +3901,7 @@
     "class_specific": {
       "aura_range": 0
     },
-    "index": 124,
+    "index": "paladin-4",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3930,7 +3930,7 @@
     "class_specific": {
       "aura_range": 0
     },
-    "index": 125,
+    "index": "paladin-5",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3959,7 +3959,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 126,
+    "index": "paladin-6",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -3983,7 +3983,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 127,
+    "index": "paladin-7",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4012,7 +4012,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 128,
+    "index": "paladin-8",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4036,7 +4036,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 129,
+    "index": "paladin-9",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4065,7 +4065,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 130,
+    "index": "paladin-10",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4094,7 +4094,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 131,
+    "index": "paladin-11",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4123,7 +4123,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 132,
+    "index": "paladin-12",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4147,7 +4147,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 133,
+    "index": "paladin-13",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4176,7 +4176,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 134,
+    "index": "paladin-14",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4200,7 +4200,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 135,
+    "index": "paladin-15",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4229,7 +4229,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 136,
+    "index": "paladin-16",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4253,7 +4253,7 @@
     "class_specific": {
       "aura_range": 10
     },
-    "index": 137,
+    "index": "paladin-17",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4282,7 +4282,7 @@
     "class_specific": {
       "aura_range": 30
     },
-    "index": 138,
+    "index": "paladin-18",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4311,7 +4311,7 @@
     "class_specific": {
       "aura_range": 30
     },
-    "index": 139,
+    "index": "paladin-19",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4335,7 +4335,7 @@
     "class_specific": {
       "aura_range": 30
     },
-    "index": 140,
+    "index": "paladin-20",
     "class": {
       "name": "Paladin",
       "url": "/api/classes/paladin"
@@ -4370,7 +4370,7 @@
       "favored_enemies": 1,
       "favored_terrain": 1
     },
-    "index": 141,
+    "index": "ranger-1",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4406,7 +4406,7 @@
       "favored_enemies": 1,
       "favored_terrain": 1
     },
-    "index": 142,
+    "index": "ranger-2",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4441,7 +4441,7 @@
       "favored_enemies": 1,
       "favored_terrain": 1
     },
-    "index": 143,
+    "index": "ranger-3",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4472,7 +4472,7 @@
       "favored_enemies": 1,
       "favored_terrain": 1
     },
-    "index": 144,
+    "index": "ranger-4",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4503,7 +4503,7 @@
       "favored_enemies": 1,
       "favored_terrain": 1
     },
-    "index": 145,
+    "index": "ranger-5",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4538,7 +4538,7 @@
       "favored_enemies": 2,
       "favored_terrain": 2
     },
-    "index": 146,
+    "index": "ranger-6",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4564,7 +4564,7 @@
       "favored_enemies": 2,
       "favored_terrain": 2
     },
-    "index": 147,
+    "index": "ranger-7",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4599,7 +4599,7 @@
       "favored_enemies": 2,
       "favored_terrain": 2
     },
-    "index": 148,
+    "index": "ranger-8",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4625,7 +4625,7 @@
       "favored_enemies": 2,
       "favored_terrain": 2
     },
-    "index": 149,
+    "index": "ranger-9",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4660,7 +4660,7 @@
       "favored_enemies": 2,
       "favored_terrain": 3
     },
-    "index": 150,
+    "index": "ranger-10",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4686,7 +4686,7 @@
       "favored_enemies": 2,
       "favored_terrain": 3
     },
-    "index": 151,
+    "index": "ranger-11",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4717,7 +4717,7 @@
       "favored_enemies": 2,
       "favored_terrain": 3
     },
-    "index": 152,
+    "index": "ranger-12",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4743,7 +4743,7 @@
       "favored_enemies": 2,
       "favored_terrain": 3
     },
-    "index": 153,
+    "index": "ranger-13",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4778,7 +4778,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 154,
+    "index": "ranger-14",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4804,7 +4804,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 155,
+    "index": "ranger-15",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4835,7 +4835,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 156,
+    "index": "ranger-16",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4861,7 +4861,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 157,
+    "index": "ranger-17",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4892,7 +4892,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 158,
+    "index": "ranger-18",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4923,7 +4923,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 159,
+    "index": "ranger-19",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4954,7 +4954,7 @@
       "favored_enemies": 3,
       "favored_terrain": 3
     },
-    "index": 160,
+    "index": "ranger-20",
     "class": {
       "name": "Ranger",
       "url": "/api/classes/ranger"
@@ -4989,7 +4989,7 @@
         "dice_value": 6
       }
     },
-    "index": 161,
+    "index": "rogue-1",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5015,7 +5015,7 @@
         "dice_value": 6
       }
     },
-    "index": 162,
+    "index": "rogue-2",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5041,7 +5041,7 @@
         "dice_value": 6
       }
     },
-    "index": 163,
+    "index": "rogue-3",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5067,7 +5067,7 @@
         "dice_value": 6
       }
     },
-    "index": 164,
+    "index": "rogue-4",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5093,7 +5093,7 @@
         "dice_value": 6
       }
     },
-    "index": 165,
+    "index": "rogue-5",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5119,7 +5119,7 @@
         "dice_value": 6
       }
     },
-    "index": 166,
+    "index": "rogue-6",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5145,7 +5145,7 @@
         "dice_value": 6
       }
     },
-    "index": 167,
+    "index": "rogue-7",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5171,7 +5171,7 @@
         "dice_value": 6
       }
     },
-    "index": 168,
+    "index": "rogue-8",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5192,7 +5192,7 @@
         "dice_value": 6
       }
     },
-    "index": 169,
+    "index": "rogue-9",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5218,7 +5218,7 @@
         "dice_value": 6
       }
     },
-    "index": 170,
+    "index": "rogue-10",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5244,7 +5244,7 @@
         "dice_value": 6
       }
     },
-    "index": 171,
+    "index": "rogue-11",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5270,7 +5270,7 @@
         "dice_value": 6
       }
     },
-    "index": 172,
+    "index": "rogue-12",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5291,7 +5291,7 @@
         "dice_value": 6
       }
     },
-    "index": 173,
+    "index": "rogue-13",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5317,7 +5317,7 @@
         "dice_value": 6
       }
     },
-    "index": 174,
+    "index": "rogue-14",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5343,7 +5343,7 @@
         "dice_value": 6
       }
     },
-    "index": 175,
+    "index": "rogue-15",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5369,7 +5369,7 @@
         "dice_value": 6
       }
     },
-    "index": 176,
+    "index": "rogue-16",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5390,7 +5390,7 @@
         "dice_value": 6
       }
     },
-    "index": 177,
+    "index": "rogue-17",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5416,7 +5416,7 @@
         "dice_value": 6
       }
     },
-    "index": 178,
+    "index": "rogue-18",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5442,7 +5442,7 @@
         "dice_value": 6
       }
     },
-    "index": 179,
+    "index": "rogue-19",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5468,7 +5468,7 @@
         "dice_value": 6
       }
     },
-    "index": 180,
+    "index": "rogue-20",
     "class": {
       "name": "Rogue",
       "url": "/api/classes/rogue"
@@ -5509,7 +5509,7 @@
       "metamagic_known": 0,
       "creating_spell_slots": []
     },
-    "index": 181,
+    "index": "sorcerer-1",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5575,7 +5575,7 @@
         }
       ]
     },
-    "index": 182,
+    "index": "sorcerer-2",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5633,7 +5633,7 @@
         }
       ]
     },
-    "index": 183,
+    "index": "sorcerer-3",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5691,7 +5691,7 @@
         }
       ]
     },
-    "index": 184,
+    "index": "sorcerer-4",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5744,7 +5744,7 @@
         }
       ]
     },
-    "index": 185,
+    "index": "sorcerer-5",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5797,7 +5797,7 @@
         }
       ]
     },
-    "index": 186,
+    "index": "sorcerer-6",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5850,7 +5850,7 @@
         }
       ]
     },
-    "index": 187,
+    "index": "sorcerer-7",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5908,7 +5908,7 @@
         }
       ]
     },
-    "index": 188,
+    "index": "sorcerer-8",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -5961,7 +5961,7 @@
         }
       ]
     },
-    "index": 189,
+    "index": "sorcerer-9",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6019,7 +6019,7 @@
         }
       ]
     },
-    "index": 190,
+    "index": "sorcerer-10",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6072,7 +6072,7 @@
         }
       ]
     },
-    "index": 191,
+    "index": "sorcerer-11",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6130,7 +6130,7 @@
         }
       ]
     },
-    "index": 192,
+    "index": "sorcerer-12",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6183,7 +6183,7 @@
         }
       ]
     },
-    "index": 193,
+    "index": "sorcerer-13",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6236,7 +6236,7 @@
         }
       ]
     },
-    "index": 194,
+    "index": "sorcerer-14",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6289,7 +6289,7 @@
         }
       ]
     },
-    "index": 195,
+    "index": "sorcerer-15",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6347,7 +6347,7 @@
         }
       ]
     },
-    "index": 196,
+    "index": "sorcerer-16",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6405,7 +6405,7 @@
         }
       ]
     },
-    "index": 197,
+    "index": "sorcerer-17",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6458,7 +6458,7 @@
         }
       ]
     },
-    "index": 198,
+    "index": "sorcerer-18",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6516,7 +6516,7 @@
         }
       ]
     },
-    "index": 199,
+    "index": "sorcerer-19",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6574,7 +6574,7 @@
         }
       ]
     },
-    "index": 200,
+    "index": "sorcerer-20",
     "class": {
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
@@ -6617,7 +6617,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 201,
+    "index": "warlock-1",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6656,7 +6656,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 202,
+    "index": "warlock-2",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6695,7 +6695,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 203,
+    "index": "warlock-3",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6734,7 +6734,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 204,
+    "index": "warlock-4",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6773,7 +6773,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 205,
+    "index": "warlock-5",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6807,7 +6807,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 206,
+    "index": "warlock-6",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6846,7 +6846,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 207,
+    "index": "warlock-7",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6885,7 +6885,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 208,
+    "index": "warlock-8",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6924,7 +6924,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 209,
+    "index": "warlock-9",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6958,7 +6958,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 210,
+    "index": "warlock-10",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -6997,7 +6997,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 211,
+    "index": "warlock-11",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7041,7 +7041,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 212,
+    "index": "warlock-12",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7080,7 +7080,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 213,
+    "index": "warlock-13",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7114,7 +7114,7 @@
       "mystic_arcanum_level_8": 0,
       "mystic_arcanum_level_9": 0
     },
-    "index": 214,
+    "index": "warlock-14",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7158,7 +7158,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 0
     },
-    "index": 215,
+    "index": "warlock-15",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7197,7 +7197,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 0
     },
-    "index": 216,
+    "index": "warlock-16",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7236,7 +7236,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 1
     },
-    "index": 217,
+    "index": "warlock-17",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7275,7 +7275,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 1
     },
-    "index": 218,
+    "index": "warlock-18",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7314,7 +7314,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 1
     },
-    "index": 219,
+    "index": "warlock-19",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7358,7 +7358,7 @@
       "mystic_arcanum_level_8": 1,
       "mystic_arcanum_level_9": 1
     },
-    "index": 220,
+    "index": "warlock-20",
     "class": {
       "name": "Warlock",
       "url": "/api/classes/warlock"
@@ -7396,7 +7396,7 @@
     "class_specific": {
       "arcane_recovery_levels": 1
     },
-    "index": 221,
+    "index": "wizard-1",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7430,7 +7430,7 @@
     "class_specific": {
       "arcane_recovery_levels": 1
     },
-    "index": 222,
+    "index": "wizard-2",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7459,7 +7459,7 @@
     "class_specific": {
       "arcane_recovery_levels": 2
     },
-    "index": 223,
+    "index": "wizard-3",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7493,7 +7493,7 @@
     "class_specific": {
       "arcane_recovery_levels": 2
     },
-    "index": 224,
+    "index": "wizard-4",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7522,7 +7522,7 @@
     "class_specific": {
       "arcane_recovery_levels": 3
     },
-    "index": 225,
+    "index": "wizard-5",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7551,7 +7551,7 @@
     "class_specific": {
       "arcane_recovery_levels": 3
     },
-    "index": 226,
+    "index": "wizard-6",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7580,7 +7580,7 @@
     "class_specific": {
       "arcane_recovery_levels": 4
     },
-    "index": 227,
+    "index": "wizard-7",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7614,7 +7614,7 @@
     "class_specific": {
       "arcane_recovery_levels": 4
     },
-    "index": 228,
+    "index": "wizard-8",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7643,7 +7643,7 @@
     "class_specific": {
       "arcane_recovery_levels": 5
     },
-    "index": 229,
+    "index": "wizard-9",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7672,7 +7672,7 @@
     "class_specific": {
       "arcane_recovery_levels": 5
     },
-    "index": 230,
+    "index": "wizard-10",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7701,7 +7701,7 @@
     "class_specific": {
       "arcane_recovery_levels": 6
     },
-    "index": 231,
+    "index": "wizard-11",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7735,7 +7735,7 @@
     "class_specific": {
       "arcane_recovery_levels": 6
     },
-    "index": 232,
+    "index": "wizard-12",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7764,7 +7764,7 @@
     "class_specific": {
       "arcane_recovery_levels": 7
     },
-    "index": 233,
+    "index": "wizard-13",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7793,7 +7793,7 @@
     "class_specific": {
       "arcane_recovery_levels": 7
     },
-    "index": 234,
+    "index": "wizard-14",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7822,7 +7822,7 @@
     "class_specific": {
       "arcane_recovery_levels": 8
     },
-    "index": 235,
+    "index": "wizard-15",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7856,7 +7856,7 @@
     "class_specific": {
       "arcane_recovery_levels": 8
     },
-    "index": 236,
+    "index": "wizard-16",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7885,7 +7885,7 @@
     "class_specific": {
       "arcane_recovery_levels": 9
     },
-    "index": 237,
+    "index": "wizard-17",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7919,7 +7919,7 @@
     "class_specific": {
       "arcane_recovery_levels": 9
     },
-    "index": 238,
+    "index": "wizard-18",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7953,7 +7953,7 @@
     "class_specific": {
       "arcane_recovery_levels": 10
     },
-    "index": 239,
+    "index": "wizard-19",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -7987,7 +7987,7 @@
     "class_specific": {
       "arcane_recovery_levels": 10
     },
-    "index": 240,
+    "index": "wizard-20",
     "class": {
       "name": "Wizard",
       "url": "/api/classes/wizard"
@@ -8014,7 +8014,7 @@
       "url": "/api/subclasses/berserker"
     },
     "url": "/api/subclasses/berserker/levels/3",
-    "index": 241
+    "index": "berserker-3"
   },
   {
     "level": 6,
@@ -8026,7 +8026,7 @@
       }
     ],
     "spellcasting": {},
-    "index": 242,
+    "index": "berserker-6",
     "class": {
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
@@ -8056,7 +8056,7 @@
       "url": "/api/subclasses/berserker"
     },
     "url": "/api/subclasses/berserker/levels/10",
-    "index": 243
+    "index": "berserker-10"
   },
   {
     "level": 14,
@@ -8077,7 +8077,7 @@
       "url": "/api/subclasses/berserker"
     },
     "url": "/api/subclasses/berserker/levels/14",
-    "index": 244
+    "index": "berserker-14"
   },
   {
     "level": 3,
@@ -8105,7 +8105,7 @@
       "url": "/api/subclasses/lore"
     },
     "url": "/api/subclasses/lore/levels/3",
-    "index": 245
+    "index": "lore-3"
   },
   {
     "level": 6,
@@ -8129,7 +8129,7 @@
       "url": "/api/subclasses/lore"
     },
     "url": "/api/subclasses/lore/levels/6",
-    "index": 246
+    "index": "lore-6"
   },
   {
     "level": 14,
@@ -8153,7 +8153,7 @@
       "url": "/api/subclasses/lore"
     },
     "url": "/api/subclasses/lore/levels/14",
-    "index": 247
+    "index": "lore-14"
   },
   {
     "level": 1,
@@ -8179,7 +8179,7 @@
       "url": "/api/subclasses/life"
     },
     "url": "/api/subclasses/life/levels/1",
-    "index": 248
+    "index": "life-1"
   },
   {
     "level": 2,
@@ -8201,7 +8201,7 @@
       "url": "/api/subclasses/life"
     },
     "url": "/api/subclasses/life/levels/2",
-    "index": 249
+    "index": "life-2"
   },
   {
     "level": 6,
@@ -8223,7 +8223,7 @@
       "url": "/api/subclasses/life"
     },
     "url": "/api/subclasses/life/levels/6",
-    "index": 250
+    "index": "life-6"
   },
   {
     "level": 8,
@@ -8232,7 +8232,7 @@
       {
         "name": "Divine Strike",
         "url": "/api/features/divine-strike"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8245,7 +8245,7 @@
       "url": "/api/subclasses/life"
     },
     "url": "/api/subclasses/life/levels/8",
-    "index": 251
+    "index": "life-8"
   },
   {
     "level": 17,
@@ -8254,7 +8254,7 @@
       {
         "name": "Supreme Healing",
         "url": "/api/features/supreme-healing"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8267,7 +8267,7 @@
       "url": "/api/subclasses/life"
     },
     "url": "/api/subclasses/life/levels/17",
-    "index": 252
+    "index": "life-17"
   },
   {
     "level": 2,
@@ -8293,7 +8293,7 @@
       "url": "/api/subclasses/land"
     },
     "url": "/api/subclasses/land/levels/2",
-    "index": 253
+    "index": "land-2"
   },
   {
     "level": 6,
@@ -8302,7 +8302,7 @@
       {
         "name": "Land's Stride",
         "url": "/api/features/druid-lands-stride"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8315,7 +8315,7 @@
       "url": "/api/subclasses/land"
     },
     "url": "/api/subclasses/land/levels/6",
-    "index": 254
+    "index": "land-6"
   },
   {
     "level": 10,
@@ -8324,7 +8324,7 @@
       {
         "name": "Nature's Ward",
         "url": "/api/features/natures-ward"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8337,7 +8337,7 @@
       "url": "/api/subclasses/land"
     },
     "url": "/api/subclasses/land/levels/10",
-    "index": 255
+    "index": "land-10"
   },
   {
     "level": 14,
@@ -8346,7 +8346,7 @@
       {
         "name": "Nature's Sanctuary",
         "url": "/api/features/natures-sanctuary"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8359,7 +8359,7 @@
       "url": "/api/subclasses/land"
     },
     "url": "/api/subclasses/land/levels/14",
-    "index": 256
+    "index": "land-14"
   },
   {
     "level": 3,
@@ -8368,7 +8368,7 @@
       {
         "name": "Improved Critical",
         "url": "/api/features/improved-critical"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8381,7 +8381,7 @@
       "url": "/api/subclasses/champion"
     },
     "url": "/api/subclasses/champion/levels/3",
-    "index": 257
+    "index": "champion-3"
   },
   {
     "level": 7,
@@ -8390,7 +8390,7 @@
       {
         "name": "Remarkable Athlete",
         "url": "/api/features/remarkable-athlete"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8403,11 +8403,11 @@
       "url": "/api/subclasses/champion"
     },
     "url": "/api/subclasses/champion/levels/7",
-    "index": 258
+    "index": "champion-7"
   },
   {
     "level": 10,
-    "feature_choices": [      
+    "feature_choices": [
       {
         "name": "Choose: Additional Fighting Style",
         "url": "/api/features/choose-additional-fighting-style"
@@ -8425,7 +8425,7 @@
       "url": "/api/subclasses/champion"
     },
     "url": "/api/subclasses/champion/levels/10",
-    "index": 259
+    "index": "champion-10"
   },
   {
     "level": 15,
@@ -8434,7 +8434,7 @@
       {
         "name": "Superior Critical",
         "url": "/api/features/superior-critical"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8447,7 +8447,7 @@
       "url": "/api/subclasses/champion"
     },
     "url": "/api/subclasses/champion/levels/15",
-    "index": 260
+    "index": "champion-15"
   },
   {
     "level": 18,
@@ -8456,7 +8456,7 @@
       {
         "name": "Survivor",
         "url": "/api/features/survivor"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8469,7 +8469,7 @@
       "url": "/api/subclasses/champion"
     },
     "url": "/api/subclasses/champion/levels/18",
-    "index": 261
+    "index": "champion-18"
   },
   {
     "level": 3,
@@ -8478,7 +8478,7 @@
       {
         "name": "Open Hand Technique",
         "url": "/api/features/open-hand-technique"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8491,7 +8491,7 @@
       "url": "/api/subclasses/open-hand"
     },
     "url": "/api/subclasses/open-hand/levels/3",
-    "index": 262
+    "index": "open-hand-3"
   },
   {
     "level": 6,
@@ -8500,7 +8500,7 @@
       {
         "name": "Wholeness of Body",
         "url": "/api/features/wholeness-of-body"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8513,7 +8513,7 @@
       "url": "/api/subclasses/open-hand"
     },
     "url": "/api/subclasses/open-hand/levels/6",
-    "index": 263
+    "index": "open-hand-6"
   },
   {
     "level": 11,
@@ -8522,7 +8522,7 @@
       {
         "name": "Tranquility",
         "url": "/api/features/tranquility"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8535,7 +8535,7 @@
       "url": "/api/subclasses/open-hand"
     },
     "url": "/api/subclasses/open-hand/levels/11",
-    "index": 264
+    "index": "open-hand-11"
   },
   {
     "level": 17,
@@ -8544,7 +8544,7 @@
       {
         "name": "Quiverying Palm",
         "url": "/api/features/quivering-palm"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8557,7 +8557,7 @@
       "url": "/api/subclasses/open-hand"
     },
     "url": "/api/subclasses/open-hand/levels/17",
-    "index": 265
+    "index": "open-hand-17"
   },
   {
     "level": 3,
@@ -8566,7 +8566,7 @@
       {
         "name": "Channel Divinity",
         "url": "/api/features/channel-divinity"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8579,7 +8579,7 @@
       "url": "/api/subclasses/devotion"
     },
     "url": "/api/subclasses/devotion/levels/3",
-    "index": 266
+    "index": "devotion-3"
   },
   {
     "level": 7,
@@ -8588,7 +8588,7 @@
       {
         "name": "Aura of Devotion",
         "url": "/api/features/aura-of-devotion"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {
@@ -8603,7 +8603,7 @@
       "url": "/api/subclasses/devotion"
     },
     "url": "/api/subclasses/devotion/levels/7",
-    "index": 267
+    "index": "devotion-7"
   },
   {
     "level": 15,
@@ -8612,7 +8612,7 @@
       {
         "name": "Purity of Spirit",
         "url": "/api/features/purity-of-spirit"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {
@@ -8627,7 +8627,7 @@
       "url": "/api/subclasses/devotion"
     },
     "url": "/api/subclasses/devotion/levels/15",
-    "index": 268
+    "index": "devotion-15"
   },
   {
     "level": 18,
@@ -8646,7 +8646,7 @@
       "url": "/api/subclasses/devotion"
     },
     "url": "/api/subclasses/devotion/levels/18",
-    "index": 269
+    "index": "devotion-18"
   },
   {
     "level": 20,
@@ -8655,7 +8655,7 @@
       {
         "name": "Holy Nimbus",
         "url": "/api/features/holy-nimbus"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {
@@ -8670,7 +8670,7 @@
       "url": "/api/subclasses/devotion"
     },
     "url": "/api/subclasses/devotion/levels/20",
-    "index": 270
+    "index": "devotion-20"
   },
   {
     "level": 3,
@@ -8692,7 +8692,7 @@
       "url": "/api/subclasses/hunter"
     },
     "url": "/api/subclasses/hunter/levels/3",
-    "index": 271
+    "index": "hunter-3"
   },
   {
     "level": 7,
@@ -8714,7 +8714,7 @@
       "url": "/api/subclasses/hunter"
     },
     "url": "/api/subclasses/hunter/levels/7",
-    "index": 272
+    "index": "hunter-7"
   },
   {
     "level": 11,
@@ -8722,7 +8722,7 @@
       {
         "name": "Choose: Multiattack",
         "url": "/api/features/choose-multiattack"
-      } 
+      }
     ],
     "features": [],
     "spellcasting": {},
@@ -8736,7 +8736,7 @@
       "url": "/api/subclasses/hunter"
     },
     "url": "/api/subclasses/hunter/levels/11",
-    "index": 273
+    "index": "hunter-11"
   },
   {
     "level": 15,
@@ -8744,7 +8744,7 @@
       {
         "name": "Choose: Superior Hunter's Defense",
         "url": "/api/features/choose-superior-hunters-defense"
-      } 
+      }
     ],
     "features": [],
     "spellcasting": {},
@@ -8758,7 +8758,7 @@
       "url": "/api/subclasses/hunter"
     },
     "url": "/api/subclasses/hunter/levels/15",
-    "index": 274
+    "index": "hunter-15"
   },
   {
     "level": 3,
@@ -8771,7 +8771,7 @@
       {
         "name": "Second-Story Work",
         "url": "/api/features/second-story-work"
-      } 
+      }
     ],
     "spellcasting": {},
     "subclass_specific": {},
@@ -8784,7 +8784,7 @@
       "url": "/api/subclasses/thief"
     },
     "url": "/api/subclasses/thief/levels/3",
-    "index": 275
+    "index": "thief-3"
   },
   {
     "level": 9,
@@ -8806,7 +8806,7 @@
       "url": "/api/subclasses/thief"
     },
     "url": "/api/subclasses/thief/levels/9",
-    "index": 276
+    "index": "thief-9"
   },
   {
     "level": 13,
@@ -8828,7 +8828,7 @@
       "url": "/api/subclasses/thief"
     },
     "url": "/api/subclasses/thief/levels/13",
-    "index": 277
+    "index": "thief-13"
   },
   {
     "level": 17,
@@ -8850,7 +8850,7 @@
       "url": "/api/subclasses/thief"
     },
     "url": "/api/subclasses/thief/levels/17",
-    "index": 278
+    "index": "thief-17"
   },
   {
     "level": 1,
@@ -8877,7 +8877,7 @@
       "url": "/api/subclasses/draconic"
     },
     "url": "/api/subclasses/draconic/levels/1",
-    "index": 279
+    "index": "draconic-1"
   },
   {
     "level": 6,
@@ -8899,7 +8899,7 @@
       "url": "/api/subclasses/draconic"
     },
     "url": "/api/subclasses/draconic/levels/6",
-    "index": 280
+    "index": "draconic-6"
   },
   {
     "level": 14,
@@ -8921,7 +8921,7 @@
       "url": "/api/subclasses/draconic"
     },
     "url": "/api/subclasses/draconic/levels/14",
-    "index": 281
+    "index": "draconic-14"
   },
   {
     "level": 18,
@@ -8943,7 +8943,7 @@
       "url": "/api/subclasses/draconic"
     },
     "url": "/api/subclasses/draconic/levels/18",
-    "index": 282
+    "index": "draconic-18"
   },
   {
     "level": 1,
@@ -8965,7 +8965,7 @@
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/1",
-    "index": 283
+    "index": "fiend-1"
   },
   {
     "level": 6,
@@ -8987,7 +8987,7 @@
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/6",
-    "index": 284
+    "index": "fiend-6"
   },
   {
     "level": 10,
@@ -9009,7 +9009,7 @@
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/10",
-    "index": 285
+    "index": "fiend-10"
   },
   {
     "level": 14,
@@ -9031,7 +9031,7 @@
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/14",
-    "index": 286
+    "index": "fiend-14"
   },
   {
     "level": 2,
@@ -9057,7 +9057,7 @@
       "url": "/api/subclasses/evocation"
     },
     "url": "/api/subclasses/evocation/levels/2",
-    "index": 287
+    "index": "evocation-2"
   },
   {
     "level": 6,
@@ -9079,7 +9079,7 @@
       "url": "/api/subclasses/evocation"
     },
     "url": "/api/subclasses/evocation/levels/6",
-    "index": 288
+    "index": "evocation-6"
   },
   {
     "level": 10,
@@ -9101,7 +9101,7 @@
       "url": "/api/subclasses/evocation"
     },
     "url": "/api/subclasses/evocation/levels/10",
-    "index": 289
+    "index": "evocation-10"
   },
   {
     "level": 14,
@@ -9123,6 +9123,6 @@
       "url": "/api/subclasses/evocation"
     },
     "url": "/api/subclasses/evocation/levels/14",
-    "index": 290
+    "index": "evocation-14"
   }
 ]


### PR DESCRIPTION
## What does this do?
Swaps Level object integer indices for strings of the pattern `<(sub)class.index>-<level>`, e.g. `barbarian-1`, `berserker-3`.

**Important: immediately after these changes are merged, [this PR in the API repo](https://github.com/bagelbits/5e-srd-api/pull/79) must be merged to ensure the API integrates with the database properly**

## How was it tested?
Validated with ESLint, tested in in parallel with changes in the the API PR.

## Is there a Github issue this is resolving?
Resolves #240 

## Here's a fun image for your troubles
![indices everywhere](https://media.makeameme.org/created/indices-indices-everywhere.jpg)
