### PR TITLE
fix(monster): add missing legendary resistance

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -3504,6 +3504,16 @@
     "languages": "Common, Draconic",
     "challenge_rating": 23,
     "xp": 50000,
+    "special_abilities": [
+      {
+        "name": "Legendary Resistance",
+        "desc": "If the dragon fails a saving throw, it can choose to succeed instead.",
+        "usage": {
+          "type": "per day",
+          "times": 3
+        }
+      }
+    ],
     "actions": [
       {
         "name": "Multiattack",


### PR DESCRIPTION
## What does this do?

For ancient blue dragon.

## Is there a Github issue this is resolving?

No, a small one. :)