### PR TITLE
fix(release): Add release to .releaserc.json

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,5 +3,6 @@
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
     "@semantic-release/github"
-  ]
+  ],
+  "release": { "branches": [ "main" ] }
 }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ If you see anything wrong with the API and not the data, please open an issue or
  * Fork this repository
  * Create a new branch for your work
  * Push up any changes to your branch, and open a pull request. Don't feel it needs to be perfect — incomplete work is totally fine. We'd love to help get it ready for merging.
+ * We use Semantic Release so here are the PR naming convetions:
+
+| Commit message                                                                                                                                                                             | Release type                                                                                             |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| fix(pencil): stop graphite breaking when too much pressure applied                                                                                                                         | Patch Fix Release                                                                                        |
+| feat(pencil): add 'graphiteWidth' option                                                                                                                                                   | Minor Feature Release                                                                                    |
+| perf(pencil): remove graphiteWidth option<br><br>BREAKING CHANGE: The graphiteWidth option has been removed.<br>The default graphite width of 10mm is always used for performance reasons. | Major Breaking Release<br><br>(Note that the BREAKING CHANGE: token must be in the footer of the commit) |
 
 # Code of Conduct
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "type": "git",
     "url": "git+https://github.com/bagelbits/5e-database.git"
   },
+  "release": { "branches": [ "main" ] },
   "author": "",
   "license": "MIT",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "type": "git",
     "url": "git+https://github.com/bagelbits/5e-database.git"
   },
-  "release": { "branches": [ "main" ] },
   "author": "",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
## What does this do?

* Adds the release to `.releaserc.json`
* Updates `README.md` with naming conventions

## How was it tested?

We're doing it live.

## Is there a Github issue this is resolving?

Nope.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
