### PR TITLE
fix(feature) - Updated prerequisite spells for several Eldritch Invocations in Features

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6400,7 +6400,7 @@
     "prerequisites": [
       {
         "type": "Spell",
-        "spell": "/api/spells/dominate-monster"
+        "spell": "/api/spells/eldritch-blast"
       }
     ],
     "desc": [
@@ -6551,7 +6551,7 @@
     "prerequisites": [
       {
         "type": "Spell",
-        "spell": "/api/spells/dominate-monster"
+        "spell": "/api/spells/eldritch-blast"
       }
     ],
     "desc": [
@@ -6676,7 +6676,7 @@
     "prerequisites": [
       {
         "type": "Spell",
-        "spell": "/api/spells/dominate-monster"
+        "spell": "/api/spells/eldritch-blast"
       }
     ],
     "desc": [


### PR DESCRIPTION
## What does this do?

- Adds "Eldritch Blast" as a prerequisite for the Eldritch Invocations Agonizing Blast, Eldritch Spear, and Repelling Blast.
- Also removes "Dominate Monster" as a prerequisite spell from each of the above. 
- (SRD pp48-49).

## How was it tested?

Pulled 5e-srd-api repo and followed instructions there to run from local database. Tested the three endpoints:
/api/features/eldritch-invocation-agonizing-blast
/api/features/eldritch-invocation-repelling-blast
/api/features/eldritch-invocation-eldritch-spear

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
