### PR TITLE
fix: Remove attack type from spells do not have one

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -11057,7 +11057,6 @@
     "concentration": false,
     "casting_time": "1 action",
     "level": 0,
-    "attack_type": "ranged",
     "damage": {
       "damage_type": {
         "index": "poison",
@@ -12384,7 +12383,6 @@
     "concentration": false,
     "casting_time": "1 action",
     "level": 0,
-    "attack_type": "ranged",
     "damage": {
       "damage_type": {
         "index": "radiant",


### PR DESCRIPTION
## What does this do?

Fixes two spells erroneously given an attack type.

## How was it tested?

loaded it as a json in Python, checked Sacred Flame and Poison Spray do not have an "attack_type"
```
>>> [_.get("attack_type") for _ in spells if _.get("name") in ("Sacred Flame", "Poison Spray")]            
[None, None]
```

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles


