### PR TITLE
feat: Add size and shape to dragonborn's breath weapon

### DIFF
--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -759,6 +759,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "5 by 30 ft. line",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -819,6 +820,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "5 by 30 ft. line",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -879,6 +881,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "5 by 30 ft. line",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -939,6 +942,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "5 by 30 ft. line",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -999,6 +1003,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "5 by 30 ft. line",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1059,6 +1064,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "15 ft. cone",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1119,6 +1125,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "15 ft. cone",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1179,6 +1186,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "15 ft. cone",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1239,6 +1247,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "15 ft. cone",
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1299,6 +1308,7 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
+        "size_and_shape": "15 ft. cone",
         "usage": {
           "type": "per rest",
           "times": 1

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -759,7 +759,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "5 by 30 ft. line",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -820,7 +823,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "5 by 30 ft. line",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -881,7 +887,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "5 by 30 ft. line",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -942,7 +951,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "5 by 30 ft. line",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1003,7 +1015,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "5 by 30 ft. line",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1064,7 +1079,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "15 ft. cone",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1125,7 +1143,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "15 ft. cone",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1186,7 +1207,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "15 ft. cone",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1247,7 +1271,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "15 ft. cone",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
         "usage": {
           "type": "per rest",
           "times": 1
@@ -1308,7 +1335,10 @@
       "breath_weapon": {
         "name": "Breath Weapon",
         "desc": "You can use your action to exhale destructive energy. Your draconic ancestry determines the size, shape, and damage type of the exhalation. When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic ancestry. The DC for this saving throw equals 8 + your Constitution modifier + your proficiency bonus. A creature takes 2d6 damage on a failed save, and half as much damage on a successful one. The damage increases to 3d6 at 6th level, 4d6 at 11th level, and 5d6 at 16th level. After you use your breath weapon, you can't use it again until you complete a short or long rest.",
-        "size_and_shape": "15 ft. cone",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
         "usage": {
           "type": "per rest",
           "times": 1


### PR DESCRIPTION
## What does this do?

Adds size and shape of dragonborn's breath weapon since the API didn't have that information already

## How was it tested?

I ran `db:refresh` and looked at the data with mongo db compass.

## Is there a Github issue this is resolving?

n/a

## Did you update the docs in the API? Please link an associated PR if applicable.

[Yes](https://github.com/5e-bits/5e-srd-api/pull/322).

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
