### PR TITLE
add Melee Weapons and Ranged Weapons categories

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1791,6 +1791,205 @@
     "url": "/api/equipment-categories/martial-weapons"
   },
   {
+    "index": "melee-weapons",
+    "name": "Melee Weapons",
+    "equipment": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/equipment/battleaxe"
+      },
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/equipment/club"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/equipment/dagger"
+      },
+      {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/equipment/greataxe"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/equipment/greatclub"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/equipment/halberd"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/equipment/javelin"
+      },
+      {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/equipment/lance"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light hammer",
+        "url": "/api/equipment/light-hammer"
+      },
+      {
+        "index": "longsword",
+        "name": "Longsword",
+        "url": "/api/equipment/longsword"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/equipment/mace"
+      },
+      {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/equipment/maul"
+      },
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "url": "/api/equipment/morningstar"
+      },
+      {
+        "index": "pike",
+        "name": "Pike",
+        "url": "/api/equipment/pike"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/equipment/quarterstaff"
+      },
+      {
+        "index": "rapier",
+        "name": "Rapier",
+        "url": "/api/equipment/rapier"
+      },
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "url": "/api/equipment/scimitar"
+      },
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "url": "/api/equipment/shortsword"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/equipment/spear"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/equipment/trident"
+      },
+      {
+        "index": "war-pick",
+        "name": "War pick",
+        "url": "/api/equipment/war-pick"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/equipment/warhammer"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/equipment/whip"
+      }
+    ],
+    "url": "/api/equipment-categories/melee-weapons"
+  },
+  {
+    "index": "ranged-weapons",
+    "name": "Ranged Weapons",
+    "equipment": [
+      {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/equipment/blowgun"
+      },
+      {
+        "index": "crossbow-hand",
+        "name": "Crossbow, hand",
+        "url": "/api/equipment/crossbow-hand"
+      },
+      {
+        "index": "crossbow-heavy",
+        "name": "Crossbow, heavy",
+        "url": "/api/equipment/crossbow-heavy"
+      },
+      {
+        "index": "crossbow-light",
+        "name": "Crossbow, light",
+        "url": "/api/equipment/crossbow-light"
+      },
+      {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/equipment/dart"
+      },
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/equipment/longbow"
+      },
+      {
+        "index": "net",
+        "name": "Net",
+        "url": "/api/equipment/net"
+      },
+      {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/equipment/shortbow"
+      },
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/equipment/sling"
+      }
+    ],
+    "url": "/api/equipment-categories/ranged-weapons"
+  },
+  {
     "index": "simple-melee-weapons",
     "name": "Simple Melee Weapons",
     "equipment": [


### PR DESCRIPTION
## What does this do?
We already synthesize the "(Simple|Martial) (Melee|Ranged) Weapons" categories into "Simple Weapons" and "Martial Weapons", so it doesn't seem unreasonable to also have mashed-up categories for melee and ranged.

**Outstanding question:** Should melee weapons with the thrown property be included in both categories? I'm conflicted about this one, but as the PR stands now the melee and ranged categories are exclusively combinations of their simple and martial subsets.

## How was it tested?
* Manually tested in Docker container.
* Manually ran Jest.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![](https://media1.tenor.com/images/87124bc0fa8556d17cc52e4ca3a85f17/tenor.gif?itemid=4713194)
