### PR TITLE
One does not simply pour wind

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -14947,7 +14947,7 @@
     "name": "Unseen Servant",
     "desc": [
       "This spell creates an invisible, mindless, shapeless force that performs simple tasks at your command until the spell ends. The servant springs into existence in an unoccupied space on the ground within range. It has AC 10, 1 hit point, and a Strength of 2, and it can't attack. If it drops to 0 hit points, the spell ends.",
-      "Once on each of your turns as a bonus action, you can mentally command the servant to move up to 15 feet and interact with an object. The servant can perform simple tasks that a human servant could do, such as fetching things, cleaning, mending, folding clothes, lighting fires, serving food, and pouring wind. Once you give the command, the servant performs the task to the best of its ability until it completes the task, then waits for your next command.",
+      "Once on each of your turns as a bonus action, you can mentally command the servant to move up to 15 feet and interact with an object. The servant can perform simple tasks that a human servant could do, such as fetching things, cleaning, mending, folding clothes, lighting fires, serving food, and pouring wine. Once you give the command, the servant performs the task to the best of its ability until it completes the task, then waits for your next command.",
       "If you command the servant to perform a task that would move it more than 60 feet away from you, the spell ends."
     ],
     "range": "60 feet",


### PR DESCRIPTION
Remove the unseen servant pouring wind

## What does this do?
\<Fixes the spelling error in unseen servant\>

## How was it tested?
\<CI\>

## Is there a Github issue this is resolving?
\<Nope\>

## Did you update the docs in the API? Please link an associated PR if applicable.
\<nada\>

## Here's a fun image for your troubles
![wine](https://static.vinepair.com/wp-content/uploads/2016/02/standard-pour-inside.jpg)
