### PR TITLE
ecs: fix deploy ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,9 +43,12 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 14.x
-      - env:
+      - name: Refresh DB contents
+        env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
-        run: npm run db:refresh
+        run: |
+          npm install
+          npm run db:refresh
   dockerhub:
     name: Deploy to Docker Hub
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What does this do?
I noticed the last two deploys failed, looks to be caused by types not being accessible when we try to execute `npm run db:refresh`.

Updates the `Deploy` job in the CI workflow to run `npm install` before `npm run db:refresh`.

## How was it tested?
- Confirmed I see the same errors locally when I attempt `npm run db:refresh` with a fresh copy of the repo. Running `npm install` resolves the errors.

## Is there a Github issue this is resolving?
na

## Did you update the docs in the API? Please link an associated PR if applicable.
na

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
