### PR TITLE
Add dc and damage to kraken ink cloud

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -23452,7 +23452,26 @@
       {
         "name": "Ink Cloud (Costs 3 Actions)",
         "desc": "While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a DC 23 Constitution saving throw, taking 16 (3d10) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn.",
-        "attack_bonus": 0
+        "attack_bonus": 0,
+        "dc": {
+          "dc_type": {
+            "index": "con",
+            "name": "CON",
+            "url": "/api/ability-scores/con"
+          },
+          "dc_value": 23,
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "poison",
+              "name": "Poison",
+              "url": "/api/damage-types/poison"
+            },
+            "damage_dice": "3d10"
+          }
+        ]
       }
     ],
     "url": "/api/monsters/kraken"


### PR DESCRIPTION
## What does this do?
Added dc and damage to kraken's ink cloud attack

## How was it tested?
Ran db:refresh and looked at the data in MongoDB compass

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
