### PR TITLE
Test to enforce consistency of references

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -1736,7 +1736,7 @@
           },
           {
             "index": "forgery-kit",
-            "name": "Forgery kit",
+            "name": "Forgery Kit",
             "url": "/api/proficiencies/forgery-kit"
           }
         ]

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -59,7 +59,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -174,7 +174,7 @@
         },
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         },
         {
@@ -359,7 +359,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -790,7 +790,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       }
     ],
@@ -1414,7 +1414,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -1616,7 +1616,7 @@
         },
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         },
         {
@@ -1837,7 +1837,7 @@
     "proficiencies": [
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -1942,7 +1942,7 @@
       "proficiencies": [
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         },
         {
@@ -2016,7 +2016,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -2189,7 +2189,7 @@
         },
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         },
         {
@@ -2310,7 +2310,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -2460,7 +2460,7 @@
         },
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         },
         {
@@ -2634,7 +2634,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       },
       {
@@ -3180,7 +3180,7 @@
       },
       {
         "index": "simple-weapons",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
       }
     ],
@@ -3333,7 +3333,7 @@
         },
         {
           "index": "simple-weapons",
-          "name": "Simple weapons",
+          "name": "Simple Weapons",
           "url": "/api/proficiencies/simple-weapons"
         }
       ]

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -3271,7 +3271,7 @@
               "from": {
                 "equipment_category": {
                   "index": "arcane-foci",
-                  "name": "Arcane foci",
+                  "name": "Arcane Foci",
                   "url": "/api/equipment-categories/arcane-foci"
                 }
               }

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -1646,32 +1646,32 @@
         "from": [
           {
             "index": "alchemists-supplies",
-            "name": "Alchemist's supplies",
+            "name": "Alchemist's Supplies",
             "url": "/api/proficiencies/alchemists-supplies"
           },
           {
             "index": "brewers-supplies",
-            "name": "Brewer's supplies",
+            "name": "Brewer's Supplies",
             "url": "/api/proficiencies/brewers-supplies"
           },
           {
             "index": "calligraphers-supplies",
-            "name": "Calligrapher's supplies",
+            "name": "Calligrapher's Supplies",
             "url": "/api/proficiencies/calligraphers-supplies"
           },
           {
             "index": "carpenters-tools",
-            "name": "Carpenter's tools",
+            "name": "Carpenter's Tools",
             "url": "/api/proficiencies/carpenters-tools"
           },
           {
             "index": "cartographers-tools",
-            "name": "Cartographer's tools",
+            "name": "Cartographer's Tools",
             "url": "/api/proficiencies/cartographers-tools"
           },
           {
             "index": "cobblers-tools",
-            "name": "Cobbler's tools",
+            "name": "Cobbler's Tools",
             "url": "/api/proficiencies/cobblers-tools"
           },
           {
@@ -1681,52 +1681,52 @@
           },
           {
             "index": "glassblowers-tools",
-            "name": "Glassblower's tools",
+            "name": "Glassblower's Tools",
             "url": "/api/proficiencies/glassblowers-tools"
           },
           {
             "index": "jewelers-tools",
-            "name": "Jeweler's tools",
+            "name": "Jeweler's Tools",
             "url": "/api/proficiencies/jewelers-tools"
           },
           {
             "index": "leatherworkers-tools",
-            "name": "Leatherworker's tools",
+            "name": "Leatherworker's Tools",
             "url": "/api/proficiencies/leatherworkers-tools"
           },
           {
             "index": "masons-tools",
-            "name": "Mason's tools",
+            "name": "Mason's Tools",
             "url": "/api/proficiencies/masons-tools"
           },
           {
             "index": "painters-supplies",
-            "name": "Painter's supplies",
+            "name": "Painter's Supplies",
             "url": "/api/proficiencies/painters-supplies"
           },
           {
             "index": "potters-tools",
-            "name": "Potter's tools",
+            "name": "Potter's Tools",
             "url": "/api/proficiencies/potters-tools"
           },
           {
             "index": "smiths-tools",
-            "name": "Smith's tools",
+            "name": "Smith's Tools",
             "url": "/api/proficiencies/smiths-tools"
           },
           {
             "index": "tinkers-tools",
-            "name": "Tinker's tools",
+            "name": "Tinker's Tools",
             "url": "/api/proficiencies/tinkers-tools"
           },
           {
             "index": "weavers-tools",
-            "name": "Weaver's tools",
+            "name": "Weaver's Tools",
             "url": "/api/proficiencies/weavers-tools"
           },
           {
             "index": "woodcarvers-tools",
-            "name": "Woodcarver's tools",
+            "name": "Woodcarver's Tools",
             "url": "/api/proficiencies/woodcarvers-tools"
           },
           {

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -1731,7 +1731,7 @@
           },
           {
             "index": "disguise-kit",
-            "name": "Disguise kit",
+            "name": "Disguise Kit",
             "url": "/api/proficiencies/disguise-kit"
           },
           {

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -64,7 +64,7 @@
       },
       {
         "index": "martial-weapons",
-        "name": "Martial weapons",
+        "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
       }
     ],
@@ -179,7 +179,7 @@
         },
         {
           "index": "martial-weapons",
-          "name": "Martial weapons",
+          "name": "Martial Weapons",
           "url": "/api/proficiencies/martial-weapons"
         }
       ]
@@ -1419,7 +1419,7 @@
       },
       {
         "index": "martial-weapons",
-        "name": "Martial weapons",
+        "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
       }
     ],
@@ -1621,7 +1621,7 @@
         },
         {
           "index": "martial-weapons",
-          "name": "Martial weapons",
+          "name": "Martial Weapons",
           "url": "/api/proficiencies/martial-weapons"
         }
       ]
@@ -2021,7 +2021,7 @@
       },
       {
         "index": "martial-weapons",
-        "name": "Martial weapons",
+        "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
       }
     ],
@@ -2194,7 +2194,7 @@
         },
         {
           "index": "martial-weapons",
-          "name": "Martial weapons",
+          "name": "Martial Weapons",
           "url": "/api/proficiencies/martial-weapons"
         }
       ]
@@ -2315,7 +2315,7 @@
       },
       {
         "index": "martial-weapons",
-        "name": "Martial weapons",
+        "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
       }
     ],
@@ -2465,7 +2465,7 @@
         },
         {
           "index": "martial-weapons",
-          "name": "Martial weapons",
+          "name": "Martial Weapons",
           "url": "/api/proficiencies/martial-weapons"
         }
       ],

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -44,7 +44,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -354,7 +354,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -775,7 +775,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -975,7 +975,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -1100,7 +1100,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -1281,7 +1281,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -1601,7 +1601,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -2174,7 +2174,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -2295,7 +2295,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -2445,7 +2445,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -2629,7 +2629,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -2802,7 +2802,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {
@@ -3175,7 +3175,7 @@
     "proficiencies": [
       {
         "index": "light-armor",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/proficiencies/light-armor"
       },
       {
@@ -3328,7 +3328,7 @@
       "proficiencies": [
         {
           "index": "light-armor",
-          "name": "Light armor",
+          "name": "Light Armor",
           "url": "/api/proficiencies/light-armor"
         },
         {

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -49,7 +49,7 @@
       },
       {
         "index": "medium-armor",
-        "name": "Medium armor",
+        "name": "Medium Armor",
         "url": "/api/proficiencies/medium-armor"
       },
       {
@@ -780,7 +780,7 @@
       },
       {
         "index": "medium-armor",
-        "name": "Medium armor",
+        "name": "Medium Armor",
         "url": "/api/proficiencies/medium-armor"
       },
       {
@@ -980,7 +980,7 @@
         },
         {
           "index": "medium-armor",
-          "name": "Medium armor",
+          "name": "Medium Armor",
           "url": "/api/proficiencies/medium-armor"
         },
         {
@@ -1105,7 +1105,7 @@
       },
       {
         "index": "medium-armor",
-        "name": "Medium armor",
+        "name": "Medium Armor",
         "url": "/api/proficiencies/medium-armor"
       },
       {
@@ -1286,7 +1286,7 @@
         },
         {
           "index": "medium-armor",
-          "name": "Medium armor",
+          "name": "Medium Armor",
           "url": "/api/proficiencies/medium-armor"
         },
         {
@@ -1606,7 +1606,7 @@
         },
         {
           "index": "medium-armor",
-          "name": "Medium armor",
+          "name": "Medium Armor",
           "url": "/api/proficiencies/medium-armor"
         },
         {
@@ -2179,7 +2179,7 @@
         },
         {
           "index": "medium-armor",
-          "name": "Medium armor",
+          "name": "Medium Armor",
           "url": "/api/proficiencies/medium-armor"
         },
         {
@@ -2300,7 +2300,7 @@
       },
       {
         "index": "medium-armor",
-        "name": "Medium armor",
+        "name": "Medium Armor",
         "url": "/api/proficiencies/medium-armor"
       },
       {
@@ -2450,7 +2450,7 @@
         },
         {
           "index": "medium-armor",
-          "name": "Medium armor",
+          "name": "Medium Armor",
           "url": "/api/proficiencies/medium-armor"
         },
         {

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -2695,7 +2695,7 @@
       {
         "equipment": {
           "index": "thieves-tools",
-          "name": "Thieves' tools",
+          "name": "Thieves' Tools",
           "url": "/api/equipment/thieves-tools"
         },
         "quantity": 1

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1198,7 +1198,7 @@
       },
       {
         "index": "dice-set",
-        "name": "Dice set",
+        "name": "Dice Set",
         "url": "/api/equipment/dice-set"
       },
       {
@@ -2760,7 +2760,7 @@
     "equipment": [
       {
         "index": "dice-set",
-        "name": "Dice set",
+        "name": "Dice Set",
         "url": "/api/equipment/dice-set"
       },
       {

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1263,7 +1263,7 @@
       },
       {
         "index": "thieves-tools",
-        "name": "Thieves' tools",
+        "name": "Thieves' Tools",
         "url": "/api/equipment/thieves-tools"
       }
     ],
@@ -2839,7 +2839,7 @@
       },
       {
         "index": "thieves-tools",
-        "name": "Thieves' tools",
+        "name": "Thieves' Tools",
         "url": "/api/equipment/thieves-tools"
       }
     ],

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1113,32 +1113,32 @@
     "equipment": [
       {
         "index": "alchemists-supplies",
-        "name": "Alchemist's supplies",
+        "name": "Alchemist's Supplies",
         "url": "/api/equipment/alchemists-supplies"
       },
       {
         "index": "brewers-supplies",
-        "name": "Brewer's supplies",
+        "name": "Brewer's Supplies",
         "url": "/api/equipment/brewers-supplies"
       },
       {
         "index": "calligraphers-supplies",
-        "name": "Calligrapher's supplies",
+        "name": "Calligrapher's Supplies",
         "url": "/api/equipment/calligraphers-supplies"
       },
       {
         "index": "carpenters-tools",
-        "name": "Carpenter's tools",
+        "name": "Carpenter's Tools",
         "url": "/api/equipment/carpenters-tools"
       },
       {
         "index": "cartographers-tools",
-        "name": "Cartographer's tools",
+        "name": "Cartographer's Tools",
         "url": "/api/equipment/cartographers-tools"
       },
       {
         "index": "cobblers-tools",
-        "name": "Cobbler's tools",
+        "name": "Cobbler's Tools",
         "url": "/api/equipment/cobblers-tools"
       },
       {
@@ -1148,52 +1148,52 @@
       },
       {
         "index": "glassblowers-tools",
-        "name": "Glassblower's tools",
+        "name": "Glassblower's Tools",
         "url": "/api/equipment/glassblowers-tools"
       },
       {
         "index": "jewelers-tools",
-        "name": "Jeweler's tools",
+        "name": "Jeweler's Tools",
         "url": "/api/equipment/jewelers-tools"
       },
       {
         "index": "leatherworkers-tools",
-        "name": "Leatherworker's tools",
+        "name": "Leatherworker's Tools",
         "url": "/api/equipment/leatherworkers-tools"
       },
       {
         "index": "masons-tools",
-        "name": "Mason's tools",
+        "name": "Mason's Tools",
         "url": "/api/equipment/masons-tools"
       },
       {
         "index": "painters-supplies",
-        "name": "Painter's supplies",
+        "name": "Painter's Supplies",
         "url": "/api/equipment/painters-supplies"
       },
       {
         "index": "potters-tools",
-        "name": "Potter's tools",
+        "name": "Potter's Tools",
         "url": "/api/equipment/potters-tools"
       },
       {
         "index": "smiths-tools",
-        "name": "Smith's tools",
+        "name": "Smith's Tools",
         "url": "/api/equipment/smiths-tools"
       },
       {
         "index": "tinkers-tools",
-        "name": "Tinker's tools",
+        "name": "Tinker's Tools",
         "url": "/api/equipment/tinkers-tools"
       },
       {
         "index": "weavers-tools",
-        "name": "Weaver's tools",
+        "name": "Weaver's Tools",
         "url": "/api/equipment/weavers-tools"
       },
       {
         "index": "woodcarvers-tools",
-        "name": "Woodcarver's tools",
+        "name": "Woodcarver's Tools",
         "url": "/api/equipment/woodcarvers-tools"
       },
       {
@@ -1203,7 +1203,7 @@
       },
       {
         "index": "playing-card-set",
-        "name": "Playing card set",
+        "name": "Playing Card Set",
         "url": "/api/equipment/playing-card-set"
       },
       {
@@ -2668,32 +2668,32 @@
     "equipment": [
       {
         "index": "alchemists-supplies",
-        "name": "Alchemist's supplies",
+        "name": "Alchemist's Supplies",
         "url": "/api/equipment/alchemists-supplies"
       },
       {
         "index": "brewers-supplies",
-        "name": "Brewer's supplies",
+        "name": "Brewer's Supplies",
         "url": "/api/equipment/brewers-supplies"
       },
       {
         "index": "calligraphers-supplies",
-        "name": "Calligrapher's supplies",
+        "name": "Calligrapher's Supplies",
         "url": "/api/equipment/calligraphers-supplies"
       },
       {
         "index": "carpenters-tools",
-        "name": "Carpenter's tools",
+        "name": "Carpenter's Tools",
         "url": "/api/equipment/carpenters-tools"
       },
       {
         "index": "cartographers-tools",
-        "name": "Cartographer's tools",
+        "name": "Cartographer's Tools",
         "url": "/api/equipment/cartographers-tools"
       },
       {
         "index": "cobblers-tools",
-        "name": "Cobbler's tools",
+        "name": "Cobbler's Tools",
         "url": "/api/equipment/cobblers-tools"
       },
       {
@@ -2703,52 +2703,52 @@
       },
       {
         "index": "glassblowers-tools",
-        "name": "Glassblower's tools",
+        "name": "Glassblower's Tools",
         "url": "/api/equipment/glassblowers-tools"
       },
       {
         "index": "jewelers-tools",
-        "name": "Jeweler's tools",
+        "name": "Jeweler's Tools",
         "url": "/api/equipment/jewelers-tools"
       },
       {
         "index": "leatherworkers-tools",
-        "name": "Leatherworker's tools",
+        "name": "Leatherworker's Tools",
         "url": "/api/equipment/leatherworkers-tools"
       },
       {
         "index": "masons-tools",
-        "name": "Mason's tools",
+        "name": "Mason's Tools",
         "url": "/api/equipment/masons-tools"
       },
       {
         "index": "painters-supplies",
-        "name": "Painter's supplies",
+        "name": "Painter's Supplies",
         "url": "/api/equipment/painters-supplies"
       },
       {
         "index": "potters-tools",
-        "name": "Potter's tools",
+        "name": "Potter's Tools",
         "url": "/api/equipment/potters-tools"
       },
       {
         "index": "smiths-tools",
-        "name": "Smith's tools",
+        "name": "Smith's Tools",
         "url": "/api/equipment/smiths-tools"
       },
       {
         "index": "tinkers-tools",
-        "name": "Tinker's tools",
+        "name": "Tinker's Tools",
         "url": "/api/equipment/tinkers-tools"
       },
       {
         "index": "weavers-tools",
-        "name": "Weaver's tools",
+        "name": "Weaver's Tools",
         "url": "/api/equipment/weavers-tools"
       },
       {
         "index": "woodcarvers-tools",
-        "name": "Woodcarver's tools",
+        "name": "Woodcarver's Tools",
         "url": "/api/equipment/woodcarvers-tools"
       }
     ],
@@ -2765,7 +2765,7 @@
       },
       {
         "index": "playing-card-set",
-        "name": "Playing card set",
+        "name": "Playing Card Set",
         "url": "/api/equipment/playing-card-set"
       }
     ],

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1258,7 +1258,7 @@
       },
       {
         "index": "navigators-tools",
-        "name": "Navigator's tools",
+        "name": "Navigator's Tools",
         "url": "/api/equipment/navigators-tools"
       },
       {
@@ -2834,7 +2834,7 @@
     "equipment": [
       {
         "index": "navigators-tools",
-        "name": "Navigator's tools",
+        "name": "Navigator's Tools",
         "url": "/api/equipment/navigators-tools"
       },
       {

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -5025,7 +5025,7 @@
   },
   {
     "index": "alchemists-supplies",
-    "name": "Alchemist's supplies",
+    "name": "Alchemist's Supplies",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5044,7 +5044,7 @@
   },
   {
     "index": "brewers-supplies",
-    "name": "Brewer's supplies",
+    "name": "Brewer's Supplies",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5063,7 +5063,7 @@
   },
   {
     "index": "calligraphers-supplies",
-    "name": "Calligrapher's supplies",
+    "name": "Calligrapher's Supplies",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5082,7 +5082,7 @@
   },
   {
     "index": "carpenters-tools",
-    "name": "Carpenter's tools",
+    "name": "Carpenter's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5101,7 +5101,7 @@
   },
   {
     "index": "cartographers-tools",
-    "name": "Cartographer's tools",
+    "name": "Cartographer's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5120,7 +5120,7 @@
   },
   {
     "index": "cobblers-tools",
-    "name": "Cobbler's tools",
+    "name": "Cobbler's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5158,7 +5158,7 @@
   },
   {
     "index": "glassblowers-tools",
-    "name": "Glassblower's tools",
+    "name": "Glassblower's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5177,7 +5177,7 @@
   },
   {
     "index": "jewelers-tools",
-    "name": "Jeweler's tools",
+    "name": "Jeweler's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5196,7 +5196,7 @@
   },
   {
     "index": "leatherworkers-tools",
-    "name": "Leatherworker's tools",
+    "name": "Leatherworker's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5215,7 +5215,7 @@
   },
   {
     "index": "masons-tools",
-    "name": "Mason's tools",
+    "name": "Mason's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5234,7 +5234,7 @@
   },
   {
     "index": "painters-supplies",
-    "name": "Painter's supplies",
+    "name": "Painter's Supplies",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5253,7 +5253,7 @@
   },
   {
     "index": "potters-tools",
-    "name": "Potter's tools",
+    "name": "Potter's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5272,7 +5272,7 @@
   },
   {
     "index": "smiths-tools",
-    "name": "Smith's tools",
+    "name": "Smith's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5291,7 +5291,7 @@
   },
   {
     "index": "tinkers-tools",
-    "name": "Tinker's tools",
+    "name": "Tinker's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5310,7 +5310,7 @@
   },
   {
     "index": "weavers-tools",
-    "name": "Weaver's tools",
+    "name": "Weaver's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5329,7 +5329,7 @@
   },
   {
     "index": "woodcarvers-tools",
-    "name": "Woodcarver's tools",
+    "name": "Woodcarver's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",
@@ -5367,7 +5367,7 @@
   },
   {
     "index": "playing-card-set",
-    "name": "Playing card set",
+    "name": "Playing Card Set",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -5595,7 +5595,7 @@
   },
   {
     "index": "thieves-tools",
-    "name": "Thieves' tools",
+    "name": "Thieves' Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -5348,7 +5348,7 @@
   },
   {
     "index": "dice-set",
-    "name": "Dice set",
+    "name": "Dice Set",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -5576,7 +5576,7 @@
   },
   {
     "index": "navigators-tools",
-    "name": "Navigator's tools",
+    "name": "Navigator's Tools",
     "equipment_category": {
       "index": "tools",
       "name": "Tools",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6386,7 +6386,7 @@
         ]
       }
     },
-    "url": "/api/features/eldritch-invocations"
+    "url": "/api/features/eldritch-invocations-1"
   },
   {
     "index": "eldritch-invocation-agonizing-blast",
@@ -6409,7 +6409,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-agonizing-blast"
   },
@@ -6429,7 +6429,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-armor-of-shadows"
   },
@@ -6449,7 +6449,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-beast-speech"
   },
@@ -6469,7 +6469,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-beguiling-influence"
   },
@@ -6495,7 +6495,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
   },
@@ -6515,7 +6515,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-devils-sight"
   },
@@ -6535,7 +6535,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-eldritch-sight"
   },
@@ -6560,7 +6560,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-eldritch-spear"
   },
@@ -6580,7 +6580,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
   },
@@ -6600,7 +6600,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-fiendish-vigor"
   },
@@ -6620,7 +6620,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
   },
@@ -6640,7 +6640,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-mask-of-many-faces"
   },
@@ -6660,7 +6660,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-misty-visions"
   },
@@ -6685,7 +6685,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-repelling-blast"
   },
@@ -6705,7 +6705,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-thief-of-five-fates"
   },
@@ -6731,7 +6731,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
   },
@@ -6756,7 +6756,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-mire-the-mind"
   },
@@ -6781,7 +6781,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-one-with-shadows"
   },
@@ -6806,7 +6806,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-sign-of-ill-omen"
   },
@@ -6835,7 +6835,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-thirsting-blade"
   },
@@ -6860,7 +6860,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-bewitching-whispers"
   },
@@ -6885,7 +6885,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-dreadful-word"
   },
@@ -6910,7 +6910,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-sculptor-of-flesh"
   },
@@ -6935,7 +6935,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-ascendant-step"
   },
@@ -6960,7 +6960,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-minions-of-chaos"
   },
@@ -6985,7 +6985,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-otherworldly-leap"
   },
@@ -7010,7 +7010,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-whispers-of-the-grave"
   },
@@ -7039,7 +7039,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-lifedrinker"
   },
@@ -7068,7 +7068,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-chains-of-carceri"
   },
@@ -7093,7 +7093,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-master-of-myriad-forms"
   },
@@ -7118,7 +7118,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-visions-of-distant-realms"
   },
@@ -7143,7 +7143,7 @@
     "parent": {
       "index": "eldritch-invocations-1",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations"
+      "url": "/api/features/eldritch-invocations-1"
     },
     "url": "/api/features/eldritch-invocation-witch-sight"
   },

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -6767,9 +6767,9 @@
     "prof_bonus": 2,
     "feature_choices": [
       {
-        "index": "eldritch-invocations",
+        "index": "eldritch-invocations-1",
         "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations"
+        "url": "/api/features/eldritch-invocations-1"
       }
     ],
     "features": [],

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -9184,7 +9184,7 @@
     },
     "subclass": {
       "index": "fiend",
-      "name": "The Fiend",
+      "name": "Fiend",
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/1",
@@ -9207,7 +9207,7 @@
     },
     "subclass": {
       "index": "fiend",
-      "name": "The Fiend",
+      "name": "Fiend",
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/6",
@@ -9230,7 +9230,7 @@
     },
     "subclass": {
       "index": "fiend",
-      "name": "The Fiend",
+      "name": "Fiend",
       "url": "/api/subclasses/fiend"
     },
     "url": "/api/subclasses/fiend/levels/10",

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -504,7 +504,7 @@
     "features": [
       {
         "index": "spellcasting-bard",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Bard",
         "url": "/api/features/spellcasting-bard"
       },
       {
@@ -1324,7 +1324,7 @@
     "features": [
       {
         "index": "spellcasting-cleric",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Cleric",
         "url": "/api/features/spellcasting-cleric"
       },
       {
@@ -2077,7 +2077,7 @@
     "features": [
       {
         "index": "spellcasting-druid",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Druid",
         "url": "/api/features/spellcasting-druid"
       },
       {
@@ -3897,7 +3897,7 @@
     "features": [
       {
         "index": "spellcasting-paladin",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Paladin",
         "url": "/api/features/spellcasting-paladin"
       },
       {
@@ -4494,7 +4494,7 @@
     "features": [
       {
         "index": "spellcasting-ranger",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Ranger",
         "url": "/api/features/spellcasting-ranger"
       }
     ],
@@ -5604,7 +5604,7 @@
     "features": [
       {
         "index": "spellcasting-sorcerer",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Sorcerer",
         "url": "/api/features/spellcasting-sorcerer"
       },
       {
@@ -7529,7 +7529,7 @@
     "features": [
       {
         "index": "spellcasting-wizard",
-        "name": "Spellcasting",
+        "name": "Spellcasting: Wizard",
         "url": "/api/features/spellcasting-wizard"
       },
       {

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -8742,7 +8742,7 @@
     "features": [
       {
         "index": "quivering-palm",
-        "name": "Quiverying Palm",
+        "name": "Quivering Palm",
         "url": "/api/features/quivering-palm"
       }
     ],

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -31,9 +31,9 @@
     "index": "amulet-of-health",
     "name": "Amulet of Health",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -45,9 +45,9 @@
     "index": "amulet-of-proof-against-detection-and-location",
     "name": "Amulet of Proof against Detection and Location",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -59,9 +59,9 @@
     "index": "amulet-of-the-planes",
     "name": "Amulet of the Planes",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -87,9 +87,9 @@
     "index": "apparatus-of-the-crab",
     "name": "Apparatus of the Crab",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -221,9 +221,9 @@
     "index": "bag-of-beans",
     "name": "Bag of Beans",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -251,9 +251,9 @@
     "index": "bag-of-devouring",
     "name": "Bag of Devouring",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -268,9 +268,9 @@
     "index": "bag-of-holding",
     "name": "Bag of Holding",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -284,9 +284,9 @@
     "index": "bag-of-tricks",
     "name": "Bag of Tricks",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -334,9 +334,9 @@
     "index": "bead-of-force",
     "name": "Bead of Force",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -350,12 +350,12 @@
     "index": "belt-of-dwarvenkind",
     "name": "Belt of Dwarvenkind",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
-      "Wondrous Item, rare (requires attunement)",
+      "Wondrous Items, rare (requires attunement)",
       "While wearing this belt, you gain the following benefits:",
       "Your Constitution score increases by 2, to a maximum of 20.",
       "You have advantage on Charisma (Persuasion) checks made to interact with Dwarves.",
@@ -370,9 +370,9 @@
     "index": "belt-of-giant-strength",
     "name": "Belt of Giant Strength",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rarity varies (requires attunement)",
@@ -408,9 +408,9 @@
     "index": "boots-of-elvenkind",
     "name": "Boots of Elvenkind",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -422,9 +422,9 @@
     "index": "boots-of-levitation",
     "name": "Boots of Levitation",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -436,9 +436,9 @@
     "index": "boots-of-speed",
     "name": "Boots of Speed",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -451,9 +451,9 @@
     "index": "boots-of-striding-and-springing",
     "name": "Boots of Striding and Springing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -465,9 +465,9 @@
     "index": "boots-of-the-winterlands",
     "name": "Boots of the Winterlands",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -482,9 +482,9 @@
     "index": "bowl-of-commanding-water-elementals",
     "name": "Bowl of Commanding Water Elementals",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -497,9 +497,9 @@
     "index": "bracers-of-archery",
     "name": "Bracers of Archery",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -511,9 +511,9 @@
     "index": "bracers-of-defense",
     "name": "Bracers of Defense",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondous item, rare (requires attunement)",
@@ -525,9 +525,9 @@
     "index": "brazier-of-commanding-fire-elementals",
     "name": "Brazier of Commanding Fire Elementals",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -540,9 +540,9 @@
     "index": "brooch-of-shielding",
     "name": "Brooch of Shielding",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -554,9 +554,9 @@
     "index": "broom-of-flying",
     "name": "Broom of Flying",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -569,9 +569,9 @@
     "index": "candle-of-invocation",
     "name": "Candle of Invocation",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -597,9 +597,9 @@
     "index": "cape-of-the-mountebank",
     "name": "Cape of the Mountebank",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -612,9 +612,9 @@
     "index": "carpet-of-flying",
     "name": "Carpet of Flying",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -634,9 +634,9 @@
     "index": "censer-of-controlling-air-elementals",
     "name": "Censer of Controlling Air Elementals",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -649,9 +649,9 @@
     "index": "chime-of-opening",
     "name": "Chime of Opening",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -664,9 +664,9 @@
     "index": "circlet-of-blasting",
     "name": "Circlet of Blasting",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -678,9 +678,9 @@
     "index": "cloak-of-arachnida",
     "name": "Cloak of Arachnida",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -697,9 +697,9 @@
     "index": "cloak-of-displacement",
     "name": "Cloak of Displacement",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -711,9 +711,9 @@
     "index": "cloak-of-elvenkind",
     "name": "Cloak of Elvenkind",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -725,9 +725,9 @@
     "index": "cloak-of-protection",
     "name": "Cloak of Protection",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -739,9 +739,9 @@
     "index": "cloak-of-the-bat",
     "name": "Cloak of the Bat",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -754,9 +754,9 @@
     "index": "cloak-of-the-manta-ray",
     "name": "Cloak of the Manta Ray",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -768,9 +768,9 @@
     "index": "crystal-ball",
     "name": "Crystal Ball",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare or legendary (requires attunement)",
@@ -786,9 +786,9 @@
     "index": "cube-of-force",
     "name": "Cube of Force",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -819,9 +819,9 @@
     "index": "cubic-gate",
     "name": "Cubic Gate",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -866,9 +866,9 @@
     "index": "decanter-of-endless-water",
     "name": "Decanter of Endless Water",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -884,9 +884,9 @@
     "index": "deck-of-illusions",
     "name": "Deck of Illusions",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -936,9 +936,9 @@
     "index": "deck-of-many-things",
     "name": "Deck of Many Things",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -1023,9 +1023,9 @@
     "index": "dimensional-shackles",
     "name": "Dimensional Shackles",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1081,9 +1081,9 @@
     "index": "dust-of-disappearance",
     "name": "Dust of Disappearance",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1095,9 +1095,9 @@
     "index": "dust-of-dryness",
     "name": "Dust of Dryness",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1111,9 +1111,9 @@
     "index": "dust-of-sneezing-and-choking",
     "name": "Dust of Sneezing and Choking",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1154,9 +1154,9 @@
     "index": "efficient-quiver",
     "name": "Efficient Quiver",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1169,9 +1169,9 @@
     "index": "efreeti-bottle",
     "name": "Efreeti Bottle",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -1189,9 +1189,9 @@
     "index": "elemental-gem",
     "name": "Elemental Gem",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1223,9 +1223,9 @@
     "index": "eversmoking-bottle",
     "name": "Eversmoking Bottle",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1238,9 +1238,9 @@
     "index": "eyes-of-charming",
     "name": "Eyes of Charming",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1252,9 +1252,9 @@
     "index": "eyes-of-minute-seeing",
     "name": "Eyes of Minute Seeing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1266,9 +1266,9 @@
     "index": "eyes-of-the-eagle",
     "name": "Eyes of the Eagle",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1280,9 +1280,9 @@
     "index": "feather-token",
     "name": "Feather Token",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1309,9 +1309,9 @@
     "index": "figurine-of-wondrous-power",
     "name": "Figurine of Wondrous Power",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rarity by figurine",
@@ -1362,9 +1362,9 @@
     "index": "folding-boat",
     "name": "Folding Boat",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1396,9 +1396,9 @@
     "index": "gauntlets-of-ogre-power",
     "name": "Gauntlets of Ogre Power",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1410,9 +1410,9 @@
     "index": "gem-of-brightness",
     "name": "Gem of Brightness",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1428,9 +1428,9 @@
     "index": "gem-of-seeing",
     "name": "Gem of Seeing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -1472,9 +1472,9 @@
     "index": "gloves-of-missile-snaring",
     "name": "Gloves of Missile Snaring",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1486,9 +1486,9 @@
     "index": "gloves-of-swimming-and-climbing",
     "name": "Gloves of Swimming and Climbing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1500,9 +1500,9 @@
     "index": "goggles-of-night",
     "name": "Goggles of Night",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1530,9 +1530,9 @@
     "index": "handy-haversack",
     "name": "Handy Haversack",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1547,9 +1547,9 @@
     "index": "hat-of-disguise",
     "name": "Hat of Disguise",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1561,9 +1561,9 @@
     "index": "headband-of-intellect",
     "name": "Headband of Intellect",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1575,9 +1575,9 @@
     "index": "helm-of-brilliance",
     "name": "Helm of Brilliance",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -1595,9 +1595,9 @@
     "index": "helm-of-comprehending-languages",
     "name": "Helm of Comprehending Languages",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1609,9 +1609,9 @@
     "index": "helm-of-telepathy",
     "name": "Helm of Telepathy",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -1624,9 +1624,9 @@
     "index": "helm-of-teleportation",
     "name": "Helm of Teleportation",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -1654,9 +1654,9 @@
     "index": "horn-of-blasting",
     "name": "Horn of Blasting",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1669,9 +1669,9 @@
     "index": "horn-of-valhalla",
     "name": "Horn of Valhalla",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (silver or brass), very rare (bronze) or legendary (iron)",
@@ -1691,9 +1691,9 @@
     "index": "horseshoes-of-a-zephyr",
     "name": "Horseshoes of a Zephyr",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -1705,9 +1705,9 @@
     "index": "horseshoes-of-speed",
     "name": "Horseshoes of Speed",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1733,9 +1733,9 @@
     "index": "instant-fortress",
     "name": "Instant Fortress",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1751,9 +1751,9 @@
     "index": "ioun-stone",
     "name": "Ioun Stone",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, varies (requires attunement)",
@@ -1785,9 +1785,9 @@
     "index": "iron-bands-of-binding",
     "name": "Iron Bands of Binding",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -1802,9 +1802,9 @@
     "index": "iron-flask",
     "name": "Iron Flask",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -1855,9 +1855,9 @@
     "index": "lantern-of-revealing",
     "name": "Lantern of Revealing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -1930,9 +1930,9 @@
     "index": "mantle-of-spell-resistance",
     "name": "Mantle of Spell Resistance",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -1944,9 +1944,9 @@
     "index": "manual-of-bodily-health",
     "name": "Manual of Bodily Health",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -1958,9 +1958,9 @@
     "index": "manual-of-gainful-exercise",
     "name": "Manual of Gainful Exercise",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -1972,9 +1972,9 @@
     "index": "manual-of-golems",
     "name": "Manual of Golems",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -1994,9 +1994,9 @@
     "index": "manual-of-quickness-of-action",
     "name": "Manual of Quickness of Action",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -2008,9 +2008,9 @@
     "index": "marvelous-pigments",
     "name": "Marvelous Pigments",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -2026,9 +2026,9 @@
     "index": "medallion-of-thoughts",
     "name": "Medallion of Thoughts",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -2040,9 +2040,9 @@
     "index": "mirror-of-life-trapping",
     "name": "Mirror of Life Trapping",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -2074,9 +2074,9 @@
     "index": "necklace-of-adaptation",
     "name": "Necklace of Adaptation",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -2088,9 +2088,9 @@
     "index": "necklace-of-fireballs",
     "name": "Necklace of Fireballs",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -2103,9 +2103,9 @@
     "index": "necklace-of-prayer-beads",
     "name": "Necklace of Prayer Beads",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement by a cleric, druid, or paladin)",
@@ -2200,9 +2200,9 @@
     "index": "pearl-of-power",
     "name": "Pearl of Power",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement by a spellcaster)",
@@ -2214,9 +2214,9 @@
     "index": "periapt-of-health",
     "name": "Periapt of Health",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -2228,9 +2228,9 @@
     "index": "periapt-of-proof-against-poison",
     "name": "Periapt of Proof against Poison",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -2242,9 +2242,9 @@
     "index": "periapt-of-wound-closure",
     "name": "Periapt of Wound Closure",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -2270,9 +2270,9 @@
     "index": "pipes-of-haunting",
     "name": "Pipes of Haunting",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -2284,9 +2284,9 @@
     "index": "pipes-of-the-sewers",
     "name": "Pipes of the Sewers",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -2314,9 +2314,9 @@
     "index": "portable-hole",
     "name": "Portable Hole",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -2584,9 +2584,9 @@
     "index": "restorative-ointment",
     "name": "Restorative Ointment",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -2962,9 +2962,9 @@
     "index": "robe-of-eyes",
     "name": "Robe of Eyes",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -2981,9 +2981,9 @@
     "index": "robe-of-scintillating-colors",
     "name": "Robe of Scintillating Colors",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -2995,9 +2995,9 @@
     "index": "robe-of-stars",
     "name": "Robe of Stars",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare (requires attunement)",
@@ -3011,9 +3011,9 @@
     "index": "robe-of-the-archmagi",
     "name": "Robe of the Archmagi",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary (requires attunement by a sorcerer, warlock, or wizard)",
@@ -3029,9 +3029,9 @@
     "index": "robe-of-useful-items",
     "name": "Robe of Useful Items",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -3154,9 +3154,9 @@
     "index": "rope-of-climbing",
     "name": "Rope of Climbing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -3170,9 +3170,9 @@
     "index": "rope-of-entanglement",
     "name": "Rope of Entanglement",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -3186,9 +3186,9 @@
     "index": "scarab-of-protection",
     "name": "Scarab of Protection",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary (requires attunement)",
@@ -3231,9 +3231,9 @@
     "index": "slippers-of-spider-climbing",
     "name": "Slippers of Spider Climbing",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -3245,9 +3245,9 @@
     "index": "sovereign-glue",
     "name": "Sovereign Glue",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -3304,9 +3304,9 @@
     "index": "sphere-of-annihilation",
     "name": "Sphere of Annihilation",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -3538,9 +3538,9 @@
     "index": "stone-of-controlling-earth-elementals",
     "name": "Stone of Controlling Earth Elementals",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare",
@@ -3552,9 +3552,9 @@
     "index": "stone-of-good-luck-(luckstone)",
     "name": "Stone of Good Luck (Luckstone)",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -3627,9 +3627,9 @@
     "index": "talisman-of-pure-good",
     "name": "Talisman of Pure Good",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary (requires attunement by a creature of good alignment)",
@@ -3643,9 +3643,9 @@
     "index": "talisman-of-the-sphere",
     "name": "Talisman of the Sphere",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary (requires attunement)",
@@ -3657,9 +3657,9 @@
     "index": "talisman-of-ultimate-evil",
     "name": "Talisman of Ultimate Evil",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary (requires attunement by a creature of evil alignment)",
@@ -3673,9 +3673,9 @@
     "index": "tome-of-clear-thought",
     "name": "Tome of Clear Thought",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -3687,9 +3687,9 @@
     "index": "tome-of-leadership-and-influence",
     "name": "Tome of Leadership and Influence",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -3701,9 +3701,9 @@
     "index": "tome-of-understanding",
     "name": "Tome of Understanding",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, very rare",
@@ -3729,9 +3729,9 @@
     "index": "universal-solvent",
     "name": "Universal Solvent",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -4004,9 +4004,9 @@
     "index": "well-of-many-worlds",
     "name": "Well of Many Worlds",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, legendary",
@@ -4019,9 +4019,9 @@
     "index": "wind-fan",
     "name": "Wind Fan",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon",
@@ -4033,9 +4033,9 @@
     "index": "winged-boots",
     "name": "Winged Boots",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, uncommon (requires attunement)",
@@ -4048,9 +4048,9 @@
     "index": "wings-of-flying",
     "name": "Wings of Flying",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, rare (requires attunement)",
@@ -4066,9 +4066,9 @@
     "index": "orb-of-dragonkind",
     "name": "Orb of Dragonkind",
     "equipment_category": {
-      "index": "wondrous-item",
-      "name": "Wondrous Item",
-      "url": "/api/equipment-categories/wondrous-item"
+      "index": "wondrous-items",
+      "name": "Wondrous Items",
+      "url": "/api/equipment-categories/wondrous-items"
     },
     "desc": [
       "Wondrous item, artifact (requires attunement)",

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -137,7 +137,7 @@
     "name": "Armor of Invulnerability",
     "equipment_category": {
       "index": "armor",
-      "name": "armor",
+      "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
     "desc": [

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -13327,7 +13327,7 @@
           "components_required": [],
           "spells": [
             {
-              "name": "Entangle",
+              "name": "Dancing Lights",
               "level": 1,
               "url": "/api/spells/dancing-lights",
               "usage": {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -29589,7 +29589,7 @@
             {
               "name": "Suggestion",
               "level": 2,
-              "url": "/api/spells/mass-suggestion",
+              "url": "/api/spells/suggestion",
               "usage": {
                 "type": "per day",
                 "times": 3

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -13571,7 +13571,7 @@
             {
               "name": "Darkness",
               "level": 2,
-              "url": "/api/spells/entangle",
+              "url": "/api/spells/darkness",
               "usage": {
                 "type": "per day",
                 "times": 1

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -13882,7 +13882,7 @@
               }
             },
             {
-              "name": "Pass without Trace",
+              "name": "Pass Without Trace",
               "level": 2,
               "url": "/api/spells/pass-without-trace",
               "usage": {
@@ -35748,7 +35748,7 @@
               }
             },
             {
-              "name": "Pass without Trace",
+              "name": "Pass Without Trace",
               "level": 2,
               "url": "/api/spells/pass-without-trace",
               "usage": {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -37014,7 +37014,7 @@
   },
   {
     "index": "werebear-bear",
-    "name": "Werebear, Bear form",
+    "name": "Werebear, Bear Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37128,7 +37128,7 @@
   },
   {
     "index": "werebear-human",
-    "name": "Werebear, Human form",
+    "name": "Werebear, Human Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37226,7 +37226,7 @@
   },
   {
     "index": "werebear-hybrid",
-    "name": "Werebear, Hybrid form",
+    "name": "Werebear, Hybrid Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37374,7 +37374,7 @@
   },
   {
     "index": "wereboar-boar",
-    "name": "Wereboar, Boar form",
+    "name": "Wereboar, Boar Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37465,7 +37465,7 @@
   },
   {
     "index": "wereboar-human",
-    "name": "Wereboar, Human form",
+    "name": "Wereboar, Human Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37568,7 +37568,7 @@
   },
   {
     "index": "wereboar-hybrid",
-    "name": "Wereboar, Hybrid form",
+    "name": "Wereboar, Hybrid Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37702,7 +37702,7 @@
   },
   {
     "index": "wererat-human",
-    "name": "Wererat, Human form",
+    "name": "Wererat, Human Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -37842,7 +37842,7 @@
   },
   {
     "index": "wererat-hybrid",
-    "name": "Wererat, Hybrid form",
+    "name": "Wererat, Hybrid Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38021,7 +38021,7 @@
   },
   {
     "index": "wererat-rat",
-    "name": "Wererat, Rat form",
+    "name": "Wererat, Rat Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38112,7 +38112,7 @@
   },
   {
     "index": "weretiger-human",
-    "name": "Weretiger, Human form",
+    "name": "Weretiger, Human Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38241,7 +38241,7 @@
   },
   {
     "index": "weretiger-hybrid",
-    "name": "Weretiger, Hybrid form",
+    "name": "Weretiger, Hybrid Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38411,7 +38411,7 @@
   },
   {
     "index": "weretiger-tiger",
-    "name": "Weretiger, Tiger form",
+    "name": "Weretiger, Tiger Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38521,7 +38521,7 @@
   },
   {
     "index": "werewolf-human",
-    "name": "Werewolf, Human form",
+    "name": "Werewolf, Human Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38633,7 +38633,7 @@
   },
   {
     "index": "werewolf-hybrid",
-    "name": "Werewolf, Hybrid form",
+    "name": "Werewolf, Hybrid Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",
@@ -38751,7 +38751,7 @@
   },
   {
     "index": "werewolf-wolf",
-    "name": "Werewolf, Wolf form",
+    "name": "Werewolf, Wolf Form",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "human",

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -373,7 +373,7 @@
   {
     "index": "simple-weapons",
     "type": "Weapons",
-    "name": "Simple weapons",
+    "name": "Simple Weapons",
     "classes": [
       {
         "index": "barbarian",
@@ -427,7 +427,7 @@
       {
         "index": "simple-weapons",
         "type": "equipment-categories",
-        "name": "Simple weapons",
+        "name": "Simple Weapons",
         "url": "/api/equipment-categories/simple-weapons"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -1549,7 +1549,7 @@
   {
     "index": "forgery-kit",
     "type": "Artisan's Tools",
-    "name": "Forgery kit",
+    "name": "Forgery Kit",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/forgery-kit",
@@ -1557,7 +1557,7 @@
       {
         "index": "forgery-kit",
         "type": "equipment",
-        "name": "Forgery kit",
+        "name": "Forgery Kit",
         "url": "/api/equipment/forgery-kit"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -1261,7 +1261,7 @@
   {
     "index": "alchemists-supplies",
     "type": "Artisan's Tools",
-    "name": "Alchemist's supplies",
+    "name": "Alchemist's Supplies",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/alchemists-supplies",
@@ -1269,7 +1269,7 @@
       {
         "index": "alchemists-supplies",
         "type": "equipment",
-        "name": "Alchemist's supplies",
+        "name": "Alchemist's Supplies",
         "url": "/api/equipment/alchemists-supplies"
       }
     ]
@@ -1277,7 +1277,7 @@
   {
     "index": "brewers-supplies",
     "type": "Artisan's Tools",
-    "name": "Brewer's supplies",
+    "name": "Brewer's Supplies",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/brewers-supplies",
@@ -1285,7 +1285,7 @@
       {
         "index": "brewers-supplies",
         "type": "equipment",
-        "name": "Brewer's supplies",
+        "name": "Brewer's Supplies",
         "url": "/api/equipment/brewers-supplies"
       }
     ]
@@ -1293,7 +1293,7 @@
   {
     "index": "calligraphers-supplies",
     "type": "Artisan's Tools",
-    "name": "Calligrapher's supplies",
+    "name": "Calligrapher's Supplies",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/calligraphers-supplies",
@@ -1301,7 +1301,7 @@
       {
         "index": "calligraphers-supplies",
         "type": "equipment",
-        "name": "Calligrapher's supplies",
+        "name": "Calligrapher's Supplies",
         "url": "/api/equipment/calligraphers-supplies"
       }
     ]
@@ -1309,7 +1309,7 @@
   {
     "index": "carpenters-tools",
     "type": "Artisan's Tools",
-    "name": "Carpenter's tools",
+    "name": "Carpenter's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/carpenters-tools",
@@ -1317,7 +1317,7 @@
       {
         "index": "carpenters-tools",
         "type": "equipment",
-        "name": "Carpenter's tools",
+        "name": "Carpenter's Tools",
         "url": "/api/equipment/carpenters-tools"
       }
     ]
@@ -1325,7 +1325,7 @@
   {
     "index": "cartographers-tools",
     "type": "Artisan's Tools",
-    "name": "Cartographer's tools",
+    "name": "Cartographer's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/cartographers-tools",
@@ -1333,7 +1333,7 @@
       {
         "index": "cartographers-tools",
         "type": "equipment",
-        "name": "Cartographer's tools",
+        "name": "Cartographer's Tools",
         "url": "/api/equipment/cartographers-tools"
       }
     ]
@@ -1341,7 +1341,7 @@
   {
     "index": "cobblers-tools",
     "type": "Artisan's Tools",
-    "name": "Cobbler's tools",
+    "name": "Cobbler's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/cobblers-tools",
@@ -1349,7 +1349,7 @@
       {
         "index": "cobblers-tools",
         "type": "equipment",
-        "name": "Cobbler's tools",
+        "name": "Cobbler's Tools",
         "url": "/api/equipment/cobblers-tools"
       }
     ]
@@ -1373,7 +1373,7 @@
   {
     "index": "glassblowers-tools",
     "type": "Artisan's Tools",
-    "name": "Glassblower's tools",
+    "name": "Glassblower's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/glassblowers-tools",
@@ -1381,7 +1381,7 @@
       {
         "index": "glassblowers-tools",
         "type": "equipment",
-        "name": "Glassblower's tools",
+        "name": "Glassblower's Tools",
         "url": "/api/equipment/glassblowers-tools"
       }
     ]
@@ -1389,7 +1389,7 @@
   {
     "index": "jewelers-tools",
     "type": "Artisan's Tools",
-    "name": "Jeweler's tools",
+    "name": "Jeweler's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/jewelers-tools",
@@ -1397,7 +1397,7 @@
       {
         "index": "jewelers-tools",
         "type": "equipment",
-        "name": "Jeweler's tools",
+        "name": "Jeweler's Tools",
         "url": "/api/equipment/jewelers-tools"
       }
     ]
@@ -1405,7 +1405,7 @@
   {
     "index": "leatherworkers-tools",
     "type": "Artisan's Tools",
-    "name": "Leatherworker's tools",
+    "name": "Leatherworker's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/leatherworkers-tools",
@@ -1413,7 +1413,7 @@
       {
         "index": "leatherworkers-tools",
         "type": "equipment",
-        "name": "Leatherworker's tools",
+        "name": "Leatherworker's Tools",
         "url": "/api/equipment/leatherworkers-tools"
       }
     ]
@@ -1421,7 +1421,7 @@
   {
     "index": "masons-tools",
     "type": "Artisan's Tools",
-    "name": "Mason's tools",
+    "name": "Mason's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/masons-tools",
@@ -1429,7 +1429,7 @@
       {
         "index": "masons-tools",
         "type": "equipment",
-        "name": "Mason's tools",
+        "name": "Mason's Tools",
         "url": "/api/equipment/masons-tools"
       }
     ]
@@ -1437,7 +1437,7 @@
   {
     "index": "painters-supplies",
     "type": "Artisan's Tools",
-    "name": "Painter's supplies",
+    "name": "Painter's Supplies",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/painters-supplies",
@@ -1445,7 +1445,7 @@
       {
         "index": "painters-supplies",
         "type": "equipment",
-        "name": "Painter's supplies",
+        "name": "Painter's Supplies",
         "url": "/api/equipment/painters-supplies"
       }
     ]
@@ -1453,7 +1453,7 @@
   {
     "index": "potters-tools",
     "type": "Artisan's Tools",
-    "name": "Potter's tools",
+    "name": "Potter's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/potters-tools",
@@ -1461,7 +1461,7 @@
       {
         "index": "potters-tools",
         "type": "equipment",
-        "name": "Potter's tools",
+        "name": "Potter's Tools",
         "url": "/api/equipment/potters-tools"
       }
     ]
@@ -1469,7 +1469,7 @@
   {
     "index": "smiths-tools",
     "type": "Artisan's Tools",
-    "name": "Smith's tools",
+    "name": "Smith's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/smiths-tools",
@@ -1477,7 +1477,7 @@
       {
         "index": "smiths-tools",
         "type": "equipment",
-        "name": "Smith's tools",
+        "name": "Smith's Tools",
         "url": "/api/equipment/smiths-tools"
       }
     ]
@@ -1485,7 +1485,7 @@
   {
     "index": "tinkers-tools",
     "type": "Artisan's Tools",
-    "name": "Tinker's tools",
+    "name": "Tinker's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/tinkers-tools",
@@ -1493,7 +1493,7 @@
       {
         "index": "tinkers-tools",
         "type": "equipment",
-        "name": "Tinker's tools",
+        "name": "Tinker's Tools",
         "url": "/api/equipment/tinkers-tools"
       }
     ]
@@ -1501,7 +1501,7 @@
   {
     "index": "weavers-tools",
     "type": "Artisan's Tools",
-    "name": "Weaver's tools",
+    "name": "Weaver's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/weavers-tools",
@@ -1509,7 +1509,7 @@
       {
         "index": "weavers-tools",
         "type": "equipment",
-        "name": "Weaver's tools",
+        "name": "Weaver's Tools",
         "url": "/api/equipment/weavers-tools"
       }
     ]
@@ -1517,7 +1517,7 @@
   {
     "index": "woodcarvers-tools",
     "type": "Artisan's Tools",
-    "name": "Woodcarver's tools",
+    "name": "Woodcarver's Tools",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/woodcarvers-tools",
@@ -1525,7 +1525,7 @@
       {
         "index": "woodcarvers-tools",
         "type": "equipment",
-        "name": "Woodcarver's tools",
+        "name": "Woodcarver's Tools",
         "url": "/api/equipment/woodcarvers-tools"
       }
     ]
@@ -1581,7 +1581,7 @@
   {
     "index": "playing-card-set",
     "type": "Gaming Sets",
-    "name": "Playing card set",
+    "name": "Playing Card Set",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/playing-card-set",
@@ -1589,7 +1589,7 @@
       {
         "index": "playing-card-set",
         "type": "equipment",
-        "name": "Playing card set",
+        "name": "Playing Card Set",
         "url": "/api/equipment/playing-card-set"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -435,7 +435,7 @@
   {
     "index": "martial-weapons",
     "type": "Weapons",
-    "name": "Martial weapons",
+    "name": "Martial Weapons",
     "classes": [
       {
         "index": "barbarian",
@@ -464,7 +464,7 @@
       {
         "index": "martial-weapons",
         "type": "equipment-categories",
-        "name": "Martial weapons",
+        "name": "Martial Weapons",
         "url": "/api/equipment-categories/martial-weapons"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -2,7 +2,7 @@
   {
     "index": "light-armor",
     "type": "Armor",
-    "name": "Light armor",
+    "name": "Light Armor",
     "classes": [
       {
         "index": "barbarian",
@@ -46,7 +46,7 @@
       {
         "index": "light-armor",
         "type": "equipment-categories",
-        "name": "Light armor",
+        "name": "Light Armor",
         "url": "/api/equipment-categories/light-armor"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -1533,7 +1533,7 @@
   {
     "index": "disguise-kit",
     "type": "Artisan's Tools",
-    "name": "Disguise kit",
+    "name": "Disguise Kit",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/disguise-kit",
@@ -1541,7 +1541,7 @@
       {
         "index": "disguise-kit",
         "type": "equipment",
-        "name": "Disguise kit",
+        "name": "Disguise Kit",
         "url": "/api/equipment/disguise-kit"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -91,7 +91,7 @@
   {
     "index": "heavy-armor",
     "type": "Armor",
-    "name": "Heavy armor",
+    "name": "Heavy Armor",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/heavy-armor",
@@ -99,7 +99,7 @@
       {
         "index": "heavy-armor",
         "type": "equipment-categories",
-        "name": "Heavy armor",
+        "name": "Heavy Armor",
         "url": "/api/equipment-categories/heavy-armor"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -126,7 +126,7 @@
       {
         "index": "armor",
         "type": "equipment-categories",
-        "name": "All armor",
+        "name": "Armor",
         "url": "/api/equipment-categories/armor"
       }
     ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -54,7 +54,7 @@
   {
     "index": "medium-armor",
     "type": "Armor",
-    "name": "Medium armor",
+    "name": "Medium Armor",
     "classes": [
       {
         "index": "barbarian",
@@ -83,7 +83,7 @@
       {
         "index": "medium-armor",
         "type": "equipment-categories",
-        "name": "Medium armor",
+        "name": "Medium Armor",
         "url": "/api/equipment-categories/medium-armor"
       }
     ]

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -45,17 +45,17 @@
       "from": [
         {
           "index": "smiths-tools",
-          "name": "Smith's tools",
+          "name": "Smith's Tools",
           "url": "/api/proficiencies/smiths-tools"
         },
         {
           "index": "brewers-supplies",
-          "name": "Brewer's supplies",
+          "name": "Brewer's Supplies",
           "url": "/api/proficiencies/brewers-supplies"
         },
         {
           "index": "masons-tools",
-          "name": "Mason's tools",
+          "name": "Mason's Tools",
           "url": "/api/proficiencies/masons-tools"
         }
       ]

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -866,9 +866,9 @@
         "url": "/api/languages/common"
       },
       {
-        "index": "abyssal",
+        "index": "infernal",
         "name": "Infernal",
-        "url": "/api/languages/abyssal"
+        "url": "/api/languages/infernal"
       }
     ],
     "language_desc": "You can speak, read, and write Common and Infernal.",

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -807,7 +807,7 @@
       },
       {
         "index": "orc",
-        "name": "Orcish",
+        "name": "Orc",
         "url": "/api/languages/orc"
       }
     ],

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -825,7 +825,7 @@
       },
       {
         "index": "relentless-endurance",
-        "name": "Restless Endurance",
+        "name": "Relentless Endurance",
         "url": "/api/traits/relentless-endurance"
       }
     ],

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -2367,7 +2367,7 @@
   },
   {
     "index": "commune-with-nature",
-    "name": "Commune with Nature",
+    "name": "Commune With Nature",
     "desc": [
       "You briefly become one with nature and gain knowledge of the surrounding territory. In the outdoors, the spell gives you knowledge of the land within 3 miles of you. In caves and other natural underground settings, the radius is limited to 300 feet. The spell doesn't function where nature has been replaced by construction, such as in dungeons and towns.",
       "You instantly gain knowledge of up to three facts of your choice about any of the following subjects as they relate to the area:",

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -10008,7 +10008,7 @@
   },
   {
     "index": "meld-into-stone",
-    "name": "Meld into Stone",
+    "name": "Meld Into Stone",
     "desc": [
       "You step into a stone object or surface large enough to fully contain your body, melding yourself and all the equipment you carry with the stone for the duration. Using your movement, you step into the stone at a point you can touch. Nothing of your presence remains visible or otherwise detectable by nonmagical senses.",
       "While merged with the stone, you can't see what occurs outside it, and any Wisdom (Perception) checks you make to hear sounds outside it are made with disadvantage. You remain aware of the passage of time and can cast spells on yourself while merged in the stone. You can use your movement to leave the stone where you entered it, which ends the spell. You otherwise can't move.",

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -11648,7 +11648,7 @@
   },
   {
     "index": "protection-from-energy",
-    "name": "Protection from Energy",
+    "name": "Protection From Energy",
     "desc": [
       "For the duration, the willing creature you touch has resistance to one damage type of your choice: acid, cold, fire, lightning, or thunder."
     ],

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -10685,7 +10685,7 @@
   },
   {
     "index": "pass-without-trace",
-    "name": "Pass without Trace",
+    "name": "Pass Without Trace",
     "desc": [
       "A veil of shadows and silence radiates from you, masking you and your companions from detection. For the duration, each creature you choose within 30 feet of you (including you) has a +10 bonus to Dexterity (Stealth) checks and can't be tracked except by magical means. A creature that receives this bonus leaves behind no tracks or other traces of its passage."
     ],

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -213,7 +213,7 @@
     "starting_proficiencies": [
       {
         "index": "tinkers-tools",
-        "name": "Tinker's tools",
+        "name": "Tinker's Tools",
         "url": "/api/proficiencies/tinkers-tools"
       }
     ],

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -117,17 +117,17 @@
       "from": [
         {
           "index": "smiths-tools",
-          "name": "Smith's tools",
+          "name": "Smith's Tools",
           "url": "/api/proficiencies/smiths-tools"
         },
         {
           "index": "brewers-supplies",
-          "name": "Brewer's supplies",
+          "name": "Brewer's Supplies",
           "url": "/api/proficiencies/brewers-supplies"
         },
         {
           "index": "masons-tools",
-          "name": "Mason's tools",
+          "name": "Mason's Tools",
           "url": "/api/proficiencies/masons-tools"
         }
       ]
@@ -1204,7 +1204,7 @@
     "proficiencies": [
       {
         "index": "tinkers-tools",
-        "name": "Tinker's tools",
+        "name": "Tinker's Tools",
         "url": "/api/proficiencies/tinkers-tools"
       }
     ],

--- a/src/tests/tables.test.js
+++ b/src/tests/tables.test.js
@@ -21,7 +21,7 @@ describe("duplicate indices", () => {
   });
 });
 
-describe.skip("broken links", () => {
+describe("broken links", () => {
   it("should not contain broken links", () => {
     let errors = [];
     let files = glob.sync("src/*.json");

--- a/src/tests/tables.test.js
+++ b/src/tests/tables.test.js
@@ -20,3 +20,60 @@ describe("duplicate indices", () => {
     expect(errors).toEqual([]);
   });
 });
+
+describe.skip("broken links", () => {
+  it("should not contain broken links", () => {
+    let errors = [];
+    let files = glob.sync("src/*.json");
+
+    let resources = {};
+
+    const walk_recursive = (resources, file, object, errors) => {
+      for (const property in object) {
+        if (property === "url") {
+          if (resources[object.url] === undefined) {
+            errors.push(`${file}: URL '${object.url}' not found.`);
+          } else {
+            if (resources[object.url].name !== undefined && resources[object.url].name !== object.name) {
+              errors.push(`${file}: Name mismatch for reference to '${object.url}', '${object.name}' should be '${resources[object.url].name}'`);
+            }
+
+            if (object.index !== undefined && resources[object.url].index !== object.index) {
+              errors.push(`${file}: Index mismatch for reference to '${object.url}', '${object.index}' should be '${resources[object.url].index}'`);
+            }
+          }
+        } else if (typeof object[property] === "object") {
+          walk_recursive(resources, file, object[property], errors);
+        }
+      }
+    };
+
+    for (const file of files) {
+      const fileText = fs.readFileSync(file, "utf8");
+      const fileJSON = JSON.parse(fileText);
+      fileJSON.forEach((entry) => {
+        if (entry.url !== undefined) {
+          if (entry.index === undefined) {
+            errors.push(`${file}: Entity with URL '${entry.url}' should have an index.`);
+          }
+
+          resources[entry.url] = { index: entry.index, name: entry.name };
+        }
+      });
+    }
+
+    for (const file of files) {
+      const fileText = fs.readFileSync(file, "utf8");
+      const fileJSON = JSON.parse(fileText);
+      fileJSON.forEach((entry) => {
+        for (const property in entry) {
+          if (typeof entry[property] === "object") {
+            walk_recursive(resources, file, entry[property], errors);
+          }
+        }
+      });
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/src/tests/tables.test.js
+++ b/src/tests/tables.test.js
@@ -29,22 +29,24 @@ describe("broken links", () => {
 
     let resources = {};
 
-    const walk_recursive = (resources, file, object, errors) => {
-      for (const property in object) {
-        if (property === "url") {
-          if (resources[object.url] === undefined) {
-            errors.push(`${file}: URL '${object.url}' not found.`);
-          } else {
-            if (resources[object.url].name !== undefined && resources[object.url].name !== object.name) {
-              errors.push(`${file}: Name mismatch for reference to '${object.url}', '${object.name}' should be '${resources[object.url].name}'`);
-            }
-
-            if (object.index !== undefined && resources[object.url].index !== object.index) {
-              errors.push(`${file}: Index mismatch for reference to '${object.url}', '${object.index}' should be '${resources[object.url].index}'`);
-            }
+    const walk_recursive = (resources, file, entry, errors) => {
+      if (entry.hasOwnProperty("url")) {
+        if (resources[entry.url] === undefined) {
+          errors.push(`${file}: URL '${entry.url}' not found.`);
+        } else {
+          if (resources[entry.url].name !== undefined && resources[entry.url].name !== entry.name) {
+            errors.push(`${file}: Name mismatch for reference to '${entry.url}', '${entry.name}' should be '${resources[entry.url].name}'`);
           }
-        } else if (typeof object[property] === "object") {
-          walk_recursive(resources, file, object[property], errors);
+
+          if (entry.index !== undefined && resources[entry.url].index !== entry.index) {
+            errors.push(`${file}: Index mismatch for reference to '${entry.url}', '${entry.index}' should be '${resources[entry.url].index}'`);
+          }
+        }
+      }
+
+      for (const property in entry) {
+        if (typeof entry[property] === "object" && entry[property] !== null) {
+          walk_recursive(resources, file, entry[property], errors);
         }
       }
     };
@@ -61,7 +63,7 @@ describe("broken links", () => {
 
     forEachFile((filename, entry) => {
       for (const property in entry) {
-        if (typeof entry[property] === "object") {
+        if (typeof entry[property] === "object" && entry[property] !== null) {
           walk_recursive(resources, filename, entry[property], errors);
         }
       }

--- a/src/tests/tables.test.js
+++ b/src/tests/tables.test.js
@@ -6,7 +6,7 @@ describe("duplicate indices", () => {
     let errors = [];
     const fileIndices = {};
 
-    forEachFile((filename, entry) => {
+    forEachFileEntry((filename, entry) => {
       if (filename in fileIndices === false) {
         fileIndices[filename] = new Set();
       }
@@ -29,7 +29,7 @@ describe("api references", () => {
 
     let resources = {};
 
-    forEachFile((filename, entry) => {
+    forEachFileEntry((filename, entry) => {
       if (entry.url === undefined) return;
 
       if (entry.index === undefined) {
@@ -39,7 +39,7 @@ describe("api references", () => {
       resources[entry.url] = { index: entry.index, name: entry.name };
     });
 
-    forEachFile((filename, topLevelEntry) => {
+    forEachFileEntry((filename, topLevelEntry) => {
       recurseIntoObject(topLevelEntry, (subEntry) => {
         if (!subEntry.hasOwnProperty("url")) return;
 
@@ -67,7 +67,7 @@ describe("api references", () => {
  * @param (function(string, object)) callback Called with filename and each
  *     top-level entry.
  */
-const forEachFile = (callback) => {
+const forEachFileEntry = (callback) => {
     let filenames = glob.sync("src/*.json");
 
     for (const filename of filenames) {

--- a/src/tests/tables.test.js
+++ b/src/tests/tables.test.js
@@ -30,27 +30,27 @@ describe("api references", () => {
     let resources = {};
 
     forEachFile((filename, entry) => {
-      if (entry.url !== undefined) {
-        if (entry.index === undefined) {
-          errors.push(`${filename}: Entry with URL '${entry.url}' should have an index.`);
-        }
+      if (entry.url === undefined) return;
 
-        resources[entry.url] = { index: entry.index, name: entry.name };
+      if (entry.index === undefined) {
+        errors.push(`${filename}: Entry with URL '${entry.url}' should have an index.`);
       }
+
+      resources[entry.url] = { index: entry.index, name: entry.name };
     });
 
     forEachFileRecursive((filename, entry) => {
-      if (entry.hasOwnProperty("url")) {
-        if (resources[entry.url] === undefined) {
-          errors.push(`${filename}: URL '${entry.url}' not found.`);
-        } else {
-          if (resources[entry.url].name !== undefined && resources[entry.url].name !== entry.name) {
-            errors.push(`${filename}: Name mismatch for reference to '${entry.url}', '${entry.name}' should be '${resources[entry.url].name}'`);
-          }
+      if (!entry.hasOwnProperty("url")) return;
 
-          if (entry.index !== undefined && resources[entry.url].index !== entry.index) {
-            errors.push(`${filename}: Index mismatch for reference to '${entry.url}', '${entry.index}' should be '${resources[entry.url].index}'`);
-          }
+      if (resources[entry.url] === undefined) {
+        errors.push(`${filename}: URL '${entry.url}' not found.`);
+      } else {
+        if (resources[entry.url].name !== undefined && resources[entry.url].name !== entry.name) {
+          errors.push(`${filename}: Name mismatch for reference to '${entry.url}', '${entry.name}' should be '${resources[entry.url].name}'`);
+        }
+
+        if (entry.index !== undefined && resources[entry.url].index !== entry.index) {
+          errors.push(`${filename}: Index mismatch for reference to '${entry.url}', '${entry.index}' should be '${resources[entry.url].index}'`);
         }
       }
     });


### PR DESCRIPTION
## What does this do?
I've been paranoid about making a typo in my `"index"`/`"name"`/`"url"` while adding references, so I added a test to verify that a) all referenced URLs are present as top-level dicts somewhere in the project, and b) the names and indexes, if present, match those of the referenced entities.

This led me down a rabbit hole of cleaning up all of the failures identified by the test. Most were capitalization related, where I preferred Title Case in all cases, but it did turn up a few interesting data errors too. Tieflings don't speak Abyssal, Drow and Dryders don't cast Entangle, and Rakshasas *definitely* don't cast Mass Suggestion.

I'm not a JS programmer, so the test is pretty hackish, but it works.

## How was it tested?
I ran it.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
N/A

## Here's a fun image for your troubles
![external-content duckduckgo com](https://user-images.githubusercontent.com/585944/127726543-91421c83-5aa9-4a7a-93bc-9973d6944dfb.gif)