### PR TITLE
Switch to using APIReferences for Equipment Pack contents

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -2545,7 +2545,9 @@
       "unit": "gp"
     },
     "weight": 1,
-    "desc": ["This wooden case can hold up to twenty crossbow bolts."],
+    "desc": [
+      "This wooden case can hold up to twenty crossbow bolts."
+    ],
     "url": "/api/equipment/case-crossbow-bolt"
   },
   {
@@ -3705,7 +3707,9 @@
       "unit": "gp"
     },
     "weight": 1,
-    "desc": ["A quiver can hold up to 20 arrows."],
+    "desc": [
+      "A quiver can hold up to 20 arrows."
+    ],
     "url": "/api/equipment/quiver"
   },
   {
@@ -4071,7 +4075,9 @@
       "unit": "gp"
     },
     "weight": 20,
-    "desc": ["A simple and portable canvas shelter, a tent sleeps two."],
+    "desc": [
+      "A simple and portable canvas shelter, a tent sleeps two."
+    ],
     "url": "/api/equipment/tent-two-person"
   },
   {

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -4206,51 +4206,99 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/ball-bearings-bag-of-1000",
+        "item": {
+          "index": "ball-bearings-bag-of-1000",
+          "name": "Ball bearings (bag of 1,000)",
+          "url": "/api/equipment/ball-bearings-bag-of-1000"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/candle",
+        "item": {
+          "index": "candle",
+          "name": "Candle",
+          "url": "/api/equipment/candle"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/crowbar",
+        "item": {
+          "index": "crowbar",
+          "name": "Crowbar",
+          "url": "/api/equipment/crowbar"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/hammer",
+        "item": {
+          "index": "hammer",
+          "name": "Hammer",
+          "url": "/api/equipment/hammer"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/piton",
+        "item": {
+          "index": "piton",
+          "name": "Piton",
+          "url": "/api/equipment/piton"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/lantern-hooded",
+        "item": {
+          "index": "lantern-hooded",
+          "name": "Lantern, hooded",
+          "url": "/api/equipment/lantern-hooded"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/oil-flask",
+        "item": {
+          "index": "oil-flask",
+          "name": "Oil (flask)",
+          "url": "/api/equipment/oil-flask"
+        },
         "quantity": 2
       },
       {
-        "item_url": "/api/equipment/rations-1-day",
+        "item": {
+          "index": "rations-1-day",
+          "name": "Rations (1 day)",
+          "url": "/api/equipment/rations-1-day"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/tinderbox",
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/equipment/tinderbox"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/waterskin",
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/equipment/waterskin"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/rope-hempen-50-feet",
+        "item": {
+          "index": "rope-hempen-50-feet",
+          "name": "Rope, hempen (50 feet)",
+          "url": "/api/equipment/rope-hempen-50-feet"
+        },
         "quantity": 1
       }
     ],
@@ -4275,47 +4323,91 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/chest",
+        "item": {
+          "index": "chest",
+          "name": "Chest",
+          "url": "/api/equipment/chest"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/case-map-or-scroll",
+        "item": {
+          "index": "case-map-or-scroll",
+          "name": "Case, map or scroll",
+          "url": "/api/equipment/case-map-or-scroll"
+        },
         "quantity": 2
       },
       {
-        "item_url": "/api/equipment/clothes-fine",
+        "item": {
+          "index": "clothes-fine",
+          "name": "Clothes, fine",
+          "url": "/api/equipment/clothes-fine"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/ink-1-ounce-bottle",
+        "item": {
+          "index": "ink-1-ounce-bottle",
+          "name": "Ink (1 ounce bottle)",
+          "url": "/api/equipment/ink-1-ounce-bottle"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/ink-pen",
+        "item": {
+          "index": "ink-pen",
+          "name": "Ink pen",
+          "url": "/api/equipment/ink-pen"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/lamp",
+        "item": {
+          "index": "lamp",
+          "name": "Lamp",
+          "url": "/api/equipment/lamp"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/oil-flask",
+        "item": {
+          "index": "oil-flask",
+          "name": "Oil (flask)",
+          "url": "/api/equipment/oil-flask"
+        },
         "quantity": 2
       },
       {
-        "item_url": "/api/equipment/paper-one-sheet",
+        "item": {
+          "index": "paper-one-sheet",
+          "name": "Paper (one sheet)",
+          "url": "/api/equipment/paper-one-sheet"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/perfume-vial",
+        "item": {
+          "index": "perfume-vial",
+          "name": "Perfume (vial)",
+          "url": "/api/equipment/perfume-vial"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/sealing-wax",
+        "item": {
+          "index": "sealing-wax",
+          "name": "Sealing wax",
+          "url": "/api/equipment/sealing-wax"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/soap",
+        "item": {
+          "index": "soap",
+          "name": "Soap",
+          "url": "/api/equipment/soap"
+        },
         "quantity": 1
       }
     ],
@@ -4340,35 +4432,67 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/crowbar",
+        "item": {
+          "index": "crowbar",
+          "name": "Crowbar",
+          "url": "/api/equipment/crowbar"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/hammer",
+        "item": {
+          "index": "hammer",
+          "name": "Hammer",
+          "url": "/api/equipment/hammer"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/piton",
+        "item": {
+          "index": "piton",
+          "name": "Piton",
+          "url": "/api/equipment/piton"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/torch",
+        "item": {
+          "index": "torch",
+          "name": "Torch",
+          "url": "/api/equipment/torch"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/rations-1-day",
+        "item": {
+          "index": "rations-1-day",
+          "name": "Rations (1 day)",
+          "url": "/api/equipment/rations-1-day"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/waterskin",
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/equipment/waterskin"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/rope-hempen-50-feet",
+        "item": {
+          "index": "rope-hempen-50-feet",
+          "name": "Rope, hempen (50 feet)",
+          "url": "/api/equipment/rope-hempen-50-feet"
+        },
         "quantity": 1
       }
     ],
@@ -4393,31 +4517,59 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/bedroll",
+        "item": {
+          "index": "bedroll",
+          "name": "Bedroll",
+          "url": "/api/equipment/bedroll"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/clothes-costume",
+        "item": {
+          "index": "clothes-costume",
+          "name": "Clothes, costume",
+          "url": "/api/equipment/clothes-costume"
+        },
         "quantity": 2
       },
       {
-        "item_url": "/api/equipment/candle",
+        "item": {
+          "index": "candle",
+          "name": "Candle",
+          "url": "/api/equipment/candle"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/rations-1-day",
+        "item": {
+          "index": "rations-1-day",
+          "name": "Rations (1 day)",
+          "url": "/api/equipment/rations-1-day"
+        },
         "quantity": 5
       },
       {
-        "item_url": "/api/equipment/waterskin",
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/equipment/waterskin"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/disguise-kit",
+        "item": {
+          "index": "disguise-kit",
+          "name": "Disguise Kit",
+          "url": "/api/equipment/disguise-kit"
+        },
         "quantity": 1
       }
     ],
@@ -4442,35 +4594,67 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/bedroll",
+        "item": {
+          "index": "bedroll",
+          "name": "Bedroll",
+          "url": "/api/equipment/bedroll"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/mess-kit",
+        "item": {
+          "index": "mess-kit",
+          "name": "Mess Kit",
+          "url": "/api/equipment/mess-kit"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/tinderbox",
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/equipment/tinderbox"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/torch",
+        "item": {
+          "index": "torch",
+          "name": "Torch",
+          "url": "/api/equipment/torch"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/rations-1-day",
+        "item": {
+          "index": "rations-1-day",
+          "name": "Rations (1 day)",
+          "url": "/api/equipment/rations-1-day"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/waterskin",
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/equipment/waterskin"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/disguise-kit",
+        "item": {
+          "index": "disguise-kit",
+          "name": "Disguise Kit",
+          "url": "/api/equipment/disguise-kit"
+        },
         "quantity": 1
       }
     ],
@@ -4495,27 +4679,51 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/blanket",
+        "item": {
+          "index": "blanket",
+          "name": "Blanket",
+          "url": "/api/equipment/blanket"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/candle",
+        "item": {
+          "index": "candle",
+          "name": "Candle",
+          "url": "/api/equipment/candle"
+        },
         "quantity": 10
       },
       {
-        "item_url": "/api/equipment/tinderbox",
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/equipment/tinderbox"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/rations-1-day",
+        "item": {
+          "index": "rations-1-day",
+          "name": "Rations (1 day)",
+          "url": "/api/equipment/rations-1-day"
+        },
         "quantity": 2
       },
       {
-        "item_url": "/api/equipment/waterskin",
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/equipment/waterskin"
+        },
         "quantity": 1
       }
     ],
@@ -4540,23 +4748,43 @@
     },
     "contents": [
       {
-        "item_url": "/api/equipment/backpack",
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/equipment/backpack"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/book",
+        "item": {
+          "index": "book",
+          "name": "Book",
+          "url": "/api/equipment/book"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/ink-1-ounce-bottle",
+        "item": {
+          "index": "ink-1-ounce-bottle",
+          "name": "Ink (1 ounce bottle)",
+          "url": "/api/equipment/ink-1-ounce-bottle"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/ink-pen",
+        "item": {
+          "index": "ink-pen",
+          "name": "Ink pen",
+          "url": "/api/equipment/ink-pen"
+        },
         "quantity": 1
       },
       {
-        "item_url": "/api/equipment/parchment-one-sheet",
+        "item": {
+          "index": "parchment-one-sheet",
+          "name": "Parchment (one sheet)",
+          "url": "/api/equipment/parchment-one-sheet"
+        },
         "quantity": 10
       }
     ],


### PR DESCRIPTION
## What does this do?
This PR updates the structure of items in equipment packs' `contents` array, exchanging `item_url` for a full APIReference under an `item` attribute.

(Also three lines had white-space updated for consistency - this was done as a separate commit, so can be reviewed separately 😄)

## How was it tested?
ESLint, Jest, loaded into mongo locally.

## Is there a Github issue this is resolving?
Resolves #294 

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![dungeoneer's pack](https://user-images.githubusercontent.com/6972523/95487579-6a64e280-098c-11eb-996d-139e8012789a.png)

