### PR TITLE
Fix dragonic origin ancestor choices from 2 to 1

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5895,7 +5895,7 @@
       "You can speak, read, and write Draconic. Additionally, whenever you make a Charisma check when interacting with dragons, your proficiency bonus is doubled if it applies to the check."
     ],
     "choice": {
-      "choose": 2,
+      "choose": 1,
       "type": "feature",
       "from": [
         {


### PR DESCRIPTION
## What does this do?
Changes the number of draconic ancestors that can be chosen as part of the "Choose: Draconic Ancestor" feature of the Draconic Ancestry Sorcerer subclass from 2 to 1.

## How was it tested?
Locally

## Is there a Github issue this is resolving?
Resolves #261

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/6972523/93097806-f3467200-f69d-11ea-9969-ed50b82e26e9.png)
