### PR TITLE
references index name, not position

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -250,9 +250,9 @@
         "spellcasting": {
           "level": 1,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 12,
           "modifier": 4,
@@ -5938,9 +5938,9 @@
         "spellcasting": {
           "level": 12,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 18,
           "modifier": 10,
@@ -6514,9 +6514,9 @@
         "spellcasting": {
           "level": 18,
           "ability": {
-            "index": "4",
+            "index": "int",
             "name": "INT",
-            "url": "/api/ability-scores/4"
+            "url": "/api/ability-scores/int"
           },
           "dc": 17,
           "modifier": 9,
@@ -11724,9 +11724,9 @@
         "spellcasting": {
           "level": 4,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 11,
           "modifier": 3,
@@ -13649,9 +13649,9 @@
         "spellcasting": {
           "level": 4,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 12,
           "modifier": 4,
@@ -20431,9 +20431,9 @@
         "spellcasting": {
           "level": 11,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 16,
           "modifier": 8,
@@ -20644,9 +20644,9 @@
         "spellcasting": {
           "level": 9,
           "ability": {
-            "index": "4",
+            "index": "int",
             "name": "INT",
-            "url": "/api/ability-scores/4"
+            "url": "/api/ability-scores/int"
           },
           "dc": 16,
           "modifier": 8,
@@ -23838,9 +23838,9 @@
         "spellcasting": {
           "level": 18,
           "ability": {
-            "index": "4",
+            "index": "int",
             "name": "INT",
-            "url": "/api/ability-scores/4"
+            "url": "/api/ability-scores/int"
           },
           "dc": 20,
           "modifier": 12,
@@ -24488,9 +24488,9 @@
         "spellcasting": {
           "level": 9,
           "ability": {
-            "index": "4",
+            "index": "int",
             "name": "INT",
-            "url": "/api/ability-scores/4"
+            "url": "/api/ability-scores/int"
           },
           "dc": 14,
           "modifier": 6,
@@ -26229,9 +26229,9 @@
         "spellcasting": {
           "level": 10,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 17,
           "modifier": 9,
@@ -28964,9 +28964,9 @@
         "spellcasting": {
           "level": 5,
           "ability": {
-            "index": "5",
+            "index": "wis",
             "name": "WIS",
-            "url": "/api/ability-scores/5"
+            "url": "/api/ability-scores/wis"
           },
           "dc": 13,
           "modifier": 5,
@@ -32573,9 +32573,9 @@
         "spellcasting": {
           "level": 10,
           "ability": {
-            "index": "4",
+            "index": "int",
             "name": "INT",
-            "url": "/api/ability-scores/4"
+            "url": "/api/ability-scores/int"
           },
           "dc": 14,
           "modifier": 6,


### PR DESCRIPTION
## What does this do?
Removes references to the position of the ability scores in their json, instead references their names.

## How was it tested?
ran locally

## Is there a Github issue this is resolving?
no

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
