### PR TITLE
Added the missing dwarf trait.

### DIFF
--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -93,6 +93,11 @@
         "index": "dwarven-combat-training",
         "name": "Dwarven Combat Training",
         "url": "/api/traits/dwarven-combat-training"
+      },
+	  {
+        "index": "tool-proficiency",
+        "name": "Tool Proficiency",
+        "url": "/api/traits/tool-proficiency"
       }
     ],
     "subraces": [

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -104,13 +104,7 @@
         "url": "/api/races/dwarf"
       }
     ],
-    "subraces": [
-      {
-        "index": "hill-dwarf",
-        "name": "Hill Dwarf",
-        "url": "/api/subraces/hill-dwarf"
-      }
-    ],
+    "subraces": [],
     "name": "Tool Proficiency",
     "desc": [
       "You gain proficiency with the artisan’s tools of your choice: smith’s tools, brewer’s supplies, or mason’s tools."

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -96,6 +96,28 @@
     "url": "/api/traits/dwarven-combat-training"
   },
   {
+    "index": "tool-proficiency",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Dwarf",
+        "url": "/api/races/dwarf"
+      }
+    ],
+    "subraces": [
+      {
+        "index": "hill-dwarf",
+        "name": "Hill Dwarf",
+        "url": "/api/subraces/hill-dwarf"
+      }
+    ],
+    "name": "Tool Proficiency",
+    "desc": [
+      "You gain proficiency with the artisan’s tools of your choice: smith’s tools, brewer’s supplies, or mason’s tools."
+    ],
+    "url": "/api/traits/tool-proficiency"
+  },
+  {
     "index": "stonecunning",
     "races": [
       {


### PR DESCRIPTION
The trait Tool Proficiency wasn't consistent with other similar traits such "Skill Versality" for the Half Elf as per issue #187.
