### PR TITLE
Added Quantity To Bard Lute

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -480,7 +480,8 @@
               "index": "lute",
               "name": "Lute",
               "url": "/api/equipment/lute"
-            }
+            },
+            "quantity": 1
           },
           {
             "equipment_option": {

--- a/src/5e-SRD-StartingEquipment.json
+++ b/src/5e-SRD-StartingEquipment.json
@@ -174,7 +174,8 @@
               "index": "lute",
               "name": "Lute",
               "url": "/api/equipment/lute"
-            }
+            },
+            "quantity": 1
           },
           {
             "equipment_option": {


### PR DESCRIPTION
## What does this do?
Adds a missing "quantity" attribute to the Lute in Bard's starting-equipment-options.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
NA

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
