### PR TITLE
SRD Accuracy and Redundancy For Features

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1700,11 +1700,11 @@
     "name": "Circle Spells",
     "level": 5,
     "prerequisites": [],
-    "desc": [
-      "Your mystical connection to the land infuses you with the ability to cast certain spells. At 3rd, 5th, 7th, and 9th level you gain access to circle spells connected to the land where you became a druid.",
-      "Choose that land--arctic, coast, desert, forest, grassland, mountain, or swamp--and consult the associated list of spells.",
-      "Once you gain access to a circle spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day. If you gain access to a spell that doesn't appear on the druid spell list, the spell is nonetheless a druid spell for you."
-    ],
+    "parent": {
+      "index": "circle-spells-1",
+      "name": "Circle Spells",
+      "url": "/api/features/circle-spells-1"
+    },
     "url": "/api/features/circle-spells-2"
   },
   {
@@ -1743,11 +1743,11 @@
     "name": "Circle Spells",
     "level": 7,
     "prerequisites": [],
-    "desc": [
-      "Your mystical connection to the land infuses you with the ability to cast certain spells. At 3rd, 5th, 7th, and 9th level you gain access to circle spells connected to the land where you became a druid.",
-      "Choose that land--arctic, coast, desert, forest, grassland, mountain, or swamp--and consult the associated list of spells.",
-      "Once you gain access to a circle spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day. If you gain access to a spell that doesn't appear on the druid spell list, the spell is nonetheless a druid spell for you."
-    ],
+    "parent": {
+      "index": "circle-spells-1",
+      "name": "Circle Spells",
+      "url": "/api/features/circle-spells-1"
+    },
     "url": "/api/features/circle-spells-3"
   },
   {
@@ -1788,11 +1788,11 @@
     "name": "Circle Spells",
     "level": 9,
     "prerequisites": [],
-    "desc": [
-      "Your mystical connection to the land infuses you with the ability to cast certain spells. At 3rd, 5th, 7th, and 9th level you gain access to circle spells connected to the land where you became a druid.",
-      "Choose that land--arctic, coast, desert, forest, grassland, mountain, or swamp--and consult the associated list of spells.",
-      "Once you gain access to a circle spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day. If you gain access to a spell that doesn't appear on the druid spell list, the spell is nonetheless a druid spell for you."
-    ],
+    "parent": {
+      "index": "circle-spells-1",
+      "name": "Circle Spells",
+      "url": "/api/features/circle-spells-1"
+    },
     "url": "/api/features/circle-spells-4"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -795,11 +795,11 @@
     "name": "Magical Secrets",
     "level": 14,
     "prerequisites": [],
-    "desc": [
-      "By 10th level, you have plundered magical knowledge from a wide spectrum of disciplines. Choose two spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip. ",
-      "The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table. ",
-      "You learn two additional spells from any class at 14th level and again at 18th level."
-    ],
+    "parent": {
+      "index": "magical-secrets-1",
+      "name": "Magical Secrets",
+      "url": "/api/features/magical-secrets-1"
+    },
     "url": "/api/features/magical-secrets-2"
   },
   {
@@ -865,11 +865,11 @@
     "name": "Magical Secrets",
     "level": 18,
     "prerequisites": [],
-    "desc": [
-      "By 10th level, you have plundered magical knowledge from a wide spectrum of disciplines. Choose two spells from any class, including this one. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip. ",
-      "The chosen spells count as bard spells for you and are included in the number in the Spells Known column of the Bard table. ",
-      "You learn two additional spells from any class at 14th level and again at 18th level."
-    ],
+    "parent": {
+      "index": "magical-secrets-1",
+      "name": "Magical Secrets",
+      "url": "/api/features/magical-secrets-1"
+    },
     "url": "/api/features/magical-secrets-3"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1041,10 +1041,11 @@
     "name": "Domain Spells",
     "level": 3,
     "prerequisites": [],
-    "desc": [
-      "Each domain has a list of spells--its domain spells--that you gain at the cleric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.",
-      "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
-    ],
+    "parent": {
+      "index": "domain-spells-1",
+      "name": "Domain Spells",
+      "url": "/api/features/domain-spells-1"
+    },
     "url": "/api/features/domain-spells-2"
   },
   {
@@ -1057,10 +1058,11 @@
     "name": "Domain Spells",
     "level": 5,
     "prerequisites": [],
-    "desc": [
-      "Each domain has a list of spells--its domain spells--that you gain at the cleric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.",
-      "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
-    ],
+    "parent": {
+      "index": "domain-spells-1",
+      "name": "Domain Spells",
+      "url": "/api/features/domain-spells-1"
+    },
     "url": "/api/features/domain-spells-3"
   },
   {
@@ -1123,10 +1125,11 @@
     "name": "Domain Spells",
     "level": 7,
     "prerequisites": [],
-    "desc": [
-      "Each domain has a list of spells--its domain spells--that you gain at the cleric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.",
-      "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
-    ],
+    "parent": {
+      "index": "domain-spells-1",
+      "name": "Domain Spells",
+      "url": "/api/features/domain-spells-1"
+    },
     "url": "/api/features/domain-spells-4"
   },
   {
@@ -1174,10 +1177,11 @@
     "name": "Domain Spells",
     "level": 9,
     "prerequisites": [],
-    "desc": [
-      "Each domain has a list of spells--its domain spells--that you gain at the cleric levels noted in the domain description. Once you gain a domain spell, you always have it prepared, and it doesn't count against the number of spells you can prepare each day.",
-      "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
-    ],
+    "parent": {
+      "index": "domain-spells-1",
+      "name": "Domain Spells",
+      "url": "/api/features/domain-spells-1"
+    },
     "url": "/api/features/domain-spells-5"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -101,21 +101,6 @@
     "url": "/api/features/frenzy"
   },
   {
-    "index": "barbarian-ability-score-improvement-1",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-1"
-  },
-  {
     "index": "barbarian-extra-attack",
     "class": {
       "index": "barbarian",
@@ -182,21 +167,6 @@
     "url": "/api/features/feral-instinct"
   },
   {
-    "index": "barbarian-ability-score-improvement-2",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-2"
-  },
-  {
     "index": "brutal-critical-1-die",
     "class": {
       "index": "barbarian",
@@ -249,21 +219,6 @@
     "url": "/api/features/relentless-rage"
   },
   {
-    "index": "barbarian-ability-score-improvement-3",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-3"
-  },
-  {
     "index": "brutal-critical-2-dice",
     "class": {
       "index": "barbarian",
@@ -314,21 +269,6 @@
     "url": "/api/features/persistent-rage"
   },
   {
-    "index": "barbarian-ability-score-improvement-4",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-4"
-  },
-  {
     "index": "brutal-critical-3-dice",
     "class": {
       "index": "barbarian",
@@ -357,21 +297,6 @@
       "Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total."
     ],
     "url": "/api/features/indomitable-might"
-  },
-  {
-    "index": "barbarian-ability-score-improvement-5",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-5"
   },
   {
     "index": "primal-champion",
@@ -623,21 +548,6 @@
     "url": "/api/features/bard-expertise-1"
   },
   {
-    "index": "bard-ability-score-improvement-1",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-1"
-  },
-  {
     "index": "bardic-inspiration-d8",
     "class": {
       "index": "bard",
@@ -703,21 +613,6 @@
       "At 6th level, you learn two spells of your choice from any class. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip. The chosen spells count as bard spells for you but don't count against the number of bard spells you know."
     ],
     "url": "/api/features/additional-magical-secrets"
-  },
-  {
-    "index": "bard-ability-score-improvement-2",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-2"
   },
   {
     "index": "song-of-rest-d8",
@@ -875,21 +770,6 @@
     "url": "/api/features/magical-secrets-1"
   },
   {
-    "index": "bard-ability-score-improvement-3",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-3"
-  },
-  {
     "index": "song-of-rest-d10",
     "class": {
       "index": "bard",
@@ -960,21 +840,6 @@
     "url": "/api/features/bardic-inspiration-d12"
   },
   {
-    "index": "bard-ability-score-improvement-4",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-4"
-  },
-  {
     "index": "song-of-rest-d12",
     "class": {
       "index": "bard",
@@ -1006,21 +871,6 @@
       "You learn two additional spells from any class at 14th level and again at 18th level."
     ],
     "url": "/api/features/magical-secrets-3"
-  },
-  {
-    "index": "bard-ability-score-improvement-5",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-5"
   },
   {
     "index": "superior-inspiration",
@@ -1198,21 +1048,6 @@
     "url": "/api/features/domain-spells-2"
   },
   {
-    "index": "cleric-ability-score-improvement-1",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-1"
-  },
-  {
     "index": "domain-spells-3",
     "class": {
       "index": "cleric",
@@ -1293,21 +1128,6 @@
       "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
     ],
     "url": "/api/features/domain-spells-4"
-  },
-  {
-    "index": "cleric-ability-score-improvement-2",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-2"
   },
   {
     "index": "destroy-undead-cr-1-or-below",
@@ -1394,21 +1214,6 @@
     "url": "/api/features/destroy-undead-cr-2-or-below"
   },
   {
-    "index": "cleric-ability-score-improvement-3",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-3"
-  },
-  {
     "index": "destroy-undead-cr-3-or-below",
     "class": {
       "index": "cleric",
@@ -1422,21 +1227,6 @@
       "Starting at 5th level, when an undead fails its saving throw against your Turn Undead feature, the creature is instantly destroyed if its challenge rating is at or below a certain threshold."
     ],
     "url": "/api/features/destroy-undead-cr-3-or-below"
-  },
-  {
-    "index": "cleric-ability-score-improvement-4",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-4"
   },
   {
     "index": "destroy-undead-cr-4-or-below",
@@ -1482,21 +1272,6 @@
       "Beginning at 6th level, you can use your Channel Divinity twice between rests, and beginning at 18th level, you can use it three times between rests. When you finish a short or long rest, you regain your expended uses."
     ],
     "url": "/api/features/channel-divinity-3-rest"
-  },
-  {
-    "index": "cleric-ability-score-improvement-5",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-5"
   },
   {
     "index": "divine-intervention-improvement",
@@ -1907,21 +1682,6 @@
     "url": "/api/features/wild-shape-cr-1-2-or-below-no-flying-speed"
   },
   {
-    "index": "druid-ability-score-improvement-1",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-1"
-  },
-  {
     "index": "circle-spells-2",
     "class": {
       "index": "druid",
@@ -2010,21 +1770,6 @@
     "url": "/api/features/wild-shape-cr-1-or-below"
   },
   {
-    "index": "druid-ability-score-improvement-2",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-2"
-  },
-  {
     "index": "circle-spells-4",
     "class": {
       "index": "druid",
@@ -2067,21 +1812,6 @@
     "url": "/api/features/natures-ward"
   },
   {
-    "index": "druid-ability-score-improvement-3",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-3"
-  },
-  {
     "index": "natures-sanctuary",
     "class": {
       "index": "druid",
@@ -2100,21 +1830,6 @@
       "When you reach 14th level, creatures of the natural world sense your connection to nature and become hesitant to attack you. When a beast or plant creature attacks you, that creature must make a Wisdom saving throw against your druid spell save DC. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you."
     ],
     "url": "/api/features/natures-sanctuary"
-  },
-  {
-    "index": "druid-ability-score-improvement-4",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-4"
   },
   {
     "index": "druid-timeless-body",
@@ -2145,21 +1860,6 @@
       "Beginning at 18th level, you can cast many of your druid spells in any shape you assume using Wild Shape. You can perform the somatic and verbal components of a druid spell while in a beast shape, but you aren't able to provide material components."
     ],
     "url": "/api/features/beast-spells"
-  },
-  {
-    "index": "druid-ability-score-improvement-5",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-5"
   },
   {
     "index": "archdruid",
@@ -2423,7 +2123,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -2453,7 +2153,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 6,
     "prerequisites": [],
     "desc": [
@@ -2488,7 +2188,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -2591,7 +2291,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -2621,7 +2321,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 14,
     "prerequisites": [],
     "desc": [
@@ -2656,7 +2356,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -2722,7 +2422,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 7",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -2915,21 +2615,6 @@
     "url": "/api/features/open-hand-technique"
   },
   {
-    "index": "monk-ability-score-improvement-1",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-1"
-  },
-  {
     "index": "slow-fall",
     "class": {
       "index": "monk",
@@ -3040,21 +2725,6 @@
     "url": "/api/features/stillness-of-mind"
   },
   {
-    "index": "monk-ability-score-improvement-2",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-2"
-  },
-  {
     "index": "unarmored-movement-2",
     "class": {
       "index": "monk",
@@ -3106,21 +2776,6 @@
     "url": "/api/features/tranquility"
   },
   {
-    "index": "monk-ability-score-improvement-3",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-3"
-  },
-  {
     "index": "tongue-of-the-sun-and-moon",
     "class": {
       "index": "monk",
@@ -3167,21 +2822,6 @@
     "url": "/api/features/monk-timeless-body"
   },
   {
-    "index": "monk-ability-score-improvement-4",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-4"
-  },
-  {
     "index": "quivering-palm",
     "class": {
       "index": "monk",
@@ -3217,21 +2857,6 @@
       "Additionally, you can spend 8 ki points to cast the astral projection spell, without needing material components. When you do so, you can't take any other creatures with you."
     ],
     "url": "/api/features/empty-body"
-  },
-  {
-    "index": "monk-ability-score-improvement-5",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-5"
   },
   {
     "index": "perfect-self",
@@ -3543,21 +3168,6 @@
     "url": "/api/features/channel-divinity-turn-the-unholy"
   },
   {
-    "index": "paladin-ability-score-improvement-1",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-1"
-  },
-  {
     "index": "paladin-extra-attack",
     "class": {
       "index": "paladin",
@@ -3610,21 +3220,6 @@
     "url": "/api/features/aura-of-devotion"
   },
   {
-    "index": "paladin-ability-score-improvement-2",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-2"
-  },
-  {
     "index": "aura-of-courage",
     "class": {
       "index": "paladin",
@@ -3654,21 +3249,6 @@
       "By 11th level, you are so suffused with righteous might that all your melee weapon strikes carry divine power with them. Whenever you hit a creature with a melee weapon, the creature takes an extra 1d8 radiant damage. If you also use your Divine Smite with an attack, you add this damage to the extra damage of your Divine Smite."
     ],
     "url": "/api/features/improved-divine-smite"
-  },
-  {
-    "index": "paladin-ability-score-improvement-3",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-3"
   },
   {
     "index": "cleansing-touch",
@@ -3707,21 +3287,6 @@
     "url": "/api/features/purity-of-spirit"
   },
   {
-    "index": "paladin-ability-score-improvement-4",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-4"
-  },
-  {
     "index": "aura-improvements",
     "class": {
       "index": "paladin",
@@ -3735,21 +3300,6 @@
       "At 18th level, the range of your auras increase to 30 feet."
     ],
     "url": "/api/features/aura-improvements"
-  },
-  {
-    "index": "paladin-ability-score-improvement-5",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-5"
   },
   {
     "index": "holy-nimbus",
@@ -4106,21 +3656,6 @@
     "url": "/api/features/primeval-awareness"
   },
   {
-    "index": "ranger-ability-score-improvement-1",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-1"
-  },
-  {
     "index": "ranger-extra-attack",
     "class": {
       "index": "ranger",
@@ -4299,21 +3834,6 @@
     "url": "/api/features/defensive-tactics-steel-will"
   },
   {
-    "index": "ranger-ability-score-improvement-2",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-2"
-  },
-  {
     "index": "ranger-lands-stride",
     "class": {
       "index": "ranger",
@@ -4457,21 +3977,6 @@
       "url": "/api/features/multiattack"
     },
     "url": "/api/features/multiattack-whirlwind-attack"
-  },
-  {
-    "index": "ranger-ability-score-improvement-3",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-3"
   },
   {
     "index": "favored-enemy-3-enemies",
@@ -4629,21 +4134,6 @@
     "url": "/api/features/superior-hunters-defense-uncanny-dodge"
   },
   {
-    "index": "ranger-ability-score-improvement-4",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-4"
-  },
-  {
     "index": "feral-senses",
     "class": {
       "index": "ranger",
@@ -4658,21 +4148,6 @@
       "You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn't hidden from you and you aren't blinded or deafened."
     ],
     "url": "/api/features/feral-senses"
-  },
-  {
-    "index": "ranger-ability-score-improvement-5",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-5"
   },
   {
     "index": "foe-slayer",
@@ -4919,7 +4394,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -5079,7 +4554,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -5114,7 +4589,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -5144,7 +4619,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -5209,7 +4684,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -5259,7 +4734,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -5951,21 +5426,6 @@
     "url": "/api/features/metamagic-twinned-spell"
   },
   {
-    "index": "sorcerer-ability-score-improvement-1",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-1"
-  },
-  {
     "index": "elemental-affinity",
     "class": {
       "index": "sorcerer",
@@ -5985,21 +5445,6 @@
     ],
     "reference": "/api/subclasses/draconic",
     "url": "/api/features/elemental-affinity"
-  },
-  {
-    "index": "sorcerer-ability-score-improvement-2",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-2"
   },
   {
     "index": "metamagic-2",
@@ -6067,21 +5512,6 @@
     "url": "/api/features/metamagic-2"
   },
   {
-    "index": "sorcerer-ability-score-improvement-3",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-3"
-  },
-  {
     "index": "dragon-wings",
     "class": {
       "index": "sorcerer",
@@ -6101,21 +5531,6 @@
       "You can't manifest your wings while wearing armor unless the armor is made to accommodate them, and clothing not made to accommodate your wings might be destroyed when you manifest them."
     ],
     "url": "/api/features/dragon-wings"
-  },
-  {
-    "index": "sorcerer-ability-score-improvement-4",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-4"
   },
   {
     "index": "metamagic-3",
@@ -6201,21 +5616,6 @@
       "Beginning at 18th level, you can channel the dread presence of your dragon ancestor, causing those around you to become awestruck or frightened. As an action, you can spend 5 sorcery points to draw on this power and exude an aura of awe or fear (your choice) to a distance of 60 feet. For 1 minute or until you lose your concentration (as if you were casting a concentration spell), each hostile creature that starts its turn in this aura must succeed on a Wisdom saving throw or be charmed (if you chose awe) or frightened (if you chose fear) until the aura ends. A creature that succeeds on this saving throw is immune to your aura for 24 hours."
     ],
     "url": "/api/features/draconic-presence"
-  },
-  {
-    "index": "sorcerer-ability-score-improvement-5",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-5"
   },
   {
     "index": "sorcerous-restoration",
@@ -7254,21 +6654,6 @@
     "url": "/api/features/pact-of-the-tome"
   },
   {
-    "index": "warlock-ability-score-improvement-1",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-1"
-  },
-  {
     "index": "additional-eldritch-invocation-1",
     "class": {
       "index": "warlock",
@@ -7500,21 +6885,6 @@
     "url": "/api/features/additional-eldritch-invocation-2"
   },
   {
-    "index": "warlock-ability-score-improvement-2",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-2"
-  },
-  {
     "index": "additional-eldritch-invocation-3",
     "class": {
       "index": "warlock",
@@ -7655,21 +7025,6 @@
       "At higher levels, you gain more warlock spells of your choice that can be cast in this way: one 7th- level spell at 13th level, one 8th-level spell at 15th level, and one 9th-level spell at 17th level. You regain all uses of your Mystic Arcanum when you finish a long rest."
     ],
     "url": "/api/features/mystic-arcanum-6th-level"
-  },
-  {
-    "index": "warlock-ability-score-improvement-3",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-3"
   },
   {
     "index": "additional-eldritch-invocation-4",
@@ -7938,21 +7293,6 @@
     "url": "/api/features/additional-eldritch-invocation-5"
   },
   {
-    "index": "warlock-ability-score-improvement-4",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-4"
-  },
-  {
     "index": "mystic-arcanum-9th-level",
     "class": {
       "index": "warlock",
@@ -8073,21 +7413,6 @@
       }
     },
     "url": "/api/features/additional-eldritch-invocation-6"
-  },
-  {
-    "index": "warlock-ability-score-improvement-5",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-5"
   },
   {
     "index": "eldritch-master",
@@ -8299,19 +7624,61 @@
     "url": "/api/features/sculpt-spells"
   },
   {
-    "index": "wizard-ability-score-improvement-1",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 1",
+    "index": "ability-score-improvement-1",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-1"
+    "url": "/api/features/ability-score-improvement-1"
   },
   {
     "index": "potent-cantrip",
@@ -8334,19 +7701,61 @@
     "url": "/api/features/potent-cantrip"
   },
   {
-    "index": "wizard-ability-score-improvement-2",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 2",
+    "index": "ability-score-improvement-2",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-2"
+    "url": "/api/features/ability-score-improvement-2"
   },
   {
     "index": "empowered-evocation",
@@ -8369,19 +7778,61 @@
     "url": "/api/features/empowered-evocation"
   },
   {
-    "index": "wizard-ability-score-improvement-3",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 3",
+    "index": "ability-score-improvement-3",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-3"
+    "url": "/api/features/ability-score-improvement-3"
   },
   {
     "index": "overchannel",
@@ -8405,19 +7856,61 @@
     "url": "/api/features/overchannel"
   },
   {
-    "index": "wizard-ability-score-improvement-4",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 4",
+    "index": "ability-score-improvement-4",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-4"
+    "url": "/api/features/ability-score-improvement-4"
   },
   {
     "index": "spell-mastery",
@@ -8436,19 +7929,61 @@
     "url": "/api/features/spell-mastery"
   },
   {
-    "index": "wizard-ability-score-improvement-5",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 5",
+    "index": "ability-score-improvement-5",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-5"
+    "url": "/api/features/ability-score-improvement-5"
   },
   {
     "index": "signature-spell",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1652,7 +1652,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 1",
+    "name": "Circle Spells",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -1697,7 +1697,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 2",
+    "name": "Circle Spells",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -1740,7 +1740,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 3",
+    "name": "Circle Spells",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -1785,7 +1785,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 4",
+    "name": "Circle Spells",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2142,7 +2142,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Extra Attack (1)",
+    "name": "Extra Attack",
     "level": 5,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -759,7 +759,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 1",
+    "name": "Magical Secrets",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -792,7 +792,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 2",
+    "name": "Magical Secrets",
     "level": 14,
     "prerequisites": [],
     "desc": [
@@ -862,7 +862,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 3",
+    "name": "Magical Secrets",
     "level": 18,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2287,9 +2287,11 @@
     "name": "Extra Attack (2)",
     "level": 11,
     "prerequisites": [],
-    "desc": [
-      "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn. The number of attacks increases to three when you reach 11th level in this class and to four when you reach 20th level in this class."
-    ],
+    "parent": {
+      "index": "extra-attack-1",
+      "name": "Extra Attack",
+      "url": "/api/features/extra-attack-1"
+    },
     "url": "/api/features/extra-attack-2"
   },
   {
@@ -2456,9 +2458,11 @@
     "name": "Extra Attack (3)",
     "level": 20,
     "prerequisites": [],
-    "desc": [
-      "Beginning at 5th level, you can attack twice, instead of once, whenever you take the Attack action on your turn. The number of attacks increases to three when you reach 11th level in this class and to four when you reach 20th level in this class."
-    ],
+    "parent": {
+      "index": "extra-attack-1",
+      "name": "Extra Attack",
+      "url": "/api/features/extra-attack-1"
+    },
     "url": "/api/features/extra-attack-3"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -516,7 +516,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Expertise 1",
+    "name": "Expertise",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -759,7 +759,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Expertise 2",
+    "name": "Expertise",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -4699,7 +4699,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Expertise 1",
+    "name": "Expertise",
     "level": 1,
     "prerequisites": [],
     "desc": [
@@ -4952,7 +4952,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Expertise 2",
+    "name": "Expertise",
     "level": 6,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6018,6 +6018,11 @@
     "name": "Metamagic",
     "level": 10,
     "prerequisites": [],
+    "parent": {
+      "index": "metamagic-1",
+      "name": "Metamagic",
+      "url": "/api/features/metamagic-1"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -6129,6 +6134,11 @@
     "name": "Metamagic",
     "level": 17,
     "prerequisites": [],
+    "parent": {
+      "index": "metamagic-1",
+      "name": "Metamagic",
+      "url": "/api/features/metamagic-1"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6694,11 +6694,11 @@
     "name": "Eldritch Invocations",
     "level": 5,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -6820,11 +6820,11 @@
     "name": "Eldritch Invocations",
     "level": 7,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -6925,11 +6925,11 @@
     "name": "Eldritch Invocations",
     "level": 9,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -7067,11 +7067,11 @@
     "name": "Eldritch Invocations",
     "level": 12,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -7228,11 +7228,11 @@
     "name": "Eldritch Invocations",
     "level": 15,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -7350,11 +7350,11 @@
     "name": "Eldritch Invocations",
     "level": 18,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -7471,11 +7471,11 @@
     "name": "Eldritch Invocations",
     "level": 20,
     "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
+    "parent": {
+      "index": "eldritch-invocations-1",
+      "name": "Eldritch Invocations",
+      "url": "/api/features/eldritch-invocations"
+    },
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -926,7 +926,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 1",
+    "name": "Domain Spells",
     "level": 1,
     "prerequisites": [],
     "desc": [
@@ -1038,7 +1038,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 2",
+    "name": "Domain Spells",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -1054,7 +1054,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 3",
+    "name": "Domain Spells",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -1120,7 +1120,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 4",
+    "name": "Domain Spells",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -1171,7 +1171,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 5",
+    "name": "Domain Spells",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2156,9 +2156,11 @@
     "name": "Ability Score Improvement",
     "level": 6,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-2"
   },
   {
@@ -2191,9 +2193,11 @@
     "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-3"
   },
   {
@@ -2294,9 +2298,11 @@
     "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-4"
   },
   {
@@ -2324,9 +2330,11 @@
     "name": "Ability Score Improvement",
     "level": 14,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-5"
   },
   {
@@ -2359,9 +2367,11 @@
     "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-6"
   },
   {
@@ -2425,9 +2435,11 @@
     "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 6th, 8th, 12th, 14th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "fighter-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/fighter-ability-score-improvement-1"
+    },
     "url": "/api/features/fighter-ability-score-improvement-7"
   },
   {
@@ -4557,9 +4569,11 @@
     "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "rogue-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/rogue-ability-score-improvement-1"
+    },
     "url": "/api/features/rogue-ability-score-improvement-2"
   },
   {
@@ -4592,9 +4606,11 @@
     "name": "Ability Score Improvement",
     "level": 10,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "rogue-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/rogue-ability-score-improvement-1"
+    },
     "url": "/api/features/rogue-ability-score-improvement-3"
   },
   {
@@ -4622,9 +4638,11 @@
     "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "rogue-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/rogue-ability-score-improvement-1"
+    },
     "url": "/api/features/rogue-ability-score-improvement-4"
   },
   {
@@ -4687,9 +4705,11 @@
     "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "rogue-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/rogue-ability-score-improvement-1"
+    },
     "url": "/api/features/rogue-ability-score-improvement-5"
   },
   {
@@ -4737,9 +4757,11 @@
     "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "rogue-ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/rogue-ability-score-improvement-1"
+    },
     "url": "/api/features/rogue-ability-score-improvement-6"
   },
   {
@@ -7752,9 +7774,11 @@
     "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/ability-score-improvement-1"
+    },
     "url": "/api/features/ability-score-improvement-2"
   },
   {
@@ -7829,9 +7853,11 @@
     "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/ability-score-improvement-1"
+    },
     "url": "/api/features/ability-score-improvement-3"
   },
   {
@@ -7907,9 +7933,11 @@
     "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/ability-score-improvement-1"
+    },
     "url": "/api/features/ability-score-improvement-4"
   },
   {
@@ -7980,9 +8008,11 @@
     "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
+    "parent": {
+      "index": "ability-score-improvement-1",
+      "name": "Ability Score Improvement",
+      "url": "/api/features/ability-score-improvement-1"
+    },
     "url": "/api/features/ability-score-improvement-5"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5715,7 +5715,7 @@
     "url": "/api/features/pact-magic"
   },
   {
-    "index": "eldritch-invocations",
+    "index": "eldritch-invocations-1",
     "class": {
       "index": "warlock",
       "name": "Warlock",
@@ -5838,7 +5838,7 @@
       "When you cast eldritch blast, add your Charisma modifier to the damage it deals on a hit."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5858,7 +5858,7 @@
       "You can cast mage armor on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5878,7 +5878,7 @@
       "You can cast speak with animals at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5898,7 +5898,7 @@
       "You gain proficiency in the Deception and Persuasion skills."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5924,7 +5924,7 @@
       "On your adventures, you can add other ritual spells to your Book of Shadows. When you find such a spell, you can add it to the book if the spell's level is equal to or less than half your warlock level (rounded up) and if you can spare the time to transcribe the spell. For each level of the spell, the transcription process takes 2 hours and costs 50 gp for the rare inks needed to inscribe it."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5944,7 +5944,7 @@
       "You can see normally in darkness, both magical and nonmagical, to a distance of 120 feet."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5964,7 +5964,7 @@
       "You can cast detect magic at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -5989,7 +5989,7 @@
       "When you cast eldritch blast, its range is 300 feet."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6009,7 +6009,7 @@
       "You can read all writing."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6029,7 +6029,7 @@
       "You can cast false life on yourself at will as a 1st-level spell, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6049,7 +6049,7 @@
       "You can use your action to touch a willing humanoid and perceive through its senses until the end of your next turn. As long as the creature is on the same plane of existence as you, you can use your action on subsequent turns to maintain this connection, extending the duration until the end of your next turn. While perceiving through the other creature's senses, you benefit from any special senses possessed by that creature, and you are blinded and deafened to your own surroundings."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6069,7 +6069,7 @@
       "You can cast disguise self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6089,7 +6089,7 @@
       "You can cast silent image at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6114,7 +6114,7 @@
       "When you hit a creature with eldritch blast, you can push the creature up to 10 feet away from you in a straight line."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6134,7 +6134,7 @@
       "You can cast bane once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6160,7 +6160,7 @@
       "Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6185,7 +6185,7 @@
       "You can cast slow once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6210,7 +6210,7 @@
       "When you are in an area of dim light or darkness, you can use your action to become invisible until you move or take an action or a reaction."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6235,7 +6235,7 @@
       "You can cast bestow curse once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6264,7 +6264,7 @@
       "You can attack with your pact weapon twice, instead of once, whenever you take the Attack action on your turn."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6289,7 +6289,7 @@
       "You can cast compulsion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6314,7 +6314,7 @@
       "You can cast confusion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6339,7 +6339,7 @@
       "You can cast polymorph once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6364,7 +6364,7 @@
       "You can cast levitate on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6389,7 +6389,7 @@
       "You can cast conjure elemental once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6414,7 +6414,7 @@
       "You can cast jump on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6439,7 +6439,7 @@
       "You can cast speak with dead at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6468,7 +6468,7 @@
       "When you hit a creature with your pact weapon, the creature takes extra necrotic damage equal to your Charisma modifier (minimum 1)."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6497,7 +6497,7 @@
       "You can cast hold monster at will--targeting a celestial, fiend, or elemental--without expending a spell slot or material components. You must finish a long rest before you can use this invocation on the same creature again."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6522,7 +6522,7 @@
       "You can cast alter self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6547,7 +6547,7 @@
       "You can cast arcane eye at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6572,7 +6572,7 @@
       "You can see the true form of any shapechanger or creature concealed by illusion or transmutation magic while the creature is within 30 feet of you and within line of sight."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6685,13 +6685,13 @@
     "url": "/api/features/pact-of-the-tome"
   },
   {
-    "index": "additional-eldritch-invocation-1",
+    "index": "eldritch-invocations-2",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -6787,7 +6787,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-1"
+    "url": "/api/features/eldritch-invocations-2"
   },
   {
     "index": "dark-ones-own-luck",
@@ -6811,13 +6811,13 @@
     "url": "/api/features/dark-ones-own-luck"
   },
   {
-    "index": "additional-eldritch-invocation-2",
+    "index": "eldritch-invocations-3",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -6913,16 +6913,16 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-2"
+    "url": "/api/features/eldritch-invocations-3"
   },
   {
-    "index": "additional-eldritch-invocation-3",
+    "index": "eldritch-invocations-4",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 9,
     "prerequisites": [],
     "desc": [
@@ -7018,7 +7018,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-3"
+    "url": "/api/features/eldritch-invocations-4"
   },
   {
     "index": "fiendish-resilience",
@@ -7058,13 +7058,13 @@
     "url": "/api/features/mystic-arcanum-6th-level"
   },
   {
-    "index": "additional-eldritch-invocation-4",
+    "index": "eldritch-invocations-5",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -7160,7 +7160,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-4"
+    "url": "/api/features/eldritch-invocations-5"
   },
   {
     "index": "mystic-arcanum-7th-level",
@@ -7219,13 +7219,13 @@
     "url": "/api/features/mystic-arcanum-8th-level"
   },
   {
-    "index": "additional-eldritch-invocation-5",
+    "index": "eldritch-invocations-6",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 15,
     "prerequisites": [],
     "desc": [
@@ -7321,7 +7321,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-5"
+    "url": "/api/features/eldritch-invocations-6"
   },
   {
     "index": "mystic-arcanum-9th-level",
@@ -7341,13 +7341,13 @@
     "url": "/api/features/mystic-arcanum-9th-level"
   },
   {
-    "index": "additional-eldritch-invocation-6",
+    "index": "eldritch-invocations-7",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 18,
     "prerequisites": [],
     "desc": [
@@ -7443,7 +7443,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-6"
+    "url": "/api/features/eldritch-invocations-7"
   },
   {
     "index": "eldritch-master",
@@ -7462,13 +7462,13 @@
     "url": "/api/features/eldritch-master"
   },
   {
-    "index": "additional-eldritch-invocation-7",
+    "index": "eldritch-invocations-8",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 20,
     "prerequisites": [],
     "desc": [
@@ -7564,7 +7564,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-7"
+    "url": "/api/features/eldritch-invocations-8"
   },
   {
     "index": "spellcasting-wizard",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5731,7 +5731,7 @@
     "url": "/api/features/flexible-casting-converting-spell-slot"
   },
   {
-    "index": "metamagic",
+    "index": "metamagic-1",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
@@ -5792,7 +5792,7 @@
         ]
       }
     },
-    "url": "/api/features/metamagic"
+    "url": "/api/features/metamagic-1"
   },
   {
     "index": "metamagic-careful-spell",
@@ -5808,9 +5808,9 @@
       "When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-careful-spell"
   },
@@ -5831,7 +5831,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-distant-spell"
   },
@@ -5852,7 +5852,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-empowered-spell"
   },
@@ -5872,7 +5872,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-extended-spell"
   },
@@ -5892,7 +5892,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-heightened-spell"
   },
@@ -5912,7 +5912,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-quickened-spell"
   },
@@ -5932,7 +5932,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-subtle-spell"
   },
@@ -6004,13 +6004,13 @@
     "url": "/api/features/sorcerer-ability-score-improvement-2"
   },
   {
-    "index": "additional-metamagic-1",
+    "index": "metamagic-2",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Additional Metamagic",
+    "name": "Metamagic",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -6065,7 +6065,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-metamagic-1"
+    "url": "/api/features/metamagic-2"
   },
   {
     "index": "sorcerer-ability-score-improvement-3",
@@ -6119,13 +6119,13 @@
     "url": "/api/features/sorcerer-ability-score-improvement-4"
   },
   {
-    "index": "additional-metamagic-2",
+    "index": "metamagic-3",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Additional Metamagic",
+    "name": "Metamagic",
     "level": 17,
     "prerequisites": [],
     "desc": [
@@ -6180,7 +6180,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-metamagic-2"
+    "url": "/api/features/metamagic-3"
   },
   {
     "index": "draconic-presence",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2750,10 +2750,11 @@
     "name": "Unarmored Movement",
     "level": 9,
     "prerequisites": [],
-    "desc": [
-      "Starting at 2nd level, your speed increases by 10 feet while you are not wearing armor or wielding a shield. This bonus increases when you reach certain monk levels, as shown in Table: The Monk.",
-      "At 9th level, you gain the ability to move along vertical surfaces and across liquids on your turn without falling during the move."
-    ],
+    "parent": {
+      "index": "unarmored-movement-1",
+      "name": "Unarmored Movement",
+      "url": "/api/features/unarmored-movement-1"
+    },
     "url": "/api/features/unarmored-movement-2"
   },
   {

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2567,7 +2567,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Unarmored Movement 1",
+    "name": "Unarmored Movement",
     "level": 2,
     "prerequisites": [],
     "desc": [
@@ -2747,7 +2747,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Unarmored Movement 2",
+    "name": "Unarmored Movement",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5829,7 +5829,7 @@
       "When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5850,7 +5850,7 @@
       "You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5870,7 +5870,7 @@
       "When you cast a spell that has a duration of 1 minute or longer, you can spend 1 sorcery point to double its duration, to a maximum duration of 24 hours."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5890,7 +5890,7 @@
       "When you cast a spell that forces a creature to make a saving throw to resist its effects, you can spend 3 sorcery points to give one target of the spell disadvantage on its first saving throw made against the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5910,7 +5910,7 @@
       "When you cast a spell that has a casting time of 1 action, you can spend 2 sorcery points to change the casting time to 1 bonus action for this casting."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5930,7 +5930,7 @@
       "When you cast a spell, you can spend 1 sorcery point to cast it without any somatic or verbal components."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5950,6 +5950,11 @@
       "When you cast a spell that targets only one creature and doesn't have a range of self, you can spend a number of sorcery points equal to the spell's level to target a second creature in range with the same spell (1 sorcery point if the spell is a cantrip).",
       "To be eligible, a spell must be incapable of targeting more than one creature at the spell's current level. For example, magic missile and scorching ray aren't eligible, but ray of frost and chromatic orb are."
     ],
+    "parent": {
+      "index": "metamagic-1",
+      "name": "Metamagic",
+      "url": "/api/features/metamagic-1"
+    },
     "url": "/api/features/metamagic-twinned-spell"
   },
   {
@@ -6013,10 +6018,6 @@
     "name": "Metamagic",
     "level": 10,
     "prerequisites": [],
-    "desc": [
-      "At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level.",
-      "You can use only one Metamagic option on a spell when you cast it, unless otherwise noted."
-    ],
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,
@@ -6128,10 +6129,6 @@
     "name": "Metamagic",
     "level": 17,
     "prerequisites": [],
-    "desc": [
-      "At 3rd level, you gain the ability to twist your spells to suit your needs. You gain two of the following Metamagic options of your choice. You gain another one at 10th and 17th level.",
-      "You can use only one Metamagic option on a spell when you cast it, unless otherwise noted."
-    ],
     "feature_specific": {
       "subfeature_options": {
         "choose": 1,

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -762,9 +762,6 @@
     "name": "Expertise",
     "level": 10,
     "prerequisites": [],
-    "desc": [
-      "At 3rd level, choose two of your skill proficiencies. Your proficiency bonus is doubled for any ability check you make that uses either of the chosen proficiencies. At 10th level, you can choose another two skill proficiencies to gain this benefit."
-    ],
     "feature_specific": {
       "expertise_options": {
         "choose": 2,
@@ -4955,10 +4952,6 @@
     "name": "Expertise",
     "level": 6,
     "prerequisites": [],
-    "desc": [
-      "At 1st level, choose two of your skill proficiencies, or one of your skill proficiencies and your proficiency with thieves' tools. Your proficiency bonus is doubled for any ability check you make that uses either of the chosen proficiencies.",
-      "At 6th level, you can choose two more of your proficiencies (in skills or with thieves' tools) to gain this benefit"
-    ],
     "feature_specific": {
       "expertise_options": {
         "choose": 2,

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -1334,7 +1334,7 @@
       },
       {
         "index": "domain-spells-1",
-        "name": "Domain Spells 1",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-1"
       }
     ],
@@ -1413,7 +1413,7 @@
     "features": [
       {
         "index": "domain-spells-2",
-        "name": "Domain Spells 2",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-2"
       }
     ],
@@ -1487,7 +1487,7 @@
     "features": [
       {
         "index": "domain-spells-3",
-        "name": "Domain Spells 3",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-3"
       },
       {
@@ -1566,7 +1566,7 @@
     "features": [
       {
         "index": "domain-spells-4",
-        "name": "Domain Spells 4",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-4"
       }
     ],
@@ -1645,7 +1645,7 @@
     "features": [
       {
         "index": "domain-spells-5",
-        "name": "Domain Spells 5",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-5"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -91,9 +91,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "barbarian-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/barbarian-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "class_specific": {
@@ -190,9 +190,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "barbarian-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/barbarian-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "class_specific": {
@@ -284,9 +284,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "barbarian-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/barbarian-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "class_specific": {
@@ -378,9 +378,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "barbarian-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/barbarian-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "class_specific": {
@@ -453,9 +453,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "barbarian-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/barbarian-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "class_specific": {
@@ -639,9 +639,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "bard-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/bard-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -798,9 +798,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "bard-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/bard-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -963,9 +963,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "bard-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/bard-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -1123,9 +1123,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "bard-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/bard-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -1243,9 +1243,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "bard-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/bard-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -1449,9 +1449,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "cleric-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/cleric-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -1602,9 +1602,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "cleric-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/cleric-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       },
       {
         "index": "destroy-undead-cr-1-or-below",
@@ -1755,9 +1755,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "cleric-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/cleric-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -1891,9 +1891,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "cleric-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/cleric-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -2002,9 +2002,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "cleric-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/cleric-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -2196,9 +2196,9 @@
         "url": "/api/features/wild-shape-cr-1-2-or-below-no-flying-speed"
       },
       {
-        "index": "druid-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/druid-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -2331,9 +2331,9 @@
         "url": "/api/features/wild-shape-cr-1-or-below"
       },
       {
-        "index": "druid-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/druid-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -2461,9 +2461,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "druid-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/druid-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -2591,9 +2591,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "druid-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/druid-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -2701,9 +2701,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "druid-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/druid-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -2857,7 +2857,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-1"
       }
     ],
@@ -2907,7 +2907,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-2"
       }
     ],
@@ -2951,7 +2951,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-3"
       }
     ],
@@ -3045,7 +3045,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-4"
       }
     ],
@@ -3095,7 +3095,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-5"
       }
     ],
@@ -3139,7 +3139,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-6",
-        "name": "Ability Score Improvement 6",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-6"
       }
     ],
@@ -3213,7 +3213,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-7",
-        "name": "Ability Score Improvement 7",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-7"
       }
     ],
@@ -3376,9 +3376,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "monk-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/monk-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       },
       {
         "index": "slow-fall",
@@ -3503,9 +3503,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "monk-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/monk-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "class_specific": {
@@ -3609,9 +3609,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "monk-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/monk-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "class_specific": {
@@ -3721,9 +3721,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "monk-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/monk-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "class_specific": {
@@ -3799,9 +3799,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "monk-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/monk-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "class_specific": {
@@ -3976,9 +3976,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "paladin-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/paladin-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -4090,9 +4090,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "paladin-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/paladin-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -4204,9 +4204,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "paladin-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/paladin-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -4312,9 +4312,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "paladin-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/paladin-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -4396,9 +4396,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "paladin-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/paladin-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -4562,9 +4562,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "ranger-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/ranger-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -4689,9 +4689,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "ranger-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/ranger-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       },
       {
         "index": "ranger-lands-stride",
@@ -4815,9 +4815,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "ranger-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/ranger-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -4936,9 +4936,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "ranger-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/ranger-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -5026,9 +5026,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "ranger-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/ranger-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -5180,7 +5180,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-1"
       }
     ],
@@ -5284,7 +5284,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-2"
       }
     ],
@@ -5330,7 +5330,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-3"
       }
     ],
@@ -5382,7 +5382,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-4"
       }
     ],
@@ -5480,7 +5480,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-5"
       }
     ],
@@ -5552,7 +5552,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-6",
-        "name": "Ability Score Improvement 6",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-6"
       }
     ],
@@ -5774,9 +5774,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "sorcerer-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/sorcerer-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -5992,9 +5992,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "sorcerer-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/sorcerer-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -6216,9 +6216,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "sorcerer-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/sorcerer-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -6434,9 +6434,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "sorcerer-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/sorcerer-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -6605,9 +6605,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "sorcerer-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/sorcerer-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -6848,9 +6848,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "warlock-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/warlock-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -7002,9 +7002,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "warlock-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/warlock-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -7162,9 +7162,9 @@
     ],
     "features": [
       {
-        "index": "warlock-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/warlock-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -7322,9 +7322,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "warlock-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/warlock-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -7442,9 +7442,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "warlock-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/warlock-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {
@@ -7632,9 +7632,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "wizard-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
-        "url": "/api/features/wizard-ability-score-improvement-1"
+        "index": "ability-score-improvement-1",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-1"
       }
     ],
     "spellcasting": {
@@ -7754,9 +7754,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "wizard-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
-        "url": "/api/features/wizard-ability-score-improvement-2"
+        "index": "ability-score-improvement-2",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-2"
       }
     ],
     "spellcasting": {
@@ -7876,9 +7876,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "wizard-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
-        "url": "/api/features/wizard-ability-score-improvement-3"
+        "index": "ability-score-improvement-3",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-3"
       }
     ],
     "spellcasting": {
@@ -7998,9 +7998,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "wizard-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
-        "url": "/api/features/wizard-ability-score-improvement-4"
+        "index": "ability-score-improvement-4",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-4"
       }
     ],
     "spellcasting": {
@@ -8097,9 +8097,9 @@
     "feature_choices": [],
     "features": [
       {
-        "index": "wizard-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
-        "url": "/api/features/wizard-ability-score-improvement-5"
+        "index": "ability-score-improvement-5",
+        "name": "Ability Score Improvement",
+        "url": "/api/features/ability-score-improvement-5"
       }
     ],
     "spellcasting": {

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -890,7 +890,7 @@
       },
       {
         "index": "magical-secrets-1",
-        "name": "Magical Secrets 1",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-1"
       }
     ],
@@ -1044,7 +1044,7 @@
     "features": [
       {
         "index": "magical-secrets-2",
-        "name": "Magical Secrets 2",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-2"
       }
     ],
@@ -1204,7 +1204,7 @@
     "features": [
       {
         "index": "magical-secrets-3",
-        "name": "Magical Secrets 3",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-3"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -593,7 +593,7 @@
     "feature_choices": [
       {
         "index": "bard-expertise-1",
-        "name": "Expertise 1",
+        "name": "Expertise",
         "url": "/api/features/bard-expertise-1"
       }
     ],
@@ -878,7 +878,7 @@
     "feature_choices": [
       {
         "index": "bard-expertise-2",
-        "name": "Expertise 2",
+        "name": "Expertise",
         "url": "/api/features/bard-expertise-2"
       }
     ],
@@ -5090,7 +5090,7 @@
     "feature_choices": [
       {
         "index": "rogue-expertise-1",
-        "name": "Expertise 1",
+        "name": "Expertise",
         "url": "/api/features/rogue-expertise-1"
       }
     ],
@@ -5231,7 +5231,7 @@
     "feature_choices": [
       {
         "index": "rogue-expertise-2",
-        "name": "Expertise 2",
+        "name": "Expertise",
         "url": "/api/features/rogue-expertise-2"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -2882,7 +2882,7 @@
     "features": [
       {
         "index": "extra-attack-1",
-        "name": "Extra Attack (1)",
+        "name": "Extra Attack",
         "url": "/api/features/extra-attack-1"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -5714,9 +5714,9 @@
     "prof_bonus": 2,
     "feature_choices": [
       {
-        "index": "metamagic",
-        "name": "Metamagic, First and Second",
-        "url": "/api/features/metamagic"
+        "index": "metamagic-1",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-1"
       }
     ],
     "features": [],
@@ -6103,9 +6103,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-metamagic-1",
-        "name": "Metamagic, Third",
-        "url": "/api/features/additional-metamagic-1"
+        "index": "metamagic-2",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-2"
       }
     ],
     "features": [],
@@ -6492,9 +6492,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-metamagic-2",
-        "name": "Metamagic, Fourth",
-        "url": "/api/features/additional-metamagic-2"
+        "index": "metamagic-3",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-3"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -3316,7 +3316,7 @@
       },
       {
         "index": "unarmored-movement-1",
-        "name": "Unarmored Movement 1",
+        "name": "Unarmored Movement",
         "url": "/api/features/unarmored-movement-1"
       }
     ],
@@ -3532,7 +3532,7 @@
     "features": [
       {
         "index": "unarmored-movement-2",
-        "name": "Unarmored Movement 2",
+        "name": "Unarmored Movement",
         "url": "/api/features/unarmored-movement-2"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -6887,9 +6887,9 @@
     "prof_bonus": 3,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-1",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-1"
+        "index": "eldritch-invocations-2",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-2"
       }
     ],
     "features": [],
@@ -6961,9 +6961,9 @@
     "prof_bonus": 3,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-2",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-2"
+        "index": "eldritch-invocations-3",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-3"
       }
     ],
     "features": [],
@@ -7041,9 +7041,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-3",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-3"
+        "index": "eldritch-invocations-4",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-4"
       }
     ],
     "features": [],
@@ -7155,9 +7155,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-4",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-4"
+        "index": "eldritch-invocations-5",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-5"
       }
     ],
     "features": [
@@ -7275,9 +7275,9 @@
     "prof_bonus": 5,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-5",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-5"
+        "index": "eldritch-invocations-6",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-6"
       }
     ],
     "features": [
@@ -7401,9 +7401,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-6",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-6"
+        "index": "eldritch-invocations-7",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-7"
       }
     ],
     "features": [],
@@ -7481,9 +7481,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-7",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-7"
+        "index": "eldritch-invocations-8",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-8"
       }
     ],
     "features": [

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -524,9 +524,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Black)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -584,9 +581,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Blue)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -644,9 +638,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Brass)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "proficiencies": [],
     "trait_specific": {
       "damage_type": {
@@ -699,9 +690,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Bronze)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -759,9 +747,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Copper)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -819,9 +804,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Gold)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -879,9 +861,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Green)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -939,9 +918,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Red)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -999,9 +975,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (Silver)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",
@@ -1059,9 +1032,6 @@
     ],
     "subraces": [],
     "name": "Draconic Ancestry (White)",
-    "desc": [
-      "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
-    ],
     "parent": {
       "index": "draconic-ancestry",
       "name": "Draconic Ancestry",


### PR DESCRIPTION
## What does this do?
This pull request makes several changes with the goal of eliminating redundancy within various features and traits, while also attempting to make them more accurate to the D&D 5e System Reference Document. The changes are as follows:

1. Some features grant additional benefits at level levels from when they're initially gained. For example, Bard's Expertise feature is granted at 3rd level. However, it grants an additional benefit (more expertise) at 10th level. While in the SRD this is noted as one individual feature, we include one for each benefit within the API so that we can better detail class leveling perks. The features are named `bard-expertise-1` and `bard-expertise-2` accordingly. Many features that have these naming schemes include the # in their name. This has been removed to be more accurate to the SRD.
2. Some other features that grant additional benefits at later levels use an "additional" naming scheme. An example is the current name for Eldritch Invocations. The first Eldritch Invocations feature has an index of `eldritch-invocation`, with the second one being `additional-eldritch-invocation-1`. Any indexes that "additional" without it being in the feature name in the SRD have had it removed, and have had their number incremented to match the original feature. (New names would be `eldritch-invocations-1`, `eldritch-invocations-2`, and so on...)
3. Most features with additional benefits duplicate the description of their original feature. This is redundant since the feature essentially points to the original (parent) feature. As such, the description has been removed from these additional features. The `parent` attribute has also been given to these features if not already possessed, which is an APIReference that points to the original feature. (Ex: `bard-expertise-2` has a `parent` attribute that is an APIReference to `bard-expertise-1`).
4. The Ability Score Improvement feature is shared by many classes. Every class except for rogue and fighter uses the same Ability Score Improvement feature in the SRD. Despite this, there is a unique feature for each class in the API, with the exact same information. This repetition of information is redundant and as such the 10 sharing classes have had their Ability Score Improvement features condensed into one (actually 5 for each level they are obtained at). They're named `ability-score-improvement-1`, `ability-score-improvement-2`, etc. The features for Fighter and Rogue are unchanged.
5. The `draconic-ancestry` trait of Dragonborns can make use of the following changes, so they have been implemented for it as well.

Some people may disagree with the 3rd changes mentioned. As such, all of the commits for it have been made separately so the other commits can be cherry picked if need be.

**Important Structural Changes:**
- There now exists some features and traits with no `desc` attribute. This is unprecedented as of now.
- There is now a `classes` attribute within Features (currently is only used by Ability Score Improvements, but there may be other applicable uses), for when a feature is used by multiple classes. It is a list of Class APIReferences.

## How was it tested?
As this is a draft PR, it has not been tested yet. Tomorrow I will build the API locally and run the typical tests on it.

## Is there a Github issue this is resolving?
There is not an issue, but there is a discussion that discussed changes 1 and 2. Link: https://github.com/5e-bits/5e-database/discussions/382

## Did you update the docs in the API? Please link an associated PR if applicable.
I will update the documentation for this before I make this PR ready for review.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
