### PR TITLE
Update prerequisites for fiend subclass spells

### DIFF
--- a/src/5e-SRD-Subclasses.json
+++ b/src/5e-SRD-Subclasses.json
@@ -1662,10 +1662,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-3",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 3",
+            "url": "/api/classes/warlock/levels/3"
           }
         ],
         "spell": {
@@ -1677,10 +1677,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-3",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 3",
+            "url": "/api/classes/warlock/levels/3"
           }
         ],
         "spell": {
@@ -1692,10 +1692,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-5",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 5",
+            "url": "/api/classes/warlock/levels/5"
           }
         ],
         "spell": {
@@ -1707,10 +1707,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-5",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 5",
+            "url": "/api/classes/warlock/levels/5"
           }
         ],
         "spell": {
@@ -1722,10 +1722,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-7",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 7",
+            "url": "/api/classes/warlock/levels/7"
           }
         ],
         "spell": {
@@ -1737,10 +1737,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-7",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 7",
+            "url": "/api/classes/warlock/levels/7"
           }
         ],
         "spell": {
@@ -1752,10 +1752,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-9",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 9",
+            "url": "/api/classes/warlock/levels/9"
           }
         ],
         "spell": {
@@ -1767,10 +1767,10 @@
       {
         "prerequisites": [
           {
-            "index": "warlock-1",
+            "index": "warlock-9",
             "type": "level",
-            "name": "Warlock 1",
-            "url": "/api/classes/warlock/levels/1"
+            "name": "Warlock 9",
+            "url": "/api/classes/warlock/levels/9"
           }
         ],
         "spell": {


### PR DESCRIPTION
## What does this do?
Updates the warlock's pact of the fiend subclass to have spell prerequisites match when the warlock will get spell slots for them.

## How was it tested?
I ran db:refresh and verified the changes in MongoDB compass

## Is there a Github issue this is resolving?
This PR resolves #424 

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
