### PR TITLE
Fix phantasmal killer typo

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -10755,7 +10755,7 @@
       "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends."
     ],
     "higher_level": [
-      "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1dl0 for each slot level above 4th."
+      "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th."
     ],
     "range": "120 feet",
     "components": ["V", "S"],

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -10755,7 +10755,7 @@
       "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends."
     ],
     "higher_level": [
-      "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1dlO for each slot level above 4th."
+      "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1dl0 for each slot level above 4th."
     ],
     "range": "120 feet",
     "components": ["V", "S"],


### PR DESCRIPTION
## What does this do?
Replaces an O in phantasmal killers spell description with a 0

## How was it tested?
CI

## Is there a Github issue this is resolving?
Nope

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a
## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
