### PR TITLE
Add Monster Armor Types

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -7,6 +7,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 135,
     "hit_dice": "18d10",
     "speed": {
@@ -321,6 +322,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 195,
     "hit_dice": "17d12",
     "speed": {
@@ -574,6 +576,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 225,
     "hit_dice": "18d12",
     "speed": {
@@ -823,6 +826,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 172,
     "hit_dice": "15d12",
     "speed": {
@@ -1068,6 +1072,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 212,
     "hit_dice": "17d12",
     "speed": {
@@ -1342,6 +1347,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 184,
     "hit_dice": "16d12",
     "speed": {
@@ -1612,6 +1618,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 256,
     "hit_dice": "19d12",
     "speed": {
@@ -1894,6 +1901,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 207,
     "hit_dice": "18d12",
     "speed": {
@@ -2177,6 +2185,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 256,
     "hit_dice": "19d12",
     "speed": {
@@ -2478,6 +2487,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 243,
     "hit_dice": "18d12",
     "speed": {
@@ -2755,6 +2765,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 200,
     "hit_dice": "16d12",
     "speed": {
@@ -3135,6 +3146,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 367,
     "hit_dice": "21d20",
     "speed": {
@@ -3388,6 +3400,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 481,
     "hit_dice": "26d20",
     "speed": {
@@ -3618,6 +3631,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 20,
+    "armor_type": "natural armor",
     "hit_points": 297,
     "hit_dice": "17d20",
     "speed": {
@@ -3900,6 +3914,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 444,
     "hit_dice": "24d20",
     "speed": {
@@ -4178,6 +4193,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 21,
+    "armor_type": "natural armor",
     "hit_points": 350,
     "hit_dice": "20d20",
     "speed": {
@@ -4452,6 +4468,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 546,
     "hit_dice": "28d20",
     "speed": {
@@ -4738,6 +4755,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 21,
+    "armor_type": "natural armor",
     "hit_points": 385,
     "hit_dice": "22d20",
     "speed": {
@@ -5021,6 +5039,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 546,
     "hit_dice": "28d20",
     "speed": {
@@ -5270,6 +5289,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 22,
+    "armor_type": "natural armor",
     "hit_points": 487,
     "hit_dice": "25d20",
     "speed": {
@@ -5551,6 +5571,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 20,
+    "armor_type": "natural armor",
     "hit_points": 333,
     "hit_dice": "18d20",
     "speed": {
@@ -5805,6 +5826,7 @@
     "subtype": null,
     "alignment": "lawful neutral",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 199,
     "hit_dice": "19d10",
     "speed": {
@@ -6123,6 +6145,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 33,
     "hit_dice": "6d8",
     "speed": {
@@ -6239,6 +6262,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "14 (natural armor), 11 while prone",
     "hit_points": 39,
     "hit_dice": "6d10",
     "speed": {
@@ -6418,6 +6442,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 12,
+    "armor_type": "15 with _mage armor_",
     "hit_points": 99,
     "hit_dice": "18d8",
     "speed": {
@@ -6681,6 +6706,7 @@
     "subtype": "any race",
     "alignment": "any non-good alignment",
     "armor_class": 15,
+    "armor_type": "studded leather",
     "hit_points": 78,
     "hit_dice": "12d8",
     "speed": {
@@ -6911,6 +6937,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 59,
     "hit_dice": "7d12",
     "speed": {
@@ -7013,6 +7040,7 @@
     "subtype": null,
     "alignment": "lawful neutral",
     "armor_class": 17,
+    "armor_type": "natural armor, shield",
     "hit_points": 39,
     "hit_dice": "6d8",
     "speed": {
@@ -7229,6 +7257,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 262,
     "hit_dice": "21d12",
     "speed": {
@@ -7433,6 +7462,7 @@
     "subtype": "any race",
     "alignment": "any non-lawful alignment",
     "armor_class": 12,
+    "armor_type": "leather armor",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -7496,6 +7526,7 @@
     "subtype": "any race",
     "alignment": "any non-lawful alignment",
     "armor_class": 15,
+    "armor_type": "studded leather",
     "hit_points": 65,
     "hit_dice": "10d8",
     "speed": {
@@ -7634,6 +7665,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 110,
     "hit_dice": "13d8",
     "speed": {
@@ -7832,6 +7864,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "8d8",
     "speed": {
@@ -7964,6 +7997,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "8d8",
     "speed": {
@@ -8097,6 +8131,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 168,
     "hit_dice": "16d12",
     "speed": {
@@ -8250,6 +8285,7 @@
     "subtype": "any race",
     "alignment": "any chaotic alignment",
     "armor_class": 13,
+    "armor_type": "hide armor",
     "hit_points": 67,
     "hit_dice": "9d8",
     "speed": {
@@ -8304,6 +8340,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 19,
     "hit_dice": "3d8",
     "speed": {
@@ -8395,6 +8432,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 33,
     "hit_dice": "6d8",
     "speed": {
@@ -8805,6 +8843,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "8d8",
     "speed": {
@@ -8942,6 +8981,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -9014,6 +9054,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 142,
     "hit_dice": "15d10",
     "speed": {
@@ -9168,6 +9209,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 16,
     "hit_dice": "3d8",
     "speed": {
@@ -9318,6 +9360,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 32,
     "hit_dice": "5d8",
     "speed": {
@@ -9474,6 +9517,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 34,
     "hit_dice": "4d10",
     "speed": {
@@ -9574,6 +9618,7 @@
     "subtype": "goblinoid",
     "alignment": "chaotic evil",
     "armor_class": 16,
+    "armor_type": "hide armor, shield",
     "hit_points": 27,
     "hit_dice": "5d8",
     "speed": {
@@ -9665,6 +9710,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 94,
     "hit_dice": "9d10",
     "speed": {
@@ -10002,6 +10048,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 85,
     "hit_dice": "10d8",
     "speed": {
@@ -10134,6 +10181,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 114,
     "hit_dice": "12d10",
     "speed": {
@@ -10317,6 +10365,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 93,
     "hit_dice": "11d10",
     "speed": {
@@ -10435,6 +10484,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 133,
     "hit_dice": "14d10",
     "speed": {
@@ -10567,6 +10617,7 @@
     "subtype": null,
     "alignment": "chaotic neutral",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 78,
     "hit_dice": "12d10",
     "speed": {
@@ -10697,6 +10748,7 @@
     "subtype": null,
     "alignment": "neutral good (50%) or neutral evil (50%)",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 200,
     "hit_dice": "16d12",
     "speed": {
@@ -11078,6 +11130,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "4d8",
     "speed": {
@@ -11228,6 +11281,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 97,
     "hit_dice": "13d8",
     "speed": {
@@ -11464,6 +11518,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 2,
     "hit_dice": "1d4",
     "speed": {
@@ -11529,6 +11584,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 19,
     "hit_dice": "3d10",
     "speed": {
@@ -11593,6 +11649,7 @@
     "subtype": "any race",
     "alignment": "any non-good alignment",
     "armor_class": 13,
+    "armor_type": "leather armor",
     "hit_points": 22,
     "hit_dice": "6d8",
     "speed": {
@@ -11750,6 +11807,7 @@
     "subtype": "any race",
     "alignment": "any non-good alignment",
     "armor_class": 12,
+    "armor_type": "leather armor",
     "hit_points": 9,
     "hit_dice": "2d8",
     "speed": {
@@ -11986,6 +12044,7 @@
     "subtype": "gnome",
     "alignment": "neutral good",
     "armor_class": 15,
+    "armor_type": "chain shirt",
     "hit_points": 16,
     "hit_dice": "3d6",
     "speed": {
@@ -12184,6 +12243,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "16d8",
     "speed": {
@@ -12373,6 +12433,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 37,
     "hit_dice": "5d10",
     "speed": {
@@ -12448,6 +12509,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 161,
     "hit_dice": "14d10",
     "speed": {
@@ -12861,6 +12923,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 20,
+    "armor_type": "natural armor",
     "hit_points": 341,
     "hit_dice": "22d20",
     "speed": {
@@ -13033,6 +13096,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 18,
     "hit_dice": "4d6",
     "speed": {
@@ -13141,6 +13205,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 123,
     "hit_dice": "13d10",
     "speed": {
@@ -13374,6 +13439,7 @@
     "subtype": "elf",
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "chain shirt",
     "hit_points": 13,
     "hit_dice": "3d8",
     "speed": {
@@ -13507,6 +13573,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 11,
+    "armor_type": "16 with _barkskin_",
     "hit_points": 27,
     "hit_dice": "5d8",
     "speed": {
@@ -13663,6 +13730,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 11,
+    "armor_type": "16 with _barkskin_",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -13824,6 +13892,7 @@
     "subtype": "dwarf",
     "alignment": "lawful evil",
     "armor_class": 16,
+    "armor_type": "scale mail, shield",
     "hit_points": 26,
     "hit_dice": "4d8",
     "speed": {
@@ -14111,6 +14180,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 126,
     "hit_dice": "12d10",
     "speed": {
@@ -14216,6 +14286,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 200,
     "hit_dice": "16d10",
     "speed": {
@@ -14444,6 +14515,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 76,
     "hit_dice": "8d12",
     "speed": {
@@ -14582,6 +14654,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "plate",
     "hit_points": 153,
     "hit_dice": "18d8",
     "speed": {
@@ -14769,6 +14842,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 44,
     "hit_dice": "8d8",
     "speed": {
@@ -14927,6 +15001,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 85,
     "hit_dice": "10d10",
     "speed": {
@@ -15163,6 +15238,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "plate",
     "hit_points": 162,
     "hit_dice": "13d12",
     "speed": {
@@ -15474,6 +15550,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 17,
     "hit_dice": "5d6",
     "speed": {
@@ -15640,6 +15717,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "patchwork armor",
     "hit_points": 138,
     "hit_dice": "12d12",
     "speed": {
@@ -15760,6 +15838,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "7d8",
     "speed": {
@@ -16534,6 +16613,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 42,
     "hit_dice": "5d10",
     "speed": {
@@ -16596,6 +16676,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 4,
     "hit_dice": "1d6",
     "speed": {
@@ -16720,6 +16801,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 13,
     "hit_dice": "3d8",
     "speed": {
@@ -16785,6 +16867,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 85,
     "hit_dice": "9d12",
     "speed": {
@@ -16985,6 +17068,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 42,
     "hit_dice": "5d12",
     "speed": {
@@ -17063,6 +17147,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 4,
     "hit_dice": "1d6",
     "speed": {
@@ -17199,6 +17284,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 19,
     "hit_dice": "3d10",
     "speed": {
@@ -17320,6 +17406,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 19,
     "hit_dice": "3d10",
     "speed": {
@@ -17713,6 +17800,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "7d10",
     "speed": {
@@ -17798,6 +17886,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 16,
     "hit_dice": "3d10",
     "speed": {
@@ -17857,6 +17946,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 126,
     "hit_dice": "11d12",
     "speed": {
@@ -17925,6 +18015,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 26,
     "hit_dice": "4d10",
     "speed": {
@@ -18503,6 +18594,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 157,
     "hit_dice": "15d10",
     "speed": {
@@ -18724,6 +18816,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 16,
+    "armor_type": "studded leather, shield",
     "hit_points": 112,
     "hit_dice": "15d8",
     "speed": {
@@ -18913,6 +19006,7 @@
     "subtype": "gnoll",
     "alignment": "chaotic evil",
     "armor_class": 15,
+    "armor_type": "hide armor, shield",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -19070,6 +19164,7 @@
     "subtype": "goblinoid",
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "leather armor, shield",
     "hit_points": 7,
     "hit_dice": "2d6",
     "speed": {
@@ -19149,6 +19244,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 60,
     "hit_dice": "8d8",
     "speed": {
@@ -19305,6 +19401,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 114,
     "hit_dice": "12d10",
     "speed": {
@@ -19520,6 +19617,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 38,
     "hit_dice": "7d8",
     "speed": {
@@ -19669,6 +19767,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 82,
     "hit_dice": "11d8",
     "speed": {
@@ -19820,6 +19919,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 27,
     "hit_dice": "6d8",
     "speed": {
@@ -20118,6 +20218,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 16,
+    "armor_type": "chain shirt, shield",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -20189,6 +20290,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 127,
     "hit_dice": "15d10",
     "speed": {
@@ -20402,6 +20504,7 @@
     "subtype": null,
     "alignment": "lawful neutral",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "16d10",
     "speed": {
@@ -20638,6 +20741,7 @@
     "subtype": "human",
     "alignment": "any alignment",
     "armor_class": 18,
+    "armor_type": "plate",
     "hit_points": 65,
     "hit_dice": "10d8",
     "speed": {
@@ -20935,6 +21039,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 45,
     "hit_dice": "7d8",
     "speed": {
@@ -21039,6 +21144,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "13d10",
     "speed": {
@@ -21187,6 +21293,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 105,
     "hit_dice": "10d12",
     "speed": {
@@ -21375,6 +21482,7 @@
     "subtype": "goblinoid",
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "chain mail, shield",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -21459,6 +21567,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 5,
     "hit_dice": "2d4",
     "speed": {
@@ -21526,6 +21635,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 148,
     "hit_dice": "17d10",
     "speed": {
@@ -21708,6 +21818,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 45,
     "hit_dice": "6d10",
     "speed": {
@@ -21776,6 +21887,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 172,
     "hit_dice": "15d12",
     "speed": {
@@ -21932,6 +22044,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 180,
     "hit_dice": "19d10",
     "speed": {
@@ -22532,6 +22645,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 20,
+    "armor_type": "natural armor",
     "hit_points": 210,
     "hit_dice": "20d10",
     "speed": {
@@ -22768,6 +22882,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 90,
     "hit_dice": "12d12",
     "speed": {
@@ -22840,6 +22955,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 18,
+    "armor_type": "plate",
     "hit_points": 52,
     "hit_dice": "8d8",
     "speed": {
@@ -23030,6 +23146,7 @@
     "subtype": "titan",
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 472,
     "hit_dice": "27d20",
     "speed": {
@@ -23255,6 +23372,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 97,
     "hit_dice": "13d10",
     "speed": {
@@ -23527,6 +23645,7 @@
     "subtype": null,
     "alignment": "any evil alignment",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 135,
     "hit_dice": "18d8",
     "speed": {
@@ -24033,6 +24152,7 @@
     "subtype": "lizardfolk",
     "alignment": "neutral",
     "armor_class": 15,
+    "armor_type": "natural armor, shield",
     "hit_points": 22,
     "hit_dice": "4d8",
     "speed": {
@@ -24239,6 +24359,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 12,
+    "armor_type": "15 with _mage armor_",
     "hit_points": 40,
     "hit_dice": "9d8",
     "speed": {
@@ -24584,6 +24705,7 @@
     "subtype": null,
     "alignment": "chaotic neutral",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 9,
     "hit_dice": "2d6",
     "speed": {
@@ -24664,6 +24786,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 126,
     "hit_dice": "11d12",
     "speed": {
@@ -24733,6 +24856,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 68,
     "hit_dice": "8d10",
     "speed": {
@@ -24847,6 +24971,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 189,
     "hit_dice": "18d10",
     "speed": {
@@ -25071,6 +25196,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 127,
     "hit_dice": "17d8",
     "speed": {
@@ -25320,6 +25446,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 45,
     "hit_dice": "6d10",
     "speed": {
@@ -25451,6 +25578,7 @@
     "subtype": "shapechanger",
     "alignment": "neutral",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 58,
     "hit_dice": "9d8",
     "speed": {
@@ -25556,6 +25684,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 76,
     "hit_dice": "9d10",
     "speed": {
@@ -25643,6 +25772,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 67,
     "hit_dice": "9d10",
     "speed": {
@@ -25782,6 +25912,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 58,
     "hit_dice": "9d8",
     "speed": {
@@ -25910,6 +26041,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 97,
     "hit_dice": "13d8",
     "speed": {
@@ -26231,6 +26363,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 184,
     "hit_dice": "16d10",
     "speed": {
@@ -26403,6 +26536,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 112,
     "hit_dice": "15d8",
     "speed": {
@@ -26593,6 +26727,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 68,
     "hit_dice": "8d10",
     "speed": {
@@ -26664,6 +26799,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 15,
+    "armor_type": "breastplate",
     "hit_points": 9,
     "hit_dice": "2d8",
     "speed": {
@@ -26938,6 +27074,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 11,
+    "armor_type": "hide armor",
     "hit_points": 59,
     "hit_dice": "7d10",
     "speed": {
@@ -27072,6 +27209,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 16,
+    "armor_type": "chain mail",
     "hit_points": 110,
     "hit_dice": "13d10",
     "speed": {
@@ -27313,6 +27451,7 @@
     "subtype": "orc",
     "alignment": "chaotic evil",
     "armor_class": 13,
+    "armor_type": "hide armor",
     "hit_points": 15,
     "hit_dice": "2d8",
     "speed": {
@@ -27392,6 +27531,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 114,
     "hit_dice": "12d10",
     "speed": {
@@ -27590,6 +27730,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 59,
     "hit_dice": "7d10",
     "speed": {
@@ -27863,6 +28004,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 32,
     "hit_dice": "5d10",
     "speed": {
@@ -27936,6 +28078,7 @@
     "subtype": "devil",
     "alignment": "lawful evil",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 300,
     "hit_dice": "24d10",
     "speed": {
@@ -28168,6 +28311,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 200,
     "hit_dice": "16d10",
     "speed": {
@@ -28411,6 +28555,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 68,
     "hit_dice": "8d10",
     "speed": {
@@ -28533,6 +28678,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 42,
     "hit_dice": "5d10",
     "speed": {
@@ -28681,6 +28827,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 13,
+    "armor_type": "chain shirt",
     "hit_points": 27,
     "hit_dice": "5d8",
     "speed": {
@@ -28833,6 +28980,7 @@
     "subtype": null,
     "alignment": "neutral good",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 7,
     "hit_dice": "2d4",
     "speed": {
@@ -28934,6 +29082,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 247,
     "hit_dice": "15d20",
     "speed": {
@@ -29207,6 +29356,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_dice": "13d8",
     "hit_points": 110,
     "speed": {
@@ -29547,6 +29697,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 75,
     "hit_dice": "10d8",
     "speed": {
@@ -29684,6 +29835,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "4d8",
     "speed": {
@@ -29752,6 +29904,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 195,
     "hit_dice": "17d12",
     "speed": {
@@ -29831,6 +29984,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 45,
     "hit_dice": "6d10",
     "speed": {
@@ -29933,6 +30087,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 248,
     "hit_dice": "16d20",
     "speed": {
@@ -30065,6 +30220,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 20,
+    "armor_type": "natural armor",
     "hit_points": 93,
     "hit_dice": "11d10",
     "speed": {
@@ -30270,6 +30426,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 27,
     "hit_dice": "5d8",
     "speed": {
@@ -30423,6 +30580,7 @@
     "subtype": "sahuagin",
     "alignment": "lawful evil",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "4d8",
     "speed": {
@@ -30573,6 +30731,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 90,
     "hit_dice": "12d10",
     "speed": {
@@ -30710,6 +30869,7 @@
     "subtype": null,
     "alignment": "chaotic neutral",
     "armor_class": 14,
+    "armor_type": "leather armor",
     "hit_points": 31,
     "hit_dice": "7d8",
     "speed": {
@@ -30823,6 +30983,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 11,
+    "armor_type": "natural armor",
     "hit_points": 1,
     "hit_dice": "1d4",
     "speed": {
@@ -30872,6 +31033,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 13,
+    "armor_type": "leather armor",
     "hit_points": 16,
     "hit_dice": "3d8",
     "speed": {
@@ -30997,6 +31159,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 52,
     "hit_dice": "7d8",
     "speed": {
@@ -31243,6 +31406,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "16d10",
     "speed": {
@@ -31351,6 +31515,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 142,
     "hit_dice": "15d10",
     "speed": {
@@ -31523,6 +31688,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 45,
     "hit_dice": "6d8",
     "speed": {
@@ -31672,6 +31838,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 13,
+    "armor_type": "armor scraps",
     "hit_points": 13,
     "hit_dice": "2d8",
     "speed": {
@@ -31742,6 +31909,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 21,
+    "armor_type": "natural armor",
     "hit_points": 243,
     "hit_dice": "18d10",
     "speed": {
@@ -32236,6 +32404,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 75,
     "hit_dice": "10d10",
     "speed": {
@@ -32425,6 +32594,7 @@
     "subtype": null,
     "alignment": "neutral good",
     "armor_class": 15,
+    "armor_type": "leather armor",
     "hit_points": 2,
     "hit_dice": "1d4",
     "speed": {
@@ -32805,6 +32975,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 2,
     "hit_dice": "1d4",
     "speed": {
@@ -32855,6 +33026,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 126,
     "hit_dice": "11d12",
     "speed": {
@@ -32988,6 +33160,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 178,
     "hit_dice": "17d10",
     "speed": {
@@ -33120,6 +33293,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 16,
+    "armor_type": "scale mail",
     "hit_points": 230,
     "hit_dice": "20d12",
     "speed": {
@@ -33364,6 +33538,7 @@
     "subtype": "shapechanger",
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 66,
     "hit_dice": "12d8",
     "speed": {
@@ -33608,6 +33783,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -33706,6 +33882,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -33803,6 +33980,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -34298,6 +34476,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -34402,6 +34581,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 12,
+    "armor_type": "natural armor",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -34499,6 +34679,7 @@
     "subtype": "titan",
     "alignment": "unaligned",
     "armor_class": 25,
+    "armor_type": "natural armor",
     "hit_points": 676,
     "hit_dice": "33d20",
     "speed": {
@@ -34760,6 +34941,7 @@
     "subtype": "any race",
     "alignment": "any non-good alignment",
     "armor_class": 11,
+    "armor_type": "leather armor",
     "hit_points": 32,
     "hit_dice": "5d8",
     "speed": {
@@ -34945,6 +35127,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 138,
     "hit_dice": "12d12",
     "speed": {
@@ -35042,6 +35225,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 12,
+    "armor_type": "hide armor",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -35110,6 +35294,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 95,
     "hit_dice": "10d12",
     "speed": {
@@ -35179,6 +35364,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 84,
     "hit_dice": "8d10",
     "speed": {
@@ -35287,6 +35473,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "13d12",
     "speed": {
@@ -35593,6 +35780,7 @@
     "subtype": "shapechanger",
     "alignment": "lawful evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 144,
     "hit_dice": "17d8",
     "speed": {
@@ -35781,6 +35969,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 82,
     "hit_dice": "11d8",
     "speed": {
@@ -35931,6 +36120,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 17,
+    "armor_type": "splint",
     "hit_points": 58,
     "hit_dice": "9d8",
     "speed": {
@@ -36149,6 +36339,7 @@
     "subtype": "demon",
     "alignment": "chaotic evil",
     "armor_class": 15,
+    "armor_type": "natural armor",
     "hit_points": 104,
     "hit_dice": "11d10",
     "speed": {
@@ -36437,6 +36628,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 13,
+    "armor_type": "barding scraps",
     "hit_points": 22,
     "hit_dice": "3d10",
     "speed": {
@@ -36497,6 +36689,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 14,
+    "armor_type": "natural armor",
     "hit_points": 114,
     "hit_dice": "12d10",
     "speed": {
@@ -36716,6 +36909,7 @@
     "subtype": "human",
     "alignment": "neutral good",
     "armor_class": 10,
+    "armor_type": "10 in humanoid form, 11 (natural armor) in bear and hybrid form",
     "hit_points": 135,
     "hit_dice": "18d8",
     "speed": {
@@ -36870,6 +37064,7 @@
     "subtype": "human",
     "alignment": "neutral evil",
     "armor_class": 10,
+    "armor_type": "10 in humanoid form, 11 (natural armor) in boar or hybrid form",
     "hit_points": 78,
     "hit_dice": "12d8",
     "speed": {
@@ -37226,6 +37421,7 @@
     "subtype": "human",
     "alignment": "chaotic evil",
     "armor_class": 11,
+    "armor_type": "11 in humanoid form, 12 (natural armor) in wolf or hybrid form",
     "hit_points": 58,
     "hit_dice": "9d8",
     "speed": {
@@ -37351,6 +37547,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 16,
+    "armor_type": "natural armor",
     "hit_points": 32,
     "hit_dice": "5d8",
     "speed": {
@@ -37489,6 +37686,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 14,
+    "armor_type": "studded leather",
     "hit_points": 45,
     "hit_dice": "6d8",
     "speed": {
@@ -37774,6 +37972,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 75,
     "hit_dice": "10d10",
     "speed": {
@@ -37881,6 +38080,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 11,
     "hit_dice": "2d8",
     "speed": {
@@ -37956,6 +38156,7 @@
     "subtype": null,
     "alignment": "neutral evil",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 26,
     "hit_dice": "4d10",
     "speed": {
@@ -38133,6 +38334,7 @@
     "subtype": null,
     "alignment": "unaligned",
     "armor_class": 13,
+    "armor_type": "natural armor",
     "hit_points": 110,
     "hit_dice": "13d10",
     "speed": {
@@ -38271,6 +38473,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 19,
+    "armor_type": "natural armor",
     "hit_points": 73,
     "hit_dice": "7d8",
     "speed": {
@@ -38391,6 +38594,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 127,
     "hit_dice": "15d10",
     "speed": {
@@ -38570,6 +38774,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 152,
     "hit_dice": "16d10",
     "speed": {
@@ -38743,6 +38948,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 110,
     "hit_dice": "13d10",
     "speed": {
@@ -38937,6 +39143,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 142,
     "hit_dice": "15d10",
     "speed": {
@@ -39137,6 +39344,7 @@
     "subtype": null,
     "alignment": "chaotic good",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 119,
     "hit_dice": "14d10",
     "speed": {
@@ -39331,6 +39539,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 178,
     "hit_dice": "17d10",
     "speed": {
@@ -39539,6 +39748,7 @@
     "subtype": null,
     "alignment": "lawful evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 136,
     "hit_dice": "16d10",
     "speed": {
@@ -39732,6 +39942,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 178,
     "hit_dice": "17d10",
     "speed": {
@@ -39905,6 +40116,7 @@
     "subtype": null,
     "alignment": "lawful good",
     "armor_class": 18,
+    "armor_type": "natural armor",
     "hit_points": 168,
     "hit_dice": "16d10",
     "speed": {
@@ -40106,6 +40318,7 @@
     "subtype": null,
     "alignment": "chaotic evil",
     "armor_class": 17,
+    "armor_type": "natural armor",
     "hit_points": 133,
     "hit_dice": "14d10",
     "speed": {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6442,7 +6442,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 12,
-    "armor_type": "15 with _mage armor_",
+    "armor_type": "15 with mage armor",
     "hit_points": 99,
     "hit_dice": "18d8",
     "speed": {
@@ -13573,7 +13573,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 11,
-    "armor_type": "16 with _barkskin_",
+    "armor_type": "16 with barkskin",
     "hit_points": 27,
     "hit_dice": "5d8",
     "speed": {
@@ -13730,7 +13730,7 @@
     "subtype": null,
     "alignment": "neutral",
     "armor_class": 11,
-    "armor_type": "16 with _barkskin_",
+    "armor_type": "16 with barkskin",
     "hit_points": 22,
     "hit_dice": "5d8",
     "speed": {
@@ -24359,7 +24359,7 @@
     "subtype": "any race",
     "alignment": "any alignment",
     "armor_class": 12,
-    "armor_type": "15 with _mage armor_",
+    "armor_type": "15 with mage armor",
     "hit_points": 40,
     "hit_dice": "9d8",
     "speed": {


### PR DESCRIPTION
## What does this do?
This adds monster armor types.

## How was it tested?
No tests. It was manually entered.

## Is there a Github issue this is resolving?
Yes #280 

## Did you update the docs in the API? Please link an associated PR if applicable.
No

## More
So right now it's a straight rip from the PDF. Let me know how you want the data actually formatted.
Here are the unique entries:
```
{'10 in humanoid form, 11 (natural armor) in bear and hybrid form',
 '10 in humanoid form, 11 (natural armor) in boar or hybrid form',
 '11 in humanoid form, 12 (natural armor) in wolf or hybrid form',
 '14 (natural armor), 11 while prone',
 '15 with _mage armor_',
 '16 with _barkskin_',
 'armor scraps',
 'barding scraps',
 'breastplate',
 'chain mail',
 'chain mail, shield',
 'chain shirt',
 'chain shirt, shield',
 'hide armor',
 'hide armor, shield',
 'leather armor',
 'leather armor, shield',
 'natural armor',
 'natural armor, shield',
 'patchwork armor',
 'plate',
 'scale mail',
 'scale mail, shield',
 'splint',
 'studded leather',
 'studded leather, shield'}
```
Words surrounded by underscores are in italics.