### PR TITLE
Remove attack_bonus from parry

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -19084,8 +19084,7 @@
     "reactions": [
       {
         "name": "Parry",
-        "desc": "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon.",
-        "attack_bonus": 0
+        "desc": "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon."
       }
     ],
     "url": "/api/monsters/gladiator"


### PR DESCRIPTION
## What does this do?
Removed attack bonus from gladiator's parry since it made no sense.

## How was it tested?
Ran db:refresh, checked in MongoDB compass

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
