### PR TITLE
monsters/ankheg updated damage type

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6328,9 +6328,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/damage-types/bludgeoning"
+              "index": "acid",
+              "name": "Acid",
+              "url": "/api/damage-types/acid"
             },
             "damage_dice": "3d6"
           }


### PR DESCRIPTION
## What does this do?
Updated the damage type for the Ankheg to be of type `acid` rather than of type `bludgeoning`. Also updates the associated index route listed in the Ankheg's damage type.

## How was it tested?
NA

## Is there a Github issue this is resolving?
NA

## Did you update the docs in the API? Please link an associated PR if applicable.
NA
