### PR TITLE
Fixed bad spell urls in 5e-SRD-Monsters.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ upload-*
 named-*
 
 /node_modules/
+
+/.idea

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -249,32 +249,32 @@
             {
               "name": "Light",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/light"
             },
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Bless",
               "level": 1,
-              "url": "/api/spells/29"
+              "url": "/api/spells/bless"
             },
             {
               "name": "Cure Wounds",
               "level": 1,
-              "url": "/api/spells/70"
+              "url": "/api/spells/cure-wounds"
             },
             {
               "name": "Sanctuary",
               "level": 1,
-              "url": "/api/spells/251"
+              "url": "/api/spells/sanctuary"
             }
           ]
         }
@@ -5622,77 +5622,77 @@
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Spare the Dying",
               "level": 0,
-              "url": "/api/spells/271"
+              "url": "/api/spells/spare-the-dying"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Command",
               "level": 1,
-              "url": "/api/spells/46"
+              "url": "/api/spells/command"
             },
             {
               "name": "Detect Evil and Good",
               "level": 1,
-              "url": "/api/spells/78"
+              "url": "/api/spells/detect-evil-and-good"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/79"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Lesser Restoration",
               "level": 2,
-              "url": "/api/spells/178"
+              "url": "/api/spells/lesser-restoration"
             },
             {
               "name": "Zone of Truth",
               "level": 2,
-              "url": "/api/spells/319"
+              "url": "/api/spells/zone-of-truth"
             },
             {
               "name": "Dispel Magic",
               "level": 3,
-              "url": "/api/spells/86"
+              "url": "/api/spells/dispel-magic"
             },
             {
               "name": "Tongues",
               "level": 3,
-              "url": "/api/spells/295"
+              "url": "/api/spells/tongues"
             },
             {
               "name": "Banishment",
               "level": 4,
-              "url": "/api/spells/23"
+              "url": "/api/spells/banishment"
             },
             {
               "name": "Freedom of Movement",
               "level": 4,
-              "url": "/api/spells/130"
+              "url": "/api/spells/freedom-of-movement"
             },
             {
               "name": "Flame Strike",
               "level": 5,
-              "url": "/api/spells/121"
+              "url": "/api/spells/flame-strike"
             },
             {
               "name": "Greater Restoration",
               "level": 5,
-              "url": "/api/spells/143"
+              "url": "/api/spells/greater-restoration"
             },
             {
               "name": "Heroes' Feast",
               "level": 6,
-              "url": "/api/spells/157"
+              "url": "/api/spells/heroes-feast"
             }
           ]
         }
@@ -6184,14 +6184,14 @@
           "spells": [
             {
               "name": "Disguise Self",
-              "url": "/api/spells/83",
+              "url": "/api/spells/disguise-self",
               "usage": {
                 "type": "at will"
               }
             },
             {
               "name": "Invisibility",
-              "url": "/api/spells/173",
+              "url": "/api/spells/invisibility",
               "usage": {
                 "type": "at will"
               }
@@ -6199,130 +6199,130 @@
             {
               "name": "Fire Bolt",
               "level": 0,
-              "url": "/api/spells/116"
+              "url": "/api/spells/fire-bolt"
             },
             {
               "name": "Light",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/light"
             },
             {
               "name": "Mage Hand",
               "level": 0,
-              "url": "/api/spells/187"
+              "url": "/api/spells/mage-hand"
             },
             {
               "name": "Prestidigitation",
               "level": 0,
-              "url": "/api/spells/227"
+              "url": "/api/spells/prestidigitation"
             },
             {
               "name": "Shocking Grasp",
               "level": 0,
-              "url": "/api/spells/264"
+              "url": "/api/spells/shocking-grasp"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/79"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Identify",
               "level": 1,
-              "url": "/api/spells/166"
+              "url": "/api/spells/identify"
             },
             {
               "name": "Mage Armor",
               "level": 1,
-              "url": "/api/spells/186",
+              "url": "/api/spells/mage-armor",
               "note": "Cast on self before combat"
             },
             {
               "name": "Magic Missile",
               "level": 1,
-              "url": "/api/spells/190"
+              "url": "/api/spells/magic-missile"
             },
             {
               "name": "Detect Thoughts",
               "level": 2,
-              "url": "/api/spells/81"
+              "url": "/api/spells/detect-thoughts"
             },
             {
               "name": "Mirror Image",
               "level": 2,
-              "url": "/api/spells/207"
+              "url": "/api/spells/mirror-image"
             },
             {
               "name": "Misty Step",
               "level": 2,
-              "url": "/api/spells/209"
+              "url": "/api/spells/misty-step"
             },
             {
               "name": "Counterspell",
               "level": 3,
-              "url": "/api/spells/65"
+              "url": "/api/spells/counterspell"
             },
             {
               "name": "Fly",
               "level": 3,
-              "url": "/api/spells/125"
+              "url": "/api/spells/fly"
             },
             {
               "name": "Lightning Bolt",
               "level": 3,
-              "url": "/api/spells/181"
+              "url": "/api/spells/lightning-bolt"
             },
             {
               "name": "Banishment",
               "level": 4,
-              "url": "/api/spells/23"
+              "url": "/api/spells/banishment"
             },
             {
               "name": "Fire Shield",
               "level": 4,
-              "url": "/api/spells/117"
+              "url": "/api/spells/fire-shield"
             },
             {
               "name": "Stoneskin",
               "level": 4,
-              "url": "/api/spells/281",
+              "url": "/api/spells/stoneskin",
               "note": "Cast on self before combat"
             },
             {
               "name": "Cone of Cold",
               "level": 5,
-              "url": "/api/spells/51"
+              "url": "/api/spells/cone-of-cold"
             },
             {
               "name": "Scrying",
               "level": 5,
-              "url": "/api/spells/253"
+              "url": "/api/spells/scrying"
             },
             {
               "name": "Wall of Force",
               "level": 5,
-              "url": "/api/spells/306"
+              "url": "/api/spells/wall-of-force"
             },
             {
               "name": "Globe of Invulnerability",
               "level": 6,
-              "url": "/api/spells/138"
+              "url": "/api/spells/globe-of-invulnerability"
             },
             {
               "name": "Teleport",
               "level": 7,
-              "url": "/api/spells/289"
+              "url": "/api/spells/teleport"
             },
             {
               "name": "Mind Blank",
               "level": 8,
-              "url": "/api/spells/204",
+              "url": "/api/spells/mind-blank",
               "note": "Cast on self before combat"
             },
             {
               "name": "Time Stop",
               "level": 9,
-              "url": "/api/spells/293"
+              "url": "/api/spells/time-stop"
             }
           ]
         }
@@ -11130,42 +11130,42 @@
             {
               "name": "Light",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/light"
             },
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Command",
               "level": 0,
-              "url": "/api/spells/46"
+              "url": "/api/spells/command"
             },
             {
               "name": "Inflict Wounds",
               "level": 0,
-              "url": "/api/spells/170"
+              "url": "/api/spells/inflict-wounds"
             },
             {
               "name": "Shield of Faith",
               "level": 0,
-              "url": "/api/spells/262"
+              "url": "/api/spells/shield-of-faith"
             },
             {
               "name": "Hold Person",
               "level": 0,
-              "url": "/api/spells/161"
+              "url": "/api/spells/hold-person"
             },
             {
               "name": "Spiritual Weapon",
               "level": 0,
-              "url": "/api/spells/278"
+              "url": "/api/spells/spiritual-weapon"
             }
           ]
         }
@@ -12957,47 +12957,47 @@
             {
               "name": "Druidcraft",
               "level": 0,
-              "url": "/api/spells/94"
+              "url": "/api/spells/druidcraft"
             },
             {
               "name": "Produce Flame",
               "level": 0,
-              "url": "/api/spells/231"
+              "url": "/api/spells/produce-flame"
             },
             {
               "name": "Shillelagh",
               "level": 0,
-              "url": "/api/spells/263"
+              "url": "/api/spells/shillelagh"
             },
             {
               "name": "Entangle",
               "level": 1,
-              "url": "/api/spells/99"
+              "url": "/api/spells/entangle"
             },
             {
               "name": "Longstrider",
               "level": 1,
-              "url": "/api/spells/185"
+              "url": "/api/spells/longstrider"
             },
             {
               "name": "Speak with Animals",
               "level": 1,
-              "url": "/api/spells/272"
+              "url": "/api/spells/speak-with-animals"
             },
             {
               "name": "Thunderwave",
               "level": 1,
-              "url": "/api/spells/292"
+              "url": "/api/spells/thunderwave"
             },
             {
               "name": "Animal Messenger",
               "level": 2,
-              "url": "/api/spells/7"
+              "url": "/api/spells/animal-messenger"
             },
             {
               "name": "Barkskin",
               "level": 2,
-              "url": "/api/spells/24"
+              "url": "/api/spells/barkskin"
             }
           ]
         }
@@ -19457,77 +19457,77 @@
             {
               "name": "Mending",
               "level": 0,
-              "url": "/api/spells/201"
+              "url": "/api/spells/mending"
             },
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Command",
               "level": 1,
-              "url": "/api/spells/46"
+              "url": "/api/spells/command"
             },
             {
               "name": "Cure Wounds",
               "level": 1,
-              "url": "/api/spells/70"
+              "url": "/api/spells/cure-wounds"
             },
             {
               "name": "Shield of Faith",
               "level": 1,
-              "url": "/api/spells/262"
+              "url": "/api/spells/shield-of-faith"
             },
             {
               "name": "Calm Emotions",
               "level": 2,
-              "url": "/api/spells/37"
+              "url": "/api/spells/calm-emotions"
             },
             {
               "name": "Hold Person",
               "level": 2,
-              "url": "/api/spells/161"
+              "url": "/api/spells/hold-person"
             },
             {
               "name": "Bestow Curse",
               "level": 3,
-              "url": "/api/spells/26"
+              "url": "/api/spells/bestow-curse"
             },
             {
               "name": "Clairvoyance",
               "level": 3,
-              "url": "/api/spells/42"
+              "url": "/api/spells/clairvoyance"
             },
             {
               "name": "Banishment",
               "level": 4,
-              "url": "/api/spells/23"
+              "url": "/api/spells/banishment"
             },
             {
               "name": "Freedom of Movement",
               "level": 4,
-              "url": "/api/spells/130"
+              "url": "/api/spells/freedom-of-movement"
             },
             {
               "name": "Flame Strike",
               "level": 5,
-              "url": "/api/spells/121"
+              "url": "/api/spells/flame-strike"
             },
             {
               "name": "Geas",
               "level": 5,
-              "url": "/api/spells/134"
+              "url": "/api/spells/geas"
             },
             {
               "name": "True Seeing",
               "level": 6,
-              "url": "/api/spells/300"
+              "url": "/api/spells/true-seeing"
             }
           ]
         }
@@ -19660,77 +19660,77 @@
             {
               "name": "Mage Hand",
               "level": 0,
-              "url": "/api/spells/187"
+              "url": "/api/spells/mage-hand"
             },
             {
               "name": "Minor Illusion",
               "level": 0,
-              "url": "/api/spells/205"
+              "url": "/api/spells/minor-illusion"
             },
             {
               "name": "Prestidigitation",
               "level": 0,
-              "url": "/api/spells/227"
+              "url": "/api/spells/prestidigitation"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/79"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Identify",
               "level": 1,
-              "url": "/api/spells/166"
+              "url": "/api/spells/identify"
             },
             {
               "name": "Shield",
               "level": 1,
-              "url": "/api/spells/261"
+              "url": "/api/spells/shield"
             },
             {
               "name": "Darkness",
               "level": 2,
-              "url": "/api/spells/72"
+              "url": "/api/spells/darkness"
             },
             {
               "name": "Locate Object",
               "level": 2,
-              "url": "/api/spells/184"
+              "url": "/api/spells/locate-object"
             },
             {
               "name": "Suggestion",
               "level": 2,
-              "url": "/api/spells/198"
+              "url": "/api/spells/suggestion"
             },
             {
               "name": "Dispel Magic",
               "level": 3,
-              "url": "/api/spells/86"
+              "url": "/api/spells/dispel-magic"
             },
             {
               "name": "Remove Curse",
               "level": 3,
-              "url": "/api/spells/243"
+              "url": "/api/spells/remove-curse"
             },
             {
               "name": "Tongues",
               "level": 3,
-              "url": "/api/spells/295"
+              "url": "/api/spells/tongues"
             },
             {
               "name": "Banishment",
               "level": 4,
-              "url": "/api/spells/23"
+              "url": "/api/spells/banishment"
             },
             {
               "name": "Greater Invisibility",
               "level": 4,
-              "url": "/api/spells/142"
+              "url": "/api/spells/greater-invisibility"
             },
             {
               "name": "Legend Lore",
               "level": 5,
-              "url": "/api/spells/177"
+              "url": "/api/spells/legend-lore"
             }
           ]
         }
@@ -22735,132 +22735,132 @@
             {
               "name": "Mage Hand",
               "level": 0,
-              "url": "/api/spells/187"
+              "url": "/api/spells/mage-hand"
             },
             {
               "name": "Prestidigitation",
               "level": 0,
-              "url": "/api/spells/227"
+              "url": "/api/spells/prestidigitation"
             },
             {
               "name": "Ray of Frost",
               "level": 0,
-              "url": "/api/spells/240"
+              "url": "/api/spells/ray-of-frost"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/179"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Magic Missile",
               "level": 1,
-              "url": "/api/spells/190"
+              "url": "/api/spells/magic-missile"
             },
             {
               "name": "Shield",
               "level": 1,
-              "url": "/api/spells/261"
+              "url": "/api/spells/shield"
             },
             {
               "name": "Thunderwave",
               "level": 1,
-              "url": "/api/spells/292"
+              "url": "/api/spells/thunderwave"
             },
             {
               "name": "Acid Arrow",
               "level": 2,
-              "url": "/api/spells/1"
+              "url": "/api/spells/acid-arrow"
             },
             {
               "name": "Detect Thoughts",
               "level": 2,
-              "url": "/api/spells/81"
+              "url": "/api/spells/detect-thoughts"
             },
             {
               "name": "Invisibility",
               "level": 2,
-              "url": "/api/spells/172"
+              "url": "/api/spells/invisibility"
             },
             {
               "name": "Mirror Image",
               "level": 2,
-              "url": "/api/spells/207"
+              "url": "/api/spells/mirror-image"
             },
             {
               "name": "Animate Dead",
               "level": 3,
-              "url": "/api/spells/9"
+              "url": "/api/spells/animate-dead"
             },
             {
               "name": "Counterspell",
               "level": 3,
-              "url": "/api/spells/65"
+              "url": "/api/spells/counterspell"
             },
             {
               "name": "Dispel Magic",
               "level": 3,
-              "url": "/api/spells/86"
+              "url": "/api/spells/dispel-magic"
             },
             {
               "name": "Fireball",
               "level": 3,
-              "url": "/api/spells/119"
+              "url": "/api/spells/fireball"
             },
             {
               "name": "Blight",
               "level": 4,
-              "url": "/api/spells/30"
+              "url": "/api/spells/blight"
             },
             {
               "name": "Dimension Door",
               "level": 4,
-              "url": "/api/spells/82"
+              "url": "/api/spells/dimension-door"
             },
             {
               "name": "Cloudkill",
               "level": 5,
-              "url": "/api/spells/44"
+              "url": "/api/spells/cloudkill"
             },
             {
               "name": "Scrying",
               "level": 5,
-              "url": "/api/spells/253"
+              "url": "/api/spells/scrying"
             },
             {
               "name": "Disintegrate",
               "level": 6,
-              "url": "/api/spells/84"
+              "url": "/api/spells/disintegrate"
             },
             {
               "name": "Globe of Invulnerability",
               "level": 6,
-              "url": "/api/spells/138"
+              "url": "/api/spells/globe-of-invulnerability"
             },
             {
               "name": "Finger of Death",
               "level": 7,
-              "url": "/api/spells/115"
+              "url": "/api/spells/finger-of-death"
             },
             {
               "name": "Plane Shift",
               "level": 7,
-              "url": "/api/spells/220"
+              "url": "/api/spells/plane-shift"
             },
             {
               "name": "Dominate Monster",
               "level": 8,
-              "url": "/api/spells/91"
+              "url": "/api/spells/dominate-monster"
             },
             {
               "name": "Power Word Stun",
               "level": 8,
-              "url": "/api/spells/225"
+              "url": "/api/spells/power-word-stun"
             },
             {
               "name": "Power Word Kill",
               "level": 9,
-              "url": "/api/spells/224"
+              "url": "/api/spells/power-word-kill"
             }
           ]
         }
@@ -23359,82 +23359,82 @@
             {
               "name": "Fire Bolt",
               "level": 0,
-              "url": "/api/spells/116"
+              "url": "/api/spells/fire-bolt"
             },
             {
               "name": "Light",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/light"
             },
             {
               "name": "Mage Hand",
               "level": 0,
-              "url": "/api/spells/187"
+              "url": "/api/spells/mage-hand"
             },
             {
               "name": "Prestidigitation",
               "level": 0,
-              "url": "/api/spells/227"
+              "url": "/api/spells/prestidigitation"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/79"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Mage Armor",
               "level": 1,
-              "url": "/api/spells/186"
+              "url": "/api/spells/mage-armor"
             },
             {
               "name": "Magic Missile",
               "level": 1,
-              "url": "/api/spells/190"
+              "url": "/api/spells/magic-missile"
             },
             {
               "name": "Shield",
               "level": 1,
-              "url": "/api/spells/261"
+              "url": "/api/spells/shield"
             },
             {
               "name": "Misty Step",
               "level": 2,
-              "url": "/api/spells/209"
+              "url": "/api/spells/misty-step"
             },
             {
               "name": "Suggestion",
               "level": 2,
-              "url": "/api/spells/283"
+              "url": "/api/spells/suggestion"
             },
             {
               "name": "Counterspell",
               "level": 3,
-              "url": "/api/spells/65"
+              "url": "/api/spells/counterspell"
             },
             {
               "name": "Fireball",
               "level": 3,
-              "url": "/api/spells/119"
+              "url": "/api/spells/fireball"
             },
             {
               "name": "Fly",
               "level": 3,
-              "url": "/api/spells/125"
+              "url": "/api/spells/fly"
             },
             {
               "name": "Greater Invisibility",
               "level": 4,
-              "url": "/api/spells/142"
+              "url": "/api/spells/greater-invisibility"
             },
             {
               "name": "Ice Storm",
               "level": 4,
-              "url": "/api/spells/165"
+              "url": "/api/spells/ice-storm"
             },
             {
               "name": "Cone of Cold",
               "level": 5,
-              "url": "/api/spells/51"
+              "url": "/api/spells/cone-of-cold"
             }
           ]
         }
@@ -25030,77 +25030,77 @@
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Command",
               "level": 1,
-              "url": "/api/spells/46"
+              "url": "/api/spells/command"
             },
             {
               "name": "Guiding Bolt",
               "level": 1,
-              "url": "/api/spells/147"
+              "url": "/api/spells/guiding-bolt"
             },
             {
               "name": "Shield of Faith",
               "level": 1,
-              "url": "/api/spells/262"
+              "url": "/api/spells/shield-of-faith"
             },
             {
               "name": "Hold Person",
               "level": 2,
-              "url": "/api/spells/161"
+              "url": "/api/spells/hold-person"
             },
             {
               "name": "Silence",
               "level": 2,
-              "url": "/api/spells/265"
+              "url": "/api/spells/silence"
             },
             {
               "name": "Spiritual Weapon",
               "level": 2,
-              "url": "/api/spells/278"
+              "url": "/api/spells/spiritual-weapon"
             },
             {
               "name": "Animate Dead",
               "level": 3,
-              "url": "/api/spells/9"
+              "url": "/api/spells/animate-dead"
             },
             {
               "name": "Dispel Magic",
               "level": 3,
-              "url": "/api/spells/86"
+              "url": "/api/spells/dispel-magic"
             },
             {
               "name": "Divination",
               "level": 4,
-              "url": "/api/spells/87"
+              "url": "/api/spells/divination"
             },
             {
               "name": "Guardian of Faith",
               "level": 4,
-              "url": "/api/spells/144"
+              "url": "/api/spells/guardian-of-faith"
             },
             {
               "name": "Contagion",
               "level": 60,
-              "url": "/api/spells/180"
+              "url": "/api/spells/contagion"
             },
             {
               "name": "Insect Plague",
               "level": 5,
-              "url": "/api/spells/171"
+              "url": "/api/spells/insect-plague"
             },
             {
               "name": "Harm",
               "level": 6,
-              "url": "/api/spells/151"
+              "url": "/api/spells/harm"
             }
           ]
         }
@@ -27623,52 +27623,52 @@
             {
               "name": "Light",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/light"
             },
             {
               "name": "Sacred Flame",
               "level": 0,
-              "url": "/api/spells/250"
+              "url": "/api/spells/sacred-flame"
             },
             {
               "name": "Thaumaturgy",
               "level": 0,
-              "url": "/api/spells/291"
+              "url": "/api/spells/thaumaturgy"
             },
             {
               "name": "Cure Wounds",
               "level": 1,
-              "url": "/api/spells/70"
+              "url": "/api/spells/cure-wounds"
             },
             {
               "name": "Guiding Bolt",
               "level": 1,
-              "url": "/api/spells/147"
+              "url": "/api/spells/guiding-bolt"
             },
             {
               "name": "Sanctuary",
               "level": 1,
-              "url": "/api/spells/251"
+              "url": "/api/spells/sanctuary"
             },
             {
               "name": "Lesser Restoration",
               "level": 2,
-              "url": "/api/spells/178"
+              "url": "/api/spells/lesser-restoration"
             },
             {
               "name": "Spiritual Weapon",
               "level": 2,
-              "url": "/api/spells/278"
+              "url": "/api/spells/spiritual-weapon"
             },
             {
               "name": "Dispel Magic",
               "level": 3,
-              "url": "/api/spells/86"
+              "url": "/api/spells/dispel-magic"
             },
             {
               "name": "Spirit Guardians",
               "level": 3,
-              "url": "/api/spells/277"
+              "url": "/api/spells/spirit-guardians"
             }
           ]
         }
@@ -31082,67 +31082,67 @@
             {
               "name": "Mage Hand",
               "level": 0,
-              "url": "/api/spells/180"
+              "url": "/api/spells/mage-hand"
             },
             {
               "name": "Minor Illusion",
               "level": 0,
-              "url": "/api/spells/205"
+              "url": "/api/spells/minor-illusion"
             },
             {
               "name": "Ray of Frost",
               "level": 0,
-              "url": "/api/spells/240"
+              "url": "/api/spells/ray-of-frost"
             },
             {
               "name": "Charm Person",
               "level": 1,
-              "url": "/api/spells/39"
+              "url": "/api/spells/charm-person"
             },
             {
               "name": "Detect Magic",
               "level": 1,
-              "url": "/api/spells/79"
+              "url": "/api/spells/detect-magic"
             },
             {
               "name": "Sleep",
               "level": 1,
-              "url": "/api/spells/268"
+              "url": "/api/spells/sleep"
             },
             {
               "name": "Detect Thoughts",
               "level": 2,
-              "url": "/api/spells/81"
+              "url": "/api/spells/detect-thoughts"
             },
             {
               "name": "Hold Person",
               "level": 2,
-              "url": "/api/spells/161"
+              "url": "/api/spells/hold-person"
             },
             {
               "name": "Lightning Bolt",
               "level": 3,
-              "url": "/api/spells/181"
+              "url": "/api/spells/lightning-bolt"
             },
             {
               "name": "Water Breathing",
               "level": 3,
-              "url": "/api/spells/311"
+              "url": "/api/spells/water-breathing"
             },
             {
               "name": "Blight",
               "level": 4,
-              "url": "/api/spells/30"
+              "url": "/api/spells/blight"
             },
             {
               "name": "Dimension Door",
               "level": 4,
-              "url": "/api/spells/82"
+              "url": "/api/spells/dimension-door"
             },
             {
               "name": "Dominate Person",
               "level": 5,
-              "url": "/api/spells/92"
+              "url": "/api/spells/dominate-person"
             }
           ]
         }


### PR DESCRIPTION
## What does this do?
Fix incorrect urls in monsters json file.

## How was it tested?
Wasn't. I did manually verify that all updated urls also exist in the spells document.

## Is there a Github issue this is resolving?
https://github.com/bagelbits/5e-database/issues/256

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
