### PR TITLE
Add spells URL to Class documents

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -90,6 +90,7 @@
       }
     ],
     "spellcasting": {},
+    "spells": "/api/classes/barbarian/spells",
     "url": "/api/classes/barbarian"
   },
   {
@@ -304,6 +305,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/bard",
+    "spells": "/api/classes/bard/spells",
     "url": "/api/classes/bard"
   },
   {
@@ -387,6 +389,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/cleric",
+    "spells": "/api/classes/cleric/spells",
     "url": "/api/classes/cleric"
   },
   {
@@ -535,6 +538,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/druid",
+    "spells": "/api/classes/druid/spells",
     "url": "/api/classes/druid"
   },
   {
@@ -633,6 +637,7 @@
       }
     ],
     "spellcasting": {},
+    "spells": "/api/classes/fighter/spells",
     "url": "/api/classes/fighter"
   },
   {
@@ -868,6 +873,7 @@
       }
     ],
     "spellcasting": {},
+    "spells": "/api/classes/monk/spells",
     "url": "/api/classes/monk"
   },
   {
@@ -956,6 +962,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/paladin",
+    "spells": "/api/classes/paladin/spells",
     "url": "/api/classes/paladin"
   },
   {
@@ -1059,6 +1066,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/ranger",
+    "spells": "/api/classes/ranger/spells",
     "url": "/api/classes/ranger"
   },
   {
@@ -1187,6 +1195,7 @@
       }
     ],
     "spellcasting": {},
+    "spells": "/api/classes/rogue/spells",
     "url": "/api/classes/rogue"
   },
   {
@@ -1275,6 +1284,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/sorcerer",
+    "spells": "/api/classes/sorcerer/spells",
     "url": "/api/classes/sorcerer"
   },
   {
@@ -1358,6 +1368,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/warlock",
+    "spells": "/api/classes/warlock/spells",
     "url": "/api/classes/warlock"
   },
   {
@@ -1446,6 +1457,7 @@
       }
     ],
     "spellcasting": "/api/spellcasting/wizard",
+    "spells": "/api/classes/wizard/spells",
     "url": "/api/classes/wizard"
   }
 ]


### PR DESCRIPTION
## What does this do?
This PR exposes the `/api/classes/${class_index}/spells` endpoint, making class spell lists discoverable by the client.

## How was it tested?
Locally (eslinted, jested, loaded into local mongodb instance)

## Is there a Github issue this is resolving?
Resolves #250 

## Did you update the docs in the API? Please link an associated PR if applicable.
Yes! [Here's the PR in the API repo](https://github.com/bagelbits/5e-srd-api/pull/93)

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/6972523/93015447-8190fa00-f5b1-11ea-81a1-e9f3f60a9b90.png)

