### PR TITLE
High Elf Cantrip trait_specific

### DIFF
--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -405,7 +405,7 @@
         "bonus": 1
       }
     ],
-    "alignment": " Dragonborn tend to extremes, making a conscious choice for one side or the other in the cosmic war between good and evil. Most dragonborn are good, but those who side with evil can be terrible villains.",
+    "alignment": "Dragonborn tend to extremes, making a conscious choice for one side or the other in the cosmic war between good and evil. Most dragonborn are good, but those who side with evil can be terrible villains.",
     "age": "Young dragonborn grow quickly. They walk hours after hatching, attain the size and development of a 10-year-old human child by the age of 3, and reach adulthood by 15. They live to be around 80.",
     "size": "Medium",
     "size_description": "Dragonborn are taller and heavier than humans, standing well over 6 feet tall and averaging almost 250 pounds. Your size is Medium.",
@@ -514,7 +514,7 @@
       }
     ],
     "alignment": "Gnomes are most often good. Those who tend toward law are sages, engineers, researchers, scholars, investigators, or inventors. Those who tend toward chaos are minstrels, tricksters, wanderers, or fanciful jewelers. Gnomes are good-hearted, and even the tricksters among them are more playful than vicious.",
-    "age": " Gnomes mature at the same rate humans do, and most are expected to settle down into an adult life by around age 40. They can live 350 to almost 500 years.",
+    "age": "Gnomes mature at the same rate humans do, and most are expected to settle down into an adult life by around age 40. They can live 350 to almost 500 years.",
     "size": "Small",
     "size_description": "Gnomes are between 3 and 4 feet tall and average about 40 pounds. Your size is Small.",
     "starting_proficiencies": [],
@@ -844,7 +844,7 @@
         "bonus": 1
       }
     ],
-    "alignment": " Half-orcs inherit a tendency toward chaos from their orc parents and are not strongly inclined toward good. Half-orcs raised among orcs and willing to live out their lives among them are usually evil.",
+    "alignment": "Half-orcs inherit a tendency toward chaos from their orc parents and are not strongly inclined toward good. Half-orcs raised among orcs and willing to live out their lives among them are usually evil.",
     "age": "Half-orcs mature a little faster than humans, reaching adulthood around age 14. They age noticeably faster and rarely live longer than 75 years.",
     "size": "Medium",
     "size_description": "Half-orcs are somewhat larger and bulkier than humans, and they range from 5 to well over 6 feet tall. Your size is Medium.",

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -152,74 +152,13 @@
         "index": "elf-weapon-training",
         "name": "Elf Weapon Training",
         "url": "/api/traits/elf-weapon-training"
+      },
+      {
+        "index": "high-elf-cantrip",
+        "name": "High Elf Cantrip",
+        "url": "/api/traits/high-elf-cantrip"
       }
     ],
-    "racial_trait_options": {
-      "choose": 1,
-      "from": [
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Light",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Mage Hand",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Mending",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Message",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Minor Illusion",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Acid Splash",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Prestidigitation",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Ray of Frost",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Shocking Grasp",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: True Strike",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Chill Touch",
-          "url": "/api/traits/high-elf-cantrip"
-        },
-        {
-          "index": "high-elf-cantrip",
-          "name": "High Elf Cantrip: Dancing Lights",
-          "url": "/api/traits/high-elf-cantrip"
-        }
-      ],
-      "type": "trait"
-    },
     "url": "/api/subraces/high-elf"
   },
   {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -283,6 +283,74 @@
       "You know one cantrip of your choice form the wizard spell list. Intelligence is your spellcasting ability for it."
     ],
     "proficiencies": [],
+    "trait_specific": {
+      "wizard_cantrip_options": {
+        "choose": 1,
+        "from": [
+          {
+            "index": "light",
+            "name": "Light",
+            "url": "/api/spells/light"
+          },
+          {
+            "index": "mage-hand",
+            "name": "Mage Hand",
+            "url": "/api/spells/mage-hand"
+          },
+          {
+            "index": "mending",
+            "name": "Mending",
+            "url": "/api/spells/mending"
+          },
+          {
+            "index": "message",
+            "name": "Message",
+            "url": "/api/spells/message"
+          },
+          {
+            "index": "minor-illusion",
+            "name": "Minor Illusion",
+            "url": "/api/spells/minor-illusion"
+          },
+          {
+            "index": "acid-splash",
+            "name": "Acid Splash",
+            "url": "/api/spells/acid-splash"
+          },
+          {
+            "index": "prestidigitation",
+            "name": "Prestidigitation",
+            "url": "/api/spells/prestidigitation"
+          },
+          {
+            "index": "ray-of-frost",
+            "name": "Ray of Frost",
+            "url": "/api/spells/ray-of-frost"
+          },
+          {
+            "index": "shocking-grasp",
+            "name": "Shocking Grasp",
+            "url": "/api/spells/shocking-grasp"
+          },
+          {
+            "index": "true-strike",
+            "name": "True Strike",
+            "url": "/api/spells/true-strike"
+          },
+          {
+            "index": "chill-touch",
+            "name": "Chill Touch",
+            "url": "/api/spells/chill-touch"
+          },
+          {
+            "index": "dancing-lights",
+            "name": "Dancing Lights",
+            "url": "/api/spells/dancing-lights"
+          }
+        ],
+        "type": "spell"
+      }
+    },
     "url": "/api/traits/high-elf-cantrip"
   },
   {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -108,7 +108,7 @@
     "subraces": [],
     "name": "Tool Proficiency",
     "desc": [
-      "You gain proficiency with the artisan’s tools of your choice: smith’s tools, brewer’s supplies, or mason’s tools."
+      "You gain proficiency with the artisan's tools of your choice: smith's tools, brewer's supplies, or mason's tools."
     ],
     "proficiencies": [],
     "proficiency_choices": {


### PR DESCRIPTION
## What does this do?
The Elf subrace "High-Elf" has a racial trait called "High Elf Cantrip". This allows them to learn one cantrip from the wizard spell list. Currently, instead of this racial trait being included in high elf's racial_traits attribute, it's included as a choice in high-elf's racial_trait_options attribute. In this choice there are 12 APIReferences that all point back to the same trait. This is redundant and doesn't make use of the trait_specific attribute of the trait like it should.

This change corrects this by doing the following:
- Removes the racial_trait_options attribute from the High Elf subrace
- Adds the trait_specific attribute to the racial trait "high-elf-cantrip"
- Adds the trait "high-elf-cantrip" to the racial_traits attribute of the High Elf subrace

## How was it tested?
It wasn't. I really ought to find out how to run the database locally from my fork...

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
No, I intend to later tonight or tomorrow.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
