### PR TITLE
fix(saving throw): Add saving throw proficiencies to class proficiencies

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -66,6 +66,16 @@
         "index": "martial-weapons",
         "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
+      },
+      {
+        "index": "saving-throw-str",
+        "name": "Saving Throw: STR",
+        "url": "/api/proficiencies/saving-throw-str"
+      },
+      {
+        "index": "saving-throw-con",
+        "name": "Saving Throw: CON",
+        "url": "/api/proficiencies/saving-throw-con"
       }
     ],
     "saving_throws": [
@@ -381,6 +391,16 @@
         "index": "hand-crossbows",
         "name": "Hand crossbows",
         "url": "/api/proficiencies/hand-crossbows"
+      },
+      {
+        "index": "saving-throw-dex",
+        "name": "Saving Throw: DEX",
+        "url": "/api/proficiencies/saving-throw-dex"
+      },
+      {
+        "index": "saving-throw-cha",
+        "name": "Saving Throw: CHA",
+        "url": "/api/proficiencies/saving-throw-cha"
       }
     ],
     "saving_throws": [
@@ -792,6 +812,16 @@
         "index": "simple-weapons",
         "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
+      },
+      {
+        "index": "saving-throw-wis",
+        "name": "Saving Throw: WIS",
+        "url": "/api/proficiencies/saving-throw-wis"
+      },
+      {
+        "index": "saving-throw-cha",
+        "name": "Saving Throw: CHA",
+        "url": "/api/proficiencies/saving-throw-cha"
       }
     ],
     "saving_throws": [
@@ -1167,6 +1197,16 @@
         "index": "herbalism-kit",
         "name": "Herbalism Kit",
         "url": "/api/proficiencies/herbalism-kit"
+      },
+      {
+        "index": "saving-throw-int",
+        "name": "Saving Throw: INT",
+        "url": "/api/proficiencies/saving-throw-int"
+      },
+      {
+        "index": "saving-throw-wis",
+        "name": "Saving Throw: WIS",
+        "url": "/api/proficiencies/saving-throw-wis"
       }
     ],
     "saving_throws": [
@@ -1423,6 +1463,16 @@
         "index": "martial-weapons",
         "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
+      },
+      {
+        "index": "saving-throw-str",
+        "name": "Saving Throw: STR",
+        "url": "/api/proficiencies/saving-throw-str"
+      },
+      {
+        "index": "saving-throw-con",
+        "name": "Saving Throw: CON",
+        "url": "/api/proficiencies/saving-throw-con"
       }
     ],
     "saving_throws": [
@@ -1846,6 +1896,16 @@
         "index": "shortswords",
         "name": "Shortswords",
         "url": "/api/proficiencies/shortswords"
+      },
+      {
+        "index": "saving-throw-dex",
+        "name": "Saving Throw: DEX",
+        "url": "/api/proficiencies/saving-throw-dex"
+      },
+      {
+        "index": "saving-throw-str",
+        "name": "Saving Throw: STR",
+        "url": "/api/proficiencies/saving-throw-str"
       }
     ],
     "saving_throws": [
@@ -2025,6 +2085,16 @@
         "index": "martial-weapons",
         "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
+      },
+      {
+        "index": "saving-throw-wis",
+        "name": "Saving Throw: WIS",
+        "url": "/api/proficiencies/saving-throw-wis"
+      },
+      {
+        "index": "saving-throw-cha",
+        "name": "Saving Throw: CHA",
+        "url": "/api/proficiencies/saving-throw-cha"
       }
     ],
     "saving_throws": [
@@ -2321,6 +2391,16 @@
         "index": "martial-weapons",
         "name": "Martial Weapons",
         "url": "/api/proficiencies/martial-weapons"
+      },
+      {
+        "index": "saving-throw-dex",
+        "name": "Saving Throw: DEX",
+        "url": "/api/proficiencies/saving-throw-dex"
+      },
+      {
+        "index": "saving-throw-str",
+        "name": "Saving Throw: STR",
+        "url": "/api/proficiencies/saving-throw-str"
       }
     ],
     "saving_throws": [
@@ -2667,6 +2747,16 @@
         "index": "thieves-tools",
         "name": "Thieves' Tools",
         "url": "/api/proficiencies/thieves-tools"
+      },
+      {
+        "index": "saving-throw-dex",
+        "name": "Saving Throw: DEX",
+        "url": "/api/proficiencies/saving-throw-dex"
+      },
+      {
+        "index": "saving-throw-int",
+        "name": "Saving Throw: INT",
+        "url": "/api/proficiencies/saving-throw-int"
       }
     ],
     "saving_throws": [
@@ -2952,6 +3042,21 @@
         "index": "slings",
         "name": "Slings",
         "url": "/api/proficiencies/slings"
+      },
+      {
+        "index": "crossbows-light",
+        "name": "Crossbows, light",
+        "url": "/api/proficiencies/crossbows-light"
+      },
+      {
+        "index": "saving-throw-con",
+        "name": "Saving Throw: CON",
+        "url": "/api/proficiencies/saving-throw-con"
+      },
+      {
+        "index": "saving-throw-cha",
+        "name": "Saving Throw: CHA",
+        "url": "/api/proficiencies/saving-throw-cha"
       }
     ],
     "saving_throws": [
@@ -3190,6 +3295,16 @@
         "index": "simple-weapons",
         "name": "Simple Weapons",
         "url": "/api/proficiencies/simple-weapons"
+      },
+      {
+        "index": "saving-throw-wis",
+        "name": "Saving Throw: WIS",
+        "url": "/api/proficiencies/saving-throw-wis"
+      },
+      {
+        "index": "saving-throw-cha",
+        "name": "Saving Throw: CHA",
+        "url": "/api/proficiencies/saving-throw-cha"
       }
     ],
     "saving_throws": [
@@ -3464,6 +3579,21 @@
         "index": "slings",
         "name": "Slings",
         "url": "/api/proficiencies/slings"
+      },
+      {
+        "index": "crossbows-light",
+        "name": "Crossbows, light",
+        "url": "/api/proficiencies/crossbows-light"
+      },
+      {
+        "index": "saving-throw-int",
+        "name": "Saving Throw: INT",
+        "url": "/api/proficiencies/saving-throw-int"
+      },
+      {
+        "index": "saving-throw-wis",
+        "name": "Saving Throw: WIS",
+        "url": "/api/proficiencies/saving-throw-wis"
       }
     ],
     "saving_throws": [

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -620,7 +620,18 @@
     "index": "crossbows-light",
     "type": "Weapons",
     "name": "Crossbows, light",
-    "classes": [],
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Sorcerer",
+        "url": "/api/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Wizard",
+        "url": "/api/classes/wizard"
+      }
+    ],
     "races": [],
     "url": "/api/proficiencies/crossbows-light",
     "reference": {


### PR DESCRIPTION
## What does this do?

Adds saving throws to class proficiencies, as well as adding light crossbow proficiency to wizard and sorcerer.

## How was it tested?

I built the API with the database changes and queried the API.

## Is there a Github issue this is resolving?

n/a

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
