### PR TITLE
fix(monster): fix condition_immunities for gelatinous cube

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -15968,9 +15968,9 @@
         "url": "/api/conditions/charmed"
       },
       {
-        "index": "blinded",
-        "name": "Blinded",
-        "url": "/api/conditions/blinded"
+        "index": "deafened",
+        "name": "Deafened",
+        "url": "/api/conditions/deafened"
       },
       {
         "index": "exhaustion",


### PR DESCRIPTION
## What does this do?

Remove the duplicate `blinded` condition from condition_immunities, and correctly replace it with an entry for the `deafened` condition.

## How was it tested?

- N/A - text update, can run tests though if that helps

## Is there a Github issue this is resolving?

- No

## Did you update the docs in the API? Please link an associated PR if applicable.

- No

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
