### PR TITLE
Added missing draconic-ancestry-brass parent

### DIFF
--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -647,6 +647,11 @@
     "desc": [
       "You have draconic ancestry. Choose one type of dragon from the Draconic Ancestry table. Your breath weapon and damage resistance are determined by the dragon type, as shown in the table."
     ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Draconic Ancestry",
+      "url": "/api/traits/draconic-ancestry"
+    },
     "proficiencies": [],
     "trait_specific": {
       "damage_type": {


### PR DESCRIPTION
## What does this do?
The sub-traits for the `draconic-ancestry` trait have a `parent` attribute which points to `draconic-ancestry`. The sub-trait `draconic-ancestry-brass` was missing this parent attribute, and it has been added.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
There isn't.

## Did you update the docs in the API? Please link an associated PR if applicable.
Not applicable.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
