### PR TITLE
Add description to Amulet of Proof against Detection and Location

### DIFF
--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -50,7 +50,7 @@
       "url": "/api/equipment-categories/wondrous-item"
     },
     "desc": [
-      "String"
+      "While wearing this amulet, you are hidden from divination magic. You can’t be targeted by such magic or perceived through magical scrying sensors."
     ],
     "url": "/api/magic-items/amulet-of-proof-against-detection-and-location"
   },


### PR DESCRIPTION
## What does this do?
Adds missing amulet description.

## How was it tested?
CI

## Is there a Github issue this is resolving?
This resolves #321

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
