### PR TITLE
Fixed a minor typo in Monsters JSON

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -16156,7 +16156,7 @@
     "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": ["necrotic"],
-    "damage_immunities": ["posion"],
+    "damage_immunities": ["poison"],
     "condition_immunities": [
       {
         "index": "poisoned",


### PR DESCRIPTION
## What does this do?

Fixes a minor typo in Monsters JSON

## How was it tested?

Ran `npm run lint` and `npm run test`

## Is there a Github issue this is resolving?

No, it's a simple typo, so didn't think it necessary.

## Did you update the docs in the API? Please link an associated PR if applicable.

Don't think it's necessary

## Here's a fun image for your troubles

![here you go](https://i.picsum.photos/id/313/200/200.jpg?hmac=rh2PdOLFkEclUr6nN2KdavcsSZIHVkYnv9D0BtJjykA)
