### PR TITLE
fix(monster): giant disesased rat special abilities

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -17778,6 +17778,16 @@
     "languages": "",
     "challenge_rating": 0.125,
     "xp": 25,
+    "special_abilities": [
+      {
+        "name": "Keen Smell",
+        "desc": "The rat has advantage on Wisdom (Perception) checks that rely on smell."
+      },
+      {
+        "name": "Pack Tactics",
+        "desc": "The rat has advantage on an attack roll against a creature if at least one of the rat's allies is within 5 ft. of the creature and the ally isn't incapacitated."
+      }
+    ],
     "actions": [
       {
         "name": "Bite",


### PR DESCRIPTION
## What does this do?

The Disesased variant has a different attack, but otherwise should be the same as a Giant Rat.

## Is there a Github issue this is resolving?

No, a small one. :)