### PR TITLE
Switch 2h_damage to two_handed_damage

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -359,7 +359,7 @@
         "url": "/api/weapon-properties/monk"
       }
     ],
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d8",
       "damage_type": {
         "index": "bludgeoning",
@@ -460,7 +460,7 @@
       "normal": 20,
       "long": 60
     },
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d8",
       "damage_type": {
         "index": "piercing",
@@ -677,7 +677,7 @@
         "url": "/api/weapon-properties/versatile"
       }
     ],
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d10",
       "damage_type": {
         "index": "slashing",
@@ -976,7 +976,7 @@
         "url": "/api/weapon-properties/versatile"
       }
     ],
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d10",
       "damage_type": {
         "index": "slashing",
@@ -1276,7 +1276,7 @@
       "normal": 20,
       "long": 60
     },
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d8",
       "damage_type": {
         "index": "piercing",
@@ -1352,7 +1352,7 @@
         "url": "/api/weapon-properties/versatile"
       }
     ],
-    "2h_damage": {
+    "two_handed_damage": {
       "damage_dice": "1d10",
       "damage_type": {
         "index": "bludgeoning",


### PR DESCRIPTION
## What does this do?
Switches the `2h_damage` key for `two_handed_damage`. Mainly this came up because GraphQL seems to hate keys that start with numbers. But really, there's no reason for this key to be abbreviated like this.

## How was it tested?
CI

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
https://github.com/bagelbits/5e-srd-api/pull/160

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
