### PR TITLE
feat(monster): add flavor text where available

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -206,6 +206,7 @@
   {
     "index": "acolyte",
     "name": "Acolyte",
+    "desc": "Acolytes are junior members of a clergy, usually answerable to a priest. They perform a variety of functions in a temple and are granted minor spellcasting power by their deities.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -6422,6 +6423,7 @@
   {
     "index": "archmage",
     "name": "Archmage",
+    "desc": "Archmages are powerful (and usually quite old) spellcasters dedicated to the study of the arcane arts. Benevolent ones counsel kings and queens, while evil ones rule as tyrants and pursue lichdom. Those who are neither good nor evil sequester themselves in remote towers to practice their magic without interruption. \n\nAn archmage typically has one or more apprentice mages, and an archmage’s abode has numerous magical wards and guardians to discourage interlopers.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -6686,6 +6688,7 @@
   {
     "index": "assassin",
     "name": "Assassin",
+    "desc": "Trained in the use of poison, assassins are remorseless killers who work for nobles, guildmasters, sovereigns, and anyone else who can afford them.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -6863,6 +6866,7 @@
   {
     "index": "awakened-shrub",
     "name": "Awakened Shrub",
+    "desc": "An awakened shrub is an ordinary shrub given sentience and mobility by the awaken spell or similar magic.",
     "size": "Small",
     "type": "plant",
     "alignment": "unaligned",
@@ -6917,6 +6921,7 @@
   {
     "index": "awakened-tree",
     "name": "Awakened Tree",
+    "desc": "An awakened tree is an ordinary tree given sentience and mobility by the awaken spell or similar magic.",
     "size": "Huge",
     "type": "plant",
     "alignment": "unaligned",
@@ -6971,6 +6976,7 @@
   {
     "index": "axe-beak",
     "name": "Axe Beak",
+    "desc": "An axe beak is a tall flightless bird with strong legs and a heavy, wedge-shaped beak. It has a nasty disposition and tends to attack any unfamiliar creature that wanders too close.",
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
@@ -7432,6 +7438,7 @@
   {
     "index": "bandit",
     "name": "Bandit",
+    "desc": "**Bandits** rove in gangs and are sometimes led by thugs, veterans, or spellcasters. Not all bandits are evil. Oppression, drought, disease, or famine can often drive otherwise honest folk to a life of banditry.\n\n**Pirates** are bandits of the high seas. They might be freebooters interested only in treasure and murder, or they might be privateers sanctioned by the crown to attack and plunder an enemy nation’s vessels.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -7496,6 +7503,7 @@
   {
     "index": "bandit-captain",
     "name": "Bandit Captain",
+    "desc": "It takes a strong personality, ruthless cunning, and a silver tongue to keep a gang of bandits in line. The **bandit captain** has these qualities in spades.\n\nIn addition to managing a crew of selfish malcontents, the **pirate captain** is a variation of the bandit captain, with a ship to protect and command. To keep the crew in line, the captain must mete out rewards and punishment on a regular basis.\n\nMore than treasure, a bandit captain or pirate captain craves infamy. A prisoner who appeals to the captain’s vanity or ego is more likely to be treated fairly than a prisoner who does not or claims not to know anything of the captain’s colorful reputation.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -8661,6 +8669,7 @@
   {
     "index": "blink-dog",
     "name": "Blink Dog",
+    "desc": "A blink dog takes its name from its ability to blink in and out of existence, a talent it uses to aid its attacks and to avoid harm.",
     "size": "Medium",
     "type": "fey",
     "alignment": "lawful good",
@@ -8741,6 +8750,7 @@
   {
     "index": "blood-hawk",
     "name": "Blood Hawk",
+    "desc": "Taking its name from its crimson feathers and aggressive nature, the blood hawk fearlessly attacks almost any animal, stabbing it with its daggerlike beak. Blood hawks flock together in large numbers, attacking as a pack to take down prey.",
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
@@ -10972,6 +10982,7 @@
   {
     "index": "commoner",
     "name": "Commoner",
+    "desc": "Commoners include peasants, serfs, slaves, servants, pilgrims, merchants, artisans, and hermits.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -11601,6 +11612,7 @@
   {
     "index": "cult-fanatic",
     "name": "Cult Fanatic",
+    "desc": "Fanatics are often part of a cult’s leadership, using their charisma and dogma to influence and prey on those of weak will. Most are interested in personal power above all else.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -11759,6 +11771,7 @@
   {
     "index": "cultist",
     "name": "Cultist",
+    "desc": "Cultists swear allegiance to dark powers such as elemental princes, demon lords, or archdevils. Most conceal their loyalties to avoid being ostracized, imprisoned, or executed for their beliefs. Unlike evil acolytes, cultists often show signs of insanity in their beliefs and practices.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -11908,6 +11921,7 @@
   {
     "index": "death-dog",
     "name": "Death Dog",
+    "desc": "A death dog is an ugly two-headed hound that roams plains, and deserts. Hate burns in a death dog’s heart, and a taste for humanoid flesh drives it to attack travelers and explorers. Death dog saliva carries a foul disease that causes a victim’s flesh to slowly rot off the bone.",
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "neutral evil",
@@ -13517,6 +13531,7 @@
   {
     "index": "druid",
     "name": "Druid",
+    "desc": "**Druids** dwell in forests and other secluded wilderness locations, where they protect the natural world from monsters and the encroachment of civilization. Some are **tribal shamans** who heal the sick, pray to animal spirits, and provide spiritual guidance.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -15384,6 +15399,7 @@
   {
     "index": "flying-snake",
     "name": "Flying Snake",
+    "desc": "A flying snake is a brightly colored, winged serpent found in remote jungles. Tribespeople and cultists sometimes domesticate flying snakes to serve as messengers that deliver scrolls wrapped in their coils.",
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
@@ -15555,6 +15571,7 @@
   {
     "index": "frog",
     "name": "Frog",
+    "desc": "A frog has no effective attacks. It feeds on small insects and typically dwells near water, in trees, or underground. The frog’s statistics can also be used to represent a toad.",
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
@@ -16880,6 +16897,7 @@
   {
     "index": "giant-eagle",
     "name": "Giant Eagle",
+    "desc": "A giant eagle is a noble creature that speaks its own language and understands speech in the Common tongue. A mated pair of giant eagles typically has up to four eggs or young in their nest (treat the young as normal eagles).",
     "size": "Large",
     "type": "beast",
     "alignment": "neutral good",
@@ -16980,6 +16998,7 @@
   {
     "index": "giant-elk",
     "name": "Giant Elk",
+    "desc": "The majestic giant elk is rare to the point that its appearance is often taken as a foreshadowing of an important event, such as the birth of a king. Legends tell of gods that take the form of giant elk when visiting the Material Plane. Many cultures therefore believe that to hunt these creatures is to invite divine wrath.",
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
@@ -17058,6 +17077,7 @@
   {
     "index": "giant-fire-beetle",
     "name": "Giant Fire Beetle",
+    "desc": "A giant fire beetle is a nocturnal creature that takes its name from a pair of glowing glands that give off light. Miners and adventurers prize these creatures, for a giant fire beetle’s glands continue to shed light for 1d6 days after the beetle dies. Giant fire beetles are most commonly found underground and in dark forests.",
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
@@ -17315,6 +17335,7 @@
   {
     "index": "giant-lizard",
     "name": "Giant Lizard",
+    "desc": "A giant lizard can be ridden or used as a draft animal. Lizardfolk also keep them as pets, and subterranean giant lizards are used as mounts and pack animals by drow, duergar, and others.",
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
@@ -17793,6 +17814,7 @@
   {
     "index": "giant-sea-horse",
     "name": "Giant Sea Horse",
+    "desc": "Like their smaller kin, giant sea horses are shy, colorful fish with elongated bodies and curled tails. Aquatic elves train them as mounts.",
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
@@ -17852,6 +17874,7 @@
   {
     "index": "giant-shark",
     "name": "Giant Shark",
+    "desc": "A giant shark is 30 feet long and normally found in deep oceans. Utterly fearless, it preys on anything that crosses its path, including whales and ships.",
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
@@ -17920,6 +17943,7 @@
   {
     "index": "giant-spider",
     "name": "Giant Spider",
+    "desc": "To snare its prey, a giant spider spins elaborate webs or shoots sticky strands of webbing from its abdomen. Giant spiders are most commonly found underground, making their lairs on ceilings or in dark, web-filled crevices. Such lairs are often festooned with web cocoons holding past victims.",
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
@@ -18076,6 +18100,7 @@
   {
     "index": "giant-vulture",
     "name": "Giant Vulture",
+    "desc": "A giant vulture has advanced intelligence and a malevolent bent. Unlike its smaller kin, it will attack a wounded creature to hasten its end. Giant vultures have been known to haunt a thirsty, starving creature for days to enjoy its suffering.",
     "size": "Large",
     "type": "beast",
     "alignment": "neutral evil",
@@ -18302,6 +18327,7 @@
   {
     "index": "giant-wolf-spider",
     "name": "Giant Wolf Spider",
+    "desc": "Smaller than a giant spider, a giant wolf spider hunts prey across open ground or hides in a burrow or crevice, or in a hidden cavity beneath debris.",
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
@@ -18712,6 +18738,7 @@
   {
     "index": "gladiator",
     "name": "Gladiator",
+    "desc": "Gladiators battle for the entertainment of raucous crowds. Some gladiators are brutal pit fighters who treat each match as a life-or-death struggle, while others are professional duelists who command huge fees but rarely fight to the death.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -20097,6 +20124,7 @@
   {
     "index": "guard",
     "name": "Guard",
+    "desc": "Guards include members of a city watch, sentries in a citadel or fortified town, and the bodyguards of merchants and nobles.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -21684,6 +21712,7 @@
   {
     "index": "hunter-shark",
     "name": "Hunter Shark",
+    "desc": "Smaller than a giant shark but larger and fiercer than a reef shark, a hunter shark haunts deep waters. It usually hunts alone, but multiple hunter sharks might feed in the same area. A fully grown hunter shark is 15 to 20 feet long.",
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
@@ -22806,6 +22835,7 @@
   {
     "index": "knight",
     "name": "Knight",
+    "desc": "Knights are warriors who pledge service to rulers, religious orders, and noble causes. A knight’s alignment determines the extent to which a pledge is honored. Whether undertaking a quest or patrolling a realm, a knight often travels with an entourage that includes squires and hirelings who are commoners.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -24246,6 +24276,7 @@
   {
     "index": "mage",
     "name": "Mage",
+    "desc": "Mages spend their lives in the study and practice of magic. Good-aligned mages offer counsel to nobles and others in power, while evil mages dwell in isolated sites to perform unspeakable experiments without interference.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -24664,6 +24695,7 @@
   {
     "index": "mammoth",
     "name": "Mammoth",
+    "desc": "A mammoth is an elephantine creature with thick fur and long tusks. Stockier and fiercer than normal elephants, mammoths inhabit a wide range of climes, from subarctic to subtropical.",
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
@@ -25001,6 +25033,7 @@
   {
     "index": "mastiff",
     "name": "Mastiff",
+    "desc": "Mastiffs are impressive hounds prized by humanoids for their loyalty and keen senses. Mastiffs can be trained as guard dogs, hunting dogs, and war dogs. Halflings and other Small humanoids ride them as mounts.",
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
@@ -26640,6 +26673,7 @@
   {
     "index": "noble",
     "name": "Noble",
+    "desc": "**Nobles** wield great authority and influence as members of the upper class, possessing wealth and connections that can make them as powerful as monarchs and generals. A noble often travels in the company of guards, as well as servants who are commoners.\n\nThe noble’s statistics can also be used to represent **courtiers** who aren’t of noble birth.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -27850,6 +27884,7 @@
   {
     "index": "phase-spider",
     "name": "Phase Spider",
+    "desc": "A phase spider possesses the magical ability to phase in and out of the Ethereal Plane. It seems to appear out of nowhere and quickly vanishes after attacking. Its movement on the Ethereal Plane before coming back to the Material Plane makes it seem like it can teleport.",
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
@@ -28669,6 +28704,7 @@
   {
     "index": "priest",
     "name": "Priest",
+    "desc": "Priests bring the teachings of their gods to the common folk. They are the spiritual leaders of temples and shrines and often hold positions of influence in their communities. Evil priests might work openly under a tyrant, or they might be the leaders of religious sects hidden in the shadows of good society, overseeing depraved rites.\n\nA priest typically has one or more acolytes to help with religious ceremonies and other sacred duties.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -29130,6 +29166,7 @@
   {
     "index": "quipper",
     "name": "Quipper",
+    "desc": "A quipper is a carnivorous fish with sharp teeth. Quippers can adapt to any aquatic environment, including cold subterranean lakes. They frequently gather in swarms; the statistics for a swarm of quippers appear later in this appendix.",
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
@@ -29666,6 +29703,7 @@
   {
     "index": "reef-shark",
     "name": "Reef Shark",
+    "desc": "Smaller than giant sharks and hunter sharks, reef sharks inhabit shallow waters and coral reefs, gathering in small packs to hunt. A full-grown specimen measures 6 to 10 feet long.",
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
@@ -30860,6 +30898,7 @@
   {
     "index": "scout",
     "name": "Scout",
+    "desc": "Scouts are skilled hunters and trackers who offer their services for a fee. Most hunt wild game, but a few work as bounty hunters, serve as guides, or provide military reconnaissance.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -32505,6 +32544,7 @@
   {
     "index": "spy",
     "name": "Spy",
+    "desc": "Rulers, nobles, merchants, guildmasters, and other wealthy individuals use spies to gain the upper hand in a world of cutthroat politics. A spy is trained to secretly gather information. Loyal spies would rather die than divulge information that could compromise them or their employers.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -34737,6 +34777,7 @@
   {
     "index": "thug",
     "name": "Thug",
+    "desc": "Thugs are ruthless enforcers skilled at intimidation and violence. They work for money and have few scruples.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -35029,6 +35070,7 @@
   {
     "index": "tribal-warrior",
     "name": "Tribal Warrior",
+    "desc": "Tribal warriors live beyond civilization, most often subsisting on fishing and hunting. Each tribe acts in accordance with the wishes of its chief, who is the greatest or oldest warrior of the tribe or a tribe member blessed by the gods.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -36248,6 +36290,7 @@
   {
     "index": "veteran",
     "name": "Veteran",
+    "desc": "Veterans are professional fighters that take up arms for pay or to protect something they believe in or value. Their ranks include soldiers retired from long service and warriors who never served anyone but themselves.",
     "size": "Medium",
     "type": "humanoid",
     "subtype": "any race",
@@ -39289,6 +39332,7 @@
   {
     "index": "winter-wolf",
     "name": "Winter Wolf",
+    "desc": "The arctic-dwelling winter wolf is as large as a dire wolf but has snow-white fur and pale blue eyes. Frost giants use these evil creatures as guards and hunting companions, putting the wolves’ deadly breath weapon to use against their foes. Winter wolves communicate with one another using growls and barks, but they speak Common and Giant well enough to follow simple conversations.",
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral evil",
@@ -39471,6 +39515,7 @@
   {
     "index": "worg",
     "name": "Worg",
+    "desc": "A worg is an evil predator that delights in hunting and devouring creatures weaker than itself. Cunning and malevolent, worgs roam across the remote wilderness or are raised by goblins and hobgoblins. Those creatures use worgs as mounts, but a worg will turn on its rider if it feels mistreated or malnourished. Worgs speak in their own language and Goblin, and a few learn to speak Common as well.",
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral evil",


### PR DESCRIPTION
## What does this do?

Adds monster flavor text, where available (mostly NPCs and some miscellaneous creatures).

I dropped some bolding, since it just feels odd and seems specific to SRD style for whatever reason, other books don't treat flavor text like that. Only kept in some places where flavor text makes a distinction that stat block can represent some other kind of monster (e.g. bandit captain / pirate captain).

Pondered if `desc` should go last in properties, as it appears in book, but that feels detrimental to readability and discovery.

Feel free to adjust, if necessary. :)

## Is there a Github issue this is resolving?

Fixes https://github.com/5e-bits/5e-database/issues/485