### PR TITLE
2 belts and an axe

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -187,6 +187,11 @@
         "index": "net",
         "name": "Net",
         "url": "/api/equipment/net"
+      },
+       {
+        "index": "berserker-axe",
+        "name": "Berserker Axe",
+        "url": "/api/magic-items/berserker-axe"
       }
     ],
     "url": "/api/equipment-categories/weapon"
@@ -2942,6 +2947,16 @@
         "index": "bead-of-force",
         "name": "Bead of Force",
         "url": "/api/magic-items/bead-of-force"
+      },
+      {
+        "index": "belt-of-giant-strength",
+        "name": "Belt of Giant Strength",
+        "url": "/api/magic-items/belt-of-giant-strength"
+      },
+        {
+        "index": "belt-of-dwarvenkind",
+        "name": "Belt of Dwarvenkind",
+        "url": "/api/magic-items/belt-of-dwarvenkind"
       }
     ],
     "url": "/api/equipment-categories/wondrous-items"

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -13,17 +13,11 @@
     "url": "/api/magic-items/adamantine-armor"
   },
   {
-    "index": "ammunition",
-    "name": "Ammunition, +1, +2, or +3",
-    "equipment_category": {
-      "name": "Weapon",
-      "url": "/api/equipment-categories/weapon"
-    },
-    "desc": [
-      "Weapon (any ammunition), uncommon (+1), rare (+2), or very rare (+3)",
-      "You have a bonus to attack and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical."
-    ],
-    "url": "/api/magic-items/ammunition"
+      "index": "ammunition",
+      "name": "Ammunition, +1, +2, or +3",
+      "equipment_category": {
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
   },
   {
     "index": "amulet-of-health",
@@ -185,20 +179,20 @@
     ],
     "url": "/api/magic-items/arrow-catching-shield"
   },
-  {
-    "index": "arrow-of-slaying",
-    "name": "Arrow of Slaying",
-    "equipment_category": {
-      "name": "Weapon",
-      "url": "/api/equipment-categories/weapon"
-    },
-    "desc": [
-      "Weapon (arrow), very rare",
-      "An arrow of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both arrows of dragon slaying and arrows of blue dragon slaying. If a creature belonging to the type, race, or group associated with an arrow of slaying takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.",
-      "Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.",
-      "Other types of magic ammunition of this kind exist, such as bolts of slaying meant for a crossbow, though arrows are most common."
-    ],
-    "url": "/api/magic-items/arrow-of-slaying"
+ {
+      "index": "arrow-of-slaying",
+      "name": "Arrow of Slaying",
+      "equipment_category": {
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
+      },
+      "desc": [
+        "Weapon (arrow), very rare",
+        "An arrow of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both arrows of dragon slaying and arrows of blue dragon slaying. If a creature belonging to the type, race, or group associated with an arrow of slaying takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra 6d10 piercing damage on a failed save, or half as much extra damage on a successful one.",
+        "Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.",
+        "Other types of magic ammunition of this kind exist, such as bolts of slaying meant for a crossbow, though arrows are most common."
+      ],
+      "url": "/api/magic-items/arrow-of-slaying"
   },
   {
     "index": "bag-of-beans",

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -324,6 +324,60 @@
     ],
     "url": "/api/magic-items/bead-of-force"
   },
+   {
+      "index": "belt-of-dwarvenkind",
+      "name": "Belt of Dwarvenkind",
+      "equipment_category": {
+        "name": "Wondrous Item",
+        "url": "/api/equipment-categories/wondrous-item"
+      },
+      "desc": [
+        "Wondrous Item, rare (requires attunement)",
+        "While wearing this belt, you gain the following benefits:",
+        "Your Constitution score increases by 2, to a maximum of 20.",
+        "You have advantage on Charisma (Persuasion) checks made to interact with Dwarves.",
+        "In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you're capable of growing one, or a visibly thicker beard if you already have one.",
+        "If you aren't a dwarf, you gain the following additional benefits while wearing the belt:",
+        "You have advantage on Saving Throws against poison, and you have Resistance against poison damage.",
+        "You can speak, read, and write Dwarvish."
+      ],
+      "url": "/api/magic-items/belt-of-dwarvenkind"
+    },
+    {
+        "index": "belt-of-giant-strength",
+        "name": "Belt of Giant Strength",
+        "equipment_category": {
+            "name": "Wondrous Item",
+            "url": "/api/equipment-categories/wondrous-item"
+        },
+        "desc": [
+          "Wondrous item, rarity varies (requires attunement)",
+          "While wearing this belt, your Strength score changes to a score granted by the belt. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you.",
+          "Six varieties of this belt exist, corresponding with and having rarity according to The Six kinds of true Giants. The belt of Stone Giant Strength and the belt of Frost Giant Strength look different, but they have the same Effect.",
+          "| Type | Strength | Rarity |",
+          "|---|---|---|",
+          "| Hill Giant | 21 | Rare |",
+          "| Stone Giant / Frost Giant | 23 | Very Rare |",
+          "| Fire Giant | 25 | Very Rare |",
+          "| Cloud Giant | 27 | Legendary |",
+          "| Storm Giant | 29 | Legendary |"
+        ],
+        "url": "/api/magic-items/belt-of-giant-strength"
+      },
+      {
+        "index": "berserker-axe",
+        "name": "Berserker Axe",
+        "equipment_category": {
+          "name": "Weapon",
+          "url": "/api/equipment-categories/weapon"
+        },
+        "desc": [
+          "You gain a +1 bonus to Attack and Damage Rolls made with this Magic Weapon. In addition, while you are attuned to this weapon, your Hit Points maximum increases by 1 for each level you have attained.",
+          "Curse. This axe is Cursed, and becoming attuned to it extends the curse to you. As long as you remain Cursed, you are unwilling to part with the axe, keeping it within reach at all times. You also have disadvantage on Attack rolls with Weapons other than this one, unless no foe is within 60 feet of you that you can see or hear.",
+          "Whenever a Hostile creature damages you while the axe is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. While berserk, you must use your action each round to Attack the creature nearest to you with the axe. If you can make extra attacks as part of the Attack action, you use those extra attacks, moving to Attack the next nearest creature after you fell your current target. If you have multiple possible Targets, you Attack one at random. You are berserk until you start Your Turn with no creatures within 60 feet of you that you can see or hear."
+        ],
+        "url": "/api/magic-items/berserker-axe"
+      },
   {
     "index": "String",
     "name": "String",

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -18,7 +18,13 @@
       "equipment_category": {
         "name": "Ammunition",
         "url": "/api/equipment-categories/ammunition"
-  },
+    },
+      "desc": [
+        "Weapon (any ammunition), uncommon (+1), rare (+2), or very rare (+3)",
+        "You have a bonus to attack and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical."
+      ],
+      "url": "/api/magic-items/ammunition"
+    },
   {
     "index": "amulet-of-health",
     "name": "Amulet of Health",


### PR DESCRIPTION
## What does this do?
Adds belt of dwarvenkind, belt of giant strength and berserker axe, also updated the weapon categories section of the 2 arrow items to ammuniton in order to match the listing in equipment-categories.json. 

## How was it tested?
CI

## Is there a Github issue this is resolving?
Nope

## Did you update the docs in the API? Please link an associated PR if applicable.
Non-applicable

## Here's a fun image for your troubles
![Belts](https://i.pinimg.com/originals/f3/bd/c8/f3bdc86e08b4eabfa83d7e701e659699.jpg)