### PR TITLE
Split out lint step and trigger API workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,5 +46,11 @@ jobs:
     - env:
         MONGODB_URI: ${{ secrets.MONGODB_URI }}
       run: npm run db:refresh
+  trigger_downstream:
+    name: Trigger downstream
+    runs-on: self-hosted
+    needs: deploy
+    if: github.ref == 'refs/heads/main'
+    steps:
     - run: |
         curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/bagelbits/5e-srd-api/dispatches --data '{"event_type": "build_application"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,29 +10,41 @@ on:
     branches: [ main ]
 
 jobs:
+  lint:
+    name: Run linter
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - run: yarn install
+    - run: yarn lint
   test:
     name: Run tests
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Use Node.js 12.x
+    - name: Use Node.js 14.x
       uses: actions/setup-node@v1
       with:
-        node-version: 12.x
+        node-version: 14.x
     - run: yarn install
-    - run: yarn lint
     - run: yarn test
   deploy:
     name: Deploy
     runs-on: self-hosted
-    needs: test
+    needs: [test, lint]
     if: github.ref == 'refs/heads/main'
     steps:
-      - uses: actions/checkout@v2
-      - name: Use Node.js 12.x
-        uses: actions/setup-node@v1
-        with:
-          node-version: 12.x
-      - env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }}
-        run: npm run db:refresh
+    - uses: actions/checkout@v2
+    - name: Use Node.js 14.x
+      uses: actions/setup-node@v1
+      with:
+        node-version: 14.x
+    - env:
+        MONGODB_URI: ${{ secrets.MONGODB_URI }}
+      run: npm run db:refresh
+    - run: |
+      curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/bagelbits/5e-srd-api/dispatches --data '{"event_type": "build_application"}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,4 +47,4 @@ jobs:
         MONGODB_URI: ${{ secrets.MONGODB_URI }}
       run: npm run db:refresh
     - run: |
-      curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/bagelbits/5e-srd-api/dispatches --data '{"event_type": "build_application"}'
+        curl -XPOST -u "${{ secrets.PAT_USERNAME}}:${{secrets.PAT_TOKEN}}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/bagelbits/5e-srd-api/dispatches --data '{"event_type": "build_application"}'


### PR DESCRIPTION
## What does this do?
- Splits the test and lint steps.
- Adds a step that triggers the 5e-srd-api deploy workflow.

## How was it tested?
CI but also wishes

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/101536968-9b8f6e00-394f-11eb-8a0b-fc187e74eaf7.png)
