### PR TITLE
Rectify some spells for land druid

### DIFF
--- a/src/5e-SRD-Subclasses.json
+++ b/src/5e-SRD-Subclasses.json
@@ -315,9 +315,9 @@
           }
         ],
         "spell": {
-          "index": "holy-aura",
-          "name": "Holy Aura",
-          "url": "/api/spells/holy-aura"
+          "index": "ice-storm",
+          "name": "Ice Storm",
+          "url": "/api/spells/ice-storm"
         }
       },
       {
@@ -336,9 +336,9 @@
           }
         ],
         "spell": {
-          "index": "commune",
-          "name": "Commune",
-          "url": "/api/spells/commune"
+          "index": "commune-with-nature",
+          "name": "Commune With Nature",
+          "url": "/api/spells/commune-with-nature"
         }
       },
       {
@@ -357,9 +357,9 @@
           }
         ],
         "spell": {
-          "index": "comprehend-languages",
-          "name": "Comprehend Languages",
-          "url": "/api/spells/comprehend-languages"
+          "index": "cone-of-cold",
+          "name": "Cone of Cold",
+          "url": "/api/spells/cone-of-cold"
         }
       },
       {


### PR DESCRIPTION
## What does this do?

Some of the spells for arctic circle of land druid were wrong. This change fixes that.

## How was it tested?

Ran db:refresh and checked the data with MongoDb Compass.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
