### PR TITLE
Add code of conduct link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ If you see anything wrong with the API and not the data, please open an issue or
  * Create a new branch for your work
  * Push up any changes to your branch, and open a pull request. Don't feel it needs to be perfect — incomplete work is totally fine. We'd love to help get it ready for merging.
 
+# Code of Conduct
+
+The Code of Conduct can be found [here.](https://github.com/5e-bits/5e-database/wiki/Code-of-Conduct)
+
 # License
 This project is licensed under the terms of the MIT license. The underlying material
 is released using the [Open Gaming License Version 1.0a](https://www.wizards.com/default.asp?x=d20/oglfaq/20040123f)


### PR DESCRIPTION
## What does this do?
Adds a link to the code of conduct to the README.md

## How was it tested?
No need

## Is there a Github issue this is resolving?
Technically yes. I just want the code of conduct to be a little more visible for this project

## Did you update the docs in the API? Please link an associated PR if applicable.
No need. But I might mirror this in the API repo

## Here's a fun image for your troubles
![image](https://user-images.githubusercontent.com/353626/129640676-44f83832-4397-486c-9d32-8ce26cfbce3d.png)
