### PR TITLE
Change id on monster forms to index

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -26202,9 +26202,7 @@
         }
       }
     ],
-    "damage_vulnerabilities": [
-      "fire"
-    ],
+    "damage_vulnerabilities": ["fire"],
     "damage_resistances": [],
     "damage_immunities": [
       "necrotic",
@@ -37024,12 +37022,12 @@
     "hit_dice": "18d8",
     "forms": [
       {
-        "id": "werebear-human",
+        "index": "werebear-human",
         "name": "Werebear, Human Form",
         "url": "/api/monsters/werebear-human"
       },
       {
-        "id": "werebear-hybrid",
+        "index": "werebear-hybrid",
         "name": "Werebear, Hybrid Form",
         "url": "/api/monsters/werebear-hybrid"
       }
@@ -37138,12 +37136,12 @@
     "hit_dice": "18d8",
     "forms": [
       {
-        "id": "werebear-bear",
+        "index": "werebear-bear",
         "name": "Werebear, Bear Form",
         "url": "/api/monsters/werebear-bear"
       },
       {
-        "id": "werebear-hybrid",
+        "index": "werebear-hybrid",
         "name": "Werebear, Hybrid Form",
         "url": "/api/monsters/werebear-hybrid"
       }
@@ -37236,12 +37234,12 @@
     "hit_dice": "18d8",
     "forms": [
       {
-        "id": "werebear-bear",
+        "index": "werebear-bear",
         "name": "Werebear, Bear Form",
         "url": "/api/monsters/werebear-bear"
       },
       {
-        "id": "werebear-human",
+        "index": "werebear-human",
         "name": "Werebear, Human Form",
         "url": "/api/monsters/werebear-human"
       }
@@ -37384,12 +37382,12 @@
     "hit_dice": "12d8",
     "forms": [
       {
-        "id": "wereboar-human",
+        "index": "wereboar-human",
         "name": "Wereboar, Human Form",
         "url": "/api/monsters/wereboar-human"
       },
       {
-        "id": "wereboar-hybrid",
+        "index": "wereboar-hybrid",
         "name": "Wereboar, Hybrid Form",
         "url": "/api/monsters/wereboar-hybrid"
       }
@@ -37475,12 +37473,12 @@
     "hit_dice": "12d8",
     "forms": [
       {
-        "id": "wereboar-boar",
+        "index": "wereboar-boar",
         "name": "Wereboar, Boar Form",
         "url": "/api/monsters/wereboar-boar"
       },
       {
-        "id": "wereboar-hybrid",
+        "index": "wereboar-hybrid",
         "name": "Wereboar, Hybrid Form",
         "url": "/api/monsters/wereboar-hybrid"
       }
@@ -37578,12 +37576,12 @@
     "hit_dice": "12d8",
     "forms": [
       {
-        "id": "wereboar-boar",
+        "index": "wereboar-boar",
         "name": "Wereboar, Boar Form",
         "url": "/api/monsters/wereboar-boar"
       },
       {
-        "id": "wereboar-human",
+        "index": "wereboar-human",
         "name": "Wereboar, Human Form",
         "url": "/api/monsters/wereboar-human"
       }
@@ -37712,12 +37710,12 @@
     "hit_dice": "6d8",
     "forms": [
       {
-        "id": "wererat-hybrid",
+        "index": "wererat-hybrid",
         "name": "Wererat, Hybrid Form",
         "url": "/api/monsters/wererat-hybrid"
       },
       {
-        "id": "wererat-rat",
+        "index": "wererat-rat",
         "name": "Wererat, Rat Form",
         "url": "/api/monsters/wererat-rat"
       }
@@ -37852,12 +37850,12 @@
     "hit_dice": "6d8",
     "forms": [
       {
-        "id": "wererat-human",
+        "index": "wererat-human",
         "name": "Wererat, Human Form",
         "url": "/api/monsters/wererat-human"
       },
       {
-        "id": "wererat-rat",
+        "index": "wererat-rat",
         "name": "Wererat, Rat Form",
         "url": "/api/monsters/wererat-rat"
       }
@@ -38031,12 +38029,12 @@
     "hit_dice": "6d8",
     "forms": [
       {
-        "id": "wererat-human",
+        "index": "wererat-human",
         "name": "Wererat, Human Form",
         "url": "/api/monsters/wererat-human"
       },
       {
-        "id": "wererat-hybrid",
+        "index": "wererat-hybrid",
         "name": "Wererat, Hybrid Form",
         "url": "/api/monsters/wererat-hybrid"
       }
@@ -38122,12 +38120,12 @@
     "hit_dice": "16d8",
     "forms": [
       {
-        "id": "weretiger-hybrid",
+        "index": "weretiger-hybrid",
         "name": "Weretiger, Hybrid Form",
         "url": "/api/monsters/weretiger-hybrid"
       },
       {
-        "id": "weretiger-tiger",
+        "index": "weretiger-tiger",
         "name": "Weretiger, Tiger Form",
         "url": "/api/monsters/weretiger-tiger"
       }
@@ -38251,12 +38249,12 @@
     "hit_dice": "16d8",
     "forms": [
       {
-        "id": "weretiger-human",
+        "index": "weretiger-human",
         "name": "Weretiger, Human Form",
         "url": "/api/monsters/weretiger-human"
       },
       {
-        "id": "weretiger-tiger",
+        "index": "weretiger-tiger",
         "name": "Weretiger, Tiger Form",
         "url": "/api/monsters/weretiger-tiger"
       }
@@ -38421,12 +38419,12 @@
     "hit_dice": "16d8",
     "forms": [
       {
-        "id": "weretiger-human",
+        "index": "weretiger-human",
         "name": "Weretiger, Human Form",
         "url": "/api/monsters/weretiger-human"
       },
       {
-        "id": "weretiger-hybrid",
+        "index": "weretiger-hybrid",
         "name": "Weretiger, Hybrid Form",
         "url": "/api/monsters/weretiger-hybrid"
       }
@@ -38531,12 +38529,12 @@
     "hit_dice": "9d8",
     "forms": [
       {
-        "id": "werewolf-hybrid",
+        "index": "werewolf-hybrid",
         "name": "Werewolf, Hybrid Form",
         "url": "/api/monsters/werewolf-hybrid"
       },
       {
-        "id": "werewolf-wolf",
+        "index": "werewolf-wolf",
         "name": "Werewolf, Wolf Form",
         "url": "/api/monsters/werewolf-wolf"
       }
@@ -38643,12 +38641,12 @@
     "hit_dice": "9d8",
     "forms": [
       {
-        "id": "werewolf-human",
+        "index": "werewolf-human",
         "name": "Werewolf, Human Form",
         "url": "/api/monsters/werewolf-human"
       },
       {
-        "id": "werewolf-wolf",
+        "index": "werewolf-wolf",
         "name": "Werewolf, Wolf Form",
         "url": "/api/monsters/werewolf-wolf"
       }
@@ -38761,12 +38759,12 @@
     "hit_dice": "9d8",
     "forms": [
       {
-        "id": "werewolf-human",
+        "index": "werewolf-human",
         "name": "Werewolf, Human Form",
         "url": "/api/monsters/werewolf-human"
       },
       {
-        "id": "werewolf-hybrid",
+        "index": "werewolf-hybrid",
         "name": "Werewolf, Hybrid Form",
         "url": "/api/monsters/werewolf-hybrid"
       }


### PR DESCRIPTION
## What does this do?
I noticed that the API references for monster forms used id instead of index. This seems inconsistent with how other API references are handled, so I changed it to index.

## How was it tested?
I ran dbRefresh, opened MongoDB Compass, and viewed all the entries with forms defined to make sure the change went through

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
