### PR TITLE
fix(shapechangers): Make vampire consistent with other shapechangers

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -35735,8 +35735,8 @@
     "url": "/api/monsters/unicorn"
   },
   {
-    "index": "vampire",
-    "name": "Vampire",
+    "index": "vampire-vampire",
+    "name": "Vampire, Vampire Form",
     "size": "Medium",
     "type": "undead",
     "subtype": "shapechanger",
@@ -35747,6 +35747,18 @@
     "speed": {
       "walk": "30 ft."
     },
+    "forms": [
+      {
+        "index": "vampire-bat",
+        "name": "Vampire, Bat Form",
+        "url": "/api/monsters/vampire-bat"
+      },
+      {
+        "index": "vampire-mist",
+        "name": "Vampire, Mist Form",
+        "url": "/api/monsters/vampire-mist"
+      }
+    ],
     "strength": 18,
     "dexterity": 18,
     "constitution": 18,
@@ -35841,11 +35853,11 @@
     ],
     "actions": [
       {
-        "name": "Multiattack (Vampire Form Only)",
+        "name": "Multiattack",
         "desc": "The vampire makes two attacks, only one of which can be a bite attack."
       },
       {
-        "name": "Unarmed Strike (Vampire Form Only)",
+        "name": "Unarmed Strike",
         "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one creature. Hit: 8 (1d8 + 4) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18).",
         "attack_bonus": 9,
         "damage": [
@@ -35860,7 +35872,7 @@
         ]
       },
       {
-        "name": "Bite (Bat or Vampire Form Only)",
+        "name": "Bite",
         "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control.",
         "attack_bonus": 9,
         "damage": [
@@ -35921,7 +35933,327 @@
         "attack_bonus": 0
       }
     ],
-    "url": "/api/monsters/vampire"
+    "url": "/api/monsters/vampire-vampire"
+  },
+  {
+    "index": "vampire-bat",
+    "name": "Vampire, Bat Form",
+    "size": "Medium",
+    "type": "undead",
+    "subtype": "shapechanger",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "hit_points": 144,
+    "hit_dice": "17d8",
+    "speed": {
+      "walk": "5 ft.",
+      "fly": "30 ft."
+    },
+    "forms": [
+      {
+        "index": "vampire-vampire",
+        "name": "Vampire, Vampire Form",
+        "url": "/api/monsters/vampire-vampire"
+      },
+      {
+        "index": "vampire-mist",
+        "name": "Vampire, Mist Form",
+        "url": "/api/monsters/vampire-mist"
+      }
+    ],
+    "strength": 18,
+    "dexterity": 18,
+    "constitution": 18,
+    "intelligence": 17,
+    "wisdom": 15,
+    "charisma": 18,
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/proficiencies/saving-throw-cha"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "skill-perception",
+          "name": "Skill: Perception",
+          "url": "/api/proficiencies/skill-perception"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "skill-stealth",
+          "name": "Skill: Stealth",
+          "url": "/api/proficiencies/skill-stealth"
+        }
+      }
+    ],
+    "damage_vulnerabilities": [],
+    "damage_resistances": [
+      "necrotic",
+      "bludgeoning, piercing, and slashing from nonmagical weapons"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
+    "languages": "the languages it knew in life",
+    "challenge_rating": 13,
+    "xp": 10000,
+    "special_abilities": [
+      {
+        "name": "Shapechanger",
+        "desc": "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.\nWhile in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.\nWhile in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+      },
+      {
+        "name": "Legendary Resistance",
+        "desc": "If the vampire fails a saving throw, it can choose to succeed instead.",
+        "usage": {
+          "type": "per day",
+          "times": 3
+        }
+      },
+      {
+        "name": "Misty Escape",
+        "desc": "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.\nWhile it has 0 hit points in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least 1 hit point. After spending 1 hour in its resting place with 0 hit points, it regains 1 hit point."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weaknesses",
+        "desc": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage if it ends its turn in running water.\nStake to the Heart. If a piercing weapon made of wood is driven into the vampire's heart while the vampire is incapacitated in its resting place, the vampire is paralyzed until the stake is removed.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [
+      {
+        "name": "Bite",
+        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 (1d6 + 4) piercing damage plus 10 (3d6) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control.",
+        "attack_bonus": 9,
+        "damage": [
+          {
+            "damage_type": {
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/damage-types/piercing"
+            },
+            "damage_dice": "1d6+4"
+          },
+          {
+            "damage_type": {
+              "index": "necrotic",
+              "name": "Necrotic",
+              "url": "/api/damage-types/necrotic"
+            },
+            "damage_dice": "3d6"
+          }
+        ]
+      },
+      {
+        "name": "Charm",
+        "desc": "The vampire targets one humanoid it can see within 30 ft. of it. If the target can see the vampire, the target must succeed on a DC 17 Wisdom saving throw against this magic or be charmed by the vampire. The charmed target regards the vampire as a trusted friend to be heeded and protected. Although the target isn't under the vampire's control, it takes the vampire's requests or actions in the most favorable way it can, and it is a willing target for the vampire's bit attack.\nEach time the vampire or the vampire's companions do anything harmful to the target, it can repeat the saving throw, ending the effect on itself on a success. Otherwise, the effect lasts 24 hours or until the vampire is destroyed, is on a different plane of existence than the target, or takes a bonus action to end the effect.",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "WIS",
+            "url": "/api/ability-scores/wis"
+          },
+          "dc_value": 17,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Children of the Night",
+        "desc": "The vampire magically calls 2d4 swarms of bats or rats, provided that the sun isn't up. While outdoors, the vampire can call 3d6 wolves instead. The called creatures arrive in 1d4 rounds, acting as allies of the vampire and obeying its spoken commands. The beasts remain for 1 hour, until the vampire dies, or until the vampire dismisses them as a bonus action.",
+        "usage": {
+          "type": "per day",
+          "times": 1
+        }
+      }
+    ],
+    "legendary_actions": [
+      {
+        "name": "Move",
+        "desc": "The vampire moves up to its speed without provoking opportunity attacks.",
+        "attack_bonus": 0
+      },
+      {
+        "name": "Unarmed Strike",
+        "desc": "The vampire makes one unarmed strike.",
+        "attack_bonus": 0
+      },
+      {
+        "name": "Bite (Costs 2 Actions)",
+        "desc": "The vampire makes one bite attack.",
+        "attack_bonus": 0
+      }
+    ],
+    "url": "/api/monsters/vampire-bat"
+  },
+  {
+    "index": "vampire-mist",
+    "name": "Vampire, Mist Form",
+    "size": "Medium",
+    "type": "undead",
+    "subtype": "shapechanger",
+    "alignment": "lawful evil",
+    "armor_class": 16,
+    "hit_points": 144,
+    "hit_dice": "17d8",
+    "speed": {
+      "fly": "20 ft."
+    },
+    "forms": [
+      {
+        "index": "vampire-vampire",
+        "name": "Vampire, Vampire Form",
+        "url": "/api/monsters/vampire-vampire"
+      },
+      {
+        "index": "vampire-bat",
+        "name": "Vampire, Bat Form",
+        "url": "/api/monsters/vampire-bat"
+      }
+    ],
+    "strength": 18,
+    "dexterity": 18,
+    "constitution": 18,
+    "intelligence": 17,
+    "wisdom": 15,
+    "charisma": 18,
+    "proficiencies": [
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-dex",
+          "name": "Saving Throw: DEX",
+          "url": "/api/proficiencies/saving-throw-dex"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "saving-throw-wis",
+          "name": "Saving Throw: WIS",
+          "url": "/api/proficiencies/saving-throw-wis"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "saving-throw-cha",
+          "name": "Saving Throw: CHA",
+          "url": "/api/proficiencies/saving-throw-cha"
+        }
+      },
+      {
+        "value": 7,
+        "proficiency": {
+          "index": "skill-perception",
+          "name": "Skill: Perception",
+          "url": "/api/proficiencies/skill-perception"
+        }
+      },
+      {
+        "value": 9,
+        "proficiency": {
+          "index": "skill-stealth",
+          "name": "Skill: Stealth",
+          "url": "/api/proficiencies/skill-stealth"
+        }
+      }
+    ],
+    "damage_vulnerabilities": [],
+    "damage_resistances": [
+      "necrotic",
+      "bludgeoning, piercing, and slashing from nonmagical weapons"
+    ],
+    "damage_immunities": [],
+    "condition_immunities": [],
+    "senses": {
+      "darkvision": "120 ft.",
+      "passive_perception": 17
+    },
+    "languages": "the languages it knew in life",
+    "challenge_rating": 13,
+    "xp": 10000,
+    "special_abilities": [
+      {
+        "name": "Shapechanger",
+        "desc": "If the vampire isn't in sun light or running water, it can use its action to polymorph into a Tiny bat or a Medium cloud of mist, or back into its true form.\nWhile in bat form, the vampire can't speak, its walking speed is 5 feet, and it has a flying speed of 30 feet. Its statistics, other than its size and speed, are unchanged. Anything it is wearing transforms with it, but nothing it is carrying does. It reverts to its true form if it dies.\nWhile in mist form, the vampire can't take any actions, speak, or manipulate objects. It is weightless, has a flying speed of 20 feet, can hover, and can enter a hostile creature's space and stop there. In addition, if air can pass through a space, the mist can do so without squeezing, and it can't pass through water. It has advantage on Strength, Dexterity, and Constitution saving throws, and it is immune to all nonmagical damage, except the damage it takes from sunlight."
+      },
+      {
+        "name": "Legendary Resistance",
+        "desc": "If the vampire fails a saving throw, it can choose to succeed instead.",
+        "usage": {
+          "type": "per day",
+          "times": 3
+        }
+      },
+      {
+        "name": "Misty Escape",
+        "desc": "When it drops to 0 hit points outside its resting place, the vampire transforms into a cloud of mist (as in the Shapechanger trait) instead of falling unconscious, provided that it isn't in sunlight or running water. If it can't transform, it is destroyed.\nWhile it has 0 hit points in mist form, it can't revert to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it reverts to its vampire form. It is then paralyzed until it regains at least 1 hit point. After spending 1 hour in its resting place with 0 hit points, it regains 1 hit point."
+      },
+      {
+        "name": "Regeneration",
+        "desc": "The vampire regains 20 hit points at the start of its turn if it has at least 1 hit point and isn't in sunlight or running water. If the vampire takes radiant damage or damage from holy water, this trait doesn't function at the start of the vampire's next turn."
+      },
+      {
+        "name": "Spider Climb",
+        "desc": "The vampire can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+      },
+      {
+        "name": "Vampire Weaknesses",
+        "desc": "The vampire has the following flaws:\nForbiddance. The vampire can't enter a residence without an invitation from one of the occupants.\nHarmed by Running Water. The vampire takes 20 acid damage if it ends its turn in running water.\nStake to the Heart. If a piercing weapon made of wood is driven into the vampire's heart while the vampire is incapacitated in its resting place, the vampire is paralyzed until the stake is removed.\nSunlight Hypersensitivity. The vampire takes 20 radiant damage when it starts its turn in sunlight. While in sunlight, it has disadvantage on attack rolls and ability checks."
+      }
+    ],
+    "actions": [],
+    "legendary_actions": [
+      {
+        "name": "Move",
+        "desc": "The vampire moves up to its speed without provoking opportunity attacks.",
+        "attack_bonus": 0
+      },
+      {
+        "name": "Unarmed Strike",
+        "desc": "The vampire makes one unarmed strike.",
+        "attack_bonus": 0
+      },
+      {
+        "name": "Bite (Costs 2 Actions)",
+        "desc": "The vampire makes one bite attack.",
+        "attack_bonus": 0
+      }
+    ],
+    "url": "/api/monsters/vampire-mist"
   },
   {
     "index": "vampire-spawn",
@@ -37618,7 +37950,7 @@
     ],
     "actions": [
       {
-        "name": "Multiattack (Humanoid or Hybrid Form Only)",
+        "name": "Multiattack",
         "desc": "The wererat makes two attacks, only one of which can be a bite.",
         "options": {
           "choose": 1,


### PR DESCRIPTION
## What does this do?

Makes vampire consistent with the other shapechangers

## How was it tested?

I ran db:refresh and checked that the changes applied in MongoDB Compass

## Is there a Github issue this is resolving?

[Yes](https://github.com/5e-bits/5e-database/issues/467)

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
