### PR TITLE
Innate spellcaster spell levels

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6561,7 +6561,7 @@
               "name": "Mage Armor",
               "level": 1,
               "url": "/api/spells/mage-armor",
-              "note": "Cast on self before combat"
+              "notes": "Cast on self before combat"
             },
             {
               "name": "Magic Missile",
@@ -6612,7 +6612,7 @@
               "name": "Stoneskin",
               "level": 4,
               "url": "/api/spells/stoneskin",
-              "note": "Cast on self before combat"
+              "notes": "Cast on self before combat"
             },
             {
               "name": "Cone of Cold",
@@ -6643,7 +6643,7 @@
               "name": "Mind Blank",
               "level": 8,
               "url": "/api/spells/mind-blank",
-              "note": "Cast on self before combat"
+              "notes": "Cast on self before combat"
             },
             {
               "name": "Time Stop",
@@ -10193,19 +10193,19 @@
             [
               {
                 "name": "Fire Breath",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "ability"
               },
               {
                 "name": "Horns",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claws",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "melee"
               }
@@ -10213,19 +10213,19 @@
             [
               {
                 "name": "Bite",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Fire Breath",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "ability"
               },
               {
                 "name": "Claws",
-                "note": "When Fire Breath is available",
+                "notes": "When Fire Breath is available",
                 "count": 1,
                 "type": "melee"
               }
@@ -10382,13 +10382,13 @@
             [
               {
                 "name": "Pincer",
-                "note": "When chuul is grappling",
+                "notes": "When chuul is grappling",
                 "count": 2,
                 "type": "melee"
               },
               {
                 "name": "Tentacles",
-                "note": "When chuul is grappling",
+                "notes": "When chuul is grappling",
                 "count": 1,
                 "type": "melee"
               }
@@ -19866,7 +19866,7 @@
               },
               {
                 "name": "Beak",
-                "note": "If tentacles attack hits",
+                "notes": "If tentacles attack hits",
                 "count": 1,
                 "type": "melee"
               }
@@ -20676,7 +20676,7 @@
               },
               {
                 "name": "Shortsword",
-                "note": "If shortsword is drawn",
+                "notes": "If shortsword is drawn",
                 "count": 1,
                 "type": "melee"
               }
@@ -26314,7 +26314,7 @@
             [
               {
                 "name": "Horror Nimbus",
-                "note": "If it can use Horror Nimbus",
+                "notes": "If it can use Horror Nimbus",
                 "count": 1,
                 "type": "ability"
               },
@@ -27246,7 +27246,7 @@
             [
               {
                 "name": "Claw",
-                "note": "If in Oni form",
+                "notes": "If in Oni form",
                 "count": 2,
                 "type": "melee"
               }
@@ -27254,13 +27254,13 @@
             [
               {
                 "name": "Glaive",
-                "note": "If in Oni form",
+                "notes": "If in Oni form",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claw",
-                "note": "If in Oni form",
+                "notes": "If in Oni form",
                 "count": 1,
                 "type": "melee"
               }
@@ -31307,13 +31307,13 @@
             [
               {
                 "name": "Slam",
-                "note": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
+                "notes": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
                 "count": 2,
                 "type": "melee"
               },
               {
                 "name": "Engulf",
-                "note": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
+                "notes": "If both slam attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the shambling mound uses its Engulf on it.",
                 "count": 2,
                 "type": "melee"
               }
@@ -34635,7 +34635,7 @@
               },
               {
                 "name": "Swallow",
-                "note": "If the target is grappled",
+                "notes": "If the target is grappled",
                 "count": 1,
                 "type": "ability"
               },
@@ -35327,13 +35327,13 @@
             [
               {
                 "name": "Bite",
-                "note": "It can't make both attacks against the same target",
+                "notes": "It can't make both attacks against the same target",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Tail",
-                "note": "It can't make both attacks against the same target",
+                "notes": "It can't make both attacks against the same target",
                 "count": 1,
                 "type": "melee"
               }
@@ -35984,7 +35984,7 @@
               },
               {
                 "name": "Shortsword",
-                "note": "If shortsword is drawn",
+                "notes": "If shortsword is drawn",
                 "count": 2,
                 "type": "melee"
               }
@@ -36784,7 +36784,7 @@
             [
               {
                 "name": "Claw",
-                "note": "Bear or Hybrid Form Only",
+                "notes": "Bear or Hybrid Form Only",
                 "count": 2,
                 "type": "melee"
               }
@@ -36792,7 +36792,7 @@
             [
               {
                 "name": "Greataxe",
-                "note": "Humanoid or Hybrid Form Only",
+                "notes": "Humanoid or Hybrid Form Only",
                 "count": 2,
                 "type": "melee"
               }
@@ -36800,13 +36800,13 @@
             [
               {
                 "name": "Greataxe",
-                "note": "Hybrid Form Only",
+                "notes": "Hybrid Form Only",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claw",
-                "note": "Hybrid Form Only",
+                "notes": "Hybrid Form Only",
                 "count": 1,
                 "type": "melee"
               }
@@ -38187,13 +38187,13 @@
             [
               {
                 "name": "Bite",
-                "note": "If flying",
+                "notes": "If flying",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claws",
-                "note": "If flying",
+                "notes": "If flying",
                 "count": 1,
                 "type": "melee"
               }
@@ -38201,13 +38201,13 @@
             [
               {
                 "name": "Stinger",
-                "note": "If flying",
+                "notes": "If flying",
                 "count": 1,
                 "type": "melee"
               },
               {
                 "name": "Claws",
-                "note": "If flying",
+                "notes": "If flying",
                 "count": 1,
                 "type": "melee"
               }

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -25993,7 +25993,7 @@
             },
             {
               "name": "Contagion",
-              "level": 60,
+              "level": 5,
               "url": "/api/spells/contagion"
             },
             {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6508,6 +6508,7 @@
           "spells": [
             {
               "name": "Disguise Self",
+              "level": 1,
               "url": "/api/spells/disguise-self",
               "usage": {
                 "type": "at will"
@@ -6515,6 +6516,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "url": "/api/spells/invisibility",
               "usage": {
                 "type": "at will"
@@ -10775,6 +10777,7 @@
           "spells": [
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -10782,6 +10785,7 @@
             },
             {
               "name": "Fog Cloud",
+              "level": 1,
               "url": "/api/spells/fog-cloud",
               "usage": {
                 "type": "at will"
@@ -10789,6 +10793,7 @@
             },
             {
               "name": "Light",
+              "level": 0,
               "url": "/api/spells/light",
               "usage": {
                 "type": "at will"
@@ -10796,6 +10801,7 @@
             },
             {
               "name": "Feather Fall",
+              "level": 1,
               "url": "/api/spells/feather-fall",
               "usage": {
                 "type": "per day",
@@ -10804,6 +10810,7 @@
             },
             {
               "name": "Fly",
+              "level": 3,
               "url": "/api/spells/fly",
               "usage": {
                 "type": "per day",
@@ -10812,6 +10819,7 @@
             },
             {
               "name": "Misty Step",
+              "level": 2,
               "url": "/api/spells/misty-step",
               "usage": {
                 "type": "per day",
@@ -10820,6 +10828,7 @@
             },
             {
               "name": "Telekinesis",
+              "level": 5,
               "url": "/api/spells/telekinesis",
               "usage": {
                 "type": "per day",
@@ -10828,6 +10837,7 @@
             },
             {
               "name": "Control Weather",
+              "level": 8,
               "url": "/api/spells/control-weather",
               "usage": {
                 "type": "per day",
@@ -10836,6 +10846,7 @@
             },
             {
               "name": "Gaseous Form",
+              "level": 3,
               "url": "/api/spells/gaseous-form",
               "usage": {
                 "type": "per day",
@@ -11283,6 +11294,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -11290,6 +11302,7 @@
             },
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -11297,6 +11310,7 @@
             },
             {
               "name": "Detect Thoughts",
+              "level": 2,
               "url": "/api/spells/detect-thoughts",
               "usage": {
                 "type": "at will"
@@ -11304,6 +11318,7 @@
             },
             {
               "name": "Bless",
+              "level": 1,
               "url": "/api/spells/bless",
               "usage": {
                 "type": "per day",
@@ -11312,6 +11327,7 @@
             },
             {
               "name": "Create Food and Water",
+              "level": 3,
               "url": "/api/spells/create-food-and-water",
               "usage": {
                 "type": "per day",
@@ -11320,6 +11336,7 @@
             },
             {
               "name": "Cure Wounds",
+              "level": 1,
               "url": "/api/spells/cure-wounds",
               "usage": {
                 "type": "per day",
@@ -11328,6 +11345,7 @@
             },
             {
               "name": "Lesser Restoration",
+              "level": 2,
               "url": "/api/spells/lesser-restoration",
               "usage": {
                 "type": "per day",
@@ -11336,6 +11354,7 @@
             },
             {
               "name": "Protection from Poison",
+              "level": 2,
               "url": "/api/spells/protection-from-poison",
               "usage": {
                 "type": "per day",
@@ -11344,6 +11363,7 @@
             },
             {
               "name": "Sanctuary",
+              "level": 1,
               "url": "/api/spells/sanctuary",
               "usage": {
                 "type": "per day",
@@ -11352,6 +11372,7 @@
             },
             {
               "name": "Shield",
+              "level": 1,
               "url": "/api/spells/shield",
               "usage": {
                 "type": "per day",
@@ -11360,6 +11381,7 @@
             },
             {
               "name": "Dream",
+              "level": 5,
               "url": "/api/spells/dream",
               "usage": {
                 "type": "per day",
@@ -11368,6 +11390,7 @@
             },
             {
               "name": "Greater Restoration",
+              "level": 5,
               "url": "/api/spells/greater-restoration",
               "usage": {
                 "type": "per day",
@@ -11376,6 +11399,7 @@
             },
             {
               "name": "Scrying",
+              "level": 5,
               "url": "/api/spells/scrying",
               "usage": {
                 "type": "per day",
@@ -11656,27 +11680,27 @@
             },
             {
               "name": "Command",
-              "level": 0,
+              "level": 1,
               "url": "/api/spells/command"
             },
             {
               "name": "Inflict Wounds",
-              "level": 0,
+              "level": 1,
               "url": "/api/spells/inflict-wounds"
             },
             {
               "name": "Shield of Faith",
-              "level": 0,
+              "level": 1,
               "url": "/api/spells/shield-of-faith"
             },
             {
               "name": "Hold Person",
-              "level": 0,
+              "level": 2,
               "url": "/api/spells/hold-person"
             },
             {
               "name": "Spiritual Weapon",
-              "level": 0,
+              "level": 2,
               "url": "/api/spells/spiritual-weapon"
             }
           ]
@@ -12032,6 +12056,7 @@
           "spells": [
             {
               "name": "Nondetection",
+              "level": 3,
               "notes": "Self only",
               "url": "/api/spells/nondetection",
               "usage": {
@@ -12040,6 +12065,7 @@
             },
             {
               "name": "Blindness/Deafness",
+              "level": 2,
               "url": "/api/spells/blindness-deafness",
               "usage": {
                 "type": "per day",
@@ -12048,6 +12074,7 @@
             },
             {
               "name": "Blur",
+              "level": 2,
               "url": "/api/spells/blur",
               "usage": {
                 "type": "per day",
@@ -12056,6 +12083,7 @@
             },
             {
               "name": "Disguise Self",
+              "level": 1,
               "url": "/api/spells/disguise-self",
               "usage": {
                 "type": "per day",
@@ -12250,6 +12278,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -12257,6 +12286,7 @@
             },
             {
               "name": "Commune",
+              "level": 5,
               "url": "/api/spells/commune",
               "usage": {
                 "type": "per day",
@@ -12265,6 +12295,7 @@
             },
             {
               "name": "Raise Dead",
+              "level": 5,
               "url": "/api/spells/raise-dead",
               "usage": {
                 "type": "per day",
@@ -12485,6 +12516,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -12492,6 +12524,7 @@
             },
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -12499,6 +12532,7 @@
             },
             {
               "name": "Thunderwave",
+              "level": 1,
               "url": "/api/spells/thunderwave",
               "usage": {
                 "type": "at will"
@@ -12506,6 +12540,7 @@
             },
             {
               "name": "Create Food and Water",
+              "level": 3,
               "notes": "Can create wine instead of water",
               "url": "/api/spells/create-food-and-water",
               "usage": {
@@ -12515,6 +12550,7 @@
             },
             {
               "name": "Tongues",
+              "level": 3,
               "url": "/api/spells/tongues",
               "usage": {
                 "type": "per day",
@@ -12523,6 +12559,7 @@
             },
             {
               "name": "Wind Walk",
+              "level": 6,
               "url": "/api/spells/wind-walk",
               "usage": {
                 "type": "per day",
@@ -12531,6 +12568,7 @@
             },
             {
               "name": "Conjure Elemental",
+              "level": 5,
               "notes": "Air Elemental Only",
               "url": "/api/spells/conjure-elemental",
               "usage": {
@@ -12540,6 +12578,7 @@
             },
             {
               "name": "Creation",
+              "level": 5,
               "url": "/api/spells/creation",
               "usage": {
                 "type": "per day",
@@ -12548,6 +12587,7 @@
             },
             {
               "name": "Gaseous Form",
+              "level": 3,
               "url": "/api/spells/gaseous-form",
               "usage": {
                 "type": "per day",
@@ -12556,6 +12596,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "url": "/api/spells/invisibility",
               "usage": {
                 "type": "per day",
@@ -12564,6 +12605,7 @@
             },
             {
               "name": "Major Image",
+              "level": 3,
               "url": "/api/spells/major-image",
               "usage": {
                 "type": "per day",
@@ -12572,6 +12614,7 @@
             },
             {
               "name": "Plane Shift",
+              "level": 7,
               "url": "/api/spells/plane-shift",
               "usage": {
                 "type": "per day",
@@ -13157,6 +13200,7 @@
           "spells": [
             {
               "name": "Entangle",
+              "level": 1,
               "url": "/api/spells/dancing-lights",
               "usage": {
                 "type": "at will"
@@ -13164,6 +13208,7 @@
             },
             {
               "name": "Darkness",
+              "level": 2,
               "url": "/api/spells/darkness",
               "usage": {
                 "type": "per day",
@@ -13172,6 +13217,7 @@
             },
             {
               "name": "Faerie Fire",
+              "level": 1,
               "url": "/api/spells/faerie-fire",
               "usage": {
                 "type": "per day",
@@ -13387,6 +13433,7 @@
           "spells": [
             {
               "name": "Dancing Lights",
+              "level": 0,
               "url": "/api/spells/dancing-lights",
               "usage": {
                 "type": "at will"
@@ -13394,6 +13441,7 @@
             },
             {
               "name": "Darkness",
+              "level": 2,
               "url": "/api/spells/entangle",
               "usage": {
                 "type": "per day",
@@ -13402,6 +13450,7 @@
             },
             {
               "name": "Faerie Fire",
+              "level": 1,
               "url": "/api/spells/faerie-fire",
               "usage": {
                 "type": "per day",
@@ -13668,6 +13717,7 @@
           "spells": [
             {
               "name": "Druidcraft",
+              "level": 0,
               "url": "/api/spells/druidcraft",
               "usage": {
                 "type": "at will"
@@ -13675,6 +13725,7 @@
             },
             {
               "name": "Entangle",
+              "level": 1,
               "url": "/api/spells/entangle",
               "usage": {
                 "type": "per day",
@@ -13683,6 +13734,7 @@
             },
             {
               "name": "Goodberry",
+              "level": 1,
               "url": "/api/spells/goodberry",
               "usage": {
                 "type": "per day",
@@ -13691,6 +13743,7 @@
             },
             {
               "name": "Barkskin",
+              "level": 2,
               "url": "/api/spells/barkskin",
               "usage": {
                 "type": "per day",
@@ -13699,6 +13752,7 @@
             },
             {
               "name": "Pass without Trace",
+              "level": 2,
               "url": "/api/spells/pass-without-trace",
               "usage": {
                 "type": "per day",
@@ -13707,6 +13761,7 @@
             },
             {
               "name": "Shillelagh",
+              "level": 0,
               "url": "/api/spells/shillelagh",
               "usage": {
                 "type": "per day",
@@ -13922,9 +13977,25 @@
       {
         "name": "Innate Spellcasting",
         "desc": "The mephit can innately cast sleep, requiring no material components. Its innate spellcasting ability is Charisma.",
-        "usage": {
-          "type": "per day",
-          "times": 1
+        "spellcasting": {
+          "ability": {
+            "index": "cha",
+            "name": "CHA",
+            "url": "/api/ability-scores/cha"
+          },
+          "dc": 10,
+          "components_required": [],
+          "spells": [
+            {
+              "name": "Sleep",
+              "level": 1,
+              "url": "/api/spells/sleep",
+              "usage": {
+                "type": "per day",
+                "times": 1
+              }
+            }
+          ]
         }
       }
     ],
@@ -14213,6 +14284,7 @@
           "spells": [
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -14220,6 +14292,7 @@
             },
             {
               "name": "Enlarge/Reduce",
+              "level": 2,
               "url": "/api/spells/enlarge-reduce",
               "usage": {
                 "type": "per day",
@@ -14228,6 +14301,7 @@
             },
             {
               "name": "Tongues",
+              "level": 3,
               "url": "/api/spells/tongues",
               "usage": {
                 "type": "per day",
@@ -14236,6 +14310,7 @@
             },
             {
               "name": "Conjure Elemental",
+              "level": 5,
               "notes": "Fire Elemental only",
               "url": "/api/spells/conjure-elemental",
               "usage": {
@@ -14245,6 +14320,7 @@
             },
             {
               "name": "Gaseous Form",
+              "level": 3,
               "url": "/api/spells/gaseous-form",
               "usage": {
                 "type": "per day",
@@ -14253,6 +14329,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "url": "/api/spells/invisibility",
               "usage": {
                 "type": "per day",
@@ -14261,6 +14338,7 @@
             },
             {
               "name": "Major Image",
+              "level": 3,
               "url": "/api/spells/major-image",
               "usage": {
                 "type": "per day",
@@ -14269,6 +14347,7 @@
             },
             {
               "name": "Plane Shift",
+              "level": 7,
               "url": "/api/spells/plane-shift",
               "usage": {
                 "type": "per day",
@@ -14277,6 +14356,7 @@
             },
             {
               "name": "Wall of Fire",
+              "level": 4,
               "url": "/api/spells/wall-of-fire",
               "usage": {
                 "type": "per day",
@@ -18504,6 +18584,7 @@
           "spells": [
             {
               "name": "Darkness",
+              "level": 2,
               "url": "/api/spells/darkness",
               "usage": {
                 "type": "at will"
@@ -18511,6 +18592,7 @@
             },
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -18518,6 +18600,7 @@
             },
             {
               "name": "Dispel Magic",
+              "level": 3,
               "url": "/api/spells/dispel-magic",
               "usage": {
                 "type": "at will"
@@ -18525,6 +18608,7 @@
             },
             {
               "name": "Confusion",
+              "level": 4,
               "url": "/api/spells/confusion",
               "usage": {
                 "type": "per day",
@@ -18533,7 +18617,8 @@
             },
             {
               "name": "Fly",
-              "url": "/api/spells/haste",
+              "level": 3,
+              "url": "/api/spells/fly",
               "usage": {
                 "type": "per day",
                 "times": 1
@@ -18541,6 +18626,7 @@
             },
             {
               "name": "Power Word Stun",
+              "level": 8,
               "url": "/api/spells/power-word-stun",
               "usage": {
                 "type": "per day",
@@ -19657,6 +19743,7 @@
           "spells": [
             {
               "name": "Dancing Lights",
+              "level": 0,
               "url": "/api/spells/dancing-lights",
               "usage": {
                 "type": "at will"
@@ -19664,6 +19751,7 @@
             },
             {
               "name": "Minor Illusion",
+              "level": 0,
               "url": "/api/spells/minor-illusion",
               "usage": {
                 "type": "at will"
@@ -19671,6 +19759,7 @@
             },
             {
               "name": "Vicious Mockery",
+              "level": 0,
               "url": "/api/spells/vicious-mockery",
               "usage": {
                 "type": "at will"
@@ -22115,6 +22204,7 @@
           "spells": [
             {
               "name": "Fog Cloud",
+              "level": 1,
               "url": "/api/spells/fog-cloud",
               "usage": {
                 "type": "per day",
@@ -23227,6 +23317,7 @@
           "spells": [
             {
               "name": "Major Image",
+              "level": 3,
               "url": "/api/spells/major-image",
               "notes": "Any Humanoid Form",
               "usage": {
@@ -23235,6 +23326,7 @@
             },
             {
               "name": "Charm Person",
+              "level": 1,
               "url": "/api/spells/charm-person",
               "usage": {
                 "type": "per day",
@@ -23243,6 +23335,7 @@
             },
             {
               "name": "Mirror Image",
+              "level": 2,
               "url": "/api/spells/mirror-image",
               "usage": {
                 "type": "per day",
@@ -23251,6 +23344,7 @@
             },
             {
               "name": "Scrying",
+              "level": 5,
               "url": "/api/spells/scrying",
               "usage": {
                 "type": "per day",
@@ -23259,6 +23353,7 @@
             },
             {
               "name": "Suggestion",
+              "level": 2,
               "url": "/api/spells/suggestion",
               "usage": {
                 "type": "per day",
@@ -23267,6 +23362,7 @@
             },
             {
               "name": "Geas",
+              "level": 5,
               "url": "/api/spells/geas",
               "usage": {
                 "type": "per day",
@@ -24400,9 +24496,25 @@
       {
         "name": "Innate Spellcasting",
         "desc": "The mephit can innately cast heat metal (spell save DC 10), requiring no material components. Its innate spellcasting ability is Charisma.",
-        "usage": {
-          "type": "per day",
-          "times": 1
+        "spellcasting": {
+          "ability": {
+            "index": "cha",
+            "name": "CHA",
+            "url": "/api/ability-scores/cha"
+          },
+          "components_required": [],
+          "dc": 10,
+          "spells": [
+            {
+              "name": "Heat Metal",
+              "level": 2,
+              "url": "/api/spells/heat-metal",
+              "usage": {
+                "type": "per day",
+                "times": 1
+              }
+            }
+          ]
         }
       }
     ],
@@ -26372,6 +26484,7 @@
           "spells": [
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -26379,6 +26492,7 @@
             },
             {
               "name": "Magic Missile",
+              "level": 1,
               "url": "/api/spells/magic-missile",
               "usage": {
                 "type": "at will"
@@ -26386,6 +26500,7 @@
             },
             {
               "name": "Plane Shift",
+              "level": 7,
               "notes": "Self Only",
               "url": "/api/spells/plane-shift",
               "usage": {
@@ -26395,6 +26510,7 @@
             },
             {
               "name": "Ray of Enfeeblement",
+              "level": 2,
               "url": "/api/spells/ray-of-enfeeblement",
               "usage": {
                 "type": "per day",
@@ -26403,6 +26519,7 @@
             },
             {
               "name": "Sleep",
+              "level": 1,
               "url": "/api/spells/sleep",
               "usage": {
                 "type": "per day",
@@ -27050,6 +27167,7 @@
           "spells": [
             {
               "name": "Darkness",
+              "level": 2,
               "url": "/api/spells/darkness",
               "usage": {
                 "type": "at will"
@@ -27057,6 +27175,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "url": "/api/spells/invisibility",
               "usage": {
                 "type": "at will"
@@ -27064,6 +27183,7 @@
             },
             {
               "name": "Charm Person",
+              "level": 1,
               "url": "/api/spells/charm-person",
               "usage": {
                 "type": "per day",
@@ -27072,6 +27192,7 @@
             },
             {
               "name": "Cone of Cold",
+              "level": 5,
               "url": "/api/spells/cone-of-cold",
               "usage": {
                 "type": "per day",
@@ -27080,6 +27201,7 @@
             },
             {
               "name": "Gaseous Form",
+              "level": 3,
               "url": "/api/spells/gaseous-form",
               "usage": {
                 "type": "per day",
@@ -27088,6 +27210,7 @@
             },
             {
               "name": "Sleep",
+              "level": 1,
               "url": "/api/spells/sleep",
               "usage": {
                 "type": "per day",
@@ -27906,6 +28029,7 @@
           "spells": [
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -27913,6 +28037,7 @@
             },
             {
               "name": "Fireball",
+              "level": 3,
               "url": "/api/spells/fireball",
               "usage": {
                 "type": "at will"
@@ -27920,6 +28045,7 @@
             },
             {
               "name": "Hold Monster",
+              "level": 5,
               "url": "/api/spells/hold-monster",
               "usage": {
                 "type": "per day",
@@ -27928,6 +28054,7 @@
             },
             {
               "name": "Wall of Fire",
+              "level": 4,
               "url": "/api/spells/wall-of-fire",
               "usage": {
                 "type": "per day",
@@ -28139,6 +28266,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -28146,6 +28274,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "notes": "Self Only",
               "url": "/api/spells/invisibility",
               "usage": {
@@ -28154,6 +28283,7 @@
             },
             {
               "name": "Blade Barrier",
+              "level": 6,
               "url": "/api/spells/blade-barrier",
               "usage": {
                 "type": "per day",
@@ -28162,6 +28292,7 @@
             },
             {
               "name": "Dispel Evil and Good",
+              "level": 5,
               "url": "/api/spells/dispel-evil-and-good",
               "usage": {
                 "type": "per day",
@@ -28170,6 +28301,7 @@
             },
             {
               "name": "Flame Strike",
+              "level": 5,
               "url": "/api/spells/flame-strike",
               "usage": {
                 "type": "per day",
@@ -28178,6 +28310,7 @@
             },
             {
               "name": "Raise Dead",
+              "level": 5,
               "url": "/api/spells/raise-dead",
               "usage": {
                 "type": "per day",
@@ -28186,6 +28319,7 @@
             },
             {
               "name": "Commune",
+              "level": 5,
               "url": "/api/spells/commune",
               "usage": {
                 "type": "per day",
@@ -28194,6 +28328,7 @@
             },
             {
               "name": "Control Weather",
+              "level": 8,
               "url": "/api/spells/control-weather",
               "usage": {
                 "type": "per day",
@@ -28202,6 +28337,7 @@
             },
             {
               "name": "Insect Plague",
+              "level": 5,
               "url": "/api/spells/insect-plague",
               "usage": {
                 "type": "per day",
@@ -29134,6 +29270,7 @@
           "spells": [
             {
               "name": "Detect Thoughts",
+              "level": 2,
               "url": "/api/spells/detect-thoughts",
               "usage": {
                 "type": "at will"
@@ -29141,6 +29278,7 @@
             },
             {
               "name": "Disguise Self",
+              "level": 1,
               "url": "/api/spells/disguise-self",
               "usage": {
                 "type": "at will"
@@ -29148,6 +29286,7 @@
             },
             {
               "name": "Mage Hand",
+              "level": 0,
               "url": "/api/spells/mage-hand",
               "usage": {
                 "type": "at will"
@@ -29155,6 +29294,7 @@
             },
             {
               "name": "Minor Illusion",
+              "level": 0,
               "url": "/api/spells/minor-illusion",
               "usage": {
                 "type": "at will"
@@ -29162,6 +29302,7 @@
             },
             {
               "name": "Charm Person",
+              "level": 1,
               "url": "/api/spells/charm-person",
               "usage": {
                 "type": "per day",
@@ -29170,6 +29311,7 @@
             },
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "per day",
@@ -29178,6 +29320,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "url": "/api/spells/invisibility",
               "usage": {
                 "type": "per day",
@@ -29186,6 +29329,7 @@
             },
             {
               "name": "Major Image",
+              "level": 3,
               "url": "/api/spells/major-image",
               "usage": {
                 "type": "per day",
@@ -29194,6 +29338,7 @@
             },
             {
               "name": "Suggestion",
+              "level": 2,
               "url": "/api/spells/mass-suggestion",
               "usage": {
                 "type": "per day",
@@ -29202,6 +29347,7 @@
             },
             {
               "name": "Dominate Person",
+              "level": 5,
               "url": "/api/spells/dominate-person",
               "usage": {
                 "type": "per day",
@@ -29210,6 +29356,7 @@
             },
             {
               "name": "Fly",
+              "level": 3,
               "url": "/api/spells/fly",
               "usage": {
                 "type": "per day",
@@ -29218,6 +29365,7 @@
             },
             {
               "name": "Plane Shift",
+              "level": 7,
               "url": "/api/spells/plane-shift",
               "usage": {
                 "type": "per day",
@@ -29226,6 +29374,7 @@
             },
             {
               "name": "True Seeing",
+              "level": 6,
               "url": "/api/spells/true-seeing",
               "usage": {
                 "type": "per day",
@@ -31696,6 +31845,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -31703,6 +31853,7 @@
             },
             {
               "name": "Invisibility",
+              "level": 2,
               "notes": "Self Only",
               "url": "/api/spells/invisibility",
               "usage": {
@@ -31711,6 +31862,7 @@
             },
             {
               "name": "Blade Barrier",
+              "level": 6,
               "url": "/api/spells/blade-barrier",
               "usage": {
                 "type": "per day",
@@ -31719,6 +31871,7 @@
             },
             {
               "name": "Dispel Evil and Good",
+              "level": 5,
               "url": "/api/spells/dispel-evil-and-good",
               "usage": {
                 "type": "per day",
@@ -31727,6 +31880,7 @@
             },
             {
               "name": "Resurrection",
+              "level": 7,
               "url": "/api/spells/resurrection",
               "usage": {
                 "type": "per day",
@@ -31735,6 +31889,7 @@
             },
             {
               "name": "Commune",
+              "level": 5,
               "url": "/api/spells/commune",
               "usage": {
                 "type": "per day",
@@ -31743,6 +31898,7 @@
             },
             {
               "name": "Control Weather",
+              "level": 8,
               "url": "/api/spells/control-weather",
               "usage": {
                 "type": "per day",
@@ -32561,9 +32717,25 @@
       {
         "name": "Innate Spellcasting",
         "desc": "The mephit can innately cast blur, requiring no material components. Its innate spellcasting ability is Charisma.",
-        "usage": {
-          "type": "per day",
-          "times": 1
+        "spellcasting": {
+          "ability": {
+            "index": "cha",
+            "name": "CHA",
+            "url": "/api/ability-scores/cha"
+          },
+          "dc": 11,
+          "components_required": [],
+          "spells": [
+            {
+              "name": "Blur",
+              "level": 2,
+              "url": "/api/spells/blur",
+              "usage": {
+                "type": "per day",
+                "times": 1
+              }
+            }
+          ]
         }
       }
     ],
@@ -33054,6 +33226,7 @@
           "spells": [
             {
               "name": "Detect Magic",
+              "level": 1,
               "url": "/api/spells/detect-magic",
               "usage": {
                 "type": "at will"
@@ -33061,6 +33234,7 @@
             },
             {
               "name": "Feather Fall",
+              "level": 1,
               "url": "/api/spells/feather-fall",
               "usage": {
                 "type": "at will"
@@ -33068,6 +33242,7 @@
             },
             {
               "name": "Levitate",
+              "level": 2,
               "url": "/api/spells/levitate",
               "usage": {
                 "type": "at will"
@@ -33075,6 +33250,7 @@
             },
             {
               "name": "Light",
+              "level": 0,
               "url": "/api/spells/light",
               "usage": {
                 "type": "at will"
@@ -33082,6 +33258,7 @@
             },
             {
               "name": "Control Weather",
+              "level": 8,
               "url": "/api/spells/control-weather",
               "usage": {
                 "type": "per day",
@@ -33090,6 +33267,7 @@
             },
             {
               "name": "Water Breathing",
+              "level": 3,
               "url": "/api/spells/water-breathing",
               "usage": {
                 "type": "per day",
@@ -35261,6 +35439,7 @@
           "spells": [
             {
               "name": "Detect Evil and Good",
+              "level": 1,
               "url": "/api/spells/detect-evil-and-good",
               "usage": {
                 "type": "at will"
@@ -35268,6 +35447,7 @@
             },
             {
               "name": "Druidcraft",
+              "level": 0,
               "url": "/api/spells/druidcraft",
               "usage": {
                 "type": "at will"
@@ -35275,6 +35455,7 @@
             },
             {
               "name": "Pass without Trace",
+              "level": 2,
               "url": "/api/spells/pass-without-trace",
               "usage": {
                 "type": "at will"
@@ -35282,6 +35463,7 @@
             },
             {
               "name": "Calm Emotions",
+              "level": 2,
               "url": "/api/spells/calm-emotions",
               "usage": {
                 "type": "per day",
@@ -35290,6 +35472,7 @@
             },
             {
               "name": "Dispel Evil and Good",
+              "level": 5,
               "url": "/api/spells/dispel-evil-and-good",
               "usage": {
                 "type": "per day",
@@ -35298,6 +35481,7 @@
             },
             {
               "name": "Entangle",
+              "level": 1,
               "url": "/api/spells/entangle",
               "usage": {
                 "type": "per day",


### PR DESCRIPTION
## What does this do?
Adds spell levels to monsters with innate spellcasting. Also fixes a few mismatched spell levels, missing spell levels, etc.

It also normalizes `note` -> `notes` in all fields (spells & abilities)

## Is there a Github issue this is resolving?
No, I discussed in Discord but did not create an issue for it

## Did you update the docs in the API? Please link an associated PR if applicable.
Docs for spells reflect necessary data already

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
