### PR TITLE
Remove attack bonus from relentless

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -37438,8 +37438,7 @@
         "usage": {
           "type": "recharge after rest",
           "rest_types": ["short", "long"]
-        },
-        "attack_bonus": 0
+        }
       }
     ],
     "actions": [
@@ -37525,8 +37524,7 @@
         "usage": {
           "type": "recharge after rest",
           "rest_types": ["short", "long"]
-        },
-        "attack_bonus": 0
+        }
       }
     ],
     "actions": [
@@ -37632,8 +37630,7 @@
         "usage": {
           "type": "recharge after rest",
           "rest_types": ["short", "long"]
-        },
-        "attack_bonus": 0
+        }
       }
     ],
     "actions": [


### PR DESCRIPTION
## What does this do?
`attack_bonus` didn't seem applicable to the relentless ability, so I removed it.

## How was it tested?
Ran db:refresh and verified changes in MongoDB compass

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
