### PR TITLE
fix(monster): innate spellcasting required components

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -10835,7 +10835,7 @@
             "name": "CHA",
             "url": "/api/ability-scores/cha"
           },
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Magic",
@@ -12118,7 +12118,7 @@
             "url": "/api/ability-scores/int"
           },
           "dc": 11,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Nondetection",
@@ -12578,7 +12578,7 @@
           },
           "dc": 17,
           "modifier": 9,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Evil and Good",
@@ -13264,7 +13264,7 @@
             "url": "/api/ability-scores/wis"
           },
           "dc": 13,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Dancing Lights",
@@ -13498,7 +13498,7 @@
           },
           "dc": 11,
           "modifier": 0,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Dancing Lights",
@@ -13783,7 +13783,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 14,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Druidcraft",
@@ -14055,7 +14055,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 10,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Sleep",
@@ -14351,7 +14351,7 @@
           },
           "dc": 15,
           "modifier": 7,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Magic",
@@ -18673,7 +18673,7 @@
             "url": "/api/ability-scores/int"
           },
           "dc": 16,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Darkness",
@@ -19834,7 +19834,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 12,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Dancing Lights",
@@ -22290,7 +22290,7 @@
             "name": "CHA",
             "url": "/api/ability-scores/cha"
           },
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Fog Cloud",
@@ -23426,7 +23426,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 13,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Major Image",
@@ -24627,7 +24627,7 @@
             "name": "CHA",
             "url": "/api/ability-scores/cha"
           },
-          "components_required": [],
+          "components_required": ["V", "S"],
           "dc": 10,
           "spells": [
             {
@@ -26609,7 +26609,7 @@
           },
           "dc": 14,
           "modifier": 6,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Magic",
@@ -27281,7 +27281,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 13,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Darkness",
@@ -28154,7 +28154,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 21,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Magic",
@@ -28391,7 +28391,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 20,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Evil and Good",
@@ -29397,7 +29397,7 @@
           },
           "dc": 18,
           "modifier": 10,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Thoughts",
@@ -31976,7 +31976,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 25,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Evil and Good",
@@ -32860,7 +32860,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 11,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Blur",
@@ -33358,7 +33358,7 @@
             "url": "/api/ability-scores/cha"
           },
           "dc": 17,
-          "components_required": [],
+          "components_required": ["V", "S"],
           "spells": [
             {
               "name": "Detect Magic",


### PR DESCRIPTION
## What does this do?

Only material is specifically excluded for these, rest of components apply as normal.

## Is there a Github issue this is resolving?

Fixes https://github.com/5e-bits/5e-database/issues/475
