### PR TITLE
Fix Mummy Lord damage vulnerabilities

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -26194,7 +26194,9 @@
         }
       }
     ],
-    "damage_vulnerabilities": ["bludgeoning"],
+    "damage_vulnerabilities": [
+      "fire"
+    ],
     "damage_resistances": [],
     "damage_immunities": [
       "necrotic",


### PR DESCRIPTION
## What does this do?
Updates the `damage_vulnerabilities` field of the `mummy-lord` Monster document to include only `"fire"`, not `"bludgeoning"`.

## How was it tested?
CI

## Is there a Github issue this is resolving?
N/A

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A
