### PR TITLE
fix(docker): also copy package-lock.json before install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ ENV MONGODB_URI mongodb://localhost/5e-database
 
 ## Add code
 WORKDIR /data/db2
-COPY --chown=mongodb:mongodb package.json /data/db2/
+COPY --chown=mongodb:mongodb package.json package-lock.json /data/db2/
 RUN npm install
 COPY --chown=mongodb:mongodb . /data/db2/
 


### PR DESCRIPTION
## What does this do?

Just a small Docker improvement to copy in the `package-lock.json` before we `npm install`.

## How was it tested?

Built the container locally.

## Is there a Github issue this is resolving?

Nope.

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
