### PR TITLE
Added / prefix to backgrounds and alignments urls

### DIFF
--- a/src/5e-SRD-Alignments.json
+++ b/src/5e-SRD-Alignments.json
@@ -4,62 +4,62 @@
         "name": "Lawful Good",
         "abbreviation": "LG",
         "desc": "Lawful good (LG) creatures can be counted on to do the right thing as expected by society. Gold dragons, paladins, and most dwarves are lawful good.",
-        "url": "api/alignments/lawful-good"
+        "url": "/api/alignments/lawful-good"
     },
     {
         "index": "neutral-good",
         "name": "Neutral Good",
         "abbreviation": "NG",
         "desc": "Neutral good (NG) folk do the best they can to help others according to their needs. Many celestials, some cloud giants, and most gnomes are neutral good.",
-        "url": "api/alignments/neutral-good"
+        "url": "/api/alignments/neutral-good"
     },
     {
         "index": "chaotic-good",
         "name": "Chaotic Good",
         "abbreviation": "CG",
         "desc": "Chaotic good (CG) creatures act as their conscience directs, with little regard for what others expect. Copper dragons, many elves, and unicorns are chaotic good.",
-        "url": "api/alignments/chaotic-good"
+        "url": "/api/alignments/chaotic-good"
     },
     {
         "index": "lawful-neutral",
         "name": "Lawful Neutral",
         "abbreviation": "LN",
         "desc": "Lawful neutral (LN) individuals act in accordance with law, tradition, or personal codes. Many monks and some wizards are lawful neutral.",
-        "url": "api/alignments/lawful-neutral"
+        "url": "/api/alignments/lawful-neutral"
     },
     {
         "index": "neutral",
         "name": "Neutral",
         "abbreviation": "N",
         "desc": "Neutral (N) is the alignment of those who prefer to steer clear of moral questions and don't take sides, doing what seems best at the time. Lizardfolk, most druids, and many humans are neutral.",
-        "url": "api/alignments/neutral"
+        "url": "/api/alignments/neutral"
     },
     {
         "index": "chaotic-neutral",
         "name": "Chaotic Neutral",
         "abbreviation": "CN",
         "desc": "Chaotic neutral (CN) creatures follow their whims, holding their personal freedom above all else. Many barbarians and rogues, and some bards, are chaotic neutral.",
-        "url": "api/alignments/chaotic-neutral"
+        "url": "/api/alignments/chaotic-neutral"
     },
     {
         "index": "lawful-evil",
         "name": "Lawful Evil",
         "abbreviation": "LE",
         "desc": "Lawful evil (LE) creatures methodically take what they want, within the limits of a code of tradition, loyalty, or order. Devils, blue dragons, and hobgoblins are lawful evil.",
-        "url": "api/alignments/lawful-evil"
+        "url": "/api/alignments/lawful-evil"
     },
     {
         "index": "neutral-evil",
         "name": "Neutral Evil",
         "abbreviation": "NE",
         "desc": "Neutral evil (NE) is the alignment of those who do whatever they can get away with, without compassion or qualms. Many drow, some cloud giants, and goblins are neutral evil.",
-        "url": "api/alignments/neutral-evil"
+        "url": "/api/alignments/neutral-evil"
     },
     {
         "index": "chaotic-evil",
         "name": "Chaotic Evil",
         "abbreviation": "CE",
         "desc": "Chaotic evil (CE) creatures act with arbitrary violence, spurred by their greed, hatred, or bloodlust. Demons, red dragons, and orcs are chaotic evil.",
-        "url": "api/alignments/chaotic-evil"
+        "url": "/api/alignments/chaotic-evil"
     }
 ]

--- a/src/5e-SRD-Backgrounds.json
+++ b/src/5e-SRD-Backgrounds.json
@@ -162,17 +162,17 @@
                         {
                             "index": "lawful-good",
                             "name": "Lawful Good",
-                            "url": "api/alignments/lawful-good"
+                            "url": "/api/alignments/lawful-good"
                         },
                         {
                             "index": "lawful-neutral",
                             "name": "Lawful Neutral",
-                            "url": "api/alignments/lawful-neutral"
+                            "url": "/api/alignments/lawful-neutral"
                         },
                         {
                             "index": "lawful-evil",
                             "name": "Lawful Evil",
-                            "url": "api/alignments/lawful-evil"
+                            "url": "/api/alignments/lawful-evil"
                         }
                     ]
                 },
@@ -182,17 +182,17 @@
                         {
                             "index": "lawful-good",
                             "name": "Lawful Good",
-                            "url": "api/alignments/lawful-good"
+                            "url": "/api/alignments/lawful-good"
                         },
                         {
                             "index": "neutral-good",
                             "name": "Neutral Good",
-                            "url": "api/alignments/neutral-good"
+                            "url": "/api/alignments/neutral-good"
                         },
                         {
                             "index": "chaotic-good",
                             "name": "Chaotic Good",
-                            "url": "api/alignments/chaotic-good"
+                            "url": "/api/alignments/chaotic-good"
                         }
                     ]
                 },
@@ -202,17 +202,17 @@
                         {
                             "index": "chaotic-good",
                             "name": "Chaotic Good",
-                            "url": "api/alignments/chaotic-good"
+                            "url": "/api/alignments/chaotic-good"
                         },
                         {
                             "index": "chaotic-neutral",
                             "name": "Chaotic Neutral",
-                            "url": "api/alignments/chaotic-neutral"
+                            "url": "/api/alignments/chaotic-neutral"
                         },
                         {
                             "index": "chaotic-evil",
                             "name": "Chaotic Evil",
-                            "url": "api/alignments/chaotic-evil"
+                            "url": "/api/alignments/chaotic-evil"
                         }
                     ]
                 },
@@ -222,17 +222,17 @@
                         {
                             "index": "lawful-good",
                             "name": "Lawful Good",
-                            "url": "api/alignments/lawful-good"
+                            "url": "/api/alignments/lawful-good"
                         },
                         {
                             "index": "lawful-neutral",
                             "name": "Lawful Neutral",
-                            "url": "api/alignments/lawful-neutral"
+                            "url": "/api/alignments/lawful-neutral"
                         },
                         {
                             "index": "lawful-evil",
                             "name": "Lawful Evil",
-                            "url": "api/alignments/lawful-evil"
+                            "url": "/api/alignments/lawful-evil"
                         }
                     ]
                 },
@@ -242,17 +242,17 @@
                         {
                             "index": "lawful-good",
                             "name": "Lawful Good",
-                            "url": "api/alignments/lawful-good"
+                            "url": "/api/alignments/lawful-good"
                         },
                         {
                             "index": "lawful-neutral",
                             "name": "Lawful Neutral",
-                            "url": "api/alignments/lawful-neutral"
+                            "url": "/api/alignments/lawful-neutral"
                         },
                         {
                             "index": "lawful-evil",
                             "name": "Lawful Evil",
-                            "url": "api/alignments/lawful-evil"
+                            "url": "/api/alignments/lawful-evil"
                         }
                     ]
                 },
@@ -262,47 +262,47 @@
                         {
                             "index": "lawful-good",
                             "name": "Lawful Good",
-                            "url": "api/alignments/lawful-good"
+                            "url": "/api/alignments/lawful-good"
                         },
                         {
                             "index": "neutral-good",
                             "name": "Neutral Good",
-                            "url": "api/alignments/neutral-good"
+                            "url": "/api/alignments/neutral-good"
                         },
                         {
                             "index": "chaotic-good",
                             "name": "Chaotic Good",
-                            "url": "api/alignments/chaotic-good"
+                            "url": "/api/alignments/chaotic-good"
                         },
                         {
                             "index": "lawful-neutral",
                             "name": "Lawful Neutral",
-                            "url": "api/alignments/lawful-neutral"
+                            "url": "/api/alignments/lawful-neutral"
                         },
                         {
                             "index": "neutral",
                             "name": "Neutral",
-                            "url": "api/alignments/neutral"
+                            "url": "/api/alignments/neutral"
                         },
                         {
                             "index": "chaotic-neutral",
                             "name": "Chaotic Neutral",
-                            "url": "api/alignments/chaotic-neutral"
+                            "url": "/api/alignments/chaotic-neutral"
                         },
                         {
                             "index": "lawful-evil",
                             "name": "Lawful Evil",
-                            "url": "api/alignments/lawful-evil"
+                            "url": "/api/alignments/lawful-evil"
                         },
                         {
                             "index": "neutral-evil",
                             "name": "Neutral Evil",
-                            "url": "api/alignments/neutral-evil"
+                            "url": "/api/alignments/neutral-evil"
                         },
                         {
                             "index": "chaotic-evil",
                             "name": "Chaotic Evil",
-                            "url": "api/alignments/chaotic-evil"
+                            "url": "/api/alignments/chaotic-evil"
                         }
                     ]
                 }


### PR DESCRIPTION
## What does this do?

Adds the missing `/` in in front of URLs for alignments and background ideals.

## How was it tested?

It wasnt

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
