### PR TITLE
feat: Add the first image

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -19557,6 +19557,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/goblin.png",
         "url": "/api/monsters/goblin"
     },
     {


### PR DESCRIPTION
## What does this do?

Adds the url for the first image

## How was it tested?

Locally

## Is there a Github issue this is resolving?

No. It was just a silly idea that a few of us in the Discord thought of.

## Did you update the docs in the API? Please link an associated PR if applicable.

https://github.com/5e-bits/5e-srd-api/pull/335

## Here's a fun image for your troubles

![goblin](https://user-images.githubusercontent.com/353626/193754585-2c50984a-e47c-4b24-9a49-647f0a57f6ab.png)
