### PR TITLE
fix: Lock MongoDB Docker version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # This recipe is pulled from: https://stackoverflow.com/a/33601894
 
 # Parent Dockerfile https://github.com/docker-library/mongo/blob/982328582c74dd2f0a9c8c77b84006f291f974c3/3.0/Dockerfile
-FROM mongo:latest
+FROM mongo:6.0.1
 
 # Modify child mongo to use /data/db2 as dbpath (because /data/db wont persist the build)
 COPY ./docker/mongodb.conf /etc


### PR DESCRIPTION
## What does this do?

This locks down our MongoDB version instead of running the `latest` tag which periodically causes issues. I've also locked it to v6, which seems to allow M1 support, which is important to me as I've started using an M1 at work.

## How was it tested?

I built the image along side the API using `docker-compose` and brought up the API locally.

## Is there a Github issue this is resolving?

This should fix #503 

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/353626/192388089-76cae016-b02b-4ce3-bcc1-3a96f6f85287.png)