### PR TITLE
Add Legendary Actions to Adult Brass Dragon

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -1063,6 +1063,39 @@
         }
       }
     ],
+    "legendary_actions": [
+      {
+        "name": "Detect",
+        "desc": "The dragon makes a Wisdom (Perception) check."
+      },
+      {
+        "name": "Tail Attack",
+        "desc": "The dragon makes a tail attack."
+      },
+      {
+        "name": "Wing Attack (Costs 2 Actions)",
+        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/ability-scores/dex"
+          },
+          "dc_value": 22,
+          "success_type": "none"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "bludgeoning",
+              "name": "Bludgeoning",
+              "url": "/api/damage-types/bludgeoning"
+            },
+            "damage_dice": "2d6+8"
+          }
+        ]
+      }
+    ],
     "url": "/api/monsters/adult-brass-dragon"
   },
   {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -1074,14 +1074,14 @@
       },
       {
         "name": "Wing Attack (Costs 2 Actions)",
-        "desc": "The dragon beats its wings. Each creature within 15 ft. of the dragon must succeed on a DC 22 Dexterity saving throw or take 15 (2d6 + 8) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
+        "desc": "The dragon beats its wings. Each creature within 10 ft. of the dragon must succeed on a DC 19 Dexterity saving throw or take 13 (2d6 + 6) bludgeoning damage and be knocked prone. The dragon can then fly up to half its flying speed.",
         "dc": {
           "dc_type": {
             "index": "dex",
             "name": "DEX",
             "url": "/api/ability-scores/dex"
           },
-          "dc_value": 22,
+          "dc_value": 19,
           "success_type": "none"
         },
         "damage": [
@@ -1091,7 +1091,7 @@
               "name": "Bludgeoning",
               "url": "/api/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6+8"
+            "damage_dice": "2d6+6"
           }
         ]
       }


### PR DESCRIPTION
## What does this do?

Currently the adult brass dragon is missing it's Legendary Actions, this PR fills the gap.

## How was it tested?

The actions were manually copied from the Ancient Brass Dragon and then verified against the SRD text to ensure correctness. I was working on an app pulling in the monster json file and no schema issues were encountered.

## Is there a Github issue this is resolving?
No current issue

## Did you update the docs in the API? Please link an associated PR if applicable.
No need for updating documentation

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
