### PR TITLE
Fix Infernal Legacy description typo

### DIFF
--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -683,7 +683,7 @@
     "subraces": [],
     "name": "Infernal Legacy",
     "desc": [
-      "You know the thaumaturgy cantrip. When you reach 3rd level, you can cast the hellish rebuke spell as a 2nd-level spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5h level, you can cast the darkness spell once with this trait and regain the ability to do so when you finish a long rest. Charisma is your spellcasting ability for these spells."
+      "You know the thaumaturgy cantrip. When you reach 3rd level, you can cast the hellish rebuke spell as a 2nd-level spell once with this trait and regain the ability to do so when you finish a long rest. When you reach 5th level, you can cast the darkness spell once with this trait and regain the ability to do so when you finish a long rest. Charisma is your spellcasting ability for these spells."
     ],
     "proficiencies": [],
     "url": "/api/traits/infernal-legacy"


### PR DESCRIPTION
## What does this do?
It fixes a single character typo in the Tiefling's Infernal Legacy trait description.

## How was it tested?
With my eyes :)

## Is there a Github issue this is resolving?
Nope

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A
