### PR TITLE
feat: Redo Warlock Eldritch Invocations

### DIFF
--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6937,7 +6937,7 @@
     "url": "/api/features/pact-magic"
   },
   {
-    "index": "eldritch-invocations-1",
+    "index": "eldritch-invocations",
     "class": {
       "index": "warlock",
       "name": "Warlock",
@@ -6953,7 +6953,7 @@
     ],
     "feature_specific": {
       "subfeature_options": {
-        "choose": 2,
+        "choose": "invocations known",
         "type": "feature",
         "from": {
           "option_set_type": "options_array",
@@ -7085,12 +7085,140 @@
                 "name": "Eldritch Invocation: Voice of the Chain Master",
                 "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
               }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-mire-the-mind",
+                "name": "Eldritch Invocation: Mire the Mind",
+                "url": "/api/features/eldritch-invocation-mire-the-mind"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-one-with-shadows",
+                "name": "Eldritch Invocation: One with Shadows",
+                "url": "/api/features/eldritch-invocation-one-with-shadows"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-sign-of-ill-omen",
+                "name": "Eldritch Invocation: Sign of Ill Omen",
+                "url": "/api/features/eldritch-invocation-sign-of-ill-omen"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-thirsting-blade",
+                "name": "Eldritch Invocation: Thirsting Blade",
+                "url": "/api/features/eldritch-invocation-thirsting-blade"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-bewitching-whispers",
+                "name": "Eldritch Invocation: Bewitching Whispers",
+                "url": "/api/features/eldritch-invocation-bewitching-whispers"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-dreadful-word",
+                "name": "Eldritch Invocation: Dreadful Word",
+                "url": "/api/features/eldritch-invocation-dreadful-word"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-sculptor-of-flesh",
+                "name": "Eldritch Invocation: Sculptor of Flesh",
+                "url": "/api/features/eldritch-invocation-sculptor-of-flesh"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-ascendant-step",
+                "name": "Eldritch Invocation: Ascendant Step",
+                "url": "/api/features/eldritch-invocation-ascendant-step"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-minions-of-chaos",
+                "name": "Eldritch Invocation: Minions of Chaos",
+                "url": "/api/features/eldritch-invocation-minions-of-chaos"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-otherworldly-leap",
+                "name": "Eldritch Invocation: Otherworldly Leap",
+                "url": "/api/features/eldritch-invocation-otherworldly-leap"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-whispers-of-the-grave",
+                "name": "Eldritch Invocation: Whispers of the Grave",
+                "url": "/api/features/eldritch-invocation-whispers-of-the-grave"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-lifedrinker",
+                "name": "Eldritch Invocation: Lifedrinker",
+                "url": "/api/features/eldritch-invocation-lifedrinker"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-chains-of-carceri",
+                "name": "Eldritch Invocation: Chains of Carceri",
+                "url": "/api/features/eldritch-invocation-chains-of-carceri"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-master-of-myriad-forms",
+                "name": "Eldritch Invocation: Master of Myriad Forms",
+                "url": "/api/features/eldritch-invocation-master-of-myriad-forms"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-visions-of-distant-realms",
+                "name": "Eldritch Invocation: Visions of Distant Realms",
+                "url": "/api/features/eldritch-invocation-visions-of-distant-realms"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "eldritch-invocation-witch-sight",
+                "name": "Eldritch Invocation: Witch Sight",
+                "url": "/api/features/eldritch-invocation-witch-sight"
+              }
             }
           ]
         }
       }
     },
-    "url": "/api/features/eldritch-invocations-1"
+    "url": "/api/features/eldritch-invocations"
   },
   {
     "index": "eldritch-invocation-agonizing-blast",
@@ -7111,9 +7239,9 @@
       "When you cast eldritch blast, add your Charisma modifier to the damage it deals on a hit."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-agonizing-blast"
   },
@@ -7131,9 +7259,9 @@
       "You can cast mage armor on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-armor-of-shadows"
   },
@@ -7151,9 +7279,9 @@
       "You can cast speak with animals at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-beast-speech"
   },
@@ -7169,9 +7297,9 @@
     "prerequisites": [],
     "desc": ["You gain proficiency in the Deception and Persuasion skills."],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-beguiling-influence"
   },
@@ -7195,9 +7323,9 @@
       "On your adventures, you can add other ritual spells to your Book of Shadows. When you find such a spell, you can add it to the book if the spell's level is equal to or less than half your warlock level (rounded up) and if you can spare the time to transcribe the spell. For each level of the spell, the transcription process takes 2 hours and costs 50 gp for the rare inks needed to inscribe it."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
   },
@@ -7215,9 +7343,9 @@
       "You can see normally in darkness, both magical and nonmagical, to a distance of 120 feet."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-devils-sight"
   },
@@ -7235,9 +7363,9 @@
       "You can cast detect magic at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-eldritch-sight"
   },
@@ -7258,9 +7386,9 @@
     ],
     "desc": ["When you cast eldritch blast, its range is 300 feet."],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-eldritch-spear"
   },
@@ -7276,9 +7404,9 @@
     "prerequisites": [],
     "desc": ["You can read all writing."],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
   },
@@ -7296,9 +7424,9 @@
       "You can cast false life on yourself at will as a 1st-level spell, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-fiendish-vigor"
   },
@@ -7316,9 +7444,9 @@
       "You can use your action to touch a willing humanoid and perceive through its senses until the end of your next turn. As long as the creature is on the same plane of existence as you, you can use your action on subsequent turns to maintain this connection, extending the duration until the end of your next turn. While perceiving through the other creature's senses, you benefit from any special senses possessed by that creature, and you are blinded and deafened to your own surroundings."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
   },
@@ -7336,9 +7464,9 @@
       "You can cast disguise self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-mask-of-many-faces"
   },
@@ -7356,9 +7484,9 @@
       "You can cast silent image at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-misty-visions"
   },
@@ -7381,9 +7509,9 @@
       "When you hit a creature with eldritch blast, you can push the creature up to 10 feet away from you in a straight line."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-repelling-blast"
   },
@@ -7401,9 +7529,9 @@
       "You can cast bane once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-thief-of-five-fates"
   },
@@ -7427,9 +7555,9 @@
       "Additionally, while perceiving through your familiar's senses, you can also speak through your familiar in your own voice, even if your familiar is normally incapable of speech."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
   },
@@ -7452,9 +7580,9 @@
       "You can cast slow once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-mire-the-mind"
   },
@@ -7477,9 +7605,9 @@
       "When you are in an area of dim light or darkness, you can use your action to become invisible until you move or take an action or a reaction."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-one-with-shadows"
   },
@@ -7502,9 +7630,9 @@
       "You can cast bestow curse once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-sign-of-ill-omen"
   },
@@ -7531,9 +7659,9 @@
       "You can attack with your pact weapon twice, instead of once, whenever you take the Attack action on your turn."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-thirsting-blade"
   },
@@ -7556,9 +7684,9 @@
       "You can cast compulsion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-bewitching-whispers"
   },
@@ -7581,9 +7709,9 @@
       "You can cast confusion once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-dreadful-word"
   },
@@ -7606,9 +7734,9 @@
       "You can cast polymorph once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-sculptor-of-flesh"
   },
@@ -7631,9 +7759,9 @@
       "You can cast levitate on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-ascendant-step"
   },
@@ -7656,9 +7784,9 @@
       "You can cast conjure elemental once using a warlock spell slot. You can't do so again until you finish a long rest."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-minions-of-chaos"
   },
@@ -7681,9 +7809,9 @@
       "You can cast jump on yourself at will, without expending a spell slot or material components."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-otherworldly-leap"
   },
@@ -7706,9 +7834,9 @@
       "You can cast speak with dead at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-whispers-of-the-grave"
   },
@@ -7735,9 +7863,9 @@
       "When you hit a creature with your pact weapon, the creature takes extra necrotic damage equal to your Charisma modifier (minimum 1)."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-lifedrinker"
   },
@@ -7764,9 +7892,9 @@
       "You can cast hold monster at will--targeting a celestial, fiend, or elemental--without expending a spell slot or material components. You must finish a long rest before you can use this invocation on the same creature again."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-chains-of-carceri"
   },
@@ -7789,9 +7917,9 @@
       "You can cast alter self at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-master-of-myriad-forms"
   },
@@ -7814,9 +7942,9 @@
       "You can cast arcane eye at will, without expending a spell slot."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-visions-of-distant-realms"
   },
@@ -7839,9 +7967,9 @@
       "You can see the true form of any shapechanger or creature concealed by illusion or transmutation magic while the creature is within 30 feet of you and within line of sight."
     ],
     "parent": {
-      "index": "eldritch-invocations-1",
+      "index": "eldritch-invocations",
       "name": "Eldritch Invocations",
-      "url": "/api/features/eldritch-invocations-1"
+      "url": "/api/features/eldritch-invocations"
     },
     "url": "/api/features/eldritch-invocation-witch-sight"
   },
@@ -7979,162 +8107,6 @@
     "url": "/api/features/warlock-ability-score-improvement-1"
   },
   {
-    "index": "eldritch-invocations-2",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 5,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-2"
-  },
-  {
     "index": "dark-ones-own-luck",
     "class": {
       "index": "warlock",
@@ -8156,162 +8128,6 @@
     "url": "/api/features/dark-ones-own-luck"
   },
   {
-    "index": "eldritch-invocations-3",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 7,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-3"
-  },
-  {
     "index": "warlock-ability-score-improvement-2",
     "class": {
       "index": "warlock",
@@ -8325,162 +8141,6 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/features/warlock-ability-score-improvement-2"
-  },
-  {
-    "index": "eldritch-invocations-4",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 9,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-4"
   },
   {
     "index": "fiendish-resilience",
@@ -8533,162 +8193,6 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/features/warlock-ability-score-improvement-3"
-  },
-  {
-    "index": "eldritch-invocations-5",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 12,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-5"
   },
   {
     "index": "mystic-arcanum-7th-level",
@@ -8747,162 +8251,6 @@
     "url": "/api/features/mystic-arcanum-8th-level"
   },
   {
-    "index": "eldritch-invocations-6",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 15,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-6"
-  },
-  {
     "index": "warlock-ability-score-improvement-4",
     "class": {
       "index": "warlock",
@@ -8935,162 +8283,6 @@
     "url": "/api/features/mystic-arcanum-9th-level"
   },
   {
-    "index": "eldritch-invocations-7",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 18,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-7"
-  },
-  {
     "index": "warlock-ability-score-improvement-5",
     "class": {
       "index": "warlock",
@@ -9120,162 +8312,6 @@
       "Once you regain spell slots with this feature, you must finish a long rest before you can do so again."
     ],
     "url": "/api/features/eldritch-master"
-  },
-  {
-    "index": "eldritch-invocations-8",
-    "class": {
-      "index": "warlock",
-      "name": "Warlock",
-      "url": "/api/classes/warlock"
-    },
-    "name": "Eldritch Invocations",
-    "level": 20,
-    "prerequisites": [],
-    "desc": [
-      "In your study of occult lore, you have unearthed eldritch invocations, fragments of forbidden knowledge that imbue you with an abiding magical ability.",
-      "At 2nd level, you gain two eldritch invocations of your choice. Your invocation options are detailed at the end of the class description. When you gain certain warlock levels, you gain additional invocations of your choice, as shown in the Invocations Known column of the Warlock table.",
-      "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
-    ],
-    "feature_specific": {
-      "subfeature_options": {
-        "choose": 1,
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "url": "/api/features/eldritch-invocations-8"
   },
   {
     "index": "spellcasting-wizard",

--- a/src/5e-SRD-Features.json
+++ b/src/5e-SRD-Features.json
@@ -6952,271 +6952,168 @@
       "Additionally, when you gain a level in this class, you can choose one of the invocations you know and replace it with another invocation that you could learn at that level."
     ],
     "feature_specific": {
-      "subfeature_options": {
-        "choose": "invocations known",
-        "type": "feature",
-        "from": {
-          "option_set_type": "options_array",
-          "options": [
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-agonizing-blast",
-                "name": "Eldritch Invocation: Agonizing Blast",
-                "url": "/api/features/eldritch-invocation-agonizing-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-armor-of-shadows",
-                "name": "Eldritch Invocation: Armor of Shadows",
-                "url": "/api/features/eldritch-invocation-armor-of-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beast-speech",
-                "name": "Eldritch Invocation: Beast Speech",
-                "url": "/api/features/eldritch-invocation-beast-speech"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-beguiling-influence",
-                "name": "Eldritch Invocation: Beguiling Influence",
-                "url": "/api/features/eldritch-invocation-beguiling-influence"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-book-of-ancient-secrets",
-                "name": "Eldritch Invocation: Book of Ancient Secrets",
-                "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-devils-sight",
-                "name": "Eldritch Invocation: Devil's Sight",
-                "url": "/api/features/eldritch-invocation-devils-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-sight",
-                "name": "Eldritch Invocation: Eldritch Sight",
-                "url": "/api/features/eldritch-invocation-eldritch-sight"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eldritch-spear",
-                "name": "Eldritch Invocation: Eldritch Spear",
-                "url": "/api/features/eldritch-invocation-eldritch-spear"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-eyes-of-the-rune-keeper",
-                "name": "Eldritch Invocation: Eyes of the Rune Keeper",
-                "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-fiendish-vigor",
-                "name": "Eldritch Invocation: Fiendish Vigor",
-                "url": "/api/features/eldritch-invocation-fiendish-vigor"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-gaze-of-two-minds",
-                "name": "Eldritch Invocation: Gaze of Two Minds",
-                "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mask-of-many-faces",
-                "name": "Eldritch Invocation: Mask of Many Faces",
-                "url": "/api/features/eldritch-invocation-mask-of-many-faces"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-misty-visions",
-                "name": "Eldritch Invocation: Misty Visions",
-                "url": "/api/features/eldritch-invocation-misty-visions"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-repelling-blast",
-                "name": "Eldritch Invocation: Repelling Blast",
-                "url": "/api/features/eldritch-invocation-repelling-blast"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thief-of-five-fates",
-                "name": "Eldritch Invocation: Thief of Five Fates",
-                "url": "/api/features/eldritch-invocation-thief-of-five-fates"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-voice-of-the-chain-master",
-                "name": "Eldritch Invocation: Voice of the Chain Master",
-                "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-mire-the-mind",
-                "name": "Eldritch Invocation: Mire the Mind",
-                "url": "/api/features/eldritch-invocation-mire-the-mind"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-one-with-shadows",
-                "name": "Eldritch Invocation: One with Shadows",
-                "url": "/api/features/eldritch-invocation-one-with-shadows"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-sign-of-ill-omen",
-                "name": "Eldritch Invocation: Sign of Ill Omen",
-                "url": "/api/features/eldritch-invocation-sign-of-ill-omen"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-thirsting-blade",
-                "name": "Eldritch Invocation: Thirsting Blade",
-                "url": "/api/features/eldritch-invocation-thirsting-blade"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-bewitching-whispers",
-                "name": "Eldritch Invocation: Bewitching Whispers",
-                "url": "/api/features/eldritch-invocation-bewitching-whispers"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-dreadful-word",
-                "name": "Eldritch Invocation: Dreadful Word",
-                "url": "/api/features/eldritch-invocation-dreadful-word"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-sculptor-of-flesh",
-                "name": "Eldritch Invocation: Sculptor of Flesh",
-                "url": "/api/features/eldritch-invocation-sculptor-of-flesh"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-ascendant-step",
-                "name": "Eldritch Invocation: Ascendant Step",
-                "url": "/api/features/eldritch-invocation-ascendant-step"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-minions-of-chaos",
-                "name": "Eldritch Invocation: Minions of Chaos",
-                "url": "/api/features/eldritch-invocation-minions-of-chaos"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-otherworldly-leap",
-                "name": "Eldritch Invocation: Otherworldly Leap",
-                "url": "/api/features/eldritch-invocation-otherworldly-leap"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-whispers-of-the-grave",
-                "name": "Eldritch Invocation: Whispers of the Grave",
-                "url": "/api/features/eldritch-invocation-whispers-of-the-grave"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-lifedrinker",
-                "name": "Eldritch Invocation: Lifedrinker",
-                "url": "/api/features/eldritch-invocation-lifedrinker"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-chains-of-carceri",
-                "name": "Eldritch Invocation: Chains of Carceri",
-                "url": "/api/features/eldritch-invocation-chains-of-carceri"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-master-of-myriad-forms",
-                "name": "Eldritch Invocation: Master of Myriad Forms",
-                "url": "/api/features/eldritch-invocation-master-of-myriad-forms"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-visions-of-distant-realms",
-                "name": "Eldritch Invocation: Visions of Distant Realms",
-                "url": "/api/features/eldritch-invocation-visions-of-distant-realms"
-              }
-            },
-            {
-              "option_type": "reference",
-              "item": {
-                "index": "eldritch-invocation-witch-sight",
-                "name": "Eldritch Invocation: Witch Sight",
-                "url": "/api/features/eldritch-invocation-witch-sight"
-              }
-            }
-          ]
+      "invocations": [
+        {
+          "index": "eldritch-invocation-agonizing-blast",
+          "name": "Eldritch Invocation: Agonizing Blast",
+          "url": "/api/features/eldritch-invocation-agonizing-blast"
+        },
+        {
+          "index": "eldritch-invocation-armor-of-shadows",
+          "name": "Eldritch Invocation: Armor of Shadows",
+          "url": "/api/features/eldritch-invocation-armor-of-shadows"
+        },
+        {
+          "index": "eldritch-invocation-beast-speech",
+          "name": "Eldritch Invocation: Beast Speech",
+          "url": "/api/features/eldritch-invocation-beast-speech"
+        },
+        {
+          "index": "eldritch-invocation-beguiling-influence",
+          "name": "Eldritch Invocation: Beguiling Influence",
+          "url": "/api/features/eldritch-invocation-beguiling-influence"
+        },
+        {
+          "index": "eldritch-invocation-book-of-ancient-secrets",
+          "name": "Eldritch Invocation: Book of Ancient Secrets",
+          "url": "/api/features/eldritch-invocation-book-of-ancient-secrets"
+        },
+        {
+          "index": "eldritch-invocation-devils-sight",
+          "name": "Eldritch Invocation: Devil's Sight",
+          "url": "/api/features/eldritch-invocation-devils-sight"
+        },
+        {
+          "index": "eldritch-invocation-eldritch-sight",
+          "name": "Eldritch Invocation: Eldritch Sight",
+          "url": "/api/features/eldritch-invocation-eldritch-sight"
+        },
+        {
+          "index": "eldritch-invocation-eldritch-spear",
+          "name": "Eldritch Invocation: Eldritch Spear",
+          "url": "/api/features/eldritch-invocation-eldritch-spear"
+        },
+        {
+          "index": "eldritch-invocation-eyes-of-the-rune-keeper",
+          "name": "Eldritch Invocation: Eyes of the Rune Keeper",
+          "url": "/api/features/eldritch-invocation-eyes-of-the-rune-keeper"
+        },
+        {
+          "index": "eldritch-invocation-fiendish-vigor",
+          "name": "Eldritch Invocation: Fiendish Vigor",
+          "url": "/api/features/eldritch-invocation-fiendish-vigor"
+        },
+        {
+          "index": "eldritch-invocation-gaze-of-two-minds",
+          "name": "Eldritch Invocation: Gaze of Two Minds",
+          "url": "/api/features/eldritch-invocation-gaze-of-two-minds"
+        },
+        {
+          "index": "eldritch-invocation-mask-of-many-faces",
+          "name": "Eldritch Invocation: Mask of Many Faces",
+          "url": "/api/features/eldritch-invocation-mask-of-many-faces"
+        },
+        {
+          "index": "eldritch-invocation-misty-visions",
+          "name": "Eldritch Invocation: Misty Visions",
+          "url": "/api/features/eldritch-invocation-misty-visions"
+        },
+        {
+          "index": "eldritch-invocation-repelling-blast",
+          "name": "Eldritch Invocation: Repelling Blast",
+          "url": "/api/features/eldritch-invocation-repelling-blast"
+        },
+        {
+          "index": "eldritch-invocation-thief-of-five-fates",
+          "name": "Eldritch Invocation: Thief of Five Fates",
+          "url": "/api/features/eldritch-invocation-thief-of-five-fates"
+        },
+        {
+          "index": "eldritch-invocation-voice-of-the-chain-master",
+          "name": "Eldritch Invocation: Voice of the Chain Master",
+          "url": "/api/features/eldritch-invocation-voice-of-the-chain-master"
+        },
+        {
+          "index": "eldritch-invocation-mire-the-mind",
+          "name": "Eldritch Invocation: Mire the Mind",
+          "url": "/api/features/eldritch-invocation-mire-the-mind"
+        },
+        {
+          "index": "eldritch-invocation-one-with-shadows",
+          "name": "Eldritch Invocation: One with Shadows",
+          "url": "/api/features/eldritch-invocation-one-with-shadows"
+        },
+        {
+          "index": "eldritch-invocation-sign-of-ill-omen",
+          "name": "Eldritch Invocation: Sign of Ill Omen",
+          "url": "/api/features/eldritch-invocation-sign-of-ill-omen"
+        },
+        {
+          "index": "eldritch-invocation-thirsting-blade",
+          "name": "Eldritch Invocation: Thirsting Blade",
+          "url": "/api/features/eldritch-invocation-thirsting-blade"
+        },
+        {
+          "index": "eldritch-invocation-bewitching-whispers",
+          "name": "Eldritch Invocation: Bewitching Whispers",
+          "url": "/api/features/eldritch-invocation-bewitching-whispers"
+        },
+        {
+          "index": "eldritch-invocation-dreadful-word",
+          "name": "Eldritch Invocation: Dreadful Word",
+          "url": "/api/features/eldritch-invocation-dreadful-word"
+        },
+        {
+          "index": "eldritch-invocation-sculptor-of-flesh",
+          "name": "Eldritch Invocation: Sculptor of Flesh",
+          "url": "/api/features/eldritch-invocation-sculptor-of-flesh"
+        },
+        {
+          "index": "eldritch-invocation-ascendant-step",
+          "name": "Eldritch Invocation: Ascendant Step",
+          "url": "/api/features/eldritch-invocation-ascendant-step"
+        },
+        {
+          "index": "eldritch-invocation-minions-of-chaos",
+          "name": "Eldritch Invocation: Minions of Chaos",
+          "url": "/api/features/eldritch-invocation-minions-of-chaos"
+        },
+        {
+          "index": "eldritch-invocation-otherworldly-leap",
+          "name": "Eldritch Invocation: Otherworldly Leap",
+          "url": "/api/features/eldritch-invocation-otherworldly-leap"
+        },
+        {
+          "index": "eldritch-invocation-whispers-of-the-grave",
+          "name": "Eldritch Invocation: Whispers of the Grave",
+          "url": "/api/features/eldritch-invocation-whispers-of-the-grave"
+        },
+        {
+          "index": "eldritch-invocation-lifedrinker",
+          "name": "Eldritch Invocation: Lifedrinker",
+          "url": "/api/features/eldritch-invocation-lifedrinker"
+        },
+        {
+          "index": "eldritch-invocation-chains-of-carceri",
+          "name": "Eldritch Invocation: Chains of Carceri",
+          "url": "/api/features/eldritch-invocation-chains-of-carceri"
+        },
+        {
+          "index": "eldritch-invocation-master-of-myriad-forms",
+          "name": "Eldritch Invocation: Master of Myriad Forms",
+          "url": "/api/features/eldritch-invocation-master-of-myriad-forms"
+        },
+        {
+          "index": "eldritch-invocation-visions-of-distant-realms",
+          "name": "Eldritch Invocation: Visions of Distant Realms",
+          "url": "/api/features/eldritch-invocation-visions-of-distant-realms"
+        },
+        {
+          "index": "eldritch-invocation-witch-sight",
+          "name": "Eldritch Invocation: Witch Sight",
+          "url": "/api/features/eldritch-invocation-witch-sight"
         }
-      }
+      ]
     },
     "url": "/api/features/eldritch-invocations"
   },

--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -6540,9 +6540,9 @@
     "prof_bonus": 2,
     "features": [
       {
-        "index": "eldritch-invocations-1",
+        "index": "eldritch-invocations",
         "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-1"
+        "url": "/api/features/eldritch-invocations"
       }
     ],
     "spellcasting": {
@@ -6655,13 +6655,7 @@
     "level": 5,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [
-      {
-        "index": "eldritch-invocations-2",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-2"
-      }
-    ],
+    "features": [],
     "spellcasting": {
       "cantrips_known": 3,
       "spells_known": 6,
@@ -6727,13 +6721,7 @@
     "level": 7,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [
-      {
-        "index": "eldritch-invocations-3",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-3"
-      }
-    ],
+    "features": [],
     "spellcasting": {
       "cantrips_known": 3,
       "spells_known": 8,
@@ -6805,13 +6793,7 @@
     "level": 9,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [
-      {
-        "index": "eldritch-invocations-4",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-4"
-      }
-    ],
+    "features": [],
     "spellcasting": {
       "cantrips_known": 3,
       "spells_known": 10,
@@ -6917,11 +6899,6 @@
     "ability_score_bonuses": 3,
     "prof_bonus": 4,
     "features": [
-      {
-        "index": "eldritch-invocations-5",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-5"
-      },
       {
         "index": "warlock-ability-score-improvement-3",
         "name": "Ability Score Improvement",
@@ -7033,11 +7010,6 @@
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
     "features": [
-      {
-        "index": "eldritch-invocations-6",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-6"
-      },
       {
         "index": "mystic-arcanum-8th-level",
         "name": "Mystic Arcanum (8th level)",
@@ -7154,13 +7126,7 @@
     "level": 18,
     "ability_score_bonuses": 4,
     "prof_bonus": 6,
-    "features": [
-      {
-        "index": "eldritch-invocations-7",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-7"
-      }
-    ],
+    "features": [],
     "spellcasting": {
       "cantrips_known": 4,
       "spells_known": 14,
@@ -7233,11 +7199,6 @@
     "ability_score_bonuses": 5,
     "prof_bonus": 6,
     "features": [
-      {
-        "index": "eldritch-invocations-8",
-        "name": "Eldritch Invocations",
-        "url": "/api/features/eldritch-invocations-8"
-      },
       {
         "index": "eldritch-master",
         "name": "Eldritch Master",


### PR DESCRIPTION
## What does this do?

Originally in the API, Eldritch Invocations were split out into 8 different features with a choice with `choose` 2 from an incomplete list of invocations. This change puts them all into one feature with `choose` set to a string value for invocations known, since that's what will really be determining how many the warlock can learn. I also made sure the list of invocations was complete per the [SRD](https://media.wizards.com/2016/downloads/DND/SRD-OGL_V5.1.pdf).

## How was it tested?

I ran `db:refresh` and checked that the data was as expected. I also ran the API and queried it to make sure it still works.

## Is there a Github issue this is resolving?

n/a

## Did you update the docs in the API? Please link an associated PR if applicable.

[Yes](https://github.com/5e-bits/5e-srd-api/pull/330)

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
