### PR TITLE
fix: Add dc to ray of enfeeblement

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -11894,6 +11894,14 @@
     "concentration": true,
     "casting_time": "1 action",
     "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/ability-scores/con"
+      },
+      "dc_success": "none",
+    },
     "attack_type": "ranged",
     "school": {
       "index": "necromancy",

--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -11900,7 +11900,7 @@
         "name": "CON",
         "url": "/api/ability-scores/con"
       },
-      "dc_success": "none",
+      "dc_success": "none"
     },
     "attack_type": "ranged",
     "school": {


### PR DESCRIPTION
## What does this do?

Add a dc to ray of enfeeblement

## How was it tested?

It wasn't

## Is there a Github issue this is resolving?

No, just discord
https://discord.com/channels/656547667601653787/1043550045343072256

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
