### PR TITLE
Add martial weapons choice to shield option

### DIFF
--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -691,14 +691,29 @@
         "choose": 1,
         "type": "equipment",
         "from": [
-          {
-            "equipment": {
-              "index": "shield",
-              "name": "Shield",
-              "url": "/api/equipment/shield"
+          [
+            {
+              "equipment": {
+                "index": "shield",
+                "name": "Shield",
+                "url": "/api/equipment/shield"
+              },
+              "quantity": 1
             },
-            "quantity": 1
-          },
+            {
+              "equipment_option": {
+                "choose": 1,
+                "type": "equipment",
+                "from": {
+                  "equipment_category": {
+                    "name": "Martial Weapons",
+                    "index": "martial-weapons",
+                    "url": "/api/equipment-categories/martial-weapons"
+                  }
+                }
+              }
+            }
+          ],
           {
             "equipment_option": {
               "choose": 2,


### PR DESCRIPTION
## What does this do?
Fixes the first equipment option in Paladin's starting equipment to include a choice of one martial weapon with the shield.

## How was it tested?
Linted, Jested, loaded into local mongo instance. 

## Is there a Github issue this is resolving?
Resolves #253 - Thanks @Freedzio!

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![weapons](https://user-images.githubusercontent.com/6972523/92231061-038f6d80-eea4-11ea-804b-6139d3cc40e3.png)

