### PR TITLE
Fix xorn xp

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -39916,7 +39916,7 @@
     },
     "languages": "Terran",
     "challenge_rating": 5,
-    "xp": 18000,
+    "xp": 1800,
     "special_abilities": [
       {
         "name": "Earth Glide",


### PR DESCRIPTION
## What does this do?

The xorn in the database had the wrong xp by a factor of 10. This PR uses the value from [DNDBeyond](https://www.dndbeyond.com/monsters/xorn).

## How was it tested?

n/a

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
