### PR TITLE
Armor Name & Index Changes

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -398,9 +398,9 @@
     "starting_equipment": [
       {
         "equipment": {
-          "index": "leather",
-          "name": "Leather",
-          "url": "/api/equipment/leather"
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
         },
         "quantity": 1
       },
@@ -863,9 +863,9 @@
           },
           {
             "equipment": {
-              "index": "leather",
-              "name": "Leather",
-              "url": "/api/equipment/leather"
+              "index": "leather-armor",
+              "name": "Leather Armor",
+              "url": "/api/equipment/leather-armor"
             },
             "quantity": 1
           },
@@ -1184,9 +1184,9 @@
     "starting_equipment": [
       {
         "equipment": {
-          "index": "leather",
-          "name": "Leather",
-          "url": "/api/equipment/leather"
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
         },
         "quantity": 1
       },
@@ -1454,9 +1454,9 @@
           [
             {
               "equipment": {
-                "index": "leather",
-                "name": "Leather",
-                "url": "/api/equipment/leather"
+                "index": "leather-armor",
+                "name": "Leather Armor",
+                "url": "/api/equipment/leather-armor"
               },
               "quantity": 1
             },
@@ -2368,9 +2368,9 @@
           },
           {
             "equipment": {
-              "index": "leather",
-              "name": "Leather",
-              "url": "/api/equipment/leather"
+              "index": "leather-armor",
+              "name": "Leather Armor",
+              "url": "/api/equipment/leather-armor"
             },
             "quantity": 1
           }
@@ -2684,9 +2684,9 @@
     "starting_equipment": [
       {
         "equipment": {
-          "index": "leather",
-          "name": "Leather",
-          "url": "/api/equipment/leather"
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
         },
         "quantity": 1
       },
@@ -3215,9 +3215,9 @@
       },
       {
         "equipment": {
-          "index": "leather",
-          "name": "Leather",
-          "url": "/api/equipment/leather"
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
         },
         "quantity": 1
       }

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -346,9 +346,9 @@
         "url": "/api/equipment/studded-leather-armor"
       },
       {
-        "index": "hide",
-        "name": "Hide",
-        "url": "/api/equipment/hide"
+        "index": "hide-armor",
+        "name": "Hide Armor",
+        "url": "/api/equipment/hide-armor"
       },
       {
         "index": "chain-shirt",
@@ -2224,9 +2224,9 @@
     "name": "Medium Armor",
     "equipment": [
       {
-        "index": "hide",
-        "name": "Hide",
-        "url": "/api/equipment/hide"
+        "index": "hide-armor",
+        "name": "Hide Armor",
+        "url": "/api/equipment/hide-armor"
       },
       {
         "index": "chain-shirt",

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -451,9 +451,9 @@
         "url": "/api/magic-items/elven-chain"
       },
       {
-        "index": "glamoured-studded-leather",
-        "name": "Glamoured Studded Leather",
-        "url": "/api/magic-items/glamoured-studded-leather"
+        "index": "glamoured-studded-leather-armor",
+        "name": "Glamoured Studded Leather Armor",
+        "url": "/api/magic-items/glamoured-studded-leather-armor"
       },
       {
         "index": "mithral-armor",

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -381,14 +381,14 @@
         "url": "/api/equipment/chain-mail"
       },
       {
-        "index": "splint",
-        "name": "Splint",
-        "url": "/api/equipment/splint"
+        "index": "splint-armor",
+        "name": "Splint Armor",
+        "url": "/api/equipment/splint-armor"
       },
       {
-        "index": "plate",
-        "name": "Plate",
-        "url": "/api/equipment/plate"
+        "index": "plate-armor",
+        "name": "Plate Armor",
+        "url": "/api/equipment/plate-armor"
       },
       {
         "index": "shield",
@@ -2266,14 +2266,14 @@
         "url": "/api/equipment/chain-mail"
       },
       {
-        "index": "splint",
-        "name": "Splint",
-        "url": "/api/equipment/splint"
+        "index": "splint-armor",
+        "name": "Splint Armor",
+        "url": "/api/equipment/splint-armor"
       },
       {
-        "index": "plate",
-        "name": "Plate",
-        "url": "/api/equipment/plate"
+        "index": "plate-armor",
+        "name": "Plate Armor",
+        "url": "/api/equipment/plate-armor"
       }
     ],
     "url": "/api/equipment-categories/heavy-armor"

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -341,9 +341,9 @@
         "url": "/api/equipment/leather-armor"
       },
       {
-        "index": "studded-leather",
-        "name": "Studded Leather",
-        "url": "/api/equipment/studded-leather"
+        "index": "studded-leather-armor",
+        "name": "Studded Leather Armor",
+        "url": "/api/equipment/studded-leather-armor"
       },
       {
         "index": "hide",
@@ -2212,9 +2212,9 @@
         "url": "/api/equipment/leather-armor"
       },
       {
-        "index": "studded-leather",
-        "name": "Studded Leather",
-        "url": "/api/equipment/studded-leather"
+        "index": "studded-leather-armor",
+        "name": "Studded Leather Armor",
+        "url": "/api/equipment/studded-leather-armor"
       }
     ],
     "url": "/api/equipment-categories/light-armor"

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -332,13 +332,13 @@
     "equipment": [
       {
         "index": "padded-armor",
-        "name": "Padded armor",
+        "name": "Padded Armor",
         "url": "/api/equipment/padded-armor"
       },
       {
-        "index": "leather",
-        "name": "Leather",
-        "url": "/api/equipment/leather"
+        "index": "leather-armor",
+        "name": "Leather Armor",
+        "url": "/api/equipment/leather-armor"
       },
       {
         "index": "studded-leather",
@@ -2203,13 +2203,13 @@
     "equipment": [
       {
         "index": "padded-armor",
-        "name": "Padded armor",
+        "name": "Padded Armor",
         "url": "/api/equipment/padded-armor"
       },
       {
-        "index": "leather",
-        "name": "Leather",
-        "url": "/api/equipment/leather"
+        "index": "leather-armor",
+        "name": "Leather Armor",
+        "url": "/api/equipment/leather-armor"
       },
       {
         "index": "studded-leather",

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -331,9 +331,9 @@
     "name": "Armor",
     "equipment": [
       {
-        "index": "padded",
-        "name": "Padded",
-        "url": "/api/equipment/padded"
+        "index": "padded-armor",
+        "name": "Padded armor",
+        "url": "/api/equipment/padded-armor"
       },
       {
         "index": "leather",
@@ -2202,9 +2202,9 @@
     "name": "Light Armor",
     "equipment": [
       {
-        "index": "padded",
-        "name": "Padded",
-        "url": "/api/equipment/padded"
+        "index": "padded-armor",
+        "name": "Padded armor",
+        "url": "/api/equipment/padded-armor"
       },
       {
         "index": "leather",

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -366,9 +366,9 @@
         "url": "/api/equipment/breastplate"
       },
       {
-        "index": "half-plate",
-        "name": "Half Plate",
-        "url": "/api/equipment/half-plate"
+        "index": "half-plate-armor",
+        "name": "Half Plate Armor",
+        "url": "/api/equipment/half-plate-armor"
       },
       {
         "index": "ring-mail",
@@ -2244,9 +2244,9 @@
         "url": "/api/equipment/breastplate"
       },
       {
-        "index": "half-plate",
-        "name": "Half Plate",
-        "url": "/api/equipment/half-plate"
+        "index": "half-plate-armor",
+        "name": "Half Plate Armor",
+        "url": "/api/equipment/half-plate-armor"
       }
     ],
     "url": "/api/equipment-categories/medium-armor"

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1635,7 +1635,7 @@
   },
   {
     "index": "padded-armor",
-    "name": "Padded armor",
+    "name": "Padded Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1657,8 +1657,8 @@
     "url": "/api/equipment/padded-armor"
   },
   {
-    "index": "leather",
-    "name": "Leather",
+    "index": "leather-armor",
+    "name": "Leather Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1677,7 +1677,7 @@
       "quantity": 10,
       "unit": "gp"
     },
-    "url": "/api/equipment/leather"
+    "url": "/api/equipment/leather-armor"
   },
   {
     "index": "studded-leather",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1634,8 +1634,8 @@
     "url": "/api/equipment/net"
   },
   {
-    "index": "padded",
-    "name": "Padded",
+    "index": "padded-armor",
+    "name": "Padded armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1654,7 +1654,7 @@
       "quantity": 5,
       "unit": "gp"
     },
-    "url": "/api/equipment/padded"
+    "url": "/api/equipment/padded-armor"
   },
   {
     "index": "leather",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1864,8 +1864,8 @@
     "url": "/api/equipment/chain-mail"
   },
   {
-    "index": "splint",
-    "name": "Splint",
+    "index": "splint-armor",
+    "name": "Splint Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1884,11 +1884,11 @@
       "quantity": 200,
       "unit": "gp"
     },
-    "url": "/api/equipment/splint"
+    "url": "/api/equipment/splint-armor"
   },
   {
-    "index": "plate",
-    "name": "Plate",
+    "index": "plate-armor",
+    "name": "Plate Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1907,7 +1907,7 @@
       "quantity": 1500,
       "unit": "gp"
     },
-    "url": "/api/equipment/plate"
+    "url": "/api/equipment/plate-armor"
   },
   {
     "index": "shield",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1795,8 +1795,8 @@
     "url": "/api/equipment/breastplate"
   },
   {
-    "index": "half-plate",
-    "name": "Half Plate",
+    "index": "half-plate-armor",
+    "name": "Half Plate Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1815,7 +1815,7 @@
       "quantity": 750,
       "unit": "gp"
     },
-    "url": "/api/equipment/half-plate"
+    "url": "/api/equipment/half-plate-armor"
   },
   {
     "index": "ring-mail",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1680,8 +1680,8 @@
     "url": "/api/equipment/leather-armor"
   },
   {
-    "index": "studded-leather",
-    "name": "Studded Leather",
+    "index": "studded-leather-armor",
+    "name": "Studded Leather Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1700,7 +1700,7 @@
       "quantity": 45,
       "unit": "gp"
     },
-    "url": "/api/equipment/studded-leather"
+    "url": "/api/equipment/studded-leather-armor"
   },
   {
     "index": "hide",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1703,8 +1703,8 @@
     "url": "/api/equipment/studded-leather-armor"
   },
   {
-    "index": "hide",
-    "name": "Hide",
+    "index": "hide-armor",
+    "name": "Hide Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1723,7 +1723,7 @@
       "quantity": 10,
       "unit": "gp"
     },
-    "url": "/api/equipment/hide"
+    "url": "/api/equipment/hide-armor"
   },
   {
     "index": "chain-shirt",

--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -1455,8 +1455,8 @@
     "url": "/api/magic-items/giant-slayer"
   },
   {
-    "index": "glamoured-studded-leather",
-    "name": "Glamoured Studded Leather",
+    "index": "glamoured-studded-leather-armor",
+    "name": "Glamoured Studded Leather Armor",
     "equipment_category": {
       "index": "armor",
       "name": "Armor",
@@ -1466,7 +1466,7 @@
       "Armor (studded leather), rare",
       "While wearing this armor, you gain a +1 bonus to AC. You can also use a bonus action to speak the armor's command word and cause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like, including color, style, and accessories, but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or remove the armor."
     ],
-    "url": "/api/magic-items/glamoured-studded-leather"
+    "url": "/api/magic-items/glamoured-studded-leather-armor"
   },
   {
     "index": "gloves-of-missile-snaring",

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -154,42 +154,42 @@
   {
     "index": "padded-armor",
     "type": "Armor",
-    "name": "Padded armor",
+    "name": "Padded Armor",
     "classes": [],
     "races": [],
     "url": "/api/proficiencies/padded-armor",
     "reference": {
       "index": "padded-armor",
-      "name": "Padded armor",
+      "name": "Padded Armor",
       "url": "/api/equipment/padded-armor"
     },
     "references": [
       {
         "index": "padded-armor",
         "type": "equipment",
-        "name": "Padded armor",
+        "name": "Padded Armor",
         "url": "/api/equipment/padded-armor"
       }
     ]
   },
   {
-    "index": "leather",
+    "index": "leather-armor",
     "type": "Armor",
-    "name": "Leather",
+    "name": "Leather Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/leather",
+    "url": "/api/proficiencies/leather-armor",
     "reference": {
-      "index": "leather",
-      "name": "Leather",
-      "url": "/api/equipment/leather"
+      "index": "leather-armor",
+      "name": "Leather Armor",
+      "url": "/api/equipment/leather-armor"
     },
     "references": [
       {
-        "index": "leather",
-        "name": "Leather",
+        "index": "leather-armor",
+        "name": "Leather Armor",
         "type": "equipment",
-        "url": "/api/equipment/leather"
+        "url": "/api/equipment/leather-armor"
       }
     ]
   },

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -215,23 +215,23 @@
     ]
   },
   {
-    "index": "hide",
+    "index": "hide-armor",
     "type": "Armor",
-    "name": "Hide",
+    "name": "Hide Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/hide",
+    "url": "/api/proficiencies/hide-armor",
     "reference": {
-      "index": "hide",
-      "name": "Hide",
-      "url": "/api/equipment/hide"
+      "index": "hide-armor",
+      "name": "Hide Armor",
+      "url": "/api/equipment/hide-armor"
     },
     "references": [
       {
-        "index": "hide",
+        "index": "hide-armor",
         "type": "equipment",
-        "name": "Hide",
-        "url": "/api/equipment/hide"
+        "name": "Hide Armor",
+        "url": "/api/equipment/hide-armor"
       }
     ]
   },

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -299,23 +299,23 @@
     ]
   },
   {
-    "index": "half-plate",
+    "index": "half-plate-armor",
     "type": "Armor",
-    "name": "Half Plate",
+    "name": "Half Plate Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/half-plate",
+    "url": "/api/proficiencies/half-plate-armor",
     "reference": {
-      "index": "half-plate",
-      "name": "Half Plate",
-      "url": "/api/equipment/half-plate"
+      "index": "half-plate-armor",
+      "name": "Half Plate Armor",
+      "url": "/api/equipment/half-plate-armor"
     },
     "references": [
       {
-        "index": "half-plate",
-        "name": "Half Plate",
+        "index": "half-plate-armor",
+        "name": "Half Plate Armor",
         "type": "equipment",
-        "url": "/api/equipment/half-plate"
+        "url": "/api/equipment/half-plate-armor"
       }
     ]
   },

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -152,23 +152,23 @@
     ]
   },
   {
-    "index": "padded",
+    "index": "padded-armor",
     "type": "Armor",
-    "name": "Padded",
+    "name": "Padded armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/padded",
+    "url": "/api/proficiencies/padded-armor",
     "reference": {
-      "index": "padded",
-      "name": "Padded",
-      "url": "/api/equipment/padded"
+      "index": "padded-armor",
+      "name": "Padded armor",
+      "url": "/api/equipment/padded-armor"
     },
     "references": [
       {
-        "index": "padded",
+        "index": "padded-armor",
         "type": "equipment",
-        "name": "Padded",
-        "url": "/api/equipment/padded"
+        "name": "Padded armor",
+        "url": "/api/equipment/padded-armor"
       }
     ]
   },

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -194,23 +194,23 @@
     ]
   },
   {
-    "index": "studded-leather",
+    "index": "studded-leather-armor",
     "type": "Armor",
-    "name": "Studded Leather",
+    "name": "Studded Leather Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/studded-leather",
+    "url": "/api/proficiencies/studded-leather-armor",
     "reference": {
-      "index": "studded-leather",
-      "name": "Studded Leather",
-      "url": "/api/equipment/studded-leather"
+      "index": "studded-leather-armor",
+      "name": "Studded Leather Armor",
+      "url": "/api/equipment/studded-leather-armor"
     },
     "references": [
       {
-        "index": "studded-leather",
+        "index": "studded-leather-armor",
         "type": "equipment",
-        "name": "Studded Leather",
-        "url": "/api/equipment/studded-leather"
+        "name": "Studded Leather Armor",
+        "url": "/api/equipment/studded-leather-armor"
       }
     ]
   },

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -362,44 +362,44 @@
     ]
   },
   {
-    "index": "splint",
+    "index": "splint-armor",
     "type": "Armor",
-    "name": "Splint",
+    "name": "Splint Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/splint",
+    "url": "/api/proficiencies/splint-armor",
     "reference": {
-      "index": "splint",
-      "name": "Splint",
-      "url": "/api/equipment/splint"
+      "index": "splint-armor",
+      "name": "Splint Armor",
+      "url": "/api/equipment/splint-armor"
     },
     "references": [
       {
-        "index": "splint",
-        "name": "Splint",
+        "index": "splint-armor",
+        "name": "Splint Armor",
         "type": "equipment",
-        "url": "/api/equipment/splint"
+        "url": "/api/equipment/splint-armor"
       }
     ]
   },
   {
-    "index": "plate",
+    "index": "plate-armor",
     "type": "Armor",
-    "name": "Plate",
+    "name": "Plate Armor",
     "classes": [],
     "races": [],
-    "url": "/api/proficiencies/plate",
+    "url": "/api/proficiencies/plate-armor",
     "reference": {
-      "index": "plate",
-      "name": "Plate",
-      "url": "/api/equipment/plate"
+      "index": "plate-armor",
+      "name": "Plate Armor",
+      "url": "/api/equipment/plate-armor"
     },
     "references": [
       {
-        "index": "plate",
-        "name": "Plate",
+        "index": "plate-armor",
+        "name": "Plate Armor",
         "type": "equipment",
-        "url": "/api/equipment/plate"
+        "url": "/api/equipment/plate-armor"
       }
     ]
   },


### PR DESCRIPTION
## What does this do?
This updates the names and indexes of some armor to be more accurate to the SRD, and grammatically correct. Relevant discussion: https://github.com/5e-bits/5e-database/discussions/394

Unlike the linked discussion, I omitted changes to `elven-chain`, `dwarven-plate`, `chain-mail`, and `ring-mail`. There is no usage of these having "Armor" fixed to the end anywhere in the SRD, unlike the other ones which were changed. Additionally it just makes less sense to do so.

## How was it tested?
It wasn't.

## Is there a Github issue this is resolving?
No.

## Did you update the docs in the API? Please link an associated PR if applicable.
No documentation changes are necessary.

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
