### PR TITLE
Adding URLs for new categories.

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -2258,7 +2258,8 @@
 				"name": "Wand"
 			}
 			
-		]
+		],
+		"url": "/api/equipment-categories/arcane-foci"
 	},
 	{
 		"index": "druidic-foci",
@@ -2280,7 +2281,8 @@
 				"url": "/api/equipment/yew-wand",
 				"name": "Yew wand"
 			}
-		]
+		],
+		"url": "/api/equipment-categories/druidic-foci"
 	},
 	{
 		"index": "holy-symbols",
@@ -2298,6 +2300,7 @@
 				"url": "/api/equipment/reliquary",
 				"name": "Reliquary"
 			}
-		]
+		],
+		"url": "/api/equipment-categories/holy-symbols"
 	}
 ]


### PR DESCRIPTION
## What does this do?
Adds missing equipment category URLs.

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolved #244 

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/91104316-5d7d7100-e622-11ea-8c6b-0a7086f8c523.png)
