### PR TITLE
Removed extra leading space in alignment/age desc

### DIFF
--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -405,7 +405,7 @@
         "bonus": 1
       }
     ],
-    "alignment": " Dragonborn tend to extremes, making a conscious choice for one side or the other in the cosmic war between good and evil. Most dragonborn are good, but those who side with evil can be terrible villains.",
+    "alignment": "Dragonborn tend to extremes, making a conscious choice for one side or the other in the cosmic war between good and evil. Most dragonborn are good, but those who side with evil can be terrible villains.",
     "age": "Young dragonborn grow quickly. They walk hours after hatching, attain the size and development of a 10-year-old human child by the age of 3, and reach adulthood by 15. They live to be around 80.",
     "size": "Medium",
     "size_description": "Dragonborn are taller and heavier than humans, standing well over 6 feet tall and averaging almost 250 pounds. Your size is Medium.",
@@ -514,7 +514,7 @@
       }
     ],
     "alignment": "Gnomes are most often good. Those who tend toward law are sages, engineers, researchers, scholars, investigators, or inventors. Those who tend toward chaos are minstrels, tricksters, wanderers, or fanciful jewelers. Gnomes are good-hearted, and even the tricksters among them are more playful than vicious.",
-    "age": " Gnomes mature at the same rate humans do, and most are expected to settle down into an adult life by around age 40. They can live 350 to almost 500 years.",
+    "age": "Gnomes mature at the same rate humans do, and most are expected to settle down into an adult life by around age 40. They can live 350 to almost 500 years.",
     "size": "Small",
     "size_description": "Gnomes are between 3 and 4 feet tall and average about 40 pounds. Your size is Small.",
     "starting_proficiencies": [],
@@ -844,7 +844,7 @@
         "bonus": 1
       }
     ],
-    "alignment": " Half-orcs inherit a tendency toward chaos from their orc parents and are not strongly inclined toward good. Half-orcs raised among orcs and willing to live out their lives among them are usually evil.",
+    "alignment": "Half-orcs inherit a tendency toward chaos from their orc parents and are not strongly inclined toward good. Half-orcs raised among orcs and willing to live out their lives among them are usually evil.",
     "age": "Half-orcs mature a little faster than humans, reaching adulthood around age 14. They age noticeably faster and rarely live longer than 75 years.",
     "size": "Medium",
     "size_description": "Half-orcs are somewhat larger and bulkier than humans, and they range from 5 to well over 6 feet tall. Your size is Medium.",


### PR DESCRIPTION
## What does this do?
Removes some leading spaces that were present in the alignment and age descriptions of some races.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
No, not applicable.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
