### PR TITLE
Fixes dice notation for a couple spells

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -10765,7 +10765,7 @@
     "index": "phantasmal-killer",
     "name": "Phantasmal Killer",
     "desc": [
-      "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends."
+      "You tap into the nightmares of a creature you can see within range and create an illusory manifestation of its deepest fears, visible only to that creature. The target must make a wisdom saving throw. On a failed save, the target becomes frightened for the duration. At the start of each of the target's turns before the spell ends, the target must succeed on a wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends."
     ],
     "higher_level": [
       "When you cast this spell using a spell slot of 5th level or higher, the damage increases by 1d10 for each slot level above 4th."
@@ -15588,7 +15588,7 @@
     "index": "weird",
     "name": "Weird",
     "desc": [
-      "Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat. At the start of each of the frightened creature's turns, it must succeed on a wisdom saving throw or take 4 d10 psychic damage. On a successful save, the spell ends for that creature."
+      "Drawing on the deepest fears of a group of creatures, you create illusory creatures in their minds, visible only to them. Each creature in a 30-foot-radius sphere centered on a point of your choice within range must make a wisdom saving throw. On a failed save, a creature becomes frightened for the duration. The illusion calls on the creature's deepest fears, manifesting its worst nightmares as an implacable threat. At the start of each of the frightened creature's turns, it must succeed on a wisdom saving throw or take 4d10 psychic damage. On a successful save, the spell ends for that creature."
     ],
     "range": "120 feet",
     "components": ["V", "S"],


### PR DESCRIPTION
## What does this do?

Fixes dice notation for Phantasmal Killer and Weird, there was an extra space between the number of dice and which dice to use.

There are other cases where the dice notation doesn't include "1" when rolling a single die, e.g. Bane: "target must roll a d4 and subtract the number". Does it make sense to turn this into "target must roll 1d4 and subtract the number"?

## How was it tested?

CI ✅ 

## Is there a Github issue this is resolving?

No, just found this while looking at the spells

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles
![random photo - update me](https://i.redd.it/ks7ni7kzkkw41.jpg)
