### PR TITLE
Proficiency reference non breaking

### DIFF
--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -42,14 +42,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/light-armor",
-    "references": [
-      {
-        "index": "light-armor",
-        "type": "equipment-categories",
-        "name": "Light Armor",
-        "url": "/api/equipment-categories/light-armor"
-      }
-    ]
+    "reference": {
+      "index": "light-armor",
+      "type": "equipment-categories",
+      "name": "Light Armor",
+      "url": "/api/equipment-categories/light-armor"
+    }
   },
   {
     "index": "medium-armor",
@@ -79,14 +77,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/medium-armor",
-    "references": [
-      {
-        "index": "medium-armor",
-        "type": "equipment-categories",
-        "name": "Medium Armor",
-        "url": "/api/equipment-categories/medium-armor"
-      }
-    ]
+    "reference": {
+      "index": "medium-armor",
+      "type": "equipment-categories",
+      "name": "Medium Armor",
+      "url": "/api/equipment-categories/medium-armor"
+    }
   },
   {
     "index": "heavy-armor",
@@ -95,14 +91,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/heavy-armor",
-    "references": [
-      {
-        "index": "heavy-armor",
-        "type": "equipment-categories",
-        "name": "Heavy Armor",
-        "url": "/api/equipment-categories/heavy-armor"
-      }
-    ]
+    "reference": {
+      "index": "heavy-armor",
+      "type": "equipment-categories",
+      "name": "Heavy Armor",
+      "url": "/api/equipment-categories/heavy-armor"
+    }
   },
   {
     "index": "all-armor",
@@ -122,14 +116,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/all-armor",
-    "references": [
-      {
-        "index": "armor",
-        "type": "equipment-categories",
-        "name": "Armor",
-        "url": "/api/equipment-categories/armor"
-      }
-    ]
+    "reference": {
+      "index": "armor",
+      "type": "equipment-categories",
+      "name": "Armor",
+      "url": "/api/equipment-categories/armor"
+    }
   },
   {
     "index": "padded",
@@ -138,14 +130,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/padded",
-    "references": [
-      {
-        "index": "padded",
-        "type": "equipment",
-        "name": "Padded",
-        "url": "/api/equipment/padded"
-      }
-    ]
+    "reference": {
+      "index": "padded",
+      "type": "equipment",
+      "name": "Padded",
+      "url": "/api/equipment/padded"
+    }
   },
   {
     "index": "leather",
@@ -154,14 +144,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/leather",
-    "references": [
-      {
-        "index": "leather",
-        "type": "equipment",
-        "name": "Leather",
-        "url": "/api/equipment/leather"
-      }
-    ]
+    "reference": {
+      "index": "leather",
+      "type": "equipment",
+      "name": "Leather",
+      "url": "/api/equipment/leather"
+    }
   },
   {
     "index": "studded-leather",
@@ -170,14 +158,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/studded-leather",
-    "references": [
-      {
-        "index": "studded-leather",
-        "type": "equipment",
-        "name": "Studded Leather",
-        "url": "/api/equipment/studded-leather"
-      }
-    ]
+    "reference": {
+      "index": "studded-leather",
+      "type": "equipment",
+      "name": "Studded Leather",
+      "url": "/api/equipment/studded-leather"
+    }
   },
   {
     "index": "hide",
@@ -186,14 +172,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/hide",
-    "references": [
-      {
-        "index": "hide",
-        "type": "equipment",
-        "name": "Hide",
-        "url": "/api/equipment/hide"
-      }
-    ]
+    "reference": {
+      "index": "hide",
+      "type": "equipment",
+      "name": "Hide",
+      "url": "/api/equipment/hide"
+    }
   },
   {
     "index": "chain-shirt",
@@ -202,14 +186,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/chain-shirt",
-    "references": [
-      {
-        "index": "chain-shirt",
-        "type": "equipment",
-        "name": "Chain Shirt",
-        "url": "/api/equipment/chain-shirt"
-      }
-    ]
+    "reference": {
+      "index": "chain-shirt",
+      "type": "equipment",
+      "name": "Chain Shirt",
+      "url": "/api/equipment/chain-shirt"
+    }
   },
   {
     "index": "scale-mail",
@@ -218,14 +200,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/scale-mail",
-    "references": [
-      {
-        "index": "scale-mail",
-        "type": "equipment",
-        "name": "Scale Mail",
-        "url": "/api/equipment/scale-mail"
-      }
-    ]
+    "reference": {
+      "index": "scale-mail",
+      "type": "equipment",
+      "name": "Scale Mail",
+      "url": "/api/equipment/scale-mail"
+    }
   },
   {
     "index": "breastplate",
@@ -234,14 +214,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/breastplate",
-    "references": [
-      {
-        "index": "breastplate",
-        "type": "equipment",
-        "name": "Breastplate",
-        "url": "/api/equipment/breastplate"
-      }
-    ]
+    "reference": {
+      "index": "breastplate",
+      "type": "equipment",
+      "name": "Breastplate",
+      "url": "/api/equipment/breastplate"
+    }
   },
   {
     "index": "half-plate",
@@ -250,14 +228,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/half-plate",
-    "references": [
-      {
-        "index": "half-plate",
-        "type": "equipment",
-        "name": "Half Plate",
-        "url": "/api/equipment/half-plate"
-      }
-    ]
+    "reference": {
+      "index": "half-plate",
+      "type": "equipment",
+      "name": "Half Plate",
+      "url": "/api/equipment/half-plate"
+    }
   },
   {
     "index": "ring-mail",
@@ -266,14 +242,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/ring-mail",
-    "references": [
-      {
-        "index": "ring-mail",
-        "type": "equipment",
-        "name": "Ring Mail",
-        "url": "/api/equipment/ring-mail"
-      }
-    ]
+    "reference": {
+      "index": "ring-mail",
+      "type": "equipment",
+      "name": "Ring Mail",
+      "url": "/api/equipment/ring-mail"
+    }
   },
   {
     "index": "chain-mail",
@@ -282,14 +256,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/chain-mail",
-    "references": [
-      {
-        "index": "chain-mail",
-        "type": "equipment",
-        "name": "Chain Mail",
-        "url": "/api/equipment/chain-mail"
-      }
-    ]
+    "reference": {
+      "index": "chain-mail",
+      "type": "equipment",
+      "name": "Chain Mail",
+      "url": "/api/equipment/chain-mail"
+    }
   },
   {
     "index": "splint",
@@ -298,14 +270,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/splint",
-    "references": [
-      {
-        "index": "splint",
-        "type": "equipment",
-        "name": "Splint",
-        "url": "/api/equipment/splint"
-      }
-    ]
+    "reference": {
+      "index": "splint",
+      "type": "equipment",
+      "name": "Splint",
+      "url": "/api/equipment/splint"
+    }
   },
   {
     "index": "plate",
@@ -314,14 +284,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/plate",
-    "references": [
-      {
-        "index": "plate",
-        "type": "equipment",
-        "name": "Plate",
-        "url": "/api/equipment/plate"
-      }
-    ]
+    "reference": {
+      "index": "plate",
+      "type": "equipment",
+      "name": "Plate",
+      "url": "/api/equipment/plate"
+    }
   },
   {
     "index": "shields",
@@ -361,14 +329,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/shields",
-    "references": [
-      {
-        "index": "shield",
-        "type": "equipment",
-        "name": "Shield",
-        "url": "/api/equipment/shield"
-      }
-    ]
+    "reference": {
+      "index": "shield",
+      "type": "equipment",
+      "name": "Shield",
+      "url": "/api/equipment/shield"
+    }
   },
   {
     "index": "simple-weapons",
@@ -423,14 +389,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/simple-weapons",
-    "references": [
-      {
-        "index": "simple-weapons",
-        "type": "equipment-categories",
-        "name": "Simple Weapons",
-        "url": "/api/equipment-categories/simple-weapons"
-      }
-    ]
+    "reference": {
+      "index": "simple-weapons",
+      "type": "equipment-categories",
+      "name": "Simple Weapons",
+      "url": "/api/equipment-categories/simple-weapons"
+    }
   },
   {
     "index": "martial-weapons",
@@ -460,14 +424,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/martial-weapons",
-    "references": [
-      {
-        "index": "martial-weapons",
-        "type": "equipment-categories",
-        "name": "Martial Weapons",
-        "url": "/api/equipment-categories/martial-weapons"
-      }
-    ]
+    "reference": {
+      "index": "martial-weapons",
+      "type": "equipment-categories",
+      "name": "Martial Weapons",
+      "url": "/api/equipment-categories/martial-weapons"
+    }
   },
   {
     "index": "clubs",
@@ -482,14 +444,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/clubs",
-    "references": [
-      {
-        "index": "club",
-        "type": "equipment",
-        "name": "Club",
-        "url": "/api/equipment/club"
-      }
-    ]
+    "reference": {
+      "index": "club",
+      "type": "equipment",
+      "name": "Club",
+      "url": "/api/equipment/club"
+    }
   },
   {
     "index": "daggers",
@@ -514,14 +474,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/daggers",
-    "references": [
-      {
-        "index": "dagger",
-        "type": "equipment",
-        "name": "Dagger",
-        "url": "/api/equipment/dagger"
-      }
-    ]
+    "reference": {
+      "index": "dagger",
+      "type": "equipment",
+      "name": "Dagger",
+      "url": "/api/equipment/dagger"
+    }
   },
   {
     "index": "greatclubs",
@@ -530,14 +488,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/greatclubs",
-    "references": [
-      {
-        "index": "greatclub",
-        "type": "equipment",
-        "name": "Greatclub",
-        "url": "/api/equipment/greatclub"
-      }
-    ]
+    "reference": {
+      "index": "greatclub",
+      "type": "equipment",
+      "name": "Greatclub",
+      "url": "/api/equipment/greatclub"
+    }
   },
   {
     "index": "handaxes",
@@ -552,14 +508,12 @@
       }
     ],
     "url": "/api/proficiencies/handaxes",
-    "references": [
-      {
-        "index": "handaxe",
-        "type": "equipment",
-        "name": "Handaxe",
-        "url": "/api/equipment/handaxe"
-      }
-    ]
+    "reference": {
+      "index": "handaxe",
+      "type": "equipment",
+      "name": "Handaxe",
+      "url": "/api/equipment/handaxe"
+    }
   },
   {
     "index": "javelins",
@@ -574,14 +528,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/javelins",
-    "references": [
-      {
-        "index": "javelin",
-        "type": "equipment",
-        "name": "Javelin",
-        "url": "/api/equipment/javelin"
-      }
-    ]
+    "reference": {
+      "index": "javelin",
+      "type": "equipment",
+      "name": "Javelin",
+      "url": "/api/equipment/javelin"
+    }
   },
   {
     "index": "light-hammers",
@@ -596,14 +548,12 @@
       }
     ],
     "url": "/api/proficiencies/light-hammers",
-    "references": [
-      {
-        "index": "light-hammer",
-        "type": "equipment",
-        "name": "Light hammer",
-        "url": "/api/equipment/light-hammer"
-      }
-    ]
+    "reference": {
+      "index": "light-hammer",
+      "type": "equipment",
+      "name": "Light hammer",
+      "url": "/api/equipment/light-hammer"
+    }
   },
   {
     "index": "maces",
@@ -618,14 +568,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/maces",
-    "references": [
-      {
-        "index": "mace",
-        "type": "equipment",
-        "name": "Mace",
-        "url": "/api/equipment/mace"
-      }
-    ]
+    "reference": {
+      "index": "mace",
+      "type": "equipment",
+      "name": "Mace",
+      "url": "/api/equipment/mace"
+    }
   },
   {
     "index": "quarterstaffs",
@@ -650,14 +598,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/quarterstaffs",
-    "references": [
-      {
-        "index": "quarterstaff",
-        "type": "equipment",
-        "name": "Quarterstaff",
-        "url": "/api/equipment/quarterstaff"
-      }
-    ]
+    "reference": {
+      "index": "quarterstaff",
+      "type": "equipment",
+      "name": "Quarterstaff",
+      "url": "/api/equipment/quarterstaff"
+    }
   },
   {
     "index": "sickles",
@@ -672,14 +618,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/sickles",
-    "references": [
-      {
-        "index": "sickle",
-        "type": "equipment",
-        "name": "Sickle",
-        "url": "/api/equipment/sickle"
-      }
-    ]
+    "reference": {
+      "index": "sickle",
+      "type": "equipment",
+      "name": "Sickle",
+      "url": "/api/equipment/sickle"
+    }
   },
   {
     "index": "spears",
@@ -694,14 +638,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/spears",
-    "references": [
-      {
-        "index": "spear",
-        "type": "equipment",
-        "name": "Spear",
-        "url": "/api/equipment/spear"
-      }
-    ]
+    "reference": {
+      "index": "spear",
+      "type": "equipment",
+      "name": "Spear",
+      "url": "/api/equipment/spear"
+    }
   },
   {
     "index": "crossbows-light",
@@ -710,14 +652,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/crossbows-light",
-    "references": [
-      {
-        "index": "crossbow-light",
-        "type": "equipment",
-        "name": "Crossbow, light",
-        "url": "/api/equipment/crossbow-light"
-      }
-    ]
+    "reference": {
+      "index": "crossbow-light",
+      "type": "equipment",
+      "name": "Crossbow, light",
+      "url": "/api/equipment/crossbow-light"
+    }
   },
   {
     "index": "darts",
@@ -742,14 +682,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/darts",
-    "references": [
-      {
-        "index": "dart",
-        "type": "equipment",
-        "name": "Dart",
-        "url": "/api/equipment/dart"
-      }
-    ]
+    "reference": {
+      "index": "dart",
+      "type": "equipment",
+      "name": "Dart",
+      "url": "/api/equipment/dart"
+    }
   },
   {
     "index": "shortbows",
@@ -764,14 +702,12 @@
       }
     ],
     "url": "/api/proficiencies/shortbows",
-    "references": [
-      {
-        "index": "shortbow",
-        "type": "equipment",
-        "name": "Shortbow",
-        "url": "/api/equipment/shortbow"
-      }
-    ]
+    "reference": {
+      "index": "shortbow",
+      "type": "equipment",
+      "name": "Shortbow",
+      "url": "/api/equipment/shortbow"
+    }
   },
   {
     "index": "slings",
@@ -796,14 +732,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/slings",
-    "references": [
-      {
-        "index": "sling",
-        "type": "equipment",
-        "name": "Sling",
-        "url": "/api/equipment/sling"
-      }
-    ]
+    "reference": {
+      "index": "sling",
+      "type": "equipment",
+      "name": "Sling",
+      "url": "/api/equipment/sling"
+    }
   },
   {
     "index": "battleaxes",
@@ -818,14 +752,12 @@
       }
     ],
     "url": "/api/proficiencies/battleaxes",
-    "references": [
-      {
-        "index": "battleaxe",
-        "type": "equipment",
-        "name": "Battleaxe",
-        "url": "/api/equipment/battleaxe"
-      }
-    ]
+    "reference": {
+      "index": "battleaxe",
+      "type": "equipment",
+      "name": "Battleaxe",
+      "url": "/api/equipment/battleaxe"
+    }
   },
   {
     "index": "flails",
@@ -834,14 +766,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/flails",
-    "references": [
-      {
-        "index": "flail",
-        "type": "equipment",
-        "name": "Flail",
-        "url": "/api/equipment/flail"
-      }
-    ]
+    "reference": {
+      "index": "flail",
+      "type": "equipment",
+      "name": "Flail",
+      "url": "/api/equipment/flail"
+    }
   },
   {
     "index": "glaives",
@@ -850,14 +780,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/glaives",
-    "references": [
-      {
-        "index": "glaive",
-        "type": "equipment",
-        "name": "Glaive",
-        "url": "/api/equipment/glaive"
-      }
-    ]
+    "reference": {
+      "index": "glaive",
+      "type": "equipment",
+      "name": "Glaive",
+      "url": "/api/equipment/glaive"
+    }
   },
   {
     "index": "greataxes",
@@ -866,14 +794,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/greataxes",
-    "references": [
-      {
-        "index": "greataxe",
-        "type": "equipment",
-        "name": "Greataxe",
-        "url": "/api/equipment/greataxe"
-      }
-    ]
+    "reference": {
+      "index": "greataxe",
+      "type": "equipment",
+      "name": "Greataxe",
+      "url": "/api/equipment/greataxe"
+    }
   },
   {
     "index": "greatswords",
@@ -882,14 +808,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/greatswords",
-    "references": [
-      {
-        "index": "greatsword",
-        "type": "equipment",
-        "name": "Greatsword",
-        "url": "/api/equipment/greatsword"
-      }
-    ]
+    "reference": {
+      "index": "greatsword",
+      "type": "equipment",
+      "name": "Greatsword",
+      "url": "/api/equipment/greatsword"
+    }
   },
   {
     "index": "halberds",
@@ -898,14 +822,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/halberds",
-    "references": [
-      {
-        "index": "halberd",
-        "type": "equipment",
-        "name": "Halberd",
-        "url": "/api/equipment/halberd"
-      }
-    ]
+    "reference": {
+      "index": "halberd",
+      "type": "equipment",
+      "name": "Halberd",
+      "url": "/api/equipment/halberd"
+    }
   },
   {
     "index": "lances",
@@ -914,14 +836,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/lances",
-    "references": [
-      {
-        "index": "lance",
-        "type": "equipment",
-        "name": "Lance",
-        "url": "/api/equipment/lance"
-      }
-    ]
+    "reference": {
+      "index": "lance",
+      "type": "equipment",
+      "name": "Lance",
+      "url": "/api/equipment/lance"
+    }
   },
   {
     "index": "longswords",
@@ -947,14 +867,12 @@
       }
     ],
     "url": "/api/proficiencies/longswords",
-    "references": [
-      {
-        "index": "longsword",
-        "type": "equipment",
-        "name": "Longsword",
-        "url": "/api/equipment/longsword"
-      }
-    ]
+    "reference": {
+      "index": "longsword",
+      "type": "equipment",
+      "name": "Longsword",
+      "url": "/api/equipment/longsword"
+    }
   },
   {
     "index": "mauls",
@@ -963,14 +881,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/mauls",
-    "references": [
-      {
-        "index": "maul",
-        "type": "equipment",
-        "name": "Maul",
-        "url": "/api/equipment/maul"
-      }
-    ]
+    "reference": {
+      "index": "maul",
+      "type": "equipment",
+      "name": "Maul",
+      "url": "/api/equipment/maul"
+    }
   },
   {
     "index": "morningstars",
@@ -979,14 +895,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/morningstars",
-    "references": [
-      {
-        "index": "morningstar",
-        "type": "equipment",
-        "name": "Morningstar",
-        "url": "/api/equipment/morningstar"
-      }
-    ]
+    "reference": {
+      "index": "morningstar",
+      "type": "equipment",
+      "name": "Morningstar",
+      "url": "/api/equipment/morningstar"
+    }
   },
   {
     "index": "pikes",
@@ -995,14 +909,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/pikes",
-    "references": [
-      {
-        "index": "pike",
-        "type": "equipment",
-        "name": "Pike",
-        "url": "/api/equipment/pike"
-      }
-    ]
+    "reference": {
+      "index": "pike",
+      "type": "equipment",
+      "name": "Pike",
+      "url": "/api/equipment/pike"
+    }
   },
   {
     "index": "rapiers",
@@ -1022,14 +934,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/rapiers",
-    "references": [
-      {
-        "index": "rapier",
-        "type": "equipment",
-        "name": "Rapier",
-        "url": "/api/equipment/rapier"
-      }
-    ]
+    "reference": {
+      "index": "rapier",
+      "type": "equipment",
+      "name": "Rapier",
+      "url": "/api/equipment/rapier"
+    }
   },
   {
     "index": "scimitars",
@@ -1044,14 +954,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/scimitars",
-    "references": [
-      {
-        "index": "scimitar",
-        "type": "equipment",
-        "name": "Scimitar",
-        "url": "/api/equipment/scimitar"
-      }
-    ]
+    "reference": {
+      "index": "scimitar",
+      "type": "equipment",
+      "name": "Scimitar",
+      "url": "/api/equipment/scimitar"
+    }
   },
   {
     "index": "shortswords",
@@ -1082,14 +990,12 @@
       }
     ],
     "url": "/api/proficiencies/shortswords",
-    "references": [
-      {
-        "index": "shortsword",
-        "type": "equipment",
-        "name": "Shortsword",
-        "url": "/api/equipment/shortsword"
-      }
-    ]
+    "reference": {
+      "index": "shortsword",
+      "type": "equipment",
+      "name": "Shortsword",
+      "url": "/api/equipment/shortsword"
+    }
   },
   {
     "index": "tridents",
@@ -1098,14 +1004,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/tridents",
-    "references": [
-      {
-        "index": "trident",
-        "type": "equipment",
-        "name": "Trident",
-        "url": "/api/equipment/trident"
-      }
-    ]
+    "reference": {
+      "index": "trident",
+      "type": "equipment",
+      "name": "Trident",
+      "url": "/api/equipment/trident"
+    }
   },
   {
     "index": "war-picks",
@@ -1114,14 +1018,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/war-picks",
-    "references": [
-      {
-        "index": "war-pick",
-        "type": "equipment",
-        "name": "War pick",
-        "url": "/api/equipment/war-pick"
-      }
-    ]
+    "reference": {
+      "index": "war-pick",
+      "type": "equipment",
+      "name": "War pick",
+      "url": "/api/equipment/war-pick"
+    }
   },
   {
     "index": "warhammers",
@@ -1136,14 +1038,12 @@
       }
     ],
     "url": "/api/proficiencies/warhammers",
-    "references": [
-      {
-        "index": "warhammer",
-        "type": "equipment",
-        "name": "Warhammer",
-        "url": "/api/equipment/warhammer"
-      }
-    ]
+    "reference": {
+      "index": "warhammer",
+      "type": "equipment",
+      "name": "Warhammer",
+      "url": "/api/equipment/warhammer"
+    }
   },
   {
     "index": "whips",
@@ -1152,14 +1052,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/whips",
-    "references": [
-      {
-        "index": "whip",
-        "type": "equipment",
-        "name": "Whip",
-        "url": "/api/equipment/whip"
-      }
-    ]
+    "reference": {
+      "index": "whip",
+      "type": "equipment",
+      "name": "Whip",
+      "url": "/api/equipment/whip"
+    }
   },
   {
     "index": "blowguns",
@@ -1168,14 +1066,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/blowguns",
-    "references": [
-      {
-        "index": "blowgun",
-        "type": "equipment",
-        "name": "Blowgun",
-        "url": "/api/equipment/blowgun"
-      }
-    ]
+    "reference": {
+      "index": "blowgun",
+      "type": "equipment",
+      "name": "Blowgun",
+      "url": "/api/equipment/blowgun"
+    }
   },
   {
     "index": "hand-crossbows",
@@ -1195,14 +1091,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/hand-crossbows",
-    "references": [
-      {
-        "index": "crossbow-hand",
-        "type": "equipment",
-        "name": "Crossbow, hand",
-        "url": "/api/equipment/crossbow-hand"
-      }
-    ]
+    "reference": {
+      "index": "crossbow-hand",
+      "type": "equipment",
+      "name": "Crossbow, hand",
+      "url": "/api/equipment/crossbow-hand"
+    }
   },
   {
     "index": "crossbows-heavy",
@@ -1211,14 +1105,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/crossbows-heavy",
-    "references": [
-      {
-        "index": "crossbow-heavy",
-        "type": "equipment",
-        "name": "Crossbow, heavy",
-        "url": "/api/equipment/crossbow-heavy"
-      }
-    ]
+    "reference": {
+      "index": "crossbow-heavy",
+      "type": "equipment",
+      "name": "Crossbow, heavy",
+      "url": "/api/equipment/crossbow-heavy"
+    }
   },
   {
     "index": "longbows",
@@ -1233,14 +1125,12 @@
       }
     ],
     "url": "/api/proficiencies/longbows",
-    "references": [
-      {
-        "index": "longbow",
-        "type": "equipment",
-        "name": "Longbow",
-        "url": "/api/equipment/longbow"
-      }
-    ]
+    "reference": {
+      "index": "longbow",
+      "type": "equipment",
+      "name": "Longbow",
+      "url": "/api/equipment/longbow"
+    }
   },
   {
     "index": "nets",
@@ -1249,14 +1139,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/nets",
-    "references": [
-      {
-        "index": "net",
-        "type": "equipment",
-        "name": "Net",
-        "url": "/api/equipment/net"
-      }
-    ]
+    "reference": {
+      "index": "net",
+      "type": "equipment",
+      "name": "Net",
+      "url": "/api/equipment/net"
+    }
   },
   {
     "index": "alchemists-supplies",
@@ -1265,14 +1153,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/alchemists-supplies",
-    "references": [
-      {
-        "index": "alchemists-supplies",
-        "type": "equipment",
-        "name": "Alchemist's Supplies",
-        "url": "/api/equipment/alchemists-supplies"
-      }
-    ]
+    "reference": {
+      "index": "alchemists-supplies",
+      "type": "equipment",
+      "name": "Alchemist's Supplies",
+      "url": "/api/equipment/alchemists-supplies"
+    }
   },
   {
     "index": "brewers-supplies",
@@ -1281,14 +1167,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/brewers-supplies",
-    "references": [
-      {
-        "index": "brewers-supplies",
-        "type": "equipment",
-        "name": "Brewer's Supplies",
-        "url": "/api/equipment/brewers-supplies"
-      }
-    ]
+    "reference": {
+      "index": "brewers-supplies",
+      "type": "equipment",
+      "name": "Brewer's Supplies",
+      "url": "/api/equipment/brewers-supplies"
+    }
   },
   {
     "index": "calligraphers-supplies",
@@ -1297,14 +1181,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/calligraphers-supplies",
-    "references": [
-      {
-        "index": "calligraphers-supplies",
-        "type": "equipment",
-        "name": "Calligrapher's Supplies",
-        "url": "/api/equipment/calligraphers-supplies"
-      }
-    ]
+    "reference": {
+      "index": "calligraphers-supplies",
+      "type": "equipment",
+      "name": "Calligrapher's Supplies",
+      "url": "/api/equipment/calligraphers-supplies"
+    }
   },
   {
     "index": "carpenters-tools",
@@ -1313,14 +1195,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/carpenters-tools",
-    "references": [
-      {
-        "index": "carpenters-tools",
-        "type": "equipment",
-        "name": "Carpenter's Tools",
-        "url": "/api/equipment/carpenters-tools"
-      }
-    ]
+    "reference": {
+      "index": "carpenters-tools",
+      "type": "equipment",
+      "name": "Carpenter's Tools",
+      "url": "/api/equipment/carpenters-tools"
+    }
   },
   {
     "index": "cartographers-tools",
@@ -1329,14 +1209,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/cartographers-tools",
-    "references": [
-      {
-        "index": "cartographers-tools",
-        "type": "equipment",
-        "name": "Cartographer's Tools",
-        "url": "/api/equipment/cartographers-tools"
-      }
-    ]
+    "reference": {
+      "index": "cartographers-tools",
+      "type": "equipment",
+      "name": "Cartographer's Tools",
+      "url": "/api/equipment/cartographers-tools"
+    }
   },
   {
     "index": "cobblers-tools",
@@ -1345,14 +1223,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/cobblers-tools",
-    "references": [
-      {
-        "index": "cobblers-tools",
-        "type": "equipment",
-        "name": "Cobbler's Tools",
-        "url": "/api/equipment/cobblers-tools"
-      }
-    ]
+    "reference": {
+      "index": "cobblers-tools",
+      "type": "equipment",
+      "name": "Cobbler's Tools",
+      "url": "/api/equipment/cobblers-tools"
+    }
   },
   {
     "index": "cooks-utensils",
@@ -1361,14 +1237,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/cooks-utensils",
-    "references": [
-      {
-        "index": "cooks-utensils",
-        "type": "equipment",
-        "name": "Cook's utensils",
-        "url": "/api/equipment/cooks-utensils"
-      }
-    ]
+    "reference": {
+      "index": "cooks-utensils",
+      "type": "equipment",
+      "name": "Cook's utensils",
+      "url": "/api/equipment/cooks-utensils"
+    }
   },
   {
     "index": "glassblowers-tools",
@@ -1377,14 +1251,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/glassblowers-tools",
-    "references": [
-      {
-        "index": "glassblowers-tools",
-        "type": "equipment",
-        "name": "Glassblower's Tools",
-        "url": "/api/equipment/glassblowers-tools"
-      }
-    ]
+    "reference": {
+      "index": "glassblowers-tools",
+      "type": "equipment",
+      "name": "Glassblower's Tools",
+      "url": "/api/equipment/glassblowers-tools"
+    }
   },
   {
     "index": "jewelers-tools",
@@ -1393,14 +1265,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/jewelers-tools",
-    "references": [
-      {
-        "index": "jewelers-tools",
-        "type": "equipment",
-        "name": "Jeweler's Tools",
-        "url": "/api/equipment/jewelers-tools"
-      }
-    ]
+    "reference": {
+      "index": "jewelers-tools",
+      "type": "equipment",
+      "name": "Jeweler's Tools",
+      "url": "/api/equipment/jewelers-tools"
+    }
   },
   {
     "index": "leatherworkers-tools",
@@ -1409,14 +1279,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/leatherworkers-tools",
-    "references": [
-      {
-        "index": "leatherworkers-tools",
-        "type": "equipment",
-        "name": "Leatherworker's Tools",
-        "url": "/api/equipment/leatherworkers-tools"
-      }
-    ]
+    "reference": {
+      "index": "leatherworkers-tools",
+      "type": "equipment",
+      "name": "Leatherworker's Tools",
+      "url": "/api/equipment/leatherworkers-tools"
+    }
   },
   {
     "index": "masons-tools",
@@ -1425,14 +1293,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/masons-tools",
-    "references": [
-      {
-        "index": "masons-tools",
-        "type": "equipment",
-        "name": "Mason's Tools",
-        "url": "/api/equipment/masons-tools"
-      }
-    ]
+    "reference": {
+      "index": "masons-tools",
+      "type": "equipment",
+      "name": "Mason's Tools",
+      "url": "/api/equipment/masons-tools"
+    }
   },
   {
     "index": "painters-supplies",
@@ -1441,14 +1307,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/painters-supplies",
-    "references": [
-      {
-        "index": "painters-supplies",
-        "type": "equipment",
-        "name": "Painter's Supplies",
-        "url": "/api/equipment/painters-supplies"
-      }
-    ]
+    "reference": {
+      "index": "painters-supplies",
+      "type": "equipment",
+      "name": "Painter's Supplies",
+      "url": "/api/equipment/painters-supplies"
+    }
   },
   {
     "index": "potters-tools",
@@ -1457,14 +1321,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/potters-tools",
-    "references": [
-      {
-        "index": "potters-tools",
-        "type": "equipment",
-        "name": "Potter's Tools",
-        "url": "/api/equipment/potters-tools"
-      }
-    ]
+    "reference": {
+      "index": "potters-tools",
+      "type": "equipment",
+      "name": "Potter's Tools",
+      "url": "/api/equipment/potters-tools"
+    }
   },
   {
     "index": "smiths-tools",
@@ -1473,14 +1335,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/smiths-tools",
-    "references": [
-      {
-        "index": "smiths-tools",
-        "type": "equipment",
-        "name": "Smith's Tools",
-        "url": "/api/equipment/smiths-tools"
-      }
-    ]
+    "reference": {
+      "index": "smiths-tools",
+      "type": "equipment",
+      "name": "Smith's Tools",
+      "url": "/api/equipment/smiths-tools"
+    }
   },
   {
     "index": "tinkers-tools",
@@ -1489,14 +1349,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/tinkers-tools",
-    "references": [
-      {
-        "index": "tinkers-tools",
-        "type": "equipment",
-        "name": "Tinker's Tools",
-        "url": "/api/equipment/tinkers-tools"
-      }
-    ]
+    "reference": {
+      "index": "tinkers-tools",
+      "type": "equipment",
+      "name": "Tinker's Tools",
+      "url": "/api/equipment/tinkers-tools"
+    }
   },
   {
     "index": "weavers-tools",
@@ -1505,14 +1363,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/weavers-tools",
-    "references": [
-      {
-        "index": "weavers-tools",
-        "type": "equipment",
-        "name": "Weaver's Tools",
-        "url": "/api/equipment/weavers-tools"
-      }
-    ]
+    "reference": {
+      "index": "weavers-tools",
+      "type": "equipment",
+      "name": "Weaver's Tools",
+      "url": "/api/equipment/weavers-tools"
+    }
   },
   {
     "index": "woodcarvers-tools",
@@ -1521,14 +1377,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/woodcarvers-tools",
-    "references": [
-      {
-        "index": "woodcarvers-tools",
-        "type": "equipment",
-        "name": "Woodcarver's Tools",
-        "url": "/api/equipment/woodcarvers-tools"
-      }
-    ]
+    "reference": {
+      "index": "woodcarvers-tools",
+      "type": "equipment",
+      "name": "Woodcarver's Tools",
+      "url": "/api/equipment/woodcarvers-tools"
+    }
   },
   {
     "index": "disguise-kit",
@@ -1537,14 +1391,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/disguise-kit",
-    "references": [
-      {
-        "index": "disguise-kit",
-        "type": "equipment",
-        "name": "Disguise Kit",
-        "url": "/api/equipment/disguise-kit"
-      }
-    ]
+    "reference": {
+      "index": "disguise-kit",
+      "type": "equipment",
+      "name": "Disguise Kit",
+      "url": "/api/equipment/disguise-kit"
+    }
   },
   {
     "index": "forgery-kit",
@@ -1553,14 +1405,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/forgery-kit",
-    "references": [
-      {
-        "index": "forgery-kit",
-        "type": "equipment",
-        "name": "Forgery Kit",
-        "url": "/api/equipment/forgery-kit"
-      }
-    ]
+    "reference": {
+      "index": "forgery-kit",
+      "type": "equipment",
+      "name": "Forgery Kit",
+      "url": "/api/equipment/forgery-kit"
+    }
   },
   {
     "index": "dice-set",
@@ -1569,14 +1419,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/dice-set",
-    "references": [
-      {
-        "index": "dice-set",
-        "type": "equipment",
-        "name": "Dice Set",
-        "url": "/api/equipment/dice-set"
-      }
-    ]
+    "reference": {
+      "index": "dice-set",
+      "type": "equipment",
+      "name": "Dice Set",
+      "url": "/api/equipment/dice-set"
+    }
   },
   {
     "index": "playing-card-set",
@@ -1585,14 +1433,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/playing-card-set",
-    "references": [
-      {
-        "index": "playing-card-set",
-        "type": "equipment",
-        "name": "Playing Card Set",
-        "url": "/api/equipment/playing-card-set"
-      }
-    ]
+    "reference": {
+      "index": "playing-card-set",
+      "type": "equipment",
+      "name": "Playing Card Set",
+      "url": "/api/equipment/playing-card-set"
+    }
   },
   {
     "index": "bagpipes",
@@ -1601,14 +1447,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/bagpipes",
-    "references": [
-      {
-        "index": "bagpipes",
-        "type": "equipment",
-        "name": "Bagpipes",
-        "url": "/api/equipment/bagpipes"
-      }
-    ]
+    "reference": {
+      "index": "bagpipes",
+      "type": "equipment",
+      "name": "Bagpipes",
+      "url": "/api/equipment/bagpipes"
+    }
   },
   {
     "index": "drum",
@@ -1617,14 +1461,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/drum",
-    "references": [
-      {
-        "index": "drum",
-        "type": "equipment",
-        "name": "Drum",
-        "url": "/api/equipment/drum"
-      }
-    ]
+    "reference": {
+      "index": "drum",
+      "type": "equipment",
+      "name": "Drum",
+      "url": "/api/equipment/drum"
+    }
   },
   {
     "index": "dulcimer",
@@ -1633,14 +1475,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/dulcimer",
-    "references": [
-      {
-        "index": "dulcimer",
-        "type": "equipment",
-        "name": "Dulcimer",
-        "url": "/api/equipment/dulcimer"
-      }
-    ]
+    "reference": {
+      "index": "dulcimer",
+      "type": "equipment",
+      "name": "Dulcimer",
+      "url": "/api/equipment/dulcimer"
+    }
   },
   {
     "index": "flute",
@@ -1649,14 +1489,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/flute",
-    "references": [
-      {
-        "index": "flute",
-        "type": "equipment",
-        "name": "Flute",
-        "url": "/api/equipment/flute"
-      }
-    ]
+    "reference": {
+      "index": "flute",
+      "type": "equipment",
+      "name": "Flute",
+      "url": "/api/equipment/flute"
+    }
   },
   {
     "index": "lute",
@@ -1665,14 +1503,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/lute",
-    "references": [
-      {
-        "index": "lute",
-        "type": "equipment",
-        "name": "Lute",
-        "url": "/api/equipment/lute"
-      }
-    ]
+    "reference": {
+      "index": "lute",
+      "type": "equipment",
+      "name": "Lute",
+      "url": "/api/equipment/lute"
+    }
   },
   {
     "index": "lyre",
@@ -1681,14 +1517,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/lyre",
-    "references": [
-      {
-        "index": "lyre",
-        "type": "equipment",
-        "name": "Lyre",
-        "url": "/api/equipment/lyre"
-      }
-    ]
+    "reference": {
+      "index": "lyre",
+      "type": "equipment",
+      "name": "Lyre",
+      "url": "/api/equipment/lyre"
+    }
   },
   {
     "index": "horn",
@@ -1697,14 +1531,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/horn",
-    "references": [
-      {
-        "index": "horn",
-        "type": "equipment",
-        "name": "Horn",
-        "url": "/api/equipment/horn"
-      }
-    ]
+    "reference": {
+      "index": "horn",
+      "type": "equipment",
+      "name": "Horn",
+      "url": "/api/equipment/horn"
+    }
   },
   {
     "index": "pan-flute",
@@ -1713,14 +1545,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/pan-flute",
-    "references": [
-      {
-        "index": "pan-flute",
-        "type": "equipment",
-        "name": "Pan flute",
-        "url": "/api/equipment/pan-flute"
-      }
-    ]
+    "reference": {
+      "index": "pan-flute",
+      "type": "equipment",
+      "name": "Pan flute",
+      "url": "/api/equipment/pan-flute"
+    }
   },
   {
     "index": "shawm",
@@ -1729,14 +1559,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/shawm",
-    "references": [
-      {
-        "index": "shawm",
-        "type": "equipment",
-        "name": "Shawm",
-        "url": "/api/equipment/shawm"
-      }
-    ]
+    "reference": {
+      "index": "shawm",
+      "type": "equipment",
+      "name": "Shawm",
+      "url": "/api/equipment/shawm"
+    }
   },
   {
     "index": "viol",
@@ -1745,14 +1573,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/viol",
-    "references": [
-      {
-        "index": "viol",
-        "type": "equipment",
-        "name": "Viol",
-        "url": "/api/equipment/viol"
-      }
-    ]
+    "reference": {
+      "index": "viol",
+      "type": "equipment",
+      "name": "Viol",
+      "url": "/api/equipment/viol"
+    }
   },
   {
     "index": "herbalism-kit",
@@ -1767,14 +1593,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/herbalism-kit",
-    "references": [
-      {
-        "index": "herbalism-kit",
-        "type": "equipment",
-        "name": "Herbalism Kit",
-        "url": "/api/equipment/herbalism-kit"
-      }
-    ]
+    "reference": {
+      "index": "herbalism-kit",
+      "type": "equipment",
+      "name": "Herbalism Kit",
+      "url": "/api/equipment/herbalism-kit"
+    }
   },
   {
     "index": "navigators-tools",
@@ -1783,14 +1607,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/navigators-tools",
-    "references": [
-      {
-        "index": "navigators-tools",
-        "type": "equipment",
-        "name": "Navigator's Tools",
-        "url": "/api/equipment/navigators-tools"
-      }
-    ]
+    "reference": {
+      "index": "navigators-tools",
+      "type": "equipment",
+      "name": "Navigator's Tools",
+      "url": "/api/equipment/navigators-tools"
+    }
   },
   {
     "index": "poisoners-kit",
@@ -1799,14 +1621,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/poisoners-kit",
-    "references": [
-      {
-        "index": "poisoners-kit",
-        "type": "equipment",
-        "name": "Poisoner's Kit",
-        "url": "/api/equipment/poisoners-kit"
-      }
-    ]
+    "reference": {
+      "index": "poisoners-kit",
+      "type": "equipment",
+      "name": "Poisoner's Kit",
+      "url": "/api/equipment/poisoners-kit"
+    }
   },
   {
     "index": "thieves-tools",
@@ -1821,14 +1641,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/thieves-tools",
-    "references": [
-      {
-        "index": "thieves-tools",
-        "type": "equipment",
-        "name": "Thieves' Tools",
-        "url": "/api/equipment/thieves-tools"
-      }
-    ]
+    "reference": {
+      "index": "thieves-tools",
+      "type": "equipment",
+      "name": "Thieves' Tools",
+      "url": "/api/equipment/thieves-tools"
+    }
   },
   {
     "index": "land-vehicles",
@@ -1837,14 +1655,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/land-vehicles",
-    "references": [
-      {
-        "index": "land-vehicles",
-        "type": "equipment-categories",
-        "name": "Land Vehicles",
-        "url": "/api/equipment-categories/land-vehicles"
-      }
-    ]
+    "reference": {
+      "index": "land-vehicles",
+      "type": "equipment-categories",
+      "name": "Land Vehicles",
+      "url": "/api/equipment-categories/land-vehicles"
+    }
   },
   {
     "index": "water-vehicles",
@@ -1853,14 +1669,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/water-vehicles",
-    "references": [
-      {
-        "index": "waterborne-vehicles",
-        "type": "equipment-categories",
-        "name": "Waterborne Vehicles",
-        "url": "/api/equipment-categories/waterborne-vehicles"
-      }
-    ]
+    "reference": {
+      "index": "waterborne-vehicles",
+      "type": "equipment-categories",
+      "name": "Waterborne Vehicles",
+      "url": "/api/equipment-categories/waterborne-vehicles"
+    }
   },
   {
     "index": "saving-throw-str",
@@ -1890,14 +1704,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-str",
-    "references": [
-      {
-        "index": "str",
-        "type": "ability-scores",
-        "name": "STR",
-        "url": "/api/ability-scores/str"
-      }
-    ]
+    "reference": {
+      "index": "str",
+      "type": "ability-scores",
+      "name": "STR",
+      "url": "/api/ability-scores/str"
+    }
   },
   {
     "index": "saving-throw-dex",
@@ -1927,14 +1739,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-dex",
-    "references": [
-      {
-        "index": "dex",
-        "type": "ability-scores",
-        "name": "DEX",
-        "url": "/api/ability-scores/dex"
-      }
-    ]
+    "reference": {
+      "index": "dex",
+      "type": "ability-scores",
+      "name": "DEX",
+      "url": "/api/ability-scores/dex"
+    }
   },
   {
     "index": "saving-throw-con",
@@ -1959,14 +1769,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-con",
-    "references": [
-      {
-        "index": "con",
-        "type": "ability-scores",
-        "name": "CON",
-        "url": "/api/ability-scores/con"
-      }
-    ]
+    "reference": {
+      "index": "con",
+      "type": "ability-scores",
+      "name": "CON",
+      "url": "/api/ability-scores/con"
+    }
   },
   {
     "index": "saving-throw-int",
@@ -1991,14 +1799,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-int",
-    "references": [
-      {
-        "index": "int",
-        "type": "ability-scores",
-        "name": "INT",
-        "url": "/api/ability-scores/int"
-      }
-    ]
+    "reference": {
+      "index": "int",
+      "type": "ability-scores",
+      "name": "INT",
+      "url": "/api/ability-scores/int"
+    }
   },
   {
     "index": "saving-throw-wis",
@@ -2033,14 +1839,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-wis",
-    "references": [
-      {
-        "index": "wis",
-        "type": "ability-scores",
-        "name": "WIS",
-        "url": "/api/ability-scores/wis"
-      }
-    ]
+    "reference": {
+      "index": "wis",
+      "type": "ability-scores",
+      "name": "WIS",
+      "url": "/api/ability-scores/wis"
+    }
   },
   {
     "index": "saving-throw-cha",
@@ -2075,14 +1879,12 @@
     ],
     "races": [],
     "url": "/api/proficiencies/saving-throw-cha",
-    "references": [
-      {
-        "index": "cha",
-        "type": "ability-scores",
-        "name": "CHA",
-        "url": "/api/ability-scores/cha"
-      }
-    ]
+    "reference": {
+      "index": "cha",
+      "type": "ability-scores",
+      "name": "CHA",
+      "url": "/api/ability-scores/cha"
+    }
   },
   {
     "index": "skill-acrobatics",
@@ -2091,14 +1893,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-acrobatics",
-    "references": [
-      {
-        "index": "acrobatics",
-        "type": "skills",
-        "name": "Acrobatics",
-        "url": "/api/skills/acrobatics"
-      }
-    ]
+    "reference": {
+      "index": "acrobatics",
+      "type": "skills",
+      "name": "Acrobatics",
+      "url": "/api/skills/acrobatics"
+    }
   },
   {
     "index": "skill-animal-handling",
@@ -2107,14 +1907,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-animal-handling",
-    "references": [
-      {
-        "index": "animal-handling",
-        "type": "skills",
-        "name": "Animal Handling",
-        "url": "/api/skills/animal-handling"
-      }
-    ]
+    "reference": {
+      "index": "animal-handling",
+      "type": "skills",
+      "name": "Animal Handling",
+      "url": "/api/skills/animal-handling"
+    }
   },
   {
     "index": "skill-arcana",
@@ -2123,14 +1921,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-arcana",
-    "references": [
-      {
-        "index": "arcana",
-        "type": "skills",
-        "name": "Arcana",
-        "url": "/api/skills/arcana"
-      }
-    ]
+    "reference": {
+      "index": "arcana",
+      "type": "skills",
+      "name": "Arcana",
+      "url": "/api/skills/arcana"
+    }
   },
   {
     "index": "skill-athletics",
@@ -2139,14 +1935,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-athletics",
-    "references": [
-      {
-        "index": "athletics",
-        "type": "skills",
-        "name": "Athletics",
-        "url": "/api/skills/athletics"
-      }
-    ]
+    "reference": {
+      "index": "athletics",
+      "type": "skills",
+      "name": "Athletics",
+      "url": "/api/skills/athletics"
+    }
   },
   {
     "index": "skill-deception",
@@ -2155,14 +1949,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-deception",
-    "references": [
-      {
-        "index": "deception",
-        "type": "skills",
-        "name": "Deception",
-        "url": "/api/skills/deception"
-      }
-    ]
+    "reference": {
+      "index": "deception",
+      "type": "skills",
+      "name": "Deception",
+      "url": "/api/skills/deception"
+    }
   },
   {
     "index": "skill-history",
@@ -2171,14 +1963,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-history",
-    "references": [
-      {
-        "index": "history",
-        "type": "skills",
-        "name": "History",
-        "url": "/api/skills/history"
-      }
-    ]
+    "reference": {
+      "index": "history",
+      "type": "skills",
+      "name": "History",
+      "url": "/api/skills/history"
+    }
   },
   {
     "index": "skill-insight",
@@ -2187,14 +1977,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-insight",
-    "references": [
-      {
-        "index": "insight",
-        "type": "skills",
-        "name": "Insight",
-        "url": "/api/skills/insight"
-      }
-    ]
+    "reference": {
+      "index": "insight",
+      "type": "skills",
+      "name": "Insight",
+      "url": "/api/skills/insight"
+    }
   },
   {
     "index": "skill-intimidation",
@@ -2203,14 +1991,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-intimidation",
-    "references": [
-      {
-        "index": "intimidation",
-        "type": "skills",
-        "name": "Intimidation",
-        "url": "/api/skills/intimidation"
-      }
-    ]
+    "reference": {
+      "index": "intimidation",
+      "type": "skills",
+      "name": "Intimidation",
+      "url": "/api/skills/intimidation"
+    }
   },
   {
     "index": "skill-investigation",
@@ -2219,14 +2005,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-investigation",
-    "references": [
-      {
-        "index": "investigation",
-        "type": "skills",
-        "name": "Investigation",
-        "url": "/api/skills/investigation"
-      }
-    ]
+    "reference": {
+      "index": "investigation",
+      "type": "skills",
+      "name": "Investigation",
+      "url": "/api/skills/investigation"
+    }
   },
   {
     "index": "skill-medicine",
@@ -2235,14 +2019,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-medicine",
-    "references": [
-      {
-        "index": "medicine",
-        "type": "skills",
-        "name": "Medicine",
-        "url": "/api/skills/medicine"
-      }
-    ]
+    "reference": {
+      "index": "medicine",
+      "type": "skills",
+      "name": "Medicine",
+      "url": "/api/skills/medicine"
+    }
   },
   {
     "index": "skill-nature",
@@ -2251,14 +2033,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-nature",
-    "references": [
-      {
-        "index": "nature",
-        "type": "skills",
-        "name": "Nature",
-        "url": "/api/skills/nature"
-      }
-    ]
+    "reference": {
+      "index": "nature",
+      "type": "skills",
+      "name": "Nature",
+      "url": "/api/skills/nature"
+    }
   },
   {
     "index": "skill-perception",
@@ -2273,14 +2053,12 @@
       }
     ],
     "url": "/api/proficiencies/skill-perception",
-    "references": [
-      {
-        "index": "perception",
-        "type": "skills",
-        "name": "Perception",
-        "url": "/api/skills/perception"
-      }
-    ]
+    "reference": {
+      "index": "perception",
+      "type": "skills",
+      "name": "Perception",
+      "url": "/api/skills/perception"
+    }
   },
   {
     "index": "skill-performance",
@@ -2289,14 +2067,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-performance",
-    "references": [
-      {
-        "index": "performance",
-        "type": "skills",
-        "name": "Performance",
-        "url": "/api/skills/performance"
-      }
-    ]
+    "reference": {
+      "index": "performance",
+      "type": "skills",
+      "name": "Performance",
+      "url": "/api/skills/performance"
+    }
   },
   {
     "index": "skill-persuasion",
@@ -2305,14 +2081,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-persuasion",
-    "references": [
-      {
-        "index": "persuasion",
-        "type": "skills",
-        "name": "Persuasion",
-        "url": "/api/skills/persuasion"
-      }
-    ]
+    "reference": {
+      "index": "persuasion",
+      "type": "skills",
+      "name": "Persuasion",
+      "url": "/api/skills/persuasion"
+    }
   },
   {
     "index": "skill-religion",
@@ -2321,14 +2095,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-religion",
-    "references": [
-      {
-        "index": "religion",
-        "type": "skills",
-        "name": "Religion",
-        "url": "/api/skills/religion"
-      }
-    ]
+    "reference": {
+      "index": "religion",
+      "type": "skills",
+      "name": "Religion",
+      "url": "/api/skills/religion"
+    }
   },
   {
     "index": "skill-sleight-of-hand",
@@ -2337,14 +2109,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-sleight-of-hand",
-    "references": [
-      {
-        "index": "sleight-of-hand",
-        "type": "skills",
-        "name": "Sleight of Hand",
-        "url": "/api/skills/sleight-of-hand"
-      }
-    ]
+    "reference": {
+      "index": "sleight-of-hand",
+      "type": "skills",
+      "name": "Sleight of Hand",
+      "url": "/api/skills/sleight-of-hand"
+    }
   },
   {
     "index": "skill-stealth",
@@ -2353,14 +2123,12 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-stealth",
-    "references": [
-      {
-        "index": "stealth",
-        "type": "skills",
-        "name": "Stealth",
-        "url": "/api/skills/stealth"
-      }
-    ]
+    "reference": {
+      "index": "stealth",
+      "type": "skills",
+      "name": "Stealth",
+      "url": "/api/skills/stealth"
+    }
   },
   {
     "index": "skill-survival",
@@ -2369,13 +2137,11 @@
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/skill-survival",
-    "references": [
-      {
-        "index": "survival",
-        "type": "skills",
-        "name": "Survival",
-        "url": "/api/skills/survival"
-      }
-    ]
+    "reference": {
+      "index": "survival",
+      "type": "skills",
+      "name": "Survival",
+      "url": "/api/skills/survival"
+    }
   }
 ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -46,7 +46,15 @@
       "index": "light-armor",
       "name": "Light Armor",
       "url": "/api/equipment-categories/light-armor"
-    }
+    },
+    "references": [
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "type": "equipment-categories",
+        "url": "/api/equipment-categories/light-armor"
+      }
+    ]
   },
   {
     "index": "medium-armor",
@@ -80,7 +88,15 @@
       "index": "medium-armor",
       "name": "Medium Armor",
       "url": "/api/equipment-categories/medium-armor"
-    }
+    },
+    "references": [
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "type": "equipment-categories",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ]
   },
   {
     "index": "heavy-armor",
@@ -93,7 +109,15 @@
       "index": "heavy-armor",
       "name": "Heavy Armor",
       "url": "/api/equipment-categories/heavy-armor"
-    }
+    },
+    "references": [
+      {
+        "index": "heavy-armor",
+        "type": "equipment-categories",
+        "name": "Heavy Armor",
+        "url": "/api/equipment-categories/heavy-armor"
+      }
+    ]
   },
   {
     "index": "all-armor",
@@ -117,7 +141,15 @@
       "index": "armor",
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
-    }
+    },
+    "references": [
+      {
+        "index": "armor",
+        "type": "equipment-categories",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }
+    ]
   },
   {
     "index": "padded",
@@ -130,7 +162,15 @@
       "index": "padded",
       "name": "Padded",
       "url": "/api/equipment/padded"
-    }
+    },
+    "references": [
+      {
+        "index": "padded",
+        "type": "equipment",
+        "name": "Padded",
+        "url": "/api/equipment/padded"
+      }
+    ]
   },
   {
     "index": "leather",
@@ -143,7 +183,15 @@
       "index": "leather",
       "name": "Leather",
       "url": "/api/equipment/leather"
-    }
+    },
+    "references": [
+      {
+        "index": "leather",
+        "name": "Leather",
+        "type": "equipment",
+        "url": "/api/equipment/leather"
+      }
+    ]
   },
   {
     "index": "studded-leather",
@@ -156,7 +204,15 @@
       "index": "studded-leather",
       "name": "Studded Leather",
       "url": "/api/equipment/studded-leather"
-    }
+    },
+    "references": [
+      {
+        "index": "studded-leather",
+        "type": "equipment",
+        "name": "Studded Leather",
+        "url": "/api/equipment/studded-leather"
+      }
+    ]
   },
   {
     "index": "hide",
@@ -169,7 +225,15 @@
       "index": "hide",
       "name": "Hide",
       "url": "/api/equipment/hide"
-    }
+    },
+    "references": [
+      {
+        "index": "hide",
+        "type": "equipment",
+        "name": "Hide",
+        "url": "/api/equipment/hide"
+      }
+    ]
   },
   {
     "index": "chain-shirt",
@@ -182,7 +246,15 @@
       "index": "chain-shirt",
       "name": "Chain Shirt",
       "url": "/api/equipment/chain-shirt"
-    }
+    },
+    "references": [
+      {
+        "index": "chain-shirt",
+        "name": "Chain Shirt",
+        "type": "equipment",
+        "url": "/api/equipment/chain-shirt"
+      }
+    ]
   },
   {
     "index": "scale-mail",
@@ -195,7 +267,15 @@
       "index": "scale-mail",
       "name": "Scale Mail",
       "url": "/api/equipment/scale-mail"
-    }
+    },
+    "references": [
+      {
+        "index": "scale-mail",
+        "name": "Scale Mail",
+        "type": "equipment",
+        "url": "/api/equipment/scale-mail"
+      }
+    ]
   },
   {
     "index": "breastplate",
@@ -208,7 +288,15 @@
       "index": "breastplate",
       "name": "Breastplate",
       "url": "/api/equipment/breastplate"
-    }
+    },
+    "references": [
+      {
+        "index": "breastplate",
+        "name": "Breastplate",
+        "type": "equipment",
+        "url": "/api/equipment/breastplate"
+      }
+    ]
   },
   {
     "index": "half-plate",
@@ -221,7 +309,15 @@
       "index": "half-plate",
       "name": "Half Plate",
       "url": "/api/equipment/half-plate"
-    }
+    },
+    "references": [
+      {
+        "index": "half-plate",
+        "name": "Half Plate",
+        "type": "equipment",
+        "url": "/api/equipment/half-plate"
+      }
+    ]
   },
   {
     "index": "ring-mail",
@@ -234,7 +330,15 @@
       "index": "ring-mail",
       "name": "Ring Mail",
       "url": "/api/equipment/ring-mail"
-    }
+    },
+    "references": [
+      {
+        "index": "ring-mail",
+        "name": "Ring Mail",
+        "type": "equipment",
+        "url": "/api/equipment/ring-mail"
+      }
+    ]
   },
   {
     "index": "chain-mail",
@@ -247,7 +351,15 @@
       "index": "chain-mail",
       "name": "Chain Mail",
       "url": "/api/equipment/chain-mail"
-    }
+    },
+    "references": [
+      {
+        "index": "chain-mail",
+        "name": "Chain Mail",
+        "type": "equipment",
+        "url": "/api/equipment/chain-mail"
+      }
+    ]
   },
   {
     "index": "splint",
@@ -260,7 +372,15 @@
       "index": "splint",
       "name": "Splint",
       "url": "/api/equipment/splint"
-    }
+    },
+    "references": [
+      {
+        "index": "splint",
+        "name": "Splint",
+        "type": "equipment",
+        "url": "/api/equipment/splint"
+      }
+    ]
   },
   {
     "index": "plate",
@@ -273,7 +393,15 @@
       "index": "plate",
       "name": "Plate",
       "url": "/api/equipment/plate"
-    }
+    },
+    "references": [
+      {
+        "index": "plate",
+        "name": "Plate",
+        "type": "equipment",
+        "url": "/api/equipment/plate"
+      }
+    ]
   },
   {
     "index": "shields",
@@ -317,7 +445,15 @@
       "index": "shield",
       "name": "Shield",
       "url": "/api/equipment/shield"
-    }
+    },
+    "references": [
+      {
+        "index": "shield",
+        "name": "Shield",
+        "type": "equipment",
+        "url": "/api/equipment/shield"
+      }
+    ]
   },
   {
     "index": "simple-weapons",
@@ -376,7 +512,15 @@
       "index": "simple-weapons",
       "name": "Simple Weapons",
       "url": "/api/equipment-categories/simple-weapons"
-    }
+    },
+    "references": [
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "type": "equipment-categories",
+        "url": "/api/equipment-categories/simple-weapons"
+      }
+    ]
   },
   {
     "index": "martial-weapons",
@@ -410,7 +554,15 @@
       "index": "martial-weapons",
       "name": "Martial Weapons",
       "url": "/api/equipment-categories/martial-weapons"
-    }
+    },
+    "references": [
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "type": "equipment-categories",
+        "url": "/api/equipment-categories/martial-weapons"
+      }
+    ]
   },
   {
     "index": "clubs",
@@ -429,7 +581,15 @@
       "index": "club",
       "name": "Club",
       "url": "/api/equipment/club"
-    }
+    },
+    "references": [
+      {
+        "index": "club",
+        "name": "Club",
+        "type": "equipment",
+        "url": "/api/equipment/club"
+      }
+    ]
   },
   {
     "index": "daggers",
@@ -458,7 +618,15 @@
       "index": "dagger",
       "name": "Dagger",
       "url": "/api/equipment/dagger"
-    }
+    },
+    "references": [
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "type": "equipment",
+        "url": "/api/equipment/dagger"
+      }
+    ]
   },
   {
     "index": "greatclubs",
@@ -471,7 +639,15 @@
       "index": "greatclub",
       "name": "Greatclub",
       "url": "/api/equipment/greatclub"
-    }
+    },
+    "references": [
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "type": "equipment",
+        "url": "/api/equipment/greatclub"
+      }
+    ]
   },
   {
     "index": "handaxes",
@@ -490,7 +666,15 @@
       "index": "handaxe",
       "name": "Handaxe",
       "url": "/api/equipment/handaxe"
-    }
+    },
+    "references": [
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "type": "equipment",
+        "url": "/api/equipment/handaxe"
+      }
+    ]
   },
   {
     "index": "javelins",
@@ -509,7 +693,15 @@
       "index": "javelin",
       "name": "Javelin",
       "url": "/api/equipment/javelin"
-    }
+    },
+    "references": [
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "type": "equipment",
+        "url": "/api/equipment/javelin"
+      }
+    ]
   },
   {
     "index": "light-hammers",
@@ -528,7 +720,15 @@
       "index": "light-hammer",
       "name": "Light hammer",
       "url": "/api/equipment/light-hammer"
-    }
+    },
+    "references": [
+      {
+        "index": "light-hammer",
+        "name": "Light hammer",
+        "type": "equipment",
+        "url": "/api/equipment/light-hammer"
+      }
+    ]
   },
   {
     "index": "maces",
@@ -547,7 +747,15 @@
       "index": "mace",
       "name": "Mace",
       "url": "/api/equipment/mace"
-    }
+    },
+    "references": [
+      {
+        "index": "mace",
+        "name": "Mace",
+        "type": "equipment",
+        "url": "/api/equipment/mace"
+      }
+    ]
   },
   {
     "index": "quarterstaffs",
@@ -576,7 +784,15 @@
       "index": "quarterstaff",
       "name": "Quarterstaff",
       "url": "/api/equipment/quarterstaff"
-    }
+    },
+    "references": [
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "type": "equipment",
+        "url": "/api/equipment/quarterstaff"
+      }
+    ]
   },
   {
     "index": "sickles",
@@ -595,7 +811,15 @@
       "index": "sickle",
       "name": "Sickle",
       "url": "/api/equipment/sickle"
-    }
+    },
+    "references": [
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "type": "equipment",
+        "url": "/api/equipment/sickle"
+      }
+    ]
   },
   {
     "index": "spears",
@@ -614,7 +838,15 @@
       "index": "spear",
       "name": "Spear",
       "url": "/api/equipment/spear"
-    }
+    },
+    "references": [
+      {
+        "index": "spear",
+        "name": "Spear",
+        "type": "equipment",
+        "url": "/api/equipment/spear"
+      }
+    ]
   },
   {
     "index": "crossbows-light",
@@ -627,7 +859,15 @@
       "index": "crossbow-light",
       "name": "Crossbow, light",
       "url": "/api/equipment/crossbow-light"
-    }
+    },
+    "references": [
+      {
+        "index": "crossbow-light",
+        "name": "Crossbow, light",
+        "type": "equipment",
+        "url": "/api/equipment/crossbow-light"
+      }
+    ]
   },
   {
     "index": "darts",
@@ -656,7 +896,15 @@
       "index": "dart",
       "name": "Dart",
       "url": "/api/equipment/dart"
-    }
+    },
+    "references": [
+      {
+        "index": "dart",
+        "name": "Dart",
+        "type": "equipment",
+        "url": "/api/equipment/dart"
+      }
+    ]
   },
   {
     "index": "shortbows",
@@ -675,7 +923,15 @@
       "index": "shortbow",
       "name": "Shortbow",
       "url": "/api/equipment/shortbow"
-    }
+    },
+    "references": [
+      {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "type": "equipment",
+        "url": "/api/equipment/shortbow"
+      }
+    ]
   },
   {
     "index": "slings",
@@ -704,7 +960,15 @@
       "index": "sling",
       "name": "Sling",
       "url": "/api/equipment/sling"
-    }
+    },
+    "references": [
+      {
+        "index": "sling",
+        "name": "Sling",
+        "type": "equipment",
+        "url": "/api/equipment/sling"
+      }
+    ]
   },
   {
     "index": "battleaxes",
@@ -723,7 +987,15 @@
       "index": "battleaxe",
       "name": "Battleaxe",
       "url": "/api/equipment/battleaxe"
-    }
+    },
+    "references": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "type": "equipment",
+        "url": "/api/equipment/battleaxe"
+      }
+    ]
   },
   {
     "index": "flails",
@@ -736,7 +1008,15 @@
       "index": "flail",
       "name": "Flail",
       "url": "/api/equipment/flail"
-    }
+    },
+    "references": [
+      {
+        "index": "flail",
+        "name": "Flail",
+        "type": "equipment",
+        "url": "/api/equipment/flail"
+      }
+    ]
   },
   {
     "index": "glaives",
@@ -749,7 +1029,15 @@
       "index": "glaive",
       "name": "Glaive",
       "url": "/api/equipment/glaive"
-    }
+    },
+    "references": [
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "type": "equipment",
+        "url": "/api/equipment/glaive"
+      }
+    ]
   },
   {
     "index": "greataxes",
@@ -762,7 +1050,15 @@
       "index": "greataxe",
       "name": "Greataxe",
       "url": "/api/equipment/greataxe"
-    }
+    },
+    "references": [
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "type": "equipment",
+        "url": "/api/equipment/greataxe"
+      }
+    ]
   },
   {
     "index": "greatswords",
@@ -775,7 +1071,15 @@
       "index": "greatsword",
       "name": "Greatsword",
       "url": "/api/equipment/greatsword"
-    }
+    },
+    "references": [
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "type": "equipment",
+        "url": "/api/equipment/greatsword"
+      }
+    ]
   },
   {
     "index": "halberds",
@@ -788,7 +1092,15 @@
       "index": "halberd",
       "name": "Halberd",
       "url": "/api/equipment/halberd"
-    }
+    },
+    "references": [
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "type": "equipment",
+        "url": "/api/equipment/halberd"
+      }
+    ]
   },
   {
     "index": "lances",
@@ -801,7 +1113,15 @@
       "index": "lance",
       "name": "Lance",
       "url": "/api/equipment/lance"
-    }
+    },
+    "references": [
+      {
+        "index": "lance",
+        "name": "Lance",
+        "type": "equipment",
+        "url": "/api/equipment/lance"
+      }
+    ]
   },
   {
     "index": "longswords",
@@ -831,7 +1151,15 @@
       "index": "longsword",
       "name": "Longsword",
       "url": "/api/equipment/longsword"
-    }
+    },
+    "references": [
+      {
+        "index": "longsword",
+        "name": "Longsword",
+        "type": "equipment",
+        "url": "/api/equipment/longsword"
+      }
+    ]
   },
   {
     "index": "mauls",
@@ -844,7 +1172,15 @@
       "index": "maul",
       "name": "Maul",
       "url": "/api/equipment/maul"
-    }
+    },
+    "references": [
+      {
+        "index": "maul",
+        "name": "Maul",
+        "type": "equipment",
+        "url": "/api/equipment/maul"
+      }
+    ]
   },
   {
     "index": "morningstars",
@@ -857,7 +1193,15 @@
       "index": "morningstar",
       "name": "Morningstar",
       "url": "/api/equipment/morningstar"
-    }
+    },
+    "references": [
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "type": "equipment",
+        "url": "/api/equipment/morningstar"
+      }
+    ]
   },
   {
     "index": "pikes",
@@ -870,7 +1214,15 @@
       "index": "pike",
       "name": "Pike",
       "url": "/api/equipment/pike"
-    }
+    },
+    "references": [
+      {
+        "index": "pike",
+        "name": "Pike",
+        "type": "equipment",
+        "url": "/api/equipment/pike"
+      }
+    ]
   },
   {
     "index": "rapiers",
@@ -894,7 +1246,15 @@
       "index": "rapier",
       "name": "Rapier",
       "url": "/api/equipment/rapier"
-    }
+    },
+    "references": [
+      {
+        "index": "rapier",
+        "name": "Rapier",
+        "type": "equipment",
+        "url": "/api/equipment/rapier"
+      }
+    ]
   },
   {
     "index": "scimitars",
@@ -913,7 +1273,15 @@
       "index": "scimitar",
       "name": "Scimitar",
       "url": "/api/equipment/scimitar"
-    }
+    },
+    "references": [
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "type": "equipment",
+        "url": "/api/equipment/scimitar"
+      }
+    ]
   },
   {
     "index": "shortswords",
@@ -948,7 +1316,15 @@
       "index": "shortsword",
       "name": "Shortsword",
       "url": "/api/equipment/shortsword"
-    }
+    },
+    "references": [
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "type": "equipment",
+        "url": "/api/equipment/shortsword"
+      }
+    ]
   },
   {
     "index": "tridents",
@@ -961,7 +1337,15 @@
       "index": "trident",
       "name": "Trident",
       "url": "/api/equipment/trident"
-    }
+    },
+    "references": [
+      {
+        "index": "trident",
+        "name": "Trident",
+        "type": "equipment",
+        "url": "/api/equipment/trident"
+      }
+    ]
   },
   {
     "index": "war-picks",
@@ -974,7 +1358,15 @@
       "index": "war-pick",
       "name": "War pick",
       "url": "/api/equipment/war-pick"
-    }
+    },
+    "references": [
+      {
+        "index": "war-pick",
+        "name": "War pick",
+        "type": "equipment",
+        "url": "/api/equipment/war-pick"
+      }
+    ]
   },
   {
     "index": "warhammers",
@@ -993,7 +1385,15 @@
       "index": "warhammer",
       "name": "Warhammer",
       "url": "/api/equipment/warhammer"
-    }
+    },
+    "references": [
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "type": "equipment",
+        "url": "/api/equipment/warhammer"
+      }
+    ]
   },
   {
     "index": "whips",
@@ -1006,7 +1406,15 @@
       "index": "whip",
       "name": "Whip",
       "url": "/api/equipment/whip"
-    }
+    },
+    "references": [
+      {
+        "index": "whip",
+        "name": "Whip",
+        "type": "equipment",
+        "url": "/api/equipment/whip"
+      }
+    ]
   },
   {
     "index": "blowguns",
@@ -1019,7 +1427,15 @@
       "index": "blowgun",
       "name": "Blowgun",
       "url": "/api/equipment/blowgun"
-    }
+    },
+    "references": [
+      {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "type": "equipment",
+        "url": "/api/equipment/blowgun"
+      }
+    ]
   },
   {
     "index": "hand-crossbows",
@@ -1043,7 +1459,15 @@
       "index": "crossbow-hand",
       "name": "Crossbow, hand",
       "url": "/api/equipment/crossbow-hand"
-    }
+    },
+    "references": [
+      {
+        "index": "crossbow-hand",
+        "name": "Crossbow, hand",
+        "type": "equipment",
+        "url": "/api/equipment/crossbow-hand"
+      }
+    ]
   },
   {
     "index": "crossbows-heavy",
@@ -1056,7 +1480,15 @@
       "index": "crossbow-heavy",
       "name": "Crossbow, heavy",
       "url": "/api/equipment/crossbow-heavy"
-    }
+    },
+    "references": [
+      {
+        "index": "crossbow-heavy",
+        "name": "Crossbow, heavy",
+        "type": "equipment",
+        "url": "/api/equipment/crossbow-heavy"
+      }
+    ]
   },
   {
     "index": "longbows",
@@ -1075,7 +1507,15 @@
       "index": "longbow",
       "name": "Longbow",
       "url": "/api/equipment/longbow"
-    }
+    },
+    "references": [
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "type": "equipment",
+        "url": "/api/equipment/longbow"
+      }
+    ]
   },
   {
     "index": "nets",
@@ -1088,7 +1528,15 @@
       "index": "net",
       "name": "Net",
       "url": "/api/equipment/net"
-    }
+    },
+    "references": [
+      {
+        "index": "net",
+        "name": "Net",
+        "type": "equipment",
+        "url": "/api/equipment/net"
+      }
+    ]
   },
   {
     "index": "alchemists-supplies",
@@ -1101,7 +1549,15 @@
       "index": "alchemists-supplies",
       "name": "Alchemist's Supplies",
       "url": "/api/equipment/alchemists-supplies"
-    }
+    },
+    "references": [
+      {
+        "index": "alchemists-supplies",
+        "name": "Alchemist's Supplies",
+        "type": "equipment",
+        "url": "/api/equipment/alchemists-supplies"
+      }
+    ]
   },
   {
     "index": "brewers-supplies",
@@ -1114,7 +1570,15 @@
       "index": "brewers-supplies",
       "name": "Brewer's Supplies",
       "url": "/api/equipment/brewers-supplies"
-    }
+    },
+    "references": [
+      {
+        "index": "brewers-supplies",
+        "name": "Brewer's Supplies",
+        "type": "equipment",
+        "url": "/api/equipment/brewers-supplies"
+      }
+    ]
   },
   {
     "index": "calligraphers-supplies",
@@ -1127,7 +1591,15 @@
       "index": "calligraphers-supplies",
       "name": "Calligrapher's Supplies",
       "url": "/api/equipment/calligraphers-supplies"
-    }
+    },
+    "references": [
+      {
+        "index": "calligraphers-supplies",
+        "name": "Calligrapher's Supplies",
+        "type": "equipment",
+        "url": "/api/equipment/calligraphers-supplies"
+      }
+    ]
   },
   {
     "index": "carpenters-tools",
@@ -1140,7 +1612,15 @@
       "index": "carpenters-tools",
       "name": "Carpenter's Tools",
       "url": "/api/equipment/carpenters-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "carpenters-tools",
+        "name": "Carpenter's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/carpenters-tools"
+      }
+    ]
   },
   {
     "index": "cartographers-tools",
@@ -1153,7 +1633,15 @@
       "index": "cartographers-tools",
       "name": "Cartographer's Tools",
       "url": "/api/equipment/cartographers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "cartographers-tools",
+        "name": "Cartographer's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/cartographers-tools"
+      }
+    ]
   },
   {
     "index": "cobblers-tools",
@@ -1166,7 +1654,15 @@
       "index": "cobblers-tools",
       "name": "Cobbler's Tools",
       "url": "/api/equipment/cobblers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "cobblers-tools",
+        "name": "Cobbler's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/cobblers-tools"
+      }
+    ]
   },
   {
     "index": "cooks-utensils",
@@ -1179,7 +1675,15 @@
       "index": "cooks-utensils",
       "name": "Cook's utensils",
       "url": "/api/equipment/cooks-utensils"
-    }
+    },
+    "references": [
+      {
+        "index": "cooks-utensils",
+        "name": "Cook's utensils",
+        "type": "equipment",
+        "url": "/api/equipment/cooks-utensils"
+      }
+    ]
   },
   {
     "index": "glassblowers-tools",
@@ -1192,7 +1696,15 @@
       "index": "glassblowers-tools",
       "name": "Glassblower's Tools",
       "url": "/api/equipment/glassblowers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "glassblowers-tools",
+        "name": "Glassblower's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/glassblowers-tools"
+      }
+    ]
   },
   {
     "index": "jewelers-tools",
@@ -1205,7 +1717,15 @@
       "index": "jewelers-tools",
       "name": "Jeweler's Tools",
       "url": "/api/equipment/jewelers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "jewelers-tools",
+        "name": "Jeweler's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/jewelers-tools"
+      }
+    ]
   },
   {
     "index": "leatherworkers-tools",
@@ -1218,7 +1738,15 @@
       "index": "leatherworkers-tools",
       "name": "Leatherworker's Tools",
       "url": "/api/equipment/leatherworkers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "leatherworkers-tools",
+        "name": "Leatherworker's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/leatherworkers-tools"
+      }
+    ]
   },
   {
     "index": "masons-tools",
@@ -1231,7 +1759,15 @@
       "index": "masons-tools",
       "name": "Mason's Tools",
       "url": "/api/equipment/masons-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "masons-tools",
+        "name": "Mason's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/masons-tools"
+      }
+    ]
   },
   {
     "index": "painters-supplies",
@@ -1244,7 +1780,15 @@
       "index": "painters-supplies",
       "name": "Painter's Supplies",
       "url": "/api/equipment/painters-supplies"
-    }
+    },
+    "references": [
+      {
+        "index": "painters-supplies",
+        "name": "Painter's Supplies",
+        "type": "equipment",
+        "url": "/api/equipment/painters-supplies"
+      }
+    ]
   },
   {
     "index": "potters-tools",
@@ -1257,7 +1801,15 @@
       "index": "potters-tools",
       "name": "Potter's Tools",
       "url": "/api/equipment/potters-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "potters-tools",
+        "name": "Potter's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/potters-tools"
+      }
+    ]
   },
   {
     "index": "smiths-tools",
@@ -1270,7 +1822,15 @@
       "index": "smiths-tools",
       "name": "Smith's Tools",
       "url": "/api/equipment/smiths-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "smiths-tools",
+        "name": "Smith's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/smiths-tools"
+      }
+    ]
   },
   {
     "index": "tinkers-tools",
@@ -1283,7 +1843,15 @@
       "index": "tinkers-tools",
       "name": "Tinker's Tools",
       "url": "/api/equipment/tinkers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "tinkers-tools",
+        "name": "Tinker's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/tinkers-tools"
+      }
+    ]
   },
   {
     "index": "weavers-tools",
@@ -1296,7 +1864,15 @@
       "index": "weavers-tools",
       "name": "Weaver's Tools",
       "url": "/api/equipment/weavers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "weavers-tools",
+        "name": "Weaver's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/weavers-tools"
+      }
+    ]
   },
   {
     "index": "woodcarvers-tools",
@@ -1309,7 +1885,15 @@
       "index": "woodcarvers-tools",
       "name": "Woodcarver's Tools",
       "url": "/api/equipment/woodcarvers-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "woodcarvers-tools",
+        "name": "Woodcarver's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/woodcarvers-tools"
+      }
+    ]
   },
   {
     "index": "disguise-kit",
@@ -1322,7 +1906,15 @@
       "index": "disguise-kit",
       "name": "Disguise Kit",
       "url": "/api/equipment/disguise-kit"
-    }
+    },
+    "references": [
+      {
+        "index": "disguise-kit",
+        "name": "Disguise Kit",
+        "type": "equipment",
+        "url": "/api/equipment/disguise-kit"
+      }
+    ]
   },
   {
     "index": "forgery-kit",
@@ -1335,7 +1927,15 @@
       "index": "forgery-kit",
       "name": "Forgery Kit",
       "url": "/api/equipment/forgery-kit"
-    }
+    },
+    "references": [
+      {
+        "index": "forgery-kit",
+        "name": "Forgery Kit",
+        "type": "equipment",
+        "url": "/api/equipment/forgery-kit"
+      }
+    ]
   },
   {
     "index": "dice-set",
@@ -1348,7 +1948,15 @@
       "index": "dice-set",
       "name": "Dice Set",
       "url": "/api/equipment/dice-set"
-    }
+    },
+    "references": [
+      {
+        "index": "dice-set",
+        "name": "Dice Set",
+        "type": "equipment",
+        "url": "/api/equipment/dice-set"
+      }
+    ]
   },
   {
     "index": "playing-card-set",
@@ -1361,7 +1969,15 @@
       "index": "playing-card-set",
       "name": "Playing Card Set",
       "url": "/api/equipment/playing-card-set"
-    }
+    },
+    "references": [
+      {
+        "index": "playing-card-set",
+        "name": "Playing Card Set",
+        "type": "equipment",
+        "url": "/api/equipment/playing-card-set"
+      }
+    ]
   },
   {
     "index": "bagpipes",
@@ -1374,7 +1990,15 @@
       "index": "bagpipes",
       "name": "Bagpipes",
       "url": "/api/equipment/bagpipes"
-    }
+    },
+    "references": [
+      {
+        "index": "bagpipes",
+        "name": "Bagpipes",
+        "type": "equipment",
+        "url": "/api/equipment/bagpipes"
+      }
+    ]
   },
   {
     "index": "drum",
@@ -1387,7 +2011,15 @@
       "index": "drum",
       "name": "Drum",
       "url": "/api/equipment/drum"
-    }
+    },
+    "references": [
+      {
+        "index": "drum",
+        "name": "Drum",
+        "type": "equipment",
+        "url": "/api/equipment/drum"
+      }
+    ]
   },
   {
     "index": "dulcimer",
@@ -1400,7 +2032,15 @@
       "index": "dulcimer",
       "name": "Dulcimer",
       "url": "/api/equipment/dulcimer"
-    }
+    },
+    "references": [
+      {
+        "index": "dulcimer",
+        "name": "Dulcimer",
+        "type": "equipment",
+        "url": "/api/equipment/dulcimer"
+      }
+    ]
   },
   {
     "index": "flute",
@@ -1413,7 +2053,15 @@
       "index": "flute",
       "name": "Flute",
       "url": "/api/equipment/flute"
-    }
+    },
+    "references": [
+      {
+        "index": "flute",
+        "name": "Flute",
+        "type": "equipment",
+        "url": "/api/equipment/flute"
+      }
+    ]
   },
   {
     "index": "lute",
@@ -1426,7 +2074,15 @@
       "index": "lute",
       "name": "Lute",
       "url": "/api/equipment/lute"
-    }
+    },
+    "references": [
+      {
+        "index": "lute",
+        "name": "Lute",
+        "type": "equipment",
+        "url": "/api/equipment/lute"
+      }
+    ]
   },
   {
     "index": "lyre",
@@ -1439,7 +2095,15 @@
       "index": "lyre",
       "name": "Lyre",
       "url": "/api/equipment/lyre"
-    }
+    },
+    "references": [
+      {
+        "index": "lyre",
+        "name": "Lyre",
+        "type": "equipment",
+        "url": "/api/equipment/lyre"
+      }
+    ]
   },
   {
     "index": "horn",
@@ -1452,7 +2116,15 @@
       "index": "horn",
       "name": "Horn",
       "url": "/api/equipment/horn"
-    }
+    },
+    "references": [
+      {
+        "index": "horn",
+        "name": "Horn",
+        "type": "equipment",
+        "url": "/api/equipment/horn"
+      }
+    ]
   },
   {
     "index": "pan-flute",
@@ -1465,7 +2137,15 @@
       "index": "pan-flute",
       "name": "Pan flute",
       "url": "/api/equipment/pan-flute"
-    }
+    },
+    "references": [
+      {
+        "index": "pan-flute",
+        "name": "Pan flute",
+        "type": "equipment",
+        "url": "/api/equipment/pan-flute"
+      }
+    ]
   },
   {
     "index": "shawm",
@@ -1478,7 +2158,15 @@
       "index": "shawm",
       "name": "Shawm",
       "url": "/api/equipment/shawm"
-    }
+    },
+    "references": [
+      {
+        "index": "shawm",
+        "name": "Shawm",
+        "type": "equipment",
+        "url": "/api/equipment/shawm"
+      }
+    ]
   },
   {
     "index": "viol",
@@ -1491,7 +2179,15 @@
       "index": "viol",
       "name": "Viol",
       "url": "/api/equipment/viol"
-    }
+    },
+    "references": [
+      {
+        "index": "viol",
+        "name": "Viol",
+        "type": "equipment",
+        "url": "/api/equipment/viol"
+      }
+    ]
   },
   {
     "index": "herbalism-kit",
@@ -1510,7 +2206,15 @@
       "index": "herbalism-kit",
       "name": "Herbalism Kit",
       "url": "/api/equipment/herbalism-kit"
-    }
+    },
+    "references": [
+      {
+        "index": "herbalism-kit",
+        "name": "Herbalism Kit",
+        "type": "equipment",
+        "url": "/api/equipment/herbalism-kit"
+      }
+    ]
   },
   {
     "index": "navigators-tools",
@@ -1523,7 +2227,15 @@
       "index": "navigators-tools",
       "name": "Navigator's Tools",
       "url": "/api/equipment/navigators-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "navigators-tools",
+        "name": "Navigator's Tools",
+        "type": "equipment",
+        "url": "/api/equipment/navigators-tools"
+      }
+    ]
   },
   {
     "index": "poisoners-kit",
@@ -1536,7 +2248,15 @@
       "index": "poisoners-kit",
       "name": "Poisoner's Kit",
       "url": "/api/equipment/poisoners-kit"
-    }
+    },
+    "references": [
+      {
+        "index": "poisoners-kit",
+        "name": "Poisoner's Kit",
+        "type": "equipment",
+        "url": "/api/equipment/poisoners-kit"
+      }
+    ]
   },
   {
     "index": "thieves-tools",
@@ -1555,7 +2275,15 @@
       "index": "thieves-tools",
       "name": "Thieves' Tools",
       "url": "/api/equipment/thieves-tools"
-    }
+    },
+    "references": [
+      {
+        "index": "thieves-tools",
+        "name": "Thieves' Tools",
+        "type": "equipment",
+        "url": "/api/equipment/thieves-tools"
+      }
+    ]
   },
   {
     "index": "land-vehicles",
@@ -1568,7 +2296,15 @@
       "index": "land-vehicles",
       "name": "Land Vehicles",
       "url": "/api/equipment-categories/land-vehicles"
-    }
+    },
+    "references": [
+      {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "type": "equipment",
+        "url": "/api/equipment-categories/land-vehicles"
+      }
+    ]
   },
   {
     "index": "water-vehicles",
@@ -1581,7 +2317,15 @@
       "index": "waterborne-vehicles",
       "name": "Waterborne Vehicles",
       "url": "/api/equipment-categories/waterborne-vehicles"
-    }
+    },
+    "references": [
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "type": "equipment",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ]
   },
   {
     "index": "saving-throw-str",
@@ -1615,7 +2359,15 @@
       "index": "str",
       "name": "STR",
       "url": "/api/ability-scores/str"
-    }
+    },
+    "references": [
+      {
+        "index": "str",
+        "name": "STR",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/str"
+      }
+    ]
   },
   {
     "index": "saving-throw-dex",
@@ -1649,7 +2401,15 @@
       "index": "dex",
       "name": "DEX",
       "url": "/api/ability-scores/dex"
-    }
+    },
+    "references": [
+      {
+        "index": "dex",
+        "name": "DEX",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/dex"
+      }
+    ]
   },
   {
     "index": "saving-throw-con",
@@ -1678,7 +2438,15 @@
       "index": "con",
       "name": "CON",
       "url": "/api/ability-scores/con"
-    }
+    },
+    "references": [
+      {
+        "index": "con",
+        "name": "CON",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/con"
+      }
+    ]
   },
   {
     "index": "saving-throw-int",
@@ -1707,7 +2475,15 @@
       "index": "int",
       "name": "INT",
       "url": "/api/ability-scores/int"
-    }
+    },
+    "references": [
+      {
+        "index": "int",
+        "name": "INT",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/int"
+      }
+    ]
   },
   {
     "index": "saving-throw-wis",
@@ -1746,7 +2522,15 @@
       "index": "wis",
       "name": "WIS",
       "url": "/api/ability-scores/wis"
-    }
+    },
+    "references": [
+      {
+        "index": "wis",
+        "name": "WIS",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/wis"
+      }
+    ]
   },
   {
     "index": "saving-throw-cha",
@@ -1785,7 +2569,15 @@
       "index": "cha",
       "name": "CHA",
       "url": "/api/ability-scores/cha"
-    }
+    },
+    "references": [
+      {
+        "index": "cha",
+        "name": "CHA",
+        "type": "ability-scores",
+        "url": "/api/ability-scores/cha"
+      }
+    ]
   },
   {
     "index": "skill-acrobatics",
@@ -1798,7 +2590,15 @@
       "index": "acrobatics",
       "name": "Acrobatics",
       "url": "/api/skills/acrobatics"
-    }
+    },
+    "references": [
+      {
+        "index": "acrobatics",
+        "name": "Acrobatics",
+        "type": "skills",
+        "url": "/api/skills/acrobatics"
+      }
+    ]
   },
   {
     "index": "skill-animal-handling",
@@ -1811,7 +2611,15 @@
       "index": "animal-handling",
       "name": "Animal Handling",
       "url": "/api/skills/animal-handling"
-    }
+    },
+    "references": [
+      {
+        "index": "animal-handling",
+        "name": "Animal Handling",
+        "type": "skills",
+        "url": "/api/skills/animal-handling"
+      }
+    ]
   },
   {
     "index": "skill-arcana",
@@ -1824,7 +2632,15 @@
       "index": "arcana",
       "name": "Arcana",
       "url": "/api/skills/arcana"
-    }
+    },
+    "references": [
+      {
+        "index": "arcana",
+        "name": "Arcana",
+        "type": "skills",
+        "url": "/api/skills/arcana"
+      }
+    ]
   },
   {
     "index": "skill-athletics",
@@ -1837,7 +2653,15 @@
       "index": "athletics",
       "name": "Athletics",
       "url": "/api/skills/athletics"
-    }
+    },
+    "references": [
+      {
+        "index": "athletics",
+        "name": "Athletics",
+        "type": "skills",
+        "url": "/api/skills/athletics"
+      }
+    ]
   },
   {
     "index": "skill-deception",
@@ -1850,7 +2674,15 @@
       "index": "deception",
       "name": "Deception",
       "url": "/api/skills/deception"
-    }
+    },
+    "references": [
+      {
+        "index": "deception",
+        "name": "Deception",
+        "type": "skills",
+        "url": "/api/skills/deception"
+      }
+    ]
   },
   {
     "index": "skill-history",
@@ -1863,7 +2695,15 @@
       "index": "history",
       "name": "History",
       "url": "/api/skills/history"
-    }
+    },
+    "references": [
+      {
+        "index": "history",
+        "name": "History",
+        "type": "skills",
+        "url": "/api/skills/history"
+      }
+    ]
   },
   {
     "index": "skill-insight",
@@ -1876,7 +2716,15 @@
       "index": "insight",
       "name": "Insight",
       "url": "/api/skills/insight"
-    }
+    },
+    "references": [
+      {
+        "index": "insight",
+        "name": "Insight",
+        "type": "skills",
+        "url": "/api/skills/insight"
+      }
+    ]
   },
   {
     "index": "skill-intimidation",
@@ -1889,7 +2737,15 @@
       "index": "intimidation",
       "name": "Intimidation",
       "url": "/api/skills/intimidation"
-    }
+    },
+    "references": [
+      {
+        "index": "intimidation",
+        "name": "Intimidation",
+        "type": "skills",
+        "url": "/api/skills/intimidation"
+      }
+    ]
   },
   {
     "index": "skill-investigation",
@@ -1902,7 +2758,15 @@
       "index": "investigation",
       "name": "Investigation",
       "url": "/api/skills/investigation"
-    }
+    },
+    "references": [
+      {
+        "index": "investigation",
+        "name": "Investigation",
+        "type": "skills",
+        "url": "/api/skills/investigation"
+      }
+    ]
   },
   {
     "index": "skill-medicine",
@@ -1915,7 +2779,15 @@
       "index": "medicine",
       "name": "Medicine",
       "url": "/api/skills/medicine"
-    }
+    },
+    "references": [
+      {
+        "index": "medicine",
+        "name": "Medicine",
+        "type": "skills",
+        "url": "/api/skills/medicine"
+      }
+    ]
   },
   {
     "index": "skill-nature",
@@ -1928,7 +2800,15 @@
       "index": "nature",
       "name": "Nature",
       "url": "/api/skills/nature"
-    }
+    },
+    "references": [
+      {
+        "index": "nature",
+        "name": "Nature",
+        "type": "skills",
+        "url": "/api/skills/nature"
+      }
+    ]
   },
   {
     "index": "skill-perception",
@@ -1947,7 +2827,15 @@
       "index": "perception",
       "name": "Perception",
       "url": "/api/skills/perception"
-    }
+    },
+    "references": [
+      {
+        "index": "perception",
+        "name": "Perception",
+        "type": "skills",
+        "url": "/api/skills/perception"
+      }
+    ]
   },
   {
     "index": "skill-performance",
@@ -1960,7 +2848,15 @@
       "index": "performance",
       "name": "Performance",
       "url": "/api/skills/performance"
-    }
+    },
+    "references": [
+      {
+        "index": "performance",
+        "name": "Performance",
+        "type": "skills",
+        "url": "/api/skills/performance"
+      }
+    ]
   },
   {
     "index": "skill-persuasion",
@@ -1973,7 +2869,15 @@
       "index": "persuasion",
       "name": "Persuasion",
       "url": "/api/skills/persuasion"
-    }
+    },
+    "references": [
+      {
+        "index": "persuasion",
+        "name": "Persuasion",
+        "type": "skills",
+        "url": "/api/skills/persuasion"
+      }
+    ]
   },
   {
     "index": "skill-religion",
@@ -1986,7 +2890,15 @@
       "index": "religion",
       "name": "Religion",
       "url": "/api/skills/religion"
-    }
+    },
+    "references": [
+      {
+        "index": "religion",
+        "name": "Religion",
+        "type": "skills",
+        "url": "/api/skills/religion"
+      }
+    ]
   },
   {
     "index": "skill-sleight-of-hand",
@@ -1999,7 +2911,15 @@
       "index": "sleight-of-hand",
       "name": "Sleight of Hand",
       "url": "/api/skills/sleight-of-hand"
-    }
+    },
+    "references": [
+      {
+        "index": "sleight-of-hand",
+        "name": "Sleight of Hand",
+        "type": "skills",
+        "url": "/api/skills/sleight-of-hand"
+      }
+    ]
   },
   {
     "index": "skill-stealth",
@@ -2012,7 +2932,15 @@
       "index": "stealth",
       "name": "Stealth",
       "url": "/api/skills/stealth"
-    }
+    },
+    "references": [
+      {
+        "index": "stealth",
+        "name": "Stealth",
+        "type": "skills",
+        "url": "/api/skills/stealth"
+      }
+    ]
   },
   {
     "index": "skill-survival",
@@ -2025,6 +2953,14 @@
       "index": "survival",
       "name": "Survival",
       "url": "/api/skills/survival"
-    }
+    },
+    "references": [
+      {
+        "index": "survival",
+        "name": "Survival",
+        "type": "skills",
+        "url": "/api/skills/survival"
+      }
+    ]
   }
 ]

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -44,7 +44,6 @@
     "url": "/api/proficiencies/light-armor",
     "reference": {
       "index": "light-armor",
-      "type": "equipment-categories",
       "name": "Light Armor",
       "url": "/api/equipment-categories/light-armor"
     }
@@ -79,7 +78,6 @@
     "url": "/api/proficiencies/medium-armor",
     "reference": {
       "index": "medium-armor",
-      "type": "equipment-categories",
       "name": "Medium Armor",
       "url": "/api/equipment-categories/medium-armor"
     }
@@ -93,7 +91,6 @@
     "url": "/api/proficiencies/heavy-armor",
     "reference": {
       "index": "heavy-armor",
-      "type": "equipment-categories",
       "name": "Heavy Armor",
       "url": "/api/equipment-categories/heavy-armor"
     }
@@ -118,7 +115,6 @@
     "url": "/api/proficiencies/all-armor",
     "reference": {
       "index": "armor",
-      "type": "equipment-categories",
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     }
@@ -132,7 +128,6 @@
     "url": "/api/proficiencies/padded",
     "reference": {
       "index": "padded",
-      "type": "equipment",
       "name": "Padded",
       "url": "/api/equipment/padded"
     }
@@ -146,7 +141,6 @@
     "url": "/api/proficiencies/leather",
     "reference": {
       "index": "leather",
-      "type": "equipment",
       "name": "Leather",
       "url": "/api/equipment/leather"
     }
@@ -160,7 +154,6 @@
     "url": "/api/proficiencies/studded-leather",
     "reference": {
       "index": "studded-leather",
-      "type": "equipment",
       "name": "Studded Leather",
       "url": "/api/equipment/studded-leather"
     }
@@ -174,7 +167,6 @@
     "url": "/api/proficiencies/hide",
     "reference": {
       "index": "hide",
-      "type": "equipment",
       "name": "Hide",
       "url": "/api/equipment/hide"
     }
@@ -188,7 +180,6 @@
     "url": "/api/proficiencies/chain-shirt",
     "reference": {
       "index": "chain-shirt",
-      "type": "equipment",
       "name": "Chain Shirt",
       "url": "/api/equipment/chain-shirt"
     }
@@ -202,7 +193,6 @@
     "url": "/api/proficiencies/scale-mail",
     "reference": {
       "index": "scale-mail",
-      "type": "equipment",
       "name": "Scale Mail",
       "url": "/api/equipment/scale-mail"
     }
@@ -216,7 +206,6 @@
     "url": "/api/proficiencies/breastplate",
     "reference": {
       "index": "breastplate",
-      "type": "equipment",
       "name": "Breastplate",
       "url": "/api/equipment/breastplate"
     }
@@ -230,7 +219,6 @@
     "url": "/api/proficiencies/half-plate",
     "reference": {
       "index": "half-plate",
-      "type": "equipment",
       "name": "Half Plate",
       "url": "/api/equipment/half-plate"
     }
@@ -244,7 +232,6 @@
     "url": "/api/proficiencies/ring-mail",
     "reference": {
       "index": "ring-mail",
-      "type": "equipment",
       "name": "Ring Mail",
       "url": "/api/equipment/ring-mail"
     }
@@ -258,7 +245,6 @@
     "url": "/api/proficiencies/chain-mail",
     "reference": {
       "index": "chain-mail",
-      "type": "equipment",
       "name": "Chain Mail",
       "url": "/api/equipment/chain-mail"
     }
@@ -272,7 +258,6 @@
     "url": "/api/proficiencies/splint",
     "reference": {
       "index": "splint",
-      "type": "equipment",
       "name": "Splint",
       "url": "/api/equipment/splint"
     }
@@ -286,7 +271,6 @@
     "url": "/api/proficiencies/plate",
     "reference": {
       "index": "plate",
-      "type": "equipment",
       "name": "Plate",
       "url": "/api/equipment/plate"
     }
@@ -331,7 +315,6 @@
     "url": "/api/proficiencies/shields",
     "reference": {
       "index": "shield",
-      "type": "equipment",
       "name": "Shield",
       "url": "/api/equipment/shield"
     }
@@ -391,7 +374,6 @@
     "url": "/api/proficiencies/simple-weapons",
     "reference": {
       "index": "simple-weapons",
-      "type": "equipment-categories",
       "name": "Simple Weapons",
       "url": "/api/equipment-categories/simple-weapons"
     }
@@ -426,7 +408,6 @@
     "url": "/api/proficiencies/martial-weapons",
     "reference": {
       "index": "martial-weapons",
-      "type": "equipment-categories",
       "name": "Martial Weapons",
       "url": "/api/equipment-categories/martial-weapons"
     }
@@ -446,7 +427,6 @@
     "url": "/api/proficiencies/clubs",
     "reference": {
       "index": "club",
-      "type": "equipment",
       "name": "Club",
       "url": "/api/equipment/club"
     }
@@ -476,7 +456,6 @@
     "url": "/api/proficiencies/daggers",
     "reference": {
       "index": "dagger",
-      "type": "equipment",
       "name": "Dagger",
       "url": "/api/equipment/dagger"
     }
@@ -490,7 +469,6 @@
     "url": "/api/proficiencies/greatclubs",
     "reference": {
       "index": "greatclub",
-      "type": "equipment",
       "name": "Greatclub",
       "url": "/api/equipment/greatclub"
     }
@@ -510,7 +488,6 @@
     "url": "/api/proficiencies/handaxes",
     "reference": {
       "index": "handaxe",
-      "type": "equipment",
       "name": "Handaxe",
       "url": "/api/equipment/handaxe"
     }
@@ -530,7 +507,6 @@
     "url": "/api/proficiencies/javelins",
     "reference": {
       "index": "javelin",
-      "type": "equipment",
       "name": "Javelin",
       "url": "/api/equipment/javelin"
     }
@@ -550,7 +526,6 @@
     "url": "/api/proficiencies/light-hammers",
     "reference": {
       "index": "light-hammer",
-      "type": "equipment",
       "name": "Light hammer",
       "url": "/api/equipment/light-hammer"
     }
@@ -570,7 +545,6 @@
     "url": "/api/proficiencies/maces",
     "reference": {
       "index": "mace",
-      "type": "equipment",
       "name": "Mace",
       "url": "/api/equipment/mace"
     }
@@ -600,7 +574,6 @@
     "url": "/api/proficiencies/quarterstaffs",
     "reference": {
       "index": "quarterstaff",
-      "type": "equipment",
       "name": "Quarterstaff",
       "url": "/api/equipment/quarterstaff"
     }
@@ -620,7 +593,6 @@
     "url": "/api/proficiencies/sickles",
     "reference": {
       "index": "sickle",
-      "type": "equipment",
       "name": "Sickle",
       "url": "/api/equipment/sickle"
     }
@@ -640,7 +612,6 @@
     "url": "/api/proficiencies/spears",
     "reference": {
       "index": "spear",
-      "type": "equipment",
       "name": "Spear",
       "url": "/api/equipment/spear"
     }
@@ -654,7 +625,6 @@
     "url": "/api/proficiencies/crossbows-light",
     "reference": {
       "index": "crossbow-light",
-      "type": "equipment",
       "name": "Crossbow, light",
       "url": "/api/equipment/crossbow-light"
     }
@@ -684,7 +654,6 @@
     "url": "/api/proficiencies/darts",
     "reference": {
       "index": "dart",
-      "type": "equipment",
       "name": "Dart",
       "url": "/api/equipment/dart"
     }
@@ -704,7 +673,6 @@
     "url": "/api/proficiencies/shortbows",
     "reference": {
       "index": "shortbow",
-      "type": "equipment",
       "name": "Shortbow",
       "url": "/api/equipment/shortbow"
     }
@@ -734,7 +702,6 @@
     "url": "/api/proficiencies/slings",
     "reference": {
       "index": "sling",
-      "type": "equipment",
       "name": "Sling",
       "url": "/api/equipment/sling"
     }
@@ -754,7 +721,6 @@
     "url": "/api/proficiencies/battleaxes",
     "reference": {
       "index": "battleaxe",
-      "type": "equipment",
       "name": "Battleaxe",
       "url": "/api/equipment/battleaxe"
     }
@@ -768,7 +734,6 @@
     "url": "/api/proficiencies/flails",
     "reference": {
       "index": "flail",
-      "type": "equipment",
       "name": "Flail",
       "url": "/api/equipment/flail"
     }
@@ -782,7 +747,6 @@
     "url": "/api/proficiencies/glaives",
     "reference": {
       "index": "glaive",
-      "type": "equipment",
       "name": "Glaive",
       "url": "/api/equipment/glaive"
     }
@@ -796,7 +760,6 @@
     "url": "/api/proficiencies/greataxes",
     "reference": {
       "index": "greataxe",
-      "type": "equipment",
       "name": "Greataxe",
       "url": "/api/equipment/greataxe"
     }
@@ -810,7 +773,6 @@
     "url": "/api/proficiencies/greatswords",
     "reference": {
       "index": "greatsword",
-      "type": "equipment",
       "name": "Greatsword",
       "url": "/api/equipment/greatsword"
     }
@@ -824,7 +786,6 @@
     "url": "/api/proficiencies/halberds",
     "reference": {
       "index": "halberd",
-      "type": "equipment",
       "name": "Halberd",
       "url": "/api/equipment/halberd"
     }
@@ -838,7 +799,6 @@
     "url": "/api/proficiencies/lances",
     "reference": {
       "index": "lance",
-      "type": "equipment",
       "name": "Lance",
       "url": "/api/equipment/lance"
     }
@@ -869,7 +829,6 @@
     "url": "/api/proficiencies/longswords",
     "reference": {
       "index": "longsword",
-      "type": "equipment",
       "name": "Longsword",
       "url": "/api/equipment/longsword"
     }
@@ -883,7 +842,6 @@
     "url": "/api/proficiencies/mauls",
     "reference": {
       "index": "maul",
-      "type": "equipment",
       "name": "Maul",
       "url": "/api/equipment/maul"
     }
@@ -897,7 +855,6 @@
     "url": "/api/proficiencies/morningstars",
     "reference": {
       "index": "morningstar",
-      "type": "equipment",
       "name": "Morningstar",
       "url": "/api/equipment/morningstar"
     }
@@ -911,7 +868,6 @@
     "url": "/api/proficiencies/pikes",
     "reference": {
       "index": "pike",
-      "type": "equipment",
       "name": "Pike",
       "url": "/api/equipment/pike"
     }
@@ -936,7 +892,6 @@
     "url": "/api/proficiencies/rapiers",
     "reference": {
       "index": "rapier",
-      "type": "equipment",
       "name": "Rapier",
       "url": "/api/equipment/rapier"
     }
@@ -956,7 +911,6 @@
     "url": "/api/proficiencies/scimitars",
     "reference": {
       "index": "scimitar",
-      "type": "equipment",
       "name": "Scimitar",
       "url": "/api/equipment/scimitar"
     }
@@ -992,7 +946,6 @@
     "url": "/api/proficiencies/shortswords",
     "reference": {
       "index": "shortsword",
-      "type": "equipment",
       "name": "Shortsword",
       "url": "/api/equipment/shortsword"
     }
@@ -1006,7 +959,6 @@
     "url": "/api/proficiencies/tridents",
     "reference": {
       "index": "trident",
-      "type": "equipment",
       "name": "Trident",
       "url": "/api/equipment/trident"
     }
@@ -1020,7 +972,6 @@
     "url": "/api/proficiencies/war-picks",
     "reference": {
       "index": "war-pick",
-      "type": "equipment",
       "name": "War pick",
       "url": "/api/equipment/war-pick"
     }
@@ -1040,7 +991,6 @@
     "url": "/api/proficiencies/warhammers",
     "reference": {
       "index": "warhammer",
-      "type": "equipment",
       "name": "Warhammer",
       "url": "/api/equipment/warhammer"
     }
@@ -1054,7 +1004,6 @@
     "url": "/api/proficiencies/whips",
     "reference": {
       "index": "whip",
-      "type": "equipment",
       "name": "Whip",
       "url": "/api/equipment/whip"
     }
@@ -1068,7 +1017,6 @@
     "url": "/api/proficiencies/blowguns",
     "reference": {
       "index": "blowgun",
-      "type": "equipment",
       "name": "Blowgun",
       "url": "/api/equipment/blowgun"
     }
@@ -1093,7 +1041,6 @@
     "url": "/api/proficiencies/hand-crossbows",
     "reference": {
       "index": "crossbow-hand",
-      "type": "equipment",
       "name": "Crossbow, hand",
       "url": "/api/equipment/crossbow-hand"
     }
@@ -1107,7 +1054,6 @@
     "url": "/api/proficiencies/crossbows-heavy",
     "reference": {
       "index": "crossbow-heavy",
-      "type": "equipment",
       "name": "Crossbow, heavy",
       "url": "/api/equipment/crossbow-heavy"
     }
@@ -1127,7 +1073,6 @@
     "url": "/api/proficiencies/longbows",
     "reference": {
       "index": "longbow",
-      "type": "equipment",
       "name": "Longbow",
       "url": "/api/equipment/longbow"
     }
@@ -1141,7 +1086,6 @@
     "url": "/api/proficiencies/nets",
     "reference": {
       "index": "net",
-      "type": "equipment",
       "name": "Net",
       "url": "/api/equipment/net"
     }
@@ -1155,7 +1099,6 @@
     "url": "/api/proficiencies/alchemists-supplies",
     "reference": {
       "index": "alchemists-supplies",
-      "type": "equipment",
       "name": "Alchemist's Supplies",
       "url": "/api/equipment/alchemists-supplies"
     }
@@ -1169,7 +1112,6 @@
     "url": "/api/proficiencies/brewers-supplies",
     "reference": {
       "index": "brewers-supplies",
-      "type": "equipment",
       "name": "Brewer's Supplies",
       "url": "/api/equipment/brewers-supplies"
     }
@@ -1183,7 +1125,6 @@
     "url": "/api/proficiencies/calligraphers-supplies",
     "reference": {
       "index": "calligraphers-supplies",
-      "type": "equipment",
       "name": "Calligrapher's Supplies",
       "url": "/api/equipment/calligraphers-supplies"
     }
@@ -1197,7 +1138,6 @@
     "url": "/api/proficiencies/carpenters-tools",
     "reference": {
       "index": "carpenters-tools",
-      "type": "equipment",
       "name": "Carpenter's Tools",
       "url": "/api/equipment/carpenters-tools"
     }
@@ -1211,7 +1151,6 @@
     "url": "/api/proficiencies/cartographers-tools",
     "reference": {
       "index": "cartographers-tools",
-      "type": "equipment",
       "name": "Cartographer's Tools",
       "url": "/api/equipment/cartographers-tools"
     }
@@ -1225,7 +1164,6 @@
     "url": "/api/proficiencies/cobblers-tools",
     "reference": {
       "index": "cobblers-tools",
-      "type": "equipment",
       "name": "Cobbler's Tools",
       "url": "/api/equipment/cobblers-tools"
     }
@@ -1239,7 +1177,6 @@
     "url": "/api/proficiencies/cooks-utensils",
     "reference": {
       "index": "cooks-utensils",
-      "type": "equipment",
       "name": "Cook's utensils",
       "url": "/api/equipment/cooks-utensils"
     }
@@ -1253,7 +1190,6 @@
     "url": "/api/proficiencies/glassblowers-tools",
     "reference": {
       "index": "glassblowers-tools",
-      "type": "equipment",
       "name": "Glassblower's Tools",
       "url": "/api/equipment/glassblowers-tools"
     }
@@ -1267,7 +1203,6 @@
     "url": "/api/proficiencies/jewelers-tools",
     "reference": {
       "index": "jewelers-tools",
-      "type": "equipment",
       "name": "Jeweler's Tools",
       "url": "/api/equipment/jewelers-tools"
     }
@@ -1281,7 +1216,6 @@
     "url": "/api/proficiencies/leatherworkers-tools",
     "reference": {
       "index": "leatherworkers-tools",
-      "type": "equipment",
       "name": "Leatherworker's Tools",
       "url": "/api/equipment/leatherworkers-tools"
     }
@@ -1295,7 +1229,6 @@
     "url": "/api/proficiencies/masons-tools",
     "reference": {
       "index": "masons-tools",
-      "type": "equipment",
       "name": "Mason's Tools",
       "url": "/api/equipment/masons-tools"
     }
@@ -1309,7 +1242,6 @@
     "url": "/api/proficiencies/painters-supplies",
     "reference": {
       "index": "painters-supplies",
-      "type": "equipment",
       "name": "Painter's Supplies",
       "url": "/api/equipment/painters-supplies"
     }
@@ -1323,7 +1255,6 @@
     "url": "/api/proficiencies/potters-tools",
     "reference": {
       "index": "potters-tools",
-      "type": "equipment",
       "name": "Potter's Tools",
       "url": "/api/equipment/potters-tools"
     }
@@ -1337,7 +1268,6 @@
     "url": "/api/proficiencies/smiths-tools",
     "reference": {
       "index": "smiths-tools",
-      "type": "equipment",
       "name": "Smith's Tools",
       "url": "/api/equipment/smiths-tools"
     }
@@ -1351,7 +1281,6 @@
     "url": "/api/proficiencies/tinkers-tools",
     "reference": {
       "index": "tinkers-tools",
-      "type": "equipment",
       "name": "Tinker's Tools",
       "url": "/api/equipment/tinkers-tools"
     }
@@ -1365,7 +1294,6 @@
     "url": "/api/proficiencies/weavers-tools",
     "reference": {
       "index": "weavers-tools",
-      "type": "equipment",
       "name": "Weaver's Tools",
       "url": "/api/equipment/weavers-tools"
     }
@@ -1379,7 +1307,6 @@
     "url": "/api/proficiencies/woodcarvers-tools",
     "reference": {
       "index": "woodcarvers-tools",
-      "type": "equipment",
       "name": "Woodcarver's Tools",
       "url": "/api/equipment/woodcarvers-tools"
     }
@@ -1393,7 +1320,6 @@
     "url": "/api/proficiencies/disguise-kit",
     "reference": {
       "index": "disguise-kit",
-      "type": "equipment",
       "name": "Disguise Kit",
       "url": "/api/equipment/disguise-kit"
     }
@@ -1407,7 +1333,6 @@
     "url": "/api/proficiencies/forgery-kit",
     "reference": {
       "index": "forgery-kit",
-      "type": "equipment",
       "name": "Forgery Kit",
       "url": "/api/equipment/forgery-kit"
     }
@@ -1421,7 +1346,6 @@
     "url": "/api/proficiencies/dice-set",
     "reference": {
       "index": "dice-set",
-      "type": "equipment",
       "name": "Dice Set",
       "url": "/api/equipment/dice-set"
     }
@@ -1435,7 +1359,6 @@
     "url": "/api/proficiencies/playing-card-set",
     "reference": {
       "index": "playing-card-set",
-      "type": "equipment",
       "name": "Playing Card Set",
       "url": "/api/equipment/playing-card-set"
     }
@@ -1449,7 +1372,6 @@
     "url": "/api/proficiencies/bagpipes",
     "reference": {
       "index": "bagpipes",
-      "type": "equipment",
       "name": "Bagpipes",
       "url": "/api/equipment/bagpipes"
     }
@@ -1463,7 +1385,6 @@
     "url": "/api/proficiencies/drum",
     "reference": {
       "index": "drum",
-      "type": "equipment",
       "name": "Drum",
       "url": "/api/equipment/drum"
     }
@@ -1477,7 +1398,6 @@
     "url": "/api/proficiencies/dulcimer",
     "reference": {
       "index": "dulcimer",
-      "type": "equipment",
       "name": "Dulcimer",
       "url": "/api/equipment/dulcimer"
     }
@@ -1491,7 +1411,6 @@
     "url": "/api/proficiencies/flute",
     "reference": {
       "index": "flute",
-      "type": "equipment",
       "name": "Flute",
       "url": "/api/equipment/flute"
     }
@@ -1505,7 +1424,6 @@
     "url": "/api/proficiencies/lute",
     "reference": {
       "index": "lute",
-      "type": "equipment",
       "name": "Lute",
       "url": "/api/equipment/lute"
     }
@@ -1519,7 +1437,6 @@
     "url": "/api/proficiencies/lyre",
     "reference": {
       "index": "lyre",
-      "type": "equipment",
       "name": "Lyre",
       "url": "/api/equipment/lyre"
     }
@@ -1533,7 +1450,6 @@
     "url": "/api/proficiencies/horn",
     "reference": {
       "index": "horn",
-      "type": "equipment",
       "name": "Horn",
       "url": "/api/equipment/horn"
     }
@@ -1547,7 +1463,6 @@
     "url": "/api/proficiencies/pan-flute",
     "reference": {
       "index": "pan-flute",
-      "type": "equipment",
       "name": "Pan flute",
       "url": "/api/equipment/pan-flute"
     }
@@ -1561,7 +1476,6 @@
     "url": "/api/proficiencies/shawm",
     "reference": {
       "index": "shawm",
-      "type": "equipment",
       "name": "Shawm",
       "url": "/api/equipment/shawm"
     }
@@ -1575,7 +1489,6 @@
     "url": "/api/proficiencies/viol",
     "reference": {
       "index": "viol",
-      "type": "equipment",
       "name": "Viol",
       "url": "/api/equipment/viol"
     }
@@ -1595,7 +1508,6 @@
     "url": "/api/proficiencies/herbalism-kit",
     "reference": {
       "index": "herbalism-kit",
-      "type": "equipment",
       "name": "Herbalism Kit",
       "url": "/api/equipment/herbalism-kit"
     }
@@ -1609,7 +1521,6 @@
     "url": "/api/proficiencies/navigators-tools",
     "reference": {
       "index": "navigators-tools",
-      "type": "equipment",
       "name": "Navigator's Tools",
       "url": "/api/equipment/navigators-tools"
     }
@@ -1623,7 +1534,6 @@
     "url": "/api/proficiencies/poisoners-kit",
     "reference": {
       "index": "poisoners-kit",
-      "type": "equipment",
       "name": "Poisoner's Kit",
       "url": "/api/equipment/poisoners-kit"
     }
@@ -1643,7 +1553,6 @@
     "url": "/api/proficiencies/thieves-tools",
     "reference": {
       "index": "thieves-tools",
-      "type": "equipment",
       "name": "Thieves' Tools",
       "url": "/api/equipment/thieves-tools"
     }
@@ -1657,7 +1566,6 @@
     "url": "/api/proficiencies/land-vehicles",
     "reference": {
       "index": "land-vehicles",
-      "type": "equipment-categories",
       "name": "Land Vehicles",
       "url": "/api/equipment-categories/land-vehicles"
     }
@@ -1671,7 +1579,6 @@
     "url": "/api/proficiencies/water-vehicles",
     "reference": {
       "index": "waterborne-vehicles",
-      "type": "equipment-categories",
       "name": "Waterborne Vehicles",
       "url": "/api/equipment-categories/waterborne-vehicles"
     }
@@ -1706,7 +1613,6 @@
     "url": "/api/proficiencies/saving-throw-str",
     "reference": {
       "index": "str",
-      "type": "ability-scores",
       "name": "STR",
       "url": "/api/ability-scores/str"
     }
@@ -1741,7 +1647,6 @@
     "url": "/api/proficiencies/saving-throw-dex",
     "reference": {
       "index": "dex",
-      "type": "ability-scores",
       "name": "DEX",
       "url": "/api/ability-scores/dex"
     }
@@ -1771,7 +1676,6 @@
     "url": "/api/proficiencies/saving-throw-con",
     "reference": {
       "index": "con",
-      "type": "ability-scores",
       "name": "CON",
       "url": "/api/ability-scores/con"
     }
@@ -1801,7 +1705,6 @@
     "url": "/api/proficiencies/saving-throw-int",
     "reference": {
       "index": "int",
-      "type": "ability-scores",
       "name": "INT",
       "url": "/api/ability-scores/int"
     }
@@ -1841,7 +1744,6 @@
     "url": "/api/proficiencies/saving-throw-wis",
     "reference": {
       "index": "wis",
-      "type": "ability-scores",
       "name": "WIS",
       "url": "/api/ability-scores/wis"
     }
@@ -1881,7 +1783,6 @@
     "url": "/api/proficiencies/saving-throw-cha",
     "reference": {
       "index": "cha",
-      "type": "ability-scores",
       "name": "CHA",
       "url": "/api/ability-scores/cha"
     }
@@ -1895,7 +1796,6 @@
     "url": "/api/proficiencies/skill-acrobatics",
     "reference": {
       "index": "acrobatics",
-      "type": "skills",
       "name": "Acrobatics",
       "url": "/api/skills/acrobatics"
     }
@@ -1909,7 +1809,6 @@
     "url": "/api/proficiencies/skill-animal-handling",
     "reference": {
       "index": "animal-handling",
-      "type": "skills",
       "name": "Animal Handling",
       "url": "/api/skills/animal-handling"
     }
@@ -1923,7 +1822,6 @@
     "url": "/api/proficiencies/skill-arcana",
     "reference": {
       "index": "arcana",
-      "type": "skills",
       "name": "Arcana",
       "url": "/api/skills/arcana"
     }
@@ -1937,7 +1835,6 @@
     "url": "/api/proficiencies/skill-athletics",
     "reference": {
       "index": "athletics",
-      "type": "skills",
       "name": "Athletics",
       "url": "/api/skills/athletics"
     }
@@ -1951,7 +1848,6 @@
     "url": "/api/proficiencies/skill-deception",
     "reference": {
       "index": "deception",
-      "type": "skills",
       "name": "Deception",
       "url": "/api/skills/deception"
     }
@@ -1965,7 +1861,6 @@
     "url": "/api/proficiencies/skill-history",
     "reference": {
       "index": "history",
-      "type": "skills",
       "name": "History",
       "url": "/api/skills/history"
     }
@@ -1979,7 +1874,6 @@
     "url": "/api/proficiencies/skill-insight",
     "reference": {
       "index": "insight",
-      "type": "skills",
       "name": "Insight",
       "url": "/api/skills/insight"
     }
@@ -1993,7 +1887,6 @@
     "url": "/api/proficiencies/skill-intimidation",
     "reference": {
       "index": "intimidation",
-      "type": "skills",
       "name": "Intimidation",
       "url": "/api/skills/intimidation"
     }
@@ -2007,7 +1900,6 @@
     "url": "/api/proficiencies/skill-investigation",
     "reference": {
       "index": "investigation",
-      "type": "skills",
       "name": "Investigation",
       "url": "/api/skills/investigation"
     }
@@ -2021,7 +1913,6 @@
     "url": "/api/proficiencies/skill-medicine",
     "reference": {
       "index": "medicine",
-      "type": "skills",
       "name": "Medicine",
       "url": "/api/skills/medicine"
     }
@@ -2035,7 +1926,6 @@
     "url": "/api/proficiencies/skill-nature",
     "reference": {
       "index": "nature",
-      "type": "skills",
       "name": "Nature",
       "url": "/api/skills/nature"
     }
@@ -2055,7 +1945,6 @@
     "url": "/api/proficiencies/skill-perception",
     "reference": {
       "index": "perception",
-      "type": "skills",
       "name": "Perception",
       "url": "/api/skills/perception"
     }
@@ -2069,7 +1958,6 @@
     "url": "/api/proficiencies/skill-performance",
     "reference": {
       "index": "performance",
-      "type": "skills",
       "name": "Performance",
       "url": "/api/skills/performance"
     }
@@ -2083,7 +1971,6 @@
     "url": "/api/proficiencies/skill-persuasion",
     "reference": {
       "index": "persuasion",
-      "type": "skills",
       "name": "Persuasion",
       "url": "/api/skills/persuasion"
     }
@@ -2097,7 +1984,6 @@
     "url": "/api/proficiencies/skill-religion",
     "reference": {
       "index": "religion",
-      "type": "skills",
       "name": "Religion",
       "url": "/api/skills/religion"
     }
@@ -2111,7 +1997,6 @@
     "url": "/api/proficiencies/skill-sleight-of-hand",
     "reference": {
       "index": "sleight-of-hand",
-      "type": "skills",
       "name": "Sleight of Hand",
       "url": "/api/skills/sleight-of-hand"
     }
@@ -2125,7 +2010,6 @@
     "url": "/api/proficiencies/skill-stealth",
     "reference": {
       "index": "stealth",
-      "type": "skills",
       "name": "Stealth",
       "url": "/api/skills/stealth"
     }
@@ -2139,7 +2023,6 @@
     "url": "/api/proficiencies/skill-survival",
     "reference": {
       "index": "survival",
-      "type": "skills",
       "name": "Survival",
       "url": "/api/skills/survival"
     }


### PR DESCRIPTION
## What does this do?
Adds `reference` to each proficiency.

## How was it tested?
I ran db:refresh and checked that each reference was set in MongoDB compass

## Is there a Github issue this is resolving?
Related to [this issue](https://github.com/5e-bits/5e-database/issues/413). It won't be resolved until the [PR with breaking changes](https://github.com/5e-bits/5e-database/pull/414) is merged.

## Did you update the docs in the API? Please link an associated PR if applicable.
[Yes](https://github.com/5e-bits/5e-srd-api/pull/242)

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
