### PR TITLE
Add Guardian of Faith to Oath of Devotion subclass

### DIFF
--- a/src/5e-SRD-Subclasses.json
+++ b/src/5e-SRD-Subclasses.json
@@ -1525,6 +1525,21 @@
       {
         "prerequisites": [
           {
+            "index": "paladin-13",
+            "type": "level",
+            "name": "Paladin 13",
+            "url": "/api/classes/paladin/levels/13"
+          }
+        ],
+        "spell": {
+          "index": "guardian-of-faith",
+          "name": "Guardian of Faith",
+          "url": "/api/spells/guardian-of-faith"
+        }
+      },
+      {
+        "prerequisites": [
+          {
             "index": "paladin-17",
             "type": "level",
             "name": "Paladin 17",


### PR DESCRIPTION
## What does this do?
I noticed the Oath of Devotion subclass was missing the spell Guardian of Faith. This PR adds it. You can confirm that it's one of the subclass spells [here](https://roll20.net/compendium/dnd5e/Subclasses:Oath%20of%20Devotion/#h-Oath%20of%20Devotion).

## How was it tested?
I ran db:refresh and verified the changes in MongoDB compass.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
