### PR TITLE
fix: Add some images for monsters

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -14096,6 +14096,7 @@
                 }
             }
         ],
+        "image": "/api/images/monsters/dryad.png",
         "url": "/api/monsters/dryad"
     },
     {
@@ -40201,6 +40202,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/wight.png",
         "url": "/api/monsters/wight"
     },
     {
@@ -40330,6 +40332,7 @@
                 "desc": "The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."
             }
         ],
+        "image": "/api/images/monsters/will-o-wisp.png",
         "url": "/api/monsters/will-o-wisp"
     },
     {
@@ -40441,6 +40444,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/winter-wolf.png",
         "url": "/api/monsters/winter-wolf"
     },
     {
@@ -40517,6 +40521,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/wolf.png",
         "url": "/api/monsters/wolf"
     },
     {
@@ -40583,6 +40588,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/worg.png",
         "url": "/api/monsters/worg"
     },
     {
@@ -40700,6 +40706,7 @@
                 "desc": "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time."
             }
         ],
+        "image": "/api/images/monsters/wraith.png",
         "url": "/api/monsters/wraith"
     },
     {
@@ -40972,6 +40979,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/xorn.png",
         "url": "/api/monsters/xorn"
     },
     {
@@ -42955,6 +42963,7 @@
                 ]
             }
         ],
+        "image": "/api/images/monsters/zombie.png",
         "url": "/api/monsters/zombie"
     }
 ]


### PR DESCRIPTION
## What does this do?

Adds images for these monsters:
* dryad
* wight
* will-o-wisp
* winter-wolf
* wolf
* worg
* wraith
* wyvern
* xorn
* zombie

## How was it tested?

N/A

## Is there a Github issue this is resolving?

Not exactly

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![00080-3465077231-concept art of a wyvern](https://user-images.githubusercontent.com/353626/194421225-83f046c6-4d52-4ac0-886c-f2063717647d.png)
