### PR TITLE
fix: Give oath of devotion correct channel divinity

### DIFF
--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -8469,9 +8469,14 @@
     "level": 3,
     "features": [
       {
-        "index": "channel-divinity",
-        "name": "Channel Divinity",
-        "url": "/api/features/channel-divinity"
+        "index": "channel-divinity-sacred-weapon",
+        "name": "Channel Divinity: Sacred Weapon",
+        "url": "/api/features/channel-divinity-sacred-weapon"
+      },
+      {
+        "index": "channel-divinity-turn-the-unholy",
+        "name": "Channel Divinity: Turn the Unholy",
+        "url": "/api/features/channel-divinity-turn-the-unholy"
       }
     ],
     "class": {


### PR DESCRIPTION
## What does this do?

Adds the expected channel divinities to the levels for oath of devotion paladin.

## How was it tested?

Ran `db:refresh` and checked the data in MongoDB Compass.

## Is there a Github issue this is resolving?

n/a

## Did you update the docs in the API? Please link an associated PR if applicable.

n/a

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
