### PR TITLE
Fix paladin wrapping

### DIFF
--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -745,10 +745,12 @@
             "equipment_option": {
               "choose": 1,
               "type": "equipment",
-              "from": {
-                "index": "simple-weapons",
-                "name": "Simple Weapons",
-                "url": "/api/equipment-categories/simple-weapons"
+              "from": "from": {
+                "equipment_category": {
+                  "index": "simple-weapons",
+                  "name": "Simple Weapons",
+                  "url": "/api/equipment-categories/simple-weapons"
+                }
               }
             }
           }

--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -745,7 +745,7 @@
             "equipment_option": {
               "choose": 1,
               "type": "equipment",
-              "from": "from": {
+              "from": {
                 "equipment_category": {
                   "index": "simple-weapons",
                   "name": "Simple Weapons",


### PR DESCRIPTION
## What does this do?
Fixes inconsistent structure of the Paladin's StartingEquipment (simple-weapons wasn't wrapped by equipment_category)

## How was it tested?
Parsed with a JSON parser and tested with a python script
