### PR TITLE
Missing levels ASI names

### DIFF
--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -92,7 +92,7 @@
     "features": [
       {
         "index": "barbarian-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/barbarian-ability-score-improvement-1"
       }
     ],
@@ -191,7 +191,7 @@
     "features": [
       {
         "index": "barbarian-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/barbarian-ability-score-improvement-2"
       }
     ],
@@ -285,7 +285,7 @@
     "features": [
       {
         "index": "barbarian-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/barbarian-ability-score-improvement-3"
       }
     ],
@@ -379,7 +379,7 @@
     "features": [
       {
         "index": "barbarian-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/barbarian-ability-score-improvement-4"
       }
     ],
@@ -454,7 +454,7 @@
     "features": [
       {
         "index": "barbarian-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/barbarian-ability-score-improvement-5"
       }
     ],
@@ -640,7 +640,7 @@
     "features": [
       {
         "index": "bard-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/bard-ability-score-improvement-1"
       }
     ],
@@ -799,7 +799,7 @@
     "features": [
       {
         "index": "bard-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/bard-ability-score-improvement-2"
       }
     ],
@@ -964,7 +964,7 @@
     "features": [
       {
         "index": "bard-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/bard-ability-score-improvement-3"
       }
     ],
@@ -1124,7 +1124,7 @@
     "features": [
       {
         "index": "bard-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/bard-ability-score-improvement-4"
       }
     ],
@@ -1244,7 +1244,7 @@
     "features": [
       {
         "index": "bard-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/bard-ability-score-improvement-5"
       }
     ],
@@ -1450,7 +1450,7 @@
     "features": [
       {
         "index": "cleric-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/cleric-ability-score-improvement-1"
       }
     ],
@@ -1603,7 +1603,7 @@
     "features": [
       {
         "index": "cleric-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/cleric-ability-score-improvement-2"
       },
       {
@@ -1756,7 +1756,7 @@
     "features": [
       {
         "index": "cleric-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/cleric-ability-score-improvement-3"
       }
     ],
@@ -1892,7 +1892,7 @@
     "features": [
       {
         "index": "cleric-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/cleric-ability-score-improvement-4"
       }
     ],
@@ -2003,7 +2003,7 @@
     "features": [
       {
         "index": "cleric-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/cleric-ability-score-improvement-5"
       }
     ],
@@ -2197,7 +2197,7 @@
       },
       {
         "index": "druid-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/druid-ability-score-improvement-1"
       }
     ],
@@ -2332,7 +2332,7 @@
       },
       {
         "index": "druid-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/druid-ability-score-improvement-2"
       }
     ],
@@ -2462,7 +2462,7 @@
     "features": [
       {
         "index": "druid-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/druid-ability-score-improvement-3"
       }
     ],
@@ -2592,7 +2592,7 @@
     "features": [
       {
         "index": "druid-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/druid-ability-score-improvement-4"
       }
     ],
@@ -2702,7 +2702,7 @@
     "features": [
       {
         "index": "druid-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/druid-ability-score-improvement-5"
       }
     ],
@@ -2857,7 +2857,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-1"
       }
     ],
@@ -2907,7 +2907,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-2"
       }
     ],
@@ -2951,7 +2951,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-3"
       }
     ],
@@ -3045,7 +3045,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-4"
       }
     ],
@@ -3095,7 +3095,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-5"
       }
     ],
@@ -3139,7 +3139,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-6",
-        "name": "Ability Score Improvement 6",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-6"
       }
     ],
@@ -3213,7 +3213,7 @@
     "features": [
       {
         "index": "fighter-ability-score-improvement-7",
-        "name": "Ability Score Improvement 7",
+        "name": "Ability Score Improvement",
         "url": "/api/features/fighter-ability-score-improvement-7"
       }
     ],
@@ -3377,7 +3377,7 @@
     "features": [
       {
         "index": "monk-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/monk-ability-score-improvement-1"
       },
       {
@@ -3504,7 +3504,7 @@
     "features": [
       {
         "index": "monk-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/monk-ability-score-improvement-2"
       }
     ],
@@ -3610,7 +3610,7 @@
     "features": [
       {
         "index": "monk-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/monk-ability-score-improvement-3"
       }
     ],
@@ -3722,7 +3722,7 @@
     "features": [
       {
         "index": "monk-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/monk-ability-score-improvement-4"
       }
     ],
@@ -3800,7 +3800,7 @@
     "features": [
       {
         "index": "monk-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/monk-ability-score-improvement-5"
       }
     ],
@@ -3977,7 +3977,7 @@
     "features": [
       {
         "index": "paladin-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/paladin-ability-score-improvement-1"
       }
     ],
@@ -4091,7 +4091,7 @@
     "features": [
       {
         "index": "paladin-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/paladin-ability-score-improvement-2"
       }
     ],
@@ -4205,7 +4205,7 @@
     "features": [
       {
         "index": "paladin-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/paladin-ability-score-improvement-3"
       }
     ],
@@ -4313,7 +4313,7 @@
     "features": [
       {
         "index": "paladin-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/paladin-ability-score-improvement-4"
       }
     ],
@@ -4397,7 +4397,7 @@
     "features": [
       {
         "index": "paladin-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/paladin-ability-score-improvement-5"
       }
     ],
@@ -4563,7 +4563,7 @@
     "features": [
       {
         "index": "ranger-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/ranger-ability-score-improvement-1"
       }
     ],
@@ -4690,7 +4690,7 @@
     "features": [
       {
         "index": "ranger-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/ranger-ability-score-improvement-2"
       },
       {
@@ -4816,7 +4816,7 @@
     "features": [
       {
         "index": "ranger-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/ranger-ability-score-improvement-3"
       }
     ],
@@ -4937,7 +4937,7 @@
     "features": [
       {
         "index": "ranger-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/ranger-ability-score-improvement-4"
       }
     ],
@@ -5027,7 +5027,7 @@
     "features": [
       {
         "index": "ranger-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/ranger-ability-score-improvement-5"
       }
     ],
@@ -5180,7 +5180,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-1"
       }
     ],
@@ -5284,7 +5284,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-2"
       }
     ],
@@ -5330,7 +5330,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-3"
       }
     ],
@@ -5382,7 +5382,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-4"
       }
     ],
@@ -5480,7 +5480,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-5"
       }
     ],
@@ -5552,7 +5552,7 @@
     "features": [
       {
         "index": "rogue-ability-score-improvement-6",
-        "name": "Ability Score Improvement 6",
+        "name": "Ability Score Improvement",
         "url": "/api/features/rogue-ability-score-improvement-6"
       }
     ],
@@ -5775,7 +5775,7 @@
     "features": [
       {
         "index": "sorcerer-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/sorcerer-ability-score-improvement-1"
       }
     ],
@@ -5993,7 +5993,7 @@
     "features": [
       {
         "index": "sorcerer-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/sorcerer-ability-score-improvement-2"
       }
     ],
@@ -6217,7 +6217,7 @@
     "features": [
       {
         "index": "sorcerer-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/sorcerer-ability-score-improvement-3"
       }
     ],
@@ -6435,7 +6435,7 @@
     "features": [
       {
         "index": "sorcerer-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/sorcerer-ability-score-improvement-4"
       }
     ],
@@ -6606,7 +6606,7 @@
     "features": [
       {
         "index": "sorcerer-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/sorcerer-ability-score-improvement-5"
       }
     ],
@@ -6849,7 +6849,7 @@
     "features": [
       {
         "index": "warlock-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/warlock-ability-score-improvement-1"
       }
     ],
@@ -7003,7 +7003,7 @@
     "features": [
       {
         "index": "warlock-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/warlock-ability-score-improvement-2"
       }
     ],
@@ -7163,7 +7163,7 @@
     "features": [
       {
         "index": "warlock-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/warlock-ability-score-improvement-3"
       }
     ],
@@ -7323,7 +7323,7 @@
     "features": [
       {
         "index": "warlock-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/warlock-ability-score-improvement-4"
       }
     ],
@@ -7443,7 +7443,7 @@
     "features": [
       {
         "index": "warlock-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/warlock-ability-score-improvement-5"
       }
     ],
@@ -7633,7 +7633,7 @@
     "features": [
       {
         "index": "wizard-ability-score-improvement-1",
-        "name": "Ability Score Improvement 1",
+        "name": "Ability Score Improvement",
         "url": "/api/features/wizard-ability-score-improvement-1"
       }
     ],
@@ -7755,7 +7755,7 @@
     "features": [
       {
         "index": "wizard-ability-score-improvement-2",
-        "name": "Ability Score Improvement 2",
+        "name": "Ability Score Improvement",
         "url": "/api/features/wizard-ability-score-improvement-2"
       }
     ],
@@ -7877,7 +7877,7 @@
     "features": [
       {
         "index": "wizard-ability-score-improvement-3",
-        "name": "Ability Score Improvement 3",
+        "name": "Ability Score Improvement",
         "url": "/api/features/wizard-ability-score-improvement-3"
       }
     ],
@@ -7999,7 +7999,7 @@
     "features": [
       {
         "index": "wizard-ability-score-improvement-4",
-        "name": "Ability Score Improvement 4",
+        "name": "Ability Score Improvement",
         "url": "/api/features/wizard-ability-score-improvement-4"
       }
     ],
@@ -8098,7 +8098,7 @@
     "features": [
       {
         "index": "wizard-ability-score-improvement-5",
-        "name": "Ability Score Improvement 5",
+        "name": "Ability Score Improvement",
         "url": "/api/features/wizard-ability-score-improvement-5"
       }
     ],


### PR DESCRIPTION
## What does this do?
The Ability Score Improvement feature was incorrectly named in the levels file for each class. It was named as "Ability Score Improvement 1", "Ability Score Improvement 2", etc. and has now had the number removed for all instances. This was meant to be included in https://github.com/5e-bits/5e-database/pull/385 but it seems the commit didn't push.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
There is not.

## Did you update the docs in the API? Please link an associated PR if applicable.
Not applicable.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
