### PR TITLE
fix(monster): remove non-srd lair actions

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -2423,58 +2423,6 @@
             "damage_dice": "18d6"
           }
         ]
-      },
-      {
-        "name": "Lair Actions",
-        "desc": "On initiative count 20 (losing initiative ties), the dragon takes a lair action to cause one of the following effects: the dragon can't use the same effect two rounds in a row:\n- Magma erupts from a point on the ground the dragon can see within 120 feet of it, creating a 20-foot-high, 5-foot-radius geyser. Each creature in the geyser's area must make a DC 15 Dexterity saving throw, taking 21 (6d6) fire damage on a failed save, or half as much damage on a successful one.\n- A tremor shakes the lair in a 60-foot-radius around the dragon. Each creature other than the dragon on the ground in that area must succeed on a DC 15 Dexterity saving throw or be knocked prone.\n- Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point the dragon can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 13 Constitution saving throw or be poisoned until the end of its turn. While poisoned in this way, a creature is incapacitated.",
-        "attacks": [
-          {
-            "name": "Magma Eruption",
-            "dc": {
-              "dc_type": {
-                "index": "dex",
-                "name": "DEX",
-                "url": "/api/ability-scores/dex"
-              },
-              "dc_value": 15,
-              "success_type": "half"
-            },
-            "damage": [
-              {
-                "damage_type": {
-                  "index": "fire",
-                  "name": "Fire",
-                  "url": "/api/damage-types/fire"
-                },
-                "damage_dice": "6d6"
-              }
-            ]
-          },
-          {
-            "name": "Tremor",
-            "dc": {
-              "dc_type": {
-                "index": "dex",
-                "name": "DEX",
-                "url": "/api/ability-scores/dex"
-              },
-              "dc_value": 15,
-              "success_type": "none"
-            }
-          },
-          {
-            "name": "Volcanic Gas",
-            "dc": {
-              "dc_type": {
-                "index": "con",
-                "name": "CON",
-                "url": "/api/ability-scores/con"
-              },
-              "dc_value": 13,
-              "success_type": "none"
-            }
-          }
-        ]
       }
     ],
     "legendary_actions": [


### PR DESCRIPTION
## What does this do?

SRD makes references to lair actions, but doesn't include any for the monsters. Likely sourced from Monster Manual.

## Is there a Github issue this is resolving?

Just a one-off. :)