### PR TITLE
Fix shriekers reaction from action

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -31840,7 +31840,7 @@
         "desc": "While the shrieker remains motionless, it is indistinguishable from an ordinary fungus."
       }
     ],
-    "actions": [
+    "reactions": [
       {
         "name": "Shriek",
         "desc": "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward"


### PR DESCRIPTION
## What does this do?

Quick change to fix Shriekers action to actually be a reaction

## How was it tested?

It was not.

## Is there a Github issue this is resolving?

no

## Did you update the docs in the API? Please link an associated PR if applicable.

no

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/9203727/157799634-cd875ce6-2d08-403e-98d1-bdc70f2e2920.png)