### PR TITLE
fix(spells): fixed the shatter spell's description

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -12840,7 +12840,7 @@
     "index": "shatter",
     "name": "Shatter",
     "desc": [
-      "A strong resonant sound painfully intense sounds of a desired point in the range of the spell. Each creature has a sphere with a 10-foot-radius sphere centered on that point must make a constitution saving throw or it suffers 3d8 thunder damage. If successful, the damage is halved. A creature made of inorganic materials such as stone, crystal or metal, makes its saving throw with a disadvantage.",
+      "A sudden loud ringing noise, painfully intense, erupts from a point of your choice within range. Each creature in a 10-foot-radius sphere centered on that point must make a Constitution saving throw. A creature takes 3d8 thunder damage on a failed save, or half as much damage on a successful one. A creature made of inorganic material such as stone, crystal, or metal has disadvantage on this saving throw.",
       "A non-magical item that is not worn or carried also suffers damage if it is in the area of the spell."
     ],
     "higher_level": [


### PR DESCRIPTION
## What does this do?

The description of the shatter spell was inaccurate and grammatically incorrect. This commit updates the description to match the SRD source material.

## How was it tested?

1. Made the change locally
2. Executed the db:refresh script
3. Started a local instance of 5e-srd-api
4. Performed GET request on http://localhost:3000/api/spells/shatter
5. Verified that the text was updated and the schema was unchanged.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

Unrelated, this is only a data change.

## Here's a fun image for your troubles

![random photo - updated!](https://imgur.com/v3lKySz)
