### PR TITLE
Fix damage and condition immunities for some undead

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -16155,13 +16155,23 @@
     "charisma": 8,
     "proficiencies": [],
     "damage_vulnerabilities": [],
-    "damage_resistances": [],
-    "damage_immunities": ["necrotic"],
+    "damage_resistances": ["necrotic"],
+    "damage_immunities": ["posion"],
     "condition_immunities": [
       {
         "index": "poisoned",
         "name": "Poisoned",
         "url": "/api/conditions/poisoned"
+      },
+      {
+        "index": "charmed",
+        "name": "Charmed",
+        "url": "/api/conditions/charmed"
+      },
+      {
+        "index": "exhaustion",
+        "name": "Exhaustion",
+        "url": "/api/conditions/exhaustion"
       }
     ],
     "senses": {
@@ -16390,12 +16400,22 @@
     "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
-    "damage_immunities": [],
+    "damage_immunities": ["poison"],
     "condition_immunities": [
       {
         "index": "poisoned",
         "name": "Poisoned",
         "url": "/api/conditions/poisoned"
+      },
+      {
+        "index": "charmed",
+        "name": "Charmed",
+        "url": "/api/conditions/charmed"
+      },
+      {
+        "index": "exhaustion",
+        "name": "Exhaustion",
+        "url": "/api/conditions/exhaustion"
       }
     ],
     "senses": {
@@ -32000,12 +32020,17 @@
     "proficiencies": [],
     "damage_vulnerabilities": ["bludgeoning"],
     "damage_resistances": [],
-    "damage_immunities": [],
+    "damage_immunities": ["poison"],
     "condition_immunities": [
       {
         "index": "poisoned",
         "name": "Poisoned",
         "url": "/api/conditions/poisoned"
+      },
+      {
+        "index": "exhaustion",
+        "name": "Exhaustion",
+        "url": "/api/conditions/exhaustion"
       }
     ],
     "senses": {
@@ -41897,7 +41922,7 @@
     ],
     "damage_vulnerabilities": [],
     "damage_resistances": [],
-    "damage_immunities": [],
+    "damage_immunities": ["poison"],
     "condition_immunities": [
       {
         "index": "poisoned",


### PR DESCRIPTION
## What does this do?
Some of the damage and condition immunities for undead monsters were wrong, so I fixed them.

## How was it tested?
I ran db:refresh and verified the changes in MongoDB compass.

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.
n/a

## Here's a fun image for your troubles
![random photo - update me](https://picsum.photos/200)
