### PR TITLE
fix: remove duplicated languages from rock-gnome subclass

### DIFF
--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -269,18 +269,7 @@
     ],
     "starting_proficiencies": [],
     "starting_proficiency_options": {},
-    "languages": [
-      {
-        "index": "common",
-        "name": "Common",
-        "url": "/api/languages/common"
-      },
-      {
-        "index": "gnomish",
-        "name": "Gnomish",
-        "url": "/api/languages/gnomish"
-      }
-    ],
+    "languages": [],
     "language_options": {},
     "racial_traits": [
       {


### PR DESCRIPTION
## What does this do?
Removes duplicated language data from Rock Gnome subclass data 

## How was it tested?
Tested against local version with API testing tool (Postman)

## Is there a Github issue this is resolving?
Issue #290  

## Did you update the docs in the API? Please link an associated PR if applicable.
Not included in docs, so guessing this isn't applicable

## Here's a fun image for your troubles
![random photo - update me](https://pbs.twimg.com/media/EQ1lL-LWoAM120J?format=jpg&name=medium)
