### PR TITLE
fixed inconsistencies for ancient blue dragon

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -3628,7 +3628,16 @@
           "dc_value": 23,
           "success_type": "half"
         },
-        "damage_dice": "16d10"
+        "damage": [
+          {
+            "damage_type": {
+              "index": "lightning",
+              "name": "Lightning",
+              "url": "/api/damage-types/lightning"
+            },
+            "damage_dice": "16d10"
+          }
+        ]
       }
     ],
     "legendary_actions": [


### PR DESCRIPTION
## What does this do?
the lightning breath for ancient dragon had no "damage" list, just a separate "damage_dice" property
this should fix that

## How was it tested?
I have not tested this change

## Is there a Github issue this is resolving?
#427 


## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
