### PR TITLE
Name/Index Discussion changes

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2441,7 +2441,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Extra Attack (1)",
+    "name": "Extra Attack",
     "level": 5,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1079,7 +1079,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 1",
+    "name": "Domain Spells",
     "level": 1,
     "prerequisites": [],
     "desc": [
@@ -1191,7 +1191,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 2",
+    "name": "Domain Spells",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -1222,7 +1222,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 3",
+    "name": "Domain Spells",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -1288,7 +1288,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 4",
+    "name": "Domain Spells",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -1354,7 +1354,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Domain Spells 5",
+    "name": "Domain Spells",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -107,7 +107,7 @@
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
     },
-    "name": "Barbarian: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -188,7 +188,7 @@
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
     },
-    "name": "Barbarian: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -255,7 +255,7 @@
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
     },
-    "name": "Barbarian: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -320,7 +320,7 @@
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
     },
-    "name": "Barbarian: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -365,7 +365,7 @@
       "name": "Barbarian",
       "url": "/api/classes/barbarian"
     },
-    "name": "Barbarian: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -629,7 +629,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Bard: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -711,7 +711,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Bard: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -884,7 +884,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Bard: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -969,7 +969,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Bard: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -1017,7 +1017,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Bard: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -1207,7 +1207,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Cleric: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -1304,7 +1304,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Cleric: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -1403,7 +1403,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Cleric: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -1433,7 +1433,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Cleric: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -1493,7 +1493,7 @@
       "name": "Cleric",
       "url": "/api/classes/cleric"
     },
-    "name": "Cleric: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -1916,7 +1916,7 @@
       "name": "Druid",
       "url": "/api/classes/druid"
     },
-    "name": "Druid: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -2019,7 +2019,7 @@
       "name": "Druid",
       "url": "/api/classes/druid"
     },
-    "name": "Druid: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -2076,7 +2076,7 @@
       "name": "Druid",
       "url": "/api/classes/druid"
     },
-    "name": "Druid: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -2111,7 +2111,7 @@
       "name": "Druid",
       "url": "/api/classes/druid"
     },
-    "name": "Druid: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -2156,7 +2156,7 @@
       "name": "Druid",
       "url": "/api/classes/druid"
     },
-    "name": "Druid: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -2426,7 +2426,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -2456,7 +2456,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 6,
     "prerequisites": [],
     "desc": [
@@ -2491,7 +2491,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -2594,7 +2594,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -2624,7 +2624,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 14,
     "prerequisites": [],
     "desc": [
@@ -2659,7 +2659,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -2725,7 +2725,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 7",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -2924,7 +2924,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Monk: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -3049,7 +3049,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Monk: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -3115,7 +3115,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Monk: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -3176,7 +3176,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Monk: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -3228,7 +3228,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Monk: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -3552,7 +3552,7 @@
       "name": "Paladin",
       "url": "/api/classes/paladin"
     },
-    "name": "Paladin: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -3619,7 +3619,7 @@
       "name": "Paladin",
       "url": "/api/classes/paladin"
     },
-    "name": "Paladin: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -3665,7 +3665,7 @@
       "name": "Paladin",
       "url": "/api/classes/paladin"
     },
-    "name": "Paladin: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -3716,7 +3716,7 @@
       "name": "Paladin",
       "url": "/api/classes/paladin"
     },
-    "name": "Paladin: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -3746,7 +3746,7 @@
       "name": "Paladin",
       "url": "/api/classes/paladin"
     },
-    "name": "Paladin: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -4115,7 +4115,7 @@
       "name": "Ranger",
       "url": "/api/classes/ranger"
     },
-    "name": "Ranger: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -4308,7 +4308,7 @@
       "name": "Ranger",
       "url": "/api/classes/ranger"
     },
-    "name": "Ranger: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -4468,7 +4468,7 @@
       "name": "Ranger",
       "url": "/api/classes/ranger"
     },
-    "name": "Ranger: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -4638,7 +4638,7 @@
       "name": "Ranger",
       "url": "/api/classes/ranger"
     },
-    "name": "Ranger: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -4669,7 +4669,7 @@
       "name": "Ranger",
       "url": "/api/classes/ranger"
     },
-    "name": "Ranger: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -4922,7 +4922,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -5086,7 +5086,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -5121,7 +5121,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -5151,7 +5151,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -5216,7 +5216,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -5266,7 +5266,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -5959,7 +5959,7 @@
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Sorcerer: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -5995,7 +5995,7 @@
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Sorcerer: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -6074,7 +6074,7 @@
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Sorcerer: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -6110,7 +6110,7 @@
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Sorcerer: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -6209,7 +6209,7 @@
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Sorcerer: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -7260,7 +7260,7 @@
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Warlock: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -7506,7 +7506,7 @@
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Warlock: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -7663,7 +7663,7 @@
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Warlock: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -7944,7 +7944,7 @@
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Warlock: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -8081,7 +8081,7 @@
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Warlock: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -8305,7 +8305,7 @@
       "name": "Wizard",
       "url": "/api/classes/wizard"
     },
-    "name": "Wizard: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -8340,7 +8340,7 @@
       "name": "Wizard",
       "url": "/api/classes/wizard"
     },
-    "name": "Wizard: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -8375,7 +8375,7 @@
       "name": "Wizard",
       "url": "/api/classes/wizard"
     },
-    "name": "Wizard: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -8411,7 +8411,7 @@
       "name": "Wizard",
       "url": "/api/classes/wizard"
     },
-    "name": "Wizard: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -8442,7 +8442,7 @@
       "name": "Wizard",
       "url": "/api/classes/wizard"
     },
-    "name": "Wizard: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6284,7 +6284,7 @@
     "url": "/api/features/pact-magic"
   },
   {
-    "index": "eldritch-invocations",
+    "index": "eldritch-invocations-1",
     "class": {
       "index": "warlock",
       "name": "Warlock",
@@ -6407,7 +6407,7 @@
       "When you cast eldritch blast, add your Charisma modifier to the damage it deals on a hit."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6427,7 +6427,7 @@
       "You can cast mage armor on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6447,7 +6447,7 @@
       "You can cast speak with animals at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6467,7 +6467,7 @@
       "You gain proficiency in the Deception and Persuasion skills."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6493,7 +6493,7 @@
       "On your adventures, you can add other ritual spells to your Book of Shadows. When you find such a spell, you can add it to the book if the spell's level is equal to or less than half your warlock level (rounded up) and if you can spare the time to transcribe the spell. For each level of the spell, the transcription process takes 2 hours and costs 50 gp for the rare inks needed to inscribe it."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6513,7 +6513,7 @@
       "You can see normally in darkness, both magical and nonmagical, to a distance of 120 feet."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6533,7 +6533,7 @@
       "You can cast detect magic at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6558,7 +6558,7 @@
       "When you cast eldritch blast, its range is 300 feet."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6578,7 +6578,7 @@
       "You can read all writing."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6598,7 +6598,7 @@
       "You can cast false life on yourself at will as a 1st-level spell, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6618,7 +6618,7 @@
       "You can use your action to touch a willing humanoid and perceive through its senses until the end of your next turn. As long as the creature is on the same plane of existence as you, you can use your action on subsequent turns to maintain this connection, extending the duration until the end of your next turn. While perceiving through the other creature's senses, you benefit from any special senses possessed by that creature, and you are blinded and deafened to your own surroundings."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6638,7 +6638,7 @@
       "You can cast disguise self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6658,7 +6658,7 @@
       "You can cast silent image at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6683,7 +6683,7 @@
       "When you hit a creature with eldritch blast, you can push the creature up to 10 feet away from you in a straight line."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6703,7 +6703,7 @@
       "You can cast bane once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6729,7 +6729,7 @@
       "Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6754,7 +6754,7 @@
       "You can cast slow once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6779,7 +6779,7 @@
       "When you are in an area of dim light or darkness, you can use your action to become invisible until you move or take an action or a reaction."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6804,7 +6804,7 @@
       "You can cast bestow curse once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6833,7 +6833,7 @@
       "You can attack with your pact weapon twice, instead of once, whenever you take the Attack action on your turn."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6858,7 +6858,7 @@
       "You can cast compulsion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6883,7 +6883,7 @@
       "You can cast confusion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6908,7 +6908,7 @@
       "You can cast polymorph once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6933,7 +6933,7 @@
       "You can cast levitate on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6958,7 +6958,7 @@
       "You can cast conjure elemental once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -6983,7 +6983,7 @@
       "You can cast jump on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7008,7 +7008,7 @@
       "You can cast speak with dead at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7037,7 +7037,7 @@
       "When you hit a creature with your pact weapon, the creature takes extra necrotic damage equal to your Charisma modifier (minimum 1)."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7066,7 +7066,7 @@
       "You can cast hold monster at will--targeting a celestial, fiend, or elemental--without expending a spell slot or material components. You must finish a long rest before you can use this invocation on the same creature again."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7091,7 +7091,7 @@
       "You can cast alter self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7116,7 +7116,7 @@
       "You can cast arcane eye at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7141,7 +7141,7 @@
       "You can see the true form of any shapechanger or creature concealed by illusion or transmutation magic while the creature is within 30 feet of you and within line of sight."
     ],
     "parent": {
-      "index": "eldritch-invocations",
+      "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
       "url": "/api/features/eldritch-invocations"
     },
@@ -7269,13 +7269,13 @@
     "url": "/api/features/warlock-ability-score-improvement-1"
   },
   {
-    "index": "additional-eldritch-invocation-1",
+    "index": "eldritch-invocations-2",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -7371,7 +7371,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-1"
+    "url": "/api/features/eldritch-invocations-2"
   },
   {
     "index": "dark-ones-own-luck",
@@ -7395,13 +7395,13 @@
     "url": "/api/features/dark-ones-own-luck"
   },
   {
-    "index": "additional-eldritch-invocation-2",
+    "index": "eldritch-invocations-3",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -7497,7 +7497,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-2"
+    "url": "/api/features/eldritch-invocations-3"
   },
   {
     "index": "warlock-ability-score-improvement-2",
@@ -7515,13 +7515,13 @@
     "url": "/api/features/warlock-ability-score-improvement-2"
   },
   {
-    "index": "additional-eldritch-invocation-3",
+    "index": "eldritch-invocations-4",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 9,
     "prerequisites": [],
     "desc": [
@@ -7617,7 +7617,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-3"
+    "url": "/api/features/eldritch-invocations-4"
   },
   {
     "index": "fiendish-resilience",
@@ -7672,13 +7672,13 @@
     "url": "/api/features/warlock-ability-score-improvement-3"
   },
   {
-    "index": "additional-eldritch-invocation-4",
+    "index": "eldritch-invocations-5",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -7774,7 +7774,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-4"
+    "url": "/api/features/eldritch-invocations-5"
   },
   {
     "index": "mystic-arcanum-7th-level",
@@ -7833,13 +7833,13 @@
     "url": "/api/features/mystic-arcanum-8th-level"
   },
   {
-    "index": "additional-eldritch-invocation-5",
+    "index": "eldritch-invocations-6",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 15,
     "prerequisites": [],
     "desc": [
@@ -7935,7 +7935,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-5"
+    "url": "/api/features/eldritch-invocations-6"
   },
   {
     "index": "warlock-ability-score-improvement-4",
@@ -7970,13 +7970,13 @@
     "url": "/api/features/mystic-arcanum-9th-level"
   },
   {
-    "index": "additional-eldritch-invocation-6",
+    "index": "eldritch-invocations-7",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 18,
     "prerequisites": [],
     "desc": [
@@ -8072,7 +8072,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-6"
+    "url": "/api/features/eldritch-invocations-7"
   },
   {
     "index": "warlock-ability-score-improvement-5",
@@ -8106,13 +8106,13 @@
     "url": "/api/features/eldritch-master"
   },
   {
-    "index": "additional-eldritch-invocation-7",
+    "index": "eldritch-invocations-8",
     "class": {
       "index": "warlock",
       "name": "Warlock",
       "url": "/api/classes/warlock"
     },
-    "name": "Additional Eldritch Invocation",
+    "name": "Eldritch Invocations",
     "level": 20,
     "prerequisites": [],
     "desc": [
@@ -8208,7 +8208,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-eldritch-invocation-7"
+    "url": "/api/features/eldritch-invocations-8"
   },
   {
     "index": "spellcasting-wizard",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -1876,7 +1876,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 1",
+    "name": "Circle Spells",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -1936,7 +1936,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 2",
+    "name": "Circle Spells",
     "level": 5,
     "prerequisites": [],
     "desc": [
@@ -1979,7 +1979,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 3",
+    "name": "Circle Spells",
     "level": 7,
     "prerequisites": [],
     "desc": [
@@ -2039,7 +2039,7 @@
       "name": "Land",
       "url": "/api/subclasses/land"
     },
-    "name": "Circle Spells 4",
+    "name": "Circle Spells",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -2854,7 +2854,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Unarmored Movement 1",
+    "name": "Unarmored Movement",
     "level": 2,
     "prerequisites": [],
     "desc": [
@@ -3064,7 +3064,7 @@
       "name": "Monk",
       "url": "/api/classes/monk"
     },
-    "name": "Unarmored Movement 2",
+    "name": "Unarmored Movement",
     "level": 9,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5829,7 +5829,7 @@
       "When you cast a spell that has a range of touch, you can spend 1 sorcery point to make the range of the spell 30 feet."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5850,7 +5850,7 @@
       "You can use Empowered Spell even if you have already used a different Metamagic option during the casting of the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5870,7 +5870,7 @@
       "When you cast a spell that has a duration of 1 minute or longer, you can spend 1 sorcery point to double its duration, to a maximum duration of 24 hours."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5890,7 +5890,7 @@
       "When you cast a spell that forces a creature to make a saving throw to resist its effects, you can spend 3 sorcery points to give one target of the spell disadvantage on its first saving throw made against the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5910,7 +5910,7 @@
       "When you cast a spell that has a casting time of 1 action, you can spend 2 sorcery points to change the casting time to 1 bonus action for this casting."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },
@@ -5930,7 +5930,7 @@
       "When you cast a spell, you can spend 1 sorcery point to cast it without any somatic or verbal components."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
       "url": "/api/features/metamagic-1"
     },

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -516,7 +516,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Expertise 1",
+    "name": "Expertise",
     "level": 3,
     "prerequisites": [],
     "desc": [
@@ -759,7 +759,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Expertise 2",
+    "name": "Expertise",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -4699,7 +4699,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Expertise 1",
+    "name": "Expertise",
     "level": 1,
     "prerequisites": [],
     "desc": [
@@ -4952,7 +4952,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Expertise 2",
+    "name": "Expertise",
     "level": 6,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -5731,7 +5731,7 @@
     "url": "/api/features/flexible-casting-converting-spell-slot"
   },
   {
-    "index": "metamagic",
+    "index": "metamagic-1",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
@@ -5792,7 +5792,7 @@
         ]
       }
     },
-    "url": "/api/features/metamagic"
+    "url": "/api/features/metamagic-1"
   },
   {
     "index": "metamagic-careful-spell",
@@ -5808,9 +5808,9 @@
       "When you cast a spell that forces other creatures to make a saving throw, you can protect some of those creatures from the spell's full force. To do so, you spend 1 sorcery point and choose a number of those creatures up to your Charisma modifier (minimum of one creature). A chosen creature automatically succeeds on its saving throw against the spell."
     ],
     "parent": {
-      "index": "metamagic",
+      "index": "metamagic-1",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-careful-spell"
   },
@@ -5831,7 +5831,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-distant-spell"
   },
@@ -5852,7 +5852,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-empowered-spell"
   },
@@ -5872,7 +5872,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-extended-spell"
   },
@@ -5892,7 +5892,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-heightened-spell"
   },
@@ -5912,7 +5912,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-quickened-spell"
   },
@@ -5932,7 +5932,7 @@
     "parent": {
       "index": "metamagic",
       "name": "Metamagic",
-      "url": "/api/features/metamagic"
+      "url": "/api/features/metamagic-1"
     },
     "url": "/api/features/metamagic-subtle-spell"
   },
@@ -6004,13 +6004,13 @@
     "url": "/api/features/sorcerer-ability-score-improvement-2"
   },
   {
-    "index": "additional-metamagic-1",
+    "index": "metamagic-2",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Additional Metamagic",
+    "name": "Metamagic",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -6065,7 +6065,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-metamagic-1"
+    "url": "/api/features/metamagic-2"
   },
   {
     "index": "sorcerer-ability-score-improvement-3",
@@ -6119,13 +6119,13 @@
     "url": "/api/features/sorcerer-ability-score-improvement-4"
   },
   {
-    "index": "additional-metamagic-2",
+    "index": "metamagic-3",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
       "url": "/api/classes/sorcerer"
     },
-    "name": "Additional Metamagic",
+    "name": "Metamagic",
     "level": 17,
     "prerequisites": [],
     "desc": [
@@ -6180,7 +6180,7 @@
         ]
       }
     },
-    "url": "/api/features/additional-metamagic-2"
+    "url": "/api/features/metamagic-3"
   },
   {
     "index": "draconic-presence",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -867,7 +867,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 1",
+    "name": "Magical Secrets",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -915,7 +915,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 2",
+    "name": "Magical Secrets",
     "level": 14,
     "prerequisites": [],
     "desc": [
@@ -1000,7 +1000,7 @@
       "name": "Bard",
       "url": "/api/classes/bard"
     },
-    "name": "Magical Secrets 3",
+    "name": "Magical Secrets",
     "level": 18,
     "prerequisites": [],
     "desc": [

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -1334,7 +1334,7 @@
       },
       {
         "index": "domain-spells-1",
-        "name": "Domain Spells 1",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-1"
       }
     ],
@@ -1413,7 +1413,7 @@
     "features": [
       {
         "index": "domain-spells-2",
-        "name": "Domain Spells 2",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-2"
       }
     ],
@@ -1487,7 +1487,7 @@
     "features": [
       {
         "index": "domain-spells-3",
-        "name": "Domain Spells 3",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-3"
       },
       {
@@ -1566,7 +1566,7 @@
     "features": [
       {
         "index": "domain-spells-4",
-        "name": "Domain Spells 4",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-4"
       }
     ],
@@ -1645,7 +1645,7 @@
     "features": [
       {
         "index": "domain-spells-5",
-        "name": "Domain Spells 5",
+        "name": "Domain Spells",
         "url": "/api/features/domain-spells-5"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -890,7 +890,7 @@
       },
       {
         "index": "magical-secrets-1",
-        "name": "Magical Secrets 1",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-1"
       }
     ],
@@ -1044,7 +1044,7 @@
     "features": [
       {
         "index": "magical-secrets-2",
-        "name": "Magical Secrets 2",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-2"
       }
     ],
@@ -1204,7 +1204,7 @@
     "features": [
       {
         "index": "magical-secrets-3",
-        "name": "Magical Secrets 3",
+        "name": "Magical Secrets",
         "url": "/api/features/magical-secrets-3"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -593,7 +593,7 @@
     "feature_choices": [
       {
         "index": "bard-expertise-1",
-        "name": "Expertise 1",
+        "name": "Expertise",
         "url": "/api/features/bard-expertise-1"
       }
     ],
@@ -878,7 +878,7 @@
     "feature_choices": [
       {
         "index": "bard-expertise-2",
-        "name": "Expertise 2",
+        "name": "Expertise",
         "url": "/api/features/bard-expertise-2"
       }
     ],
@@ -5090,7 +5090,7 @@
     "feature_choices": [
       {
         "index": "rogue-expertise-1",
-        "name": "Expertise 1",
+        "name": "Expertise",
         "url": "/api/features/rogue-expertise-1"
       }
     ],
@@ -5231,7 +5231,7 @@
     "feature_choices": [
       {
         "index": "rogue-expertise-2",
-        "name": "Expertise 2",
+        "name": "Expertise",
         "url": "/api/features/rogue-expertise-2"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -2882,7 +2882,7 @@
     "features": [
       {
         "index": "extra-attack-1",
-        "name": "Extra Attack (1)",
+        "name": "Extra Attack",
         "url": "/api/features/extra-attack-1"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -5714,9 +5714,9 @@
     "prof_bonus": 2,
     "feature_choices": [
       {
-        "index": "metamagic",
-        "name": "Metamagic, First and Second",
-        "url": "/api/features/metamagic"
+        "index": "metamagic-1",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-1"
       }
     ],
     "features": [],
@@ -6103,9 +6103,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-metamagic-1",
-        "name": "Metamagic, Third",
-        "url": "/api/features/additional-metamagic-1"
+        "index": "metamagic-2",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-2"
       }
     ],
     "features": [],
@@ -6492,9 +6492,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-metamagic-2",
-        "name": "Metamagic, Fourth",
-        "url": "/api/features/additional-metamagic-2"
+        "index": "metamagic-3",
+        "name": "Metamagic",
+        "url": "/api/features/metamagic-3"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -3316,7 +3316,7 @@
       },
       {
         "index": "unarmored-movement-1",
-        "name": "Unarmored Movement 1",
+        "name": "Unarmored Movement",
         "url": "/api/features/unarmored-movement-1"
       }
     ],
@@ -3532,7 +3532,7 @@
     "features": [
       {
         "index": "unarmored-movement-2",
-        "name": "Unarmored Movement 2",
+        "name": "Unarmored Movement",
         "url": "/api/features/unarmored-movement-2"
       }
     ],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -6887,9 +6887,9 @@
     "prof_bonus": 3,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-1",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-1"
+        "index": "eldritch-invocations-2",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-2"
       }
     ],
     "features": [],
@@ -6961,9 +6961,9 @@
     "prof_bonus": 3,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-2",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-2"
+        "index": "eldritch-invocations-3",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-3"
       }
     ],
     "features": [],
@@ -7041,9 +7041,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-3",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-3"
+        "index": "eldritch-invocations-4",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-4"
       }
     ],
     "features": [],
@@ -7155,9 +7155,9 @@
     "prof_bonus": 4,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-4",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-4"
+        "index": "eldritch-invocations-5",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-5"
       }
     ],
     "features": [
@@ -7275,9 +7275,9 @@
     "prof_bonus": 5,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-5",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-5"
+        "index": "eldritch-invocations-6",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-6"
       }
     ],
     "features": [
@@ -7401,9 +7401,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-6",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-6"
+        "index": "eldritch-invocations-7",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-7"
       }
     ],
     "features": [],
@@ -7481,9 +7481,9 @@
     "prof_bonus": 6,
     "feature_choices": [
       {
-        "index": "additional-eldritch-invocation-7",
-        "name": "Additional Eldritch Invocation",
-        "url": "/api/features/additional-eldritch-invocation-7"
+        "index": "eldritch-invocations-8",
+        "name": "Eldritch Invocations",
+        "url": "/api/features/eldritch-invocations-8"
       }
     ],
     "features": [


### PR DESCRIPTION
## What does this do?
There was a brief discussion about names and indexes of certain features not being accurate to the SRD and it seemed to be agreed that the proposed changes were good. I have implemented them. Here is the relevant discussion link: https://github.com/5e-bits/5e-database/discussions/382

It adds the following:

1. Some features grant additional benefits at level levels from when they're initially gained. For example, Bard's Expertise feature is granted at 3rd level. However, it grants an additional benefit (more expertise) at 10th level. While in the SRD this is noted as one individual feature, we include one for each benefit within the API so that we can better detail class leveling perks. The features are named bard-expertise-1 and bard-expertise-2 accordingly. Many features that have these naming schemes include the # in their name. This has been removed to be more accurate to the SRD.
2. Some other features that grant additional benefits at later levels use an "additional" naming scheme. An example is the current name for Eldritch Invocations. The first Eldritch Invocations feature has an index of eldritch-invocation, with the second one being additional-eldritch-invocation-1. Any indexes that "additional" without it being in the feature name in the SRD have had it removed, and have had their number incremented to match the original feature. (New names would be eldritch-invocations-1, eldritch-invocations-2, and so on...)

Previous draft PR (some commits were cherry picked into this one): https://github.com/5e-bits/5e-database/pull/384

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No, but the relevant discussion is linked.

## Did you update the docs in the API? Please link an associated PR if applicable.
Not needed.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
