### PR TITLE
Ability Score Improvement Redundancy

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -101,21 +101,6 @@
     "url": "/api/features/frenzy"
   },
   {
-    "index": "barbarian-ability-score-improvement-1",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-1"
-  },
-  {
     "index": "barbarian-extra-attack",
     "class": {
       "index": "barbarian",
@@ -182,21 +167,6 @@
     "url": "/api/features/feral-instinct"
   },
   {
-    "index": "barbarian-ability-score-improvement-2",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-2"
-  },
-  {
     "index": "brutal-critical-1-die",
     "class": {
       "index": "barbarian",
@@ -249,21 +219,6 @@
     "url": "/api/features/relentless-rage"
   },
   {
-    "index": "barbarian-ability-score-improvement-3",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-3"
-  },
-  {
     "index": "brutal-critical-2-dice",
     "class": {
       "index": "barbarian",
@@ -314,21 +269,6 @@
     "url": "/api/features/persistent-rage"
   },
   {
-    "index": "barbarian-ability-score-improvement-4",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-4"
-  },
-  {
     "index": "brutal-critical-3-dice",
     "class": {
       "index": "barbarian",
@@ -357,21 +297,6 @@
       "Beginning at 18th level, if your total for a Strength check is less than your Strength score, you can use that score in place of the total."
     ],
     "url": "/api/features/indomitable-might"
-  },
-  {
-    "index": "barbarian-ability-score-improvement-5",
-    "class": {
-      "index": "barbarian",
-      "name": "Barbarian",
-      "url": "/api/classes/barbarian"
-    },
-    "name": "Barbarian: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/barbarian-ability-score-improvement-5"
   },
   {
     "index": "primal-champion",
@@ -623,21 +548,6 @@
     "url": "/api/features/bard-expertise-1"
   },
   {
-    "index": "bard-ability-score-improvement-1",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-1"
-  },
-  {
     "index": "bardic-inspiration-d8",
     "class": {
       "index": "bard",
@@ -703,21 +613,6 @@
       "At 6th level, you learn two spells of your choice from any class. A spell you choose must be of a level you can cast, as shown on the Bard table, or a cantrip. The chosen spells count as bard spells for you but don't count against the number of bard spells you know."
     ],
     "url": "/api/features/additional-magical-secrets"
-  },
-  {
-    "index": "bard-ability-score-improvement-2",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-2"
   },
   {
     "index": "song-of-rest-d8",
@@ -878,21 +773,6 @@
     "url": "/api/features/magical-secrets-1"
   },
   {
-    "index": "bard-ability-score-improvement-3",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-3"
-  },
-  {
     "index": "song-of-rest-d10",
     "class": {
       "index": "bard",
@@ -963,21 +843,6 @@
     "url": "/api/features/bardic-inspiration-d12"
   },
   {
-    "index": "bard-ability-score-improvement-4",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-4"
-  },
-  {
     "index": "song-of-rest-d12",
     "class": {
       "index": "bard",
@@ -1009,21 +874,6 @@
       "You learn two additional spells from any class at 14th level and again at 18th level."
     ],
     "url": "/api/features/magical-secrets-3"
-  },
-  {
-    "index": "bard-ability-score-improvement-5",
-    "class": {
-      "index": "bard",
-      "name": "Bard",
-      "url": "/api/classes/bard"
-    },
-    "name": "Bard: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/bard-ability-score-improvement-5"
   },
   {
     "index": "superior-inspiration",
@@ -1201,21 +1051,6 @@
     "url": "/api/features/domain-spells-2"
   },
   {
-    "index": "cleric-ability-score-improvement-1",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-1"
-  },
-  {
     "index": "domain-spells-3",
     "class": {
       "index": "cleric",
@@ -1296,21 +1131,6 @@
       "If you have a domain spell that doesn't appear on the cleric spell list, the spell is nonetheless a cleric spell for you."
     ],
     "url": "/api/features/domain-spells-4"
-  },
-  {
-    "index": "cleric-ability-score-improvement-2",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-2"
   },
   {
     "index": "destroy-undead-cr-1-or-below",
@@ -1397,21 +1217,6 @@
     "url": "/api/features/destroy-undead-cr-2-or-below"
   },
   {
-    "index": "cleric-ability-score-improvement-3",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-3"
-  },
-  {
     "index": "destroy-undead-cr-3-or-below",
     "class": {
       "index": "cleric",
@@ -1425,21 +1230,6 @@
       "Starting at 5th level, when an undead fails its saving throw against your Turn Undead feature, the creature is instantly destroyed if its challenge rating is at or below a certain threshold."
     ],
     "url": "/api/features/destroy-undead-cr-3-or-below"
-  },
-  {
-    "index": "cleric-ability-score-improvement-4",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-4"
   },
   {
     "index": "destroy-undead-cr-4-or-below",
@@ -1485,21 +1275,6 @@
       "Beginning at 6th level, you can use your Channel Divinity twice between rests, and beginning at 18th level, you can use it three times between rests. When you finish a short or long rest, you regain your expended uses."
     ],
     "url": "/api/features/channel-divinity-3-rest"
-  },
-  {
-    "index": "cleric-ability-score-improvement-5",
-    "class": {
-      "index": "cleric",
-      "name": "Cleric",
-      "url": "/api/classes/cleric"
-    },
-    "name": "Cleric: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/cleric-ability-score-improvement-5"
   },
   {
     "index": "divine-intervention-improvement",
@@ -1910,21 +1685,6 @@
     "url": "/api/features/wild-shape-cr-1-2-or-below-no-flying-speed"
   },
   {
-    "index": "druid-ability-score-improvement-1",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-1"
-  },
-  {
     "index": "circle-spells-2",
     "class": {
       "index": "druid",
@@ -2013,21 +1773,6 @@
     "url": "/api/features/wild-shape-cr-1-or-below"
   },
   {
-    "index": "druid-ability-score-improvement-2",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-2"
-  },
-  {
     "index": "circle-spells-4",
     "class": {
       "index": "druid",
@@ -2070,21 +1815,6 @@
     "url": "/api/features/natures-ward"
   },
   {
-    "index": "druid-ability-score-improvement-3",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-3"
-  },
-  {
     "index": "natures-sanctuary",
     "class": {
       "index": "druid",
@@ -2103,21 +1833,6 @@
       "When you reach 14th level, creatures of the natural world sense your connection to nature and become hesitant to attack you. When a beast or plant creature attacks you, that creature must make a Wisdom saving throw against your druid spell save DC. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you."
     ],
     "url": "/api/features/natures-sanctuary"
-  },
-  {
-    "index": "druid-ability-score-improvement-4",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-4"
   },
   {
     "index": "druid-timeless-body",
@@ -2148,21 +1863,6 @@
       "Beginning at 18th level, you can cast many of your druid spells in any shape you assume using Wild Shape. You can perform the somatic and verbal components of a druid spell while in a beast shape, but you aren't able to provide material components."
     ],
     "url": "/api/features/beast-spells"
-  },
-  {
-    "index": "druid-ability-score-improvement-5",
-    "class": {
-      "index": "druid",
-      "name": "Druid",
-      "url": "/api/classes/druid"
-    },
-    "name": "Druid: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/druid-ability-score-improvement-5"
   },
   {
     "index": "archdruid",
@@ -2426,7 +2126,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -2456,7 +2156,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 6,
     "prerequisites": [],
     "desc": [
@@ -2491,7 +2191,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -2594,7 +2294,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -2624,7 +2324,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 14,
     "prerequisites": [],
     "desc": [
@@ -2659,7 +2359,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -2725,7 +2425,7 @@
       "name": "Fighter",
       "url": "/api/classes/fighter"
     },
-    "name": "Fighter: Ability Score Improvement 7",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -2918,21 +2618,6 @@
     "url": "/api/features/open-hand-technique"
   },
   {
-    "index": "monk-ability-score-improvement-1",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-1"
-  },
-  {
     "index": "slow-fall",
     "class": {
       "index": "monk",
@@ -3043,21 +2728,6 @@
     "url": "/api/features/stillness-of-mind"
   },
   {
-    "index": "monk-ability-score-improvement-2",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-2"
-  },
-  {
     "index": "unarmored-movement-2",
     "class": {
       "index": "monk",
@@ -3109,21 +2779,6 @@
     "url": "/api/features/tranquility"
   },
   {
-    "index": "monk-ability-score-improvement-3",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-3"
-  },
-  {
     "index": "tongue-of-the-sun-and-moon",
     "class": {
       "index": "monk",
@@ -3170,21 +2825,6 @@
     "url": "/api/features/monk-timeless-body"
   },
   {
-    "index": "monk-ability-score-improvement-4",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-4"
-  },
-  {
     "index": "quivering-palm",
     "class": {
       "index": "monk",
@@ -3220,21 +2860,6 @@
       "Additionally, you can spend 8 ki points to cast the astral projection spell, without needing material components. When you do so, you can't take any other creatures with you."
     ],
     "url": "/api/features/empty-body"
-  },
-  {
-    "index": "monk-ability-score-improvement-5",
-    "class": {
-      "index": "monk",
-      "name": "Monk",
-      "url": "/api/classes/monk"
-    },
-    "name": "Monk: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/monk-ability-score-improvement-5"
   },
   {
     "index": "perfect-self",
@@ -3546,21 +3171,6 @@
     "url": "/api/features/channel-divinity-turn-the-unholy"
   },
   {
-    "index": "paladin-ability-score-improvement-1",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-1"
-  },
-  {
     "index": "paladin-extra-attack",
     "class": {
       "index": "paladin",
@@ -3613,21 +3223,6 @@
     "url": "/api/features/aura-of-devotion"
   },
   {
-    "index": "paladin-ability-score-improvement-2",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-2"
-  },
-  {
     "index": "aura-of-courage",
     "class": {
       "index": "paladin",
@@ -3657,21 +3252,6 @@
       "By 11th level, you are so suffused with righteous might that all your melee weapon strikes carry divine power with them. Whenever you hit a creature with a melee weapon, the creature takes an extra 1d8 radiant damage. If you also use your Divine Smite with an attack, you add this damage to the extra damage of your Divine Smite."
     ],
     "url": "/api/features/improved-divine-smite"
-  },
-  {
-    "index": "paladin-ability-score-improvement-3",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-3"
   },
   {
     "index": "cleansing-touch",
@@ -3710,21 +3290,6 @@
     "url": "/api/features/purity-of-spirit"
   },
   {
-    "index": "paladin-ability-score-improvement-4",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-4"
-  },
-  {
     "index": "aura-improvements",
     "class": {
       "index": "paladin",
@@ -3738,21 +3303,6 @@
       "At 18th level, the range of your auras increase to 30 feet."
     ],
     "url": "/api/features/aura-improvements"
-  },
-  {
-    "index": "paladin-ability-score-improvement-5",
-    "class": {
-      "index": "paladin",
-      "name": "Paladin",
-      "url": "/api/classes/paladin"
-    },
-    "name": "Paladin: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/paladin-ability-score-improvement-5"
   },
   {
     "index": "holy-nimbus",
@@ -4109,21 +3659,6 @@
     "url": "/api/features/primeval-awareness"
   },
   {
-    "index": "ranger-ability-score-improvement-1",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-1"
-  },
-  {
     "index": "ranger-extra-attack",
     "class": {
       "index": "ranger",
@@ -4302,21 +3837,6 @@
     "url": "/api/features/defensive-tactics-steel-will"
   },
   {
-    "index": "ranger-ability-score-improvement-2",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-2"
-  },
-  {
     "index": "ranger-lands-stride",
     "class": {
       "index": "ranger",
@@ -4460,21 +3980,6 @@
       "url": "/api/features/multiattack"
     },
     "url": "/api/features/multiattack-whirlwind-attack"
-  },
-  {
-    "index": "ranger-ability-score-improvement-3",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-3"
   },
   {
     "index": "favored-enemy-3-enemies",
@@ -4632,21 +4137,6 @@
     "url": "/api/features/superior-hunters-defense-uncanny-dodge"
   },
   {
-    "index": "ranger-ability-score-improvement-4",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-4"
-  },
-  {
     "index": "feral-senses",
     "class": {
       "index": "ranger",
@@ -4661,21 +4151,6 @@
       "You are also aware of the location of any invisible creature within 30 feet of you, provided that the creature isn't hidden from you and you aren't blinded or deafened."
     ],
     "url": "/api/features/feral-senses"
-  },
-  {
-    "index": "ranger-ability-score-improvement-5",
-    "class": {
-      "index": "ranger",
-      "name": "Ranger",
-      "url": "/api/classes/ranger"
-    },
-    "name": "Ranger: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/ranger-ability-score-improvement-5"
   },
   {
     "index": "foe-slayer",
@@ -4922,7 +4397,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 1",
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
@@ -5086,7 +4561,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 2",
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
@@ -5121,7 +4596,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 3",
+    "name": "Ability Score Improvement",
     "level": 10,
     "prerequisites": [],
     "desc": [
@@ -5151,7 +4626,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 4",
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
@@ -5216,7 +4691,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 5",
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
@@ -5266,7 +4741,7 @@
       "name": "Rogue",
       "url": "/api/classes/rogue"
     },
-    "name": "Rogue: Ability Score Improvement 6",
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
@@ -5953,21 +5428,6 @@
     "url": "/api/features/metamagic-twinned-spell"
   },
   {
-    "index": "sorcerer-ability-score-improvement-1",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-1"
-  },
-  {
     "index": "elemental-affinity",
     "class": {
       "index": "sorcerer",
@@ -6004,7 +5464,7 @@
     "url": "/api/features/sorcerer-ability-score-improvement-2"
   },
   {
-    "index": "additional-metamagic-1",
+    "index": "metamagic-2",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
@@ -6068,21 +5528,6 @@
     "url": "/api/features/additional-metamagic-1"
   },
   {
-    "index": "sorcerer-ability-score-improvement-3",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-3"
-  },
-  {
     "index": "dragon-wings",
     "class": {
       "index": "sorcerer",
@@ -6119,7 +5564,7 @@
     "url": "/api/features/sorcerer-ability-score-improvement-4"
   },
   {
-    "index": "additional-metamagic-2",
+    "index": "metamagic-3",
     "class": {
       "index": "sorcerer",
       "name": "Sorcerer",
@@ -6201,21 +5646,6 @@
       "Beginning at 18th level, you can channel the dread presence of your dragon ancestor, causing those around you to become awestruck or frightened. As an action, you can spend 5 sorcery points to draw on this power and exude an aura of awe or fear (your choice) to a distance of 60 feet. For 1 minute or until you lose your concentration (as if you were casting a concentration spell), each hostile creature that starts its turn in this aura must succeed on a Wisdom saving throw or be charmed (if you chose awe) or frightened (if you chose fear) until the aura ends. A creature that succeeds on this saving throw is immune to your aura for 24 hours."
     ],
     "url": "/api/features/draconic-presence"
-  },
-  {
-    "index": "sorcerer-ability-score-improvement-5",
-    "class": {
-      "index": "sorcerer",
-      "name": "Sorcerer",
-      "url": "/api/classes/sorcerer"
-    },
-    "name": "Sorcerer: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/sorcerer-ability-score-improvement-5"
   },
   {
     "index": "sorcerous-restoration",
@@ -7254,21 +6684,6 @@
     "url": "/api/features/pact-of-the-tome"
   },
   {
-    "index": "warlock-ability-score-improvement-1",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 1",
-    "level": 4,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-1"
-  },
-  {
     "index": "additional-eldritch-invocation-1",
     "class": {
       "index": "warlock",
@@ -7500,21 +6915,6 @@
     "url": "/api/features/additional-eldritch-invocation-2"
   },
   {
-    "index": "warlock-ability-score-improvement-2",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 2",
-    "level": 8,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-2"
-  },
-  {
     "index": "additional-eldritch-invocation-3",
     "class": {
       "index": "warlock",
@@ -7655,21 +7055,6 @@
       "At higher levels, you gain more warlock spells of your choice that can be cast in this way: one 7th- level spell at 13th level, one 8th-level spell at 15th level, and one 9th-level spell at 17th level. You regain all uses of your Mystic Arcanum when you finish a long rest."
     ],
     "url": "/api/features/mystic-arcanum-6th-level"
-  },
-  {
-    "index": "warlock-ability-score-improvement-3",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 3",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-3"
   },
   {
     "index": "additional-eldritch-invocation-4",
@@ -7938,21 +7323,6 @@
     "url": "/api/features/additional-eldritch-invocation-5"
   },
   {
-    "index": "warlock-ability-score-improvement-4",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 4",
-    "level": 16,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-4"
-  },
-  {
     "index": "mystic-arcanum-9th-level",
     "class": {
       "index": "warlock",
@@ -8073,21 +7443,6 @@
       }
     },
     "url": "/api/features/additional-eldritch-invocation-6"
-  },
-  {
-    "index": "warlock-ability-score-improvement-5",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Warlock: Ability Score Improvement 5",
-    "level": 19,
-    "prerequisites": [],
-    "desc": [
-      "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
-    ],
-    "url": "/api/features/warlock-ability-score-improvement-5"
   },
   {
     "index": "eldritch-master",
@@ -8299,19 +7654,61 @@
     "url": "/api/features/sculpt-spells"
   },
   {
-    "index": "wizard-ability-score-improvement-1",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 1",
+    "index": "ability-score-improvement-1",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 4,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-1"
+    "url": "/api/features/ability-score-improvement-1"
   },
   {
     "index": "potent-cantrip",
@@ -8334,19 +7731,61 @@
     "url": "/api/features/potent-cantrip"
   },
   {
-    "index": "wizard-ability-score-improvement-2",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 2",
+    "index": "ability-score-improvement-2",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 8,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-2"
+    "url": "/api/features/ability-score-improvement-2"
   },
   {
     "index": "empowered-evocation",
@@ -8369,19 +7808,61 @@
     "url": "/api/features/empowered-evocation"
   },
   {
-    "index": "wizard-ability-score-improvement-3",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 3",
+    "index": "ability-score-improvement-3",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 12,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-3"
+    "url": "/api/features/ability-score-improvement-3"
   },
   {
     "index": "overchannel",
@@ -8405,19 +7886,61 @@
     "url": "/api/features/overchannel"
   },
   {
-    "index": "wizard-ability-score-improvement-4",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 4",
+    "index": "ability-score-improvement-4",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 16,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-4"
+    "url": "/api/features/ability-score-improvement-4"
   },
   {
     "index": "spell-mastery",
@@ -8436,19 +7959,61 @@
     "url": "/api/features/spell-mastery"
   },
   {
-    "index": "wizard-ability-score-improvement-5",
-    "class": {
-      "index": "wizard",
-      "name": "Wizard",
-      "url": "/api/classes/wizard"
-    },
-    "name": "Wizard: Ability Score Improvement 5",
+    "index": "ability-score-improvement-5",
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Bard",
+        "url": "/api/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Cleric",
+        "url": "/api/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
+      },
+      {
+        "index": "monk",
+        "name": "Monk",
+        "url": "/api/classes/monk"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Ranger",
+        "url": "/api/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Warlock",
+        "url": "/api/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
+    "name": "Ability Score Improvement",
     "level": 19,
     "prerequisites": [],
     "desc": [
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
-    "url": "/api/features/wizard-ability-score-improvement-5"
+    "url": "/api/features/ability-score-improvement-5"
   },
   {
     "index": "signature-spell",


### PR DESCRIPTION
## What does this do?
The Ability Score Improvement feature is shared by many classes. Every class except for rogue and fighter uses the same Ability Score Improvement feature in the SRD. Despite this, there is a unique feature for each class in the API, with the exact same information. This repetition of information is redundant and as such the 10 sharing classes have had their Ability Score Improvement features condensed into one (actually 5 for each level they are obtained at). They're named `ability-score-improvement-1`, `ability-score-improvement-2`, etc. The features for Fighter and Rogue are unchanged.

Currently features have a `class` attribute which indicates which class has the feature. Currently this supports only one class reference. As such, I've given the new ability score improvement features an attribute called `classes` which is just an array of class APIReferences.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
