### PR TITLE
Remove attack type from spells without attack roll

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -9792,7 +9792,6 @@
     "concentration": false,
     "casting_time": "1 action",
     "level": 5,
-    "attack_type": "ranged",
     "heal_at_slot_level": {
       "5": "3d8 + MOD",
       "6": "4d8 + MOD",
@@ -15040,7 +15039,6 @@
     "concentration": false,
     "casting_time": "1 action",
     "level": 0,
-    "attack_type": "ranged",
     "damage": {
       "damage_type": {
         "index": "psychic",


### PR DESCRIPTION
## What does this do?

As the title says, there were some spells (Vicious Mockery and Mass Cure Wounds) that don't have attack rolls that were listed as having an attack type. This change rectifies that.

## How was it tested?

n/a

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
