### PR TITLE
feat: Add Monster Armor Types

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -596,7 +596,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 225,
     "hit_dice": "18d12",
     "hit_points_roll": "18d12+108",
@@ -844,7 +849,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 172,
     "hit_dice": "15d12",
     "hit_points_roll": "15d12+75",
@@ -1126,7 +1136,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 212,
     "hit_dice": "17d12",
     "hit_points_roll": "17d12+102",
@@ -1404,7 +1419,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 184,
     "hit_dice": "16d12",
     "hit_points_roll": "16d12+80",
@@ -1678,7 +1698,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 256,
     "hit_dice": "19d12",
     "hit_points_roll": "19d12+133",
@@ -1964,7 +1989,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 207,
     "hit_dice": "18d12",
     "hit_points_roll": "18d12+90",
@@ -2246,7 +2276,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 256,
     "hit_dice": "19d12",
     "hit_points_roll": "19d12+133",
@@ -2494,7 +2529,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 243,
     "hit_dice": "18d12",
     "hit_points_roll": "18d12+126",
@@ -2775,7 +2815,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 200,
     "hit_dice": "16d12",
     "hit_points_roll": "16d12+96",
@@ -3028,7 +3073,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 15
+      }
+    ],
     "hit_points": 90,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+24",
@@ -3412,7 +3462,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 481,
     "hit_dice": "26d20",
     "hit_points_roll": "26d20+208",
@@ -3660,7 +3715,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 20,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 20
+      }
+    ],
     "hit_points": 297,
     "hit_dice": "17d20",
     "hit_points_roll": "17d20+119",
@@ -3946,7 +4006,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 444,
     "hit_dice": "24d20",
     "hit_points_roll": "24d20+192",
@@ -4228,7 +4293,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 21,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 21
+      }
+    ],
     "hit_points": 350,
     "hit_dice": "20d20",
     "hit_points_roll": "20d20+140",
@@ -4506,7 +4576,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 546,
     "hit_dice": "28d20",
     "hit_points_roll": "28d20+252",
@@ -4796,7 +4871,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 21,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 21
+      }
+    ],
     "hit_points": 385,
     "hit_dice": "22d20",
     "hit_points_roll": "22d20+154",
@@ -5078,7 +5158,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 546,
     "hit_dice": "28d20",
     "hit_points_roll": "28d20+252",
@@ -5326,7 +5411,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 487,
     "hit_dice": "25d20",
     "hit_points_roll": "25d20+225",
@@ -5611,7 +5701,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 20,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 20
+      }
+    ],
     "hit_points": 333,
     "hit_dice": "18d20",
     "hit_points_roll": "18d20+144",
@@ -8999,7 +9094,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+16",
@@ -9375,7 +9475,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 16,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+3",
@@ -9533,7 +9638,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 32,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+10",
@@ -11396,7 +11506,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+4",
@@ -13229,7 +13344,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "neutral",
-    "armor_class": 20,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 20
+      }
+    ],
     "hit_points": 341,
     "hit_dice": "22d20",
     "hit_points_roll": "22d20+110",
@@ -13536,7 +13656,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 123,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+52",
@@ -13794,7 +13919,17 @@
     "type": "humanoid",
     "subtype": "elf",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": {
+          "index": "chain-shirt",
+          "name": "Chain Shirt",
+          "url": "/api/equipment/chain-shirt"
+        }
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -14111,7 +14246,20 @@
     "size": "Medium",
     "type": "fey",
     "alignment": "neutral",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }, {
+        "type": "spell",
+        "value": 16,
+        "spell": {
+          "index": "barkskin",
+          "name": "Barkskin",
+          "url": "/api/spells/barkskin"
+        }
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -14278,7 +14426,24 @@
     "type": "humanoid",
     "subtype": "dwarf",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [
+          {
+            "index": "scale-mail",
+            "name": "Scale Mail",
+            "url": "/api/equipment/scale-mail"
+          },
+          {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
+      }
+    ],
     "hit_points": 26,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+8",
@@ -14575,7 +14740,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 126,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+60",
@@ -15292,7 +15462,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 44,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+8",
@@ -15432,7 +15607,12 @@
     "size": "Large",
     "type": "giant",
     "alignment": "chaotic evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 85,
     "hit_dice": "10d10",
     "hit_points_roll": "10d10+30",
@@ -15533,7 +15713,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 102,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+36",
@@ -19762,7 +19947,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 60,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+24",
@@ -20147,7 +20337,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 38,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+7",
@@ -30529,7 +30724,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 75,
     "hit_dice": "10d8",
     "hit_points_roll": "10d8+30",
@@ -32562,7 +32762,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+18",
@@ -38051,7 +38256,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 114,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+48",
@@ -40165,7 +40375,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 32,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+10",
@@ -41451,7 +41666,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 152,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+64",
@@ -41623,7 +41843,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 110,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+39",
@@ -41821,7 +42046,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 142,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+60",
@@ -42025,7 +42255,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "chaotic good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 119,
     "hit_dice": "14d10",
     "hit_points_roll": "14d10+42",
@@ -42223,7 +42458,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 178,
     "hit_dice": "17d10",
     "hit_points_roll": "17d10+85",
@@ -42435,7 +42675,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+48",
@@ -42627,7 +42872,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 178,
     "hit_dice": "17d10",
     "hit_points_roll": "17d10+85",
@@ -42799,7 +43049,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "lawful good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 168,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+80",
@@ -43004,7 +43259,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 133,
     "hit_dice": "14d10",
     "hit_points_roll": "14d10+56",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -10851,7 +10851,12 @@
     "size": "Large",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 133,
     "hit_dice": "14d10",
     "hit_points_roll": "14d10+56",
@@ -11115,7 +11120,12 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "neutral good (50%) or neutral evil (50%)",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 200,
     "hit_dice": "16d12",
     "hit_points_roll": "16d12+96",
@@ -12451,7 +12461,17 @@
     "type": "humanoid",
     "subtype": "gnome",
     "alignment": "neutral good",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "chain-shirt",
+          "name": "Chain Shirt",
+          "url": "/api/equipment/chain-shirt"
+        }]
+      }
+    ],
     "hit_points": 16,
     "hit_dice": "3d6",
     "hit_points_roll": "3d6+6",
@@ -12923,7 +12943,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "chaotic good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 161,
     "hit_dice": "14d10",
     "hit_points_roll": "14d10+84",
@@ -14852,7 +14877,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "lawful evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 200,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+112",
@@ -15850,7 +15880,19 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 18,
+        "armor": [
+          {
+            "index": "plate-armor",
+            "name": "Plate Armor",
+            "url": "/api/equipment/plate-armor"
+          }
+        ]
+      }
+    ],
     "hit_points": 162,
     "hit_dice": "13d12",
     "hit_points_roll": "13d12+78",
@@ -15969,7 +16011,12 @@
     "size": "Medium",
     "type": "construct",
     "alignment": "neutral",
-    "armor_class": 9,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 9
+      }
+    ],
     "hit_points": 93,
     "hit_dice": "11d8",
     "hit_points_roll": "11d8+44",
@@ -16336,7 +16383,13 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "desc": "patchwork armor"
+      }
+    ],
     "hit_points": 138,
     "hit_dice": "12d12",
     "hit_points_roll": "12d12+60",
@@ -16455,7 +16508,12 @@
     "size": "Medium",
     "type": "elemental",
     "alignment": "chaotic evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+21",
@@ -16678,7 +16736,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 36,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8",
@@ -16782,7 +16845,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "any alignment",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "10d8",
     "hit_points_roll": "10d8",
@@ -16930,7 +16998,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "chaotic evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -19137,7 +19210,12 @@
     "size": "Medium",
     "type": "aberration",
     "alignment": "neutral",
-    "armor_class": 9,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 9
+      }
+    ],
     "hit_points": 67,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+27",
@@ -19699,7 +19777,24 @@
     "type": "humanoid",
     "subtype": "gnoll",
     "alignment": "chaotic evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [
+          {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          },
+          {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -19866,7 +19961,21 @@
     "type": "humanoid",
     "subtype": "goblinoid",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }, {
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6",
@@ -20116,7 +20225,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 114,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+48",
@@ -20494,7 +20608,12 @@
     "size": "Medium",
     "type": "fey",
     "alignment": "neutral evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 82,
     "hit_dice": "11d8",
     "hit_points_roll": "11d8+33",
@@ -20637,7 +20756,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8",
@@ -20728,7 +20852,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 59,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+21",
@@ -20827,7 +20956,12 @@
     "type": "humanoid",
     "subtype": "grimlock",
     "alignment": "neutral evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -21468,7 +21602,17 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "any alignment",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 18,
+        "armor": [{
+          "index": "plate-armor",
+          "name": "Plate Armor",
+          "url": "/api/equipment/plate-armor"
+        }]
+      }
+    ],
     "hit_points": 65,
     "hit_dice": "10d8",
     "hit_points_roll": "10d8+20",
@@ -21617,7 +21761,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 38,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+7",
@@ -21768,7 +21917,12 @@
     "size": "Medium",
     "type": "fiend",
     "alignment": "lawful evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+14",
@@ -22020,7 +22174,12 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 105,
     "hit_dice": "10d12",
     "hit_points_roll": "10d12+40",
@@ -22105,7 +22264,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -23415,7 +23579,12 @@
     "size": "Large",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 20,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 20
+      }
+    ],
     "hit_points": 210,
     "hit_dice": "20d10",
     "hit_points_roll": "20d10+100",
@@ -27518,7 +27687,12 @@
     "size": "Medium",
     "type": "fiend",
     "alignment": "neutral evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 112,
     "hit_dice": "15d8",
     "hit_points_roll": "15d8+45",
@@ -32240,7 +32414,12 @@
     "size": "Medium",
     "type": "fey",
     "alignment": "chaotic evil",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+21",
@@ -32701,7 +32880,12 @@
     "size": "Medium",
     "type": "plant",
     "alignment": "unaligned",
-    "armor_class": 5,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 5
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -34135,7 +34319,12 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "neutral",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 126,
     "hit_dice": "11d12",
     "hit_points_roll": "11d12+55",
@@ -34265,7 +34454,12 @@
     "size": "Large",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 178,
     "hit_dice": "17d10",
     "hit_points_roll": "17d10+85",
@@ -34394,7 +34588,19 @@
     "size": "Huge",
     "type": "giant",
     "alignment": "chaotic good",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [
+          {
+            "index": "scale-mail",
+            "name": "Scale Mail",
+            "url": "/api/equipment/scale-mail"
+          }
+        ]
+      }
+    ],
     "hit_points": 230,
     "hit_dice": "20d12",
     "hit_points_roll": "20d12+100",
@@ -37819,7 +38025,12 @@
     "size": "Medium",
     "type": "plant",
     "alignment": "unaligned",
-    "armor_class": 5,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 5
+      }
+    ],
     "hit_points": 18,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -15315,7 +15315,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "2d10",
     "hit_points_roll": "2d10+2",
@@ -16270,7 +16275,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 14
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "2d4",
     "hit_points_roll": "2d4",
@@ -16452,7 +16462,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -17221,7 +17236,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 157,
     "hit_dice": "15d12",
     "hit_points_roll": "15d12+60",
@@ -17315,7 +17335,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+4",
@@ -17404,7 +17429,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10",
@@ -17465,7 +17495,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 42,
     "hit_dice": "5d10",
     "hit_points_roll": "5d10+15",
@@ -17531,7 +17566,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 4,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6+1",
@@ -17582,7 +17622,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 60,
     "hit_dice": "8d12",
     "hit_points_roll": "8d12+8",
@@ -17657,7 +17702,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -17723,7 +17773,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 85,
     "hit_dice": "9d12",
     "hit_points_roll": "9d12+27",
@@ -17821,7 +17876,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "neutral good",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 26,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10+4",
@@ -17919,7 +17979,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 42,
     "hit_dice": "5d12",
     "hit_points_roll": "5d12+10",
@@ -17999,7 +18064,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 4,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6+1",
@@ -18055,7 +18125,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 18,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8",
@@ -18137,7 +18212,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -18196,7 +18276,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -18261,7 +18346,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -18312,7 +18402,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+8",
@@ -18405,7 +18500,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "neutral",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -18483,7 +18583,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 14
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -18543,7 +18648,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6",
@@ -18603,7 +18713,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6",
@@ -18663,7 +18778,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+14",
@@ -18746,7 +18866,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 16,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10",
@@ -18807,7 +18932,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 126,
     "hit_dice": "11d12",
     "hit_points_roll": "11d12+55",
@@ -18877,7 +19007,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 26,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10+4",
@@ -18962,7 +19097,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 39,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+6",
@@ -19036,7 +19176,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "neutral evil",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+6",
@@ -19137,7 +19282,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -19188,7 +19338,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 9,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8",
@@ -19262,7 +19417,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -20036,7 +20196,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 4,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -15062,9 +15062,9 @@
         "value": 18,
         "armor": [
           {
-            "index": "plate",
-            "name": "plate",
-            "url": "/api/equipment/plate"
+            "index": "plate-armor",
+            "name": "Plate Armor",
+            "url": "/api/equipment/plate-armor"
           }
         ]
       }

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6897,11 +6897,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "studded-leather-armor",
-          "name": "Studded Leather Armor",
-          "url": "/api/equipment/studded-leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "studded-leather-armor",
+            "name": "Studded Leather Armor",
+            "url": "/api/equipment/studded-leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 78,
@@ -7276,11 +7278,13 @@
       {
         "type": "armor",
         "value": 17,
-        "armor": [{
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 39,
@@ -7722,11 +7726,13 @@
       {
         "type": "armor",
         "value": 12,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 11,
@@ -7798,11 +7804,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "studded-leather-armor",
-          "name": "Studded Leather Armor",
-          "url": "/api/equipment/studded-leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "studded-leather-armor",
+            "name": "Studded Leather Armor",
+            "url": "/api/equipment/studded-leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 65,
@@ -8614,11 +8622,13 @@
       {
         "type": "armor",
         "value": 13,
-        "armor": [{
-          "index": "hide-armor",
-          "name": "Hide Armor",
-          "url": "/api/equipment/hide-armor"
-        }]
+        "armor": [
+          {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          }
+        ]
       }
     ],
     "hit_points": 67,
@@ -10037,15 +10047,17 @@
       {
         "type": "armor",
         "value": 16,
-        "armor": [{
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }, {
-          "index": "hide-armor",
-          "name": "Hide Armor",
-          "url": "/api/equipment/hide-armor"
-        }]
+        "armor": [
+          {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }, {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          }
+        ]
       }
     ],
     "hit_points": 27,
@@ -12221,11 +12233,13 @@
       {
         "type": "armor",
         "value": 13,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 22,
@@ -12391,11 +12405,13 @@
       {
         "type": "armor",
         "value": 12,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 9,
@@ -12648,11 +12664,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "chain-shirt",
-          "name": "Chain Shirt",
-          "url": "/api/equipment/chain-shirt"
-        }]
+        "armor": [
+          {
+            "index": "chain-shirt",
+            "name": "Chain Shirt",
+            "url": "/api/equipment/chain-shirt"
+          }
+        ]
       }
     ],
     "hit_points": 16,
@@ -14146,11 +14164,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": {
-          "index": "chain-shirt",
-          "name": "Chain Shirt",
-          "url": "/api/equipment/chain-shirt"
-        }
+        "armor": [
+          {
+            "index": "chain-shirt",
+            "name": "Chain Shirt",
+            "url": "/api/equipment/chain-shirt"
+          }
+        ]
       }
     ],
     "hit_points": 13,
@@ -19963,15 +19983,17 @@
       {
         "type": "armor",
         "value": 16,
-        "armor": [{
-          "index": "studded-leather-armor",
-          "name": "Studded Leather Armor",
-          "url": "/api/equipment/studded-leather-armor"
-        }, {
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "studded-leather-armor",
+            "name": "Studded Leather Armor",
+            "url": "/api/equipment/studded-leather-armor"
+          }, {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 112,
@@ -20375,15 +20397,17 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }, {
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }, {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 7,
@@ -21485,15 +21509,17 @@
       {
         "type": "armor",
         "value": 16,
-        "armor": [{
-          "index": "chain-shirt",
-          "name": "Chain Shirt",
-          "url": "/api/equipment/chain-shirt"
-        }, {
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "chain-shirt",
+            "name": "Chain Shirt",
+            "url": "/api/equipment/chain-shirt"
+          }, {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 11,
@@ -22045,11 +22071,13 @@
       {
         "type": "armor",
         "value": 18,
-        "armor": [{
-          "index": "plate-armor",
-          "name": "Plate Armor",
-          "url": "/api/equipment/plate-armor"
-        }]
+        "armor": [
+          {
+            "index": "plate-armor",
+            "name": "Plate Armor",
+            "url": "/api/equipment/plate-armor"
+          }
+        ]
       }
     ],
     "hit_points": 65,
@@ -22815,15 +22843,17 @@
       {
         "type": "armor",
         "value": 18,
-        "armor": [{
-          "index": "chain-mail",
-          "name": "Chain Mail",
-          "url": "/api/equipment/chain-mail"
-        }, {
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "chain-mail",
+            "name": "Chain Mail",
+            "url": "/api/equipment/chain-mail"
+          }, {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 11,
@@ -24419,11 +24449,13 @@
       {
         "type": "armor",
         "value": 18,
-        "armor": [{
-          "index": "plate-armor",
-          "name": "Plate Armor",
-          "url": "/api/equipment/plate-armor"
-        }]
+        "armor": [
+          {
+            "index": "plate-armor",
+            "name": "Plate Armor",
+            "url": "/api/equipment/plate-armor"
+          }
+        ]
       }
     ],
     "hit_points": 52,
@@ -25752,11 +25784,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "shield",
-          "name": "Shield",
-          "url": "/api/equipment/shield"
-        }]
+        "armor": [
+          {
+            "index": "shield",
+            "name": "Shield",
+            "url": "/api/equipment/shield"
+          }
+        ]
       }
     ],
     "hit_points": 22,
@@ -28594,11 +28628,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "breastplate",
-          "name": "Breastplate",
-          "url": "/api/equipment/breastplate"
-        }]
+        "armor": [
+          {
+            "index": "breastplate",
+            "name": "Breastplate",
+            "url": "/api/equipment/breastplate"
+          }
+        ]
       }
     ],
     "hit_points": 9,
@@ -28899,11 +28935,13 @@
       {
         "type": "armor",
         "value": 11,
-        "armor": [{
-          "index": "hide-armor",
-          "name": "Hide Armor",
-          "url": "/api/equipment/hide-armor"
-        }]
+        "armor": [
+          {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          }
+        ]
       }
     ],
     "hit_points": 59,
@@ -29052,11 +29090,13 @@
       {
         "type": "armor",
         "value": 16,
-        "armor": [{
-          "index": "chain-mail",
-          "name": "Chain Mail",
-          "url": "/api/equipment/chain-mail"
-        }]
+        "armor": [
+          {
+            "index": "chain-mail",
+            "name": "Chain Mail",
+            "url": "/api/equipment/chain-mail"
+          }
+        ]
       }
     ],
     "hit_points": 110,
@@ -29315,11 +29355,13 @@
       {
         "type": "armor",
         "value": 13,
-        "armor": [{
-          "index": "hide-armor",
-          "name": "Hide Armor",
-          "url": "/api/equipment/hide-armor"
-        }]
+        "armor": [
+          {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          }
+        ]
       }
     ],
     "hit_points": 15,
@@ -30768,11 +30810,13 @@
       {
         "type": "armor",
         "value": 13,
-        "armor": [{
-          "index": "chain-shirt",
-          "name": "Chain Shirt",
-          "url": "/api/equipment/chain-shirt"
-        }]
+        "armor": [
+          {
+            "index": "chain-shirt",
+            "name": "Chain Shirt",
+            "url": "/api/equipment/chain-shirt"
+          }
+        ]
       }
     ],
     "hit_points": 27,
@@ -32957,11 +33001,13 @@
       {
         "type": "armor",
         "value": 14,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 31,
@@ -33134,11 +33180,13 @@
       {
         "type": "armor",
         "value": 13,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 16,
@@ -34789,11 +34837,13 @@
       {
         "type": "armor",
         "value": 15,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 2,
@@ -37307,11 +37357,13 @@
       {
         "type": "armor",
         "value": 11,
-        "armor": [{
-          "index": "leather-armor",
-          "name": "Leather Armor",
-          "url": "/api/equipment/leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "leather-armor",
+            "name": "Leather Armor",
+            "url": "/api/equipment/leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 32,
@@ -37620,11 +37672,13 @@
       {
         "type": "armor",
         "value": 12,
-        "armor": [{
-          "index": "hide-armor",
-          "name": "Hide Armor",
-          "url": "/api/equipment/hide-armor"
-        }]
+        "armor": [
+          {
+            "index": "hide-armor",
+            "name": "Hide Armor",
+            "url": "/api/equipment/hide-armor"
+          }
+        ]
       }
     ],
     "hit_points": 11,
@@ -38936,11 +38990,13 @@
       {
         "type": "armor",
         "value": 17,
-        "armor": [{
-          "index": "splint-armor",
-          "name": "Splint Armor",
-          "url": "/api/equipment/splint-armor"
-        }]
+        "armor": [
+          {
+            "index": "splint-armor",
+            "name": "Splint Armor",
+            "url": "/api/equipment/splint-armor"
+          }
+        ]
       }
     ],
     "hit_points": 58,
@@ -41883,11 +41939,13 @@
       {
         "type": "armor",
         "value": 14,
-        "armor": [{
-          "index": "studded-leather-armor",
-          "name": "Studded Leather Armor",
-          "url": "/api/equipment/studded-leather-armor"
-        }]
+        "armor": [
+          {
+            "index": "studded-leather-armor",
+            "name": "Studded Leather Armor",
+            "url": "/api/equipment/studded-leather-armor"
+          }
+        ]
       }
     ],
     "hit_points": 45,

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -5,7 +5,12 @@
     "size": "Large",
     "type": "aberration",
     "alignment": "lawful evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 135,
     "hit_dice": "18d10",
     "hit_points_roll": "18d10+36",
@@ -333,7 +338,12 @@
     "size": "Huge",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 195,
     "hit_dice": "17d12",
     "hit_points_roll": "17d12+85",
@@ -3144,7 +3154,12 @@
     "size": "Gargantuan",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 22,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 22
+      }
+    ],
     "hit_points": 367,
     "hit_dice": "21d20",
     "hit_points_roll": "21d20+147",
@@ -6167,7 +6182,12 @@
     "size": "Medium",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+6",
@@ -6284,7 +6304,21 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      },
+      {
+        "type": "condition",
+        "value": 11,
+        "condition": {
+          "index": "prone",
+          "name": "Prone",
+          "url": "/api/conditions/prone"
+        }
+      }
+    ],
     "hit_points": 39,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+6",
@@ -7086,7 +7120,21 @@
     "size": "Medium",
     "type": "elemental",
     "alignment": "lawful neutral",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      },
+      {
+        "type": "armor",
+        "value": 17,
+        "armor": [{
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 39,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+12",
@@ -7309,7 +7357,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 262,
     "hit_dice": "21d12",
     "hit_points_roll": "21d12+126",
@@ -7722,7 +7775,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 110,
     "hit_dice": "13d8",
     "hit_points_roll": "13d8+52",
@@ -7933,7 +7991,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+16",
@@ -8068,7 +8131,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+16",
@@ -8201,7 +8269,12 @@
     "size": "Huge",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 168,
     "hit_dice": "16d12",
     "hit_points_roll": "16d12+64",
@@ -8497,7 +8570,12 @@
     "size": "Medium",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+6",
@@ -9138,7 +9216,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 142,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+60",
@@ -9712,7 +9795,21 @@
     "type": "humanoid",
     "subtype": "goblinoid",
     "alignment": "chaotic evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [{
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }, {
+          "index": "hide-armor",
+          "name": "Hide Armor",
+          "url": "/api/equipment/hide-armor"
+        }]
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+5",
@@ -9804,7 +9901,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 94,
     "hit_dice": "9d10",
     "hit_points_roll": "9d10+45",
@@ -9997,7 +10099,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral good",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -10155,7 +10262,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 85,
     "hit_dice": "10d8",
     "hit_points_roll": "10d8+40",
@@ -10290,7 +10402,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 114,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+48",
@@ -10491,7 +10608,12 @@
     "size": "Large",
     "type": "aberration",
     "alignment": "chaotic evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 93,
     "hit_dice": "11d10",
     "hit_points_roll": "11d10+33",
@@ -10748,7 +10870,12 @@
     "size": "Large",
     "type": "aberration",
     "alignment": "chaotic neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 78,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+12",
@@ -11096,7 +11223,12 @@
     "size": "Small",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "6d6",
     "hit_points_roll": "6d6+6",
@@ -11422,7 +11554,12 @@
     "size": "Medium",
     "type": "celestial",
     "alignment": "lawful good",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 97,
     "hit_dice": "13d8",
     "hit_points_roll": "13d8+39",
@@ -12029,7 +12166,12 @@
     "size": "Small",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d6",
     "hit_points_roll": "5d6+5",
@@ -12397,7 +12539,12 @@
     "size": "Medium",
     "type": "celestial",
     "alignment": "lawful good",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "16d8",
     "hit_points_roll": "16d8+64",
@@ -12925,7 +13072,12 @@
     "type": "monstrosity",
     "subtype": "shapechanger",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 14
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+16",
@@ -13268,7 +13420,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 18,
     "hit_dice": "4d6",
     "hit_points_roll": "4d6+4",
@@ -14899,7 +15056,19 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 18,
+        "armor": [
+          {
+            "index": "plate",
+            "name": "plate",
+            "url": "/api/equipment/plate"
+          }
+        ]
+      }
+    ],
     "hit_points": 153,
     "hit_dice": "18d8",
     "hit_points_roll": "18d8+72",
@@ -15805,7 +15974,12 @@
     "size": "Small",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 17,
     "hit_dice": "5d6",
     "hit_points_roll": "5d6",
@@ -18890,7 +19064,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 157,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+75",
@@ -21502,7 +21681,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+65",
@@ -21987,7 +22171,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 178,
     "hit_dice": "17d10",
     "hit_points_roll": "17d10+85",
@@ -22419,7 +22608,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 180,
     "hit_dice": "19d10",
     "hit_points_roll": "19d10+76",
@@ -22771,7 +22965,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 10,
     "hit_dice": "3d4",
     "hit_points_roll": "3d4+3",
@@ -24030,7 +24229,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 7,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 7
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -25512,7 +25716,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 189,
     "hit_dice": "18d10",
     "hit_points_roll": "18d10+90",
@@ -26947,7 +27156,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 184,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+96",
@@ -28676,7 +28890,12 @@
     "type": "fiend",
     "subtype": "devil",
     "alignment": "lawful evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 300,
     "hit_dice": "24d10",
     "hit_points_roll": "24d10+168",
@@ -28911,7 +29130,12 @@
     "size": "Large",
     "type": "celestial",
     "alignment": "lawful good",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 200,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+112",
@@ -29154,7 +29378,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 68,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+24",
@@ -29789,7 +30018,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "3d4",
     "hit_points_roll": "3d4",
@@ -30934,7 +31168,12 @@
     "size": "Large",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10",
@@ -32560,7 +32799,12 @@
     "size": "Large",
     "type": "celestial",
     "alignment": "lawful good",
-    "armor_class": 21,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 21
+      }
+    ],
     "hit_points": 243,
     "hit_dice": "18d10",
     "hit_points_roll": "18d10+144",
@@ -36036,7 +36280,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 95,
     "hit_dice": "10d12",
     "hit_points_roll": "10d12+30",
@@ -36207,7 +36456,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "13d12",
     "hit_points_roll": "13d12+52",
@@ -37445,7 +37699,12 @@
     "type": "fiend",
     "subtype": "demon",
     "alignment": "chaotic evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 104,
     "hit_dice": "11d10",
     "hit_points_roll": "11d10+44",
@@ -41008,7 +41267,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 127,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+45",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -5959,7 +5959,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "lawful neutral",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 199,
     "hit_dice": "19d10",
     "hit_points_roll": "19d10+95",
@@ -6497,7 +6502,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+6",
@@ -7042,7 +7052,12 @@
     "size": "Small",
     "type": "plant",
     "alignment": "unaligned",
-    "armor_class": 9,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 9
+      }
+    ],
     "hit_points": 10,
     "hit_dice": "3d6",
     "hit_points_roll": "3d6",
@@ -7103,7 +7118,12 @@
     "size": "Huge",
     "type": "plant",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 59,
     "hit_dice": "7d12",
     "hit_points_roll": "7d12+14",
@@ -7165,7 +7185,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -7338,7 +7363,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 3,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6",
@@ -7394,7 +7424,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 3,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4+1",
@@ -8164,7 +8199,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -8577,7 +8617,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+6",
@@ -8817,7 +8862,12 @@
     "size": "Large",
     "type": "ooze",
     "alignment": "unaligned",
-    "armor_class": 7,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 7
+      }
+    ],
     "hit_points": 85,
     "hit_dice": "10d10",
     "hit_points_roll": "10d10+30",
@@ -8943,7 +8993,12 @@
     "size": "Medium",
     "type": "fey",
     "alignment": "lawful good",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+4",
@@ -9025,7 +9080,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6",
@@ -9239,7 +9299,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -9807,7 +9872,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 34,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10+12",
@@ -10087,7 +10157,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 9,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 9
+      }
+    ],
     "hit_points": 15,
     "hit_dice": "2d10",
     "hit_points_roll": "2d10+4",
@@ -10136,7 +10211,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -11450,7 +11530,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "2d10",
     "hit_points_roll": "2d10+2",
@@ -11925,7 +12010,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -11991,7 +12081,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -12375,7 +12470,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 39,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+12",
@@ -12625,7 +12725,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 4,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8",
@@ -12867,7 +12972,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 37,
     "hit_dice": "5d10",
     "hit_points_roll": "5d10+10",
@@ -13320,7 +13430,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -14705,7 +14820,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 3,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6",
@@ -15120,7 +15240,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 76,
     "hit_dice": "8d12",
     "hit_points_roll": "8d12+24",
@@ -16627,7 +16752,12 @@
     "size": "Large",
     "type": "ooze",
     "alignment": "unaligned",
-    "armor_class": 6,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 6
+      }
+    ],
     "hit_points": 84,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+40",
@@ -20339,7 +20469,12 @@
     "size": "Medium",
     "type": "ooze",
     "alignment": "unaligned",
-    "armor_class": 8,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 8
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+9",
@@ -21373,7 +21508,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "lawful neutral",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+48",
@@ -27038,7 +27178,12 @@
     "size": "Large",
     "type": "undead",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 67,
     "hit_dice": "9d10",
     "hit_points_roll": "9d10+18",
@@ -28163,7 +28308,12 @@
     "size": "Large",
     "type": "ooze",
     "alignment": "unaligned",
-    "armor_class": 8,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 8
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -28368,7 +28518,17 @@
     "size": "Large",
     "type": "giant",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 11,
+        "armor": [{
+          "index": "hide-armor",
+          "name": "Hide Armor",
+          "url": "/api/equipment/hide-armor"
+        }]
+      }
+    ],
     "hit_points": 59,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+21",
@@ -28433,7 +28593,12 @@
     "size": "Large",
     "type": "undead",
     "alignment": "neutral evil",
-    "armor_class": 8,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 8
+      }
+    ],
     "hit_points": 85,
     "hit_dice": "9d10",
     "hit_points_roll": "9d10+36",
@@ -28506,7 +28671,17 @@
     "size": "Large",
     "type": "giant",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [{
+          "index": "chain-mail",
+          "name": "Chain Mail",
+          "url": "/api/equipment/chain-mail"
+        }]
+      }
+    ],
     "hit_points": 110,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+39",
@@ -28759,7 +28934,17 @@
     "type": "humanoid",
     "subtype": "orc",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "armor": [{
+          "index": "hide-armor",
+          "name": "Hide Armor",
+          "url": "/api/equipment/hide-armor"
+        }]
+      }
+    ],
     "hit_points": 15,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+6",
@@ -28839,7 +29024,12 @@
     "size": "Large",
     "type": "aberration",
     "alignment": "neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 114,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+48",
@@ -29035,7 +29225,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 59,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+21",
@@ -29233,7 +29428,12 @@
     "size": "Large",
     "type": "celestial",
     "alignment": "chaotic good",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 59,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+21",
@@ -30314,7 +30514,12 @@
     "size": "Tiny",
     "type": "dragon",
     "alignment": "neutral good",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 7,
     "hit_dice": "2d4",
     "hit_points_roll": "2d4+2",
@@ -30412,7 +30617,12 @@
     "size": "Gargantuan",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 247,
     "hit_dice": "15d20",
     "hit_points_roll": "15d20+90",
@@ -30689,7 +30899,12 @@
     "size": "Medium",
     "type": "fiend",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_dice": "13d8",
     "hit_points": 110,
     "hit_points_roll": "13d8+52",
@@ -31246,7 +31461,12 @@
     "size": "Huge",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 195,
     "hit_dice": "17d12",
     "hit_points_roll": "17d12+85",
@@ -31433,7 +31653,12 @@
     "size": "Gargantuan",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 248,
     "hit_dice": "16d20",
     "hit_points_roll": "16d20+80",
@@ -31562,7 +31787,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 20,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 20
+      }
+    ],
     "hit_points": 93,
     "hit_dice": "11d10",
     "hit_points_roll": "11d10+33",
@@ -31773,7 +32003,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+5",
@@ -31938,7 +32173,12 @@
     "type": "humanoid",
     "subtype": "sahuagin",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+4",
@@ -32111,7 +32351,12 @@
     "size": "Large",
     "type": "elemental",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 90,
     "hit_dice": "12d10",
     "hit_points_roll": "12d10+24",
@@ -32668,7 +32913,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "chaotic evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 16,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+3",
@@ -32794,7 +33044,12 @@
     "size": "Large",
     "type": "plant",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 136,
     "hit_dice": "16d10",
     "hit_points_roll": "16d10+48",
@@ -32902,7 +33157,12 @@
     "size": "Large",
     "type": "construct",
     "alignment": "unaligned",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 142,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+60",
@@ -33241,7 +33501,13 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "lawful evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "desc": "armor scraps"
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+4",
@@ -33636,7 +33902,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "chaotic evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -34027,7 +34298,17 @@
     "size": "Tiny",
     "type": "fey",
     "alignment": "neutral good",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armo",
+        "value": 15,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment-categories/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -34411,7 +34692,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -34993,7 +35279,12 @@
     "type": "fiend",
     "subtype": "shapechanger",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 66,
     "hit_dice": "12d8",
     "hit_points_roll": "12d8+12",
@@ -36180,7 +36471,12 @@
     "type": "monstrosity",
     "subtype": "titan",
     "alignment": "unaligned",
-    "armor_class": 25,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 25
+      }
+    ],
     "hit_points": 676,
     "hit_dice": "33d20",
     "hit_points_roll": "33d20+330",
@@ -36657,7 +36953,12 @@
     "size": "Huge",
     "type": "plant",
     "alignment": "chaotic good",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 138,
     "hit_dice": "12d12",
     "hit_points_roll": "12d12+60",
@@ -36909,7 +37210,12 @@
     "size": "Large",
     "type": "giant",
     "alignment": "chaotic evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 84,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+40",
@@ -37105,7 +37411,12 @@
     "size": "Large",
     "type": "celestial",
     "alignment": "lawful good",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 67,
     "hit_dice": "9d10",
     "hit_points_roll": "9d10+18",
@@ -37316,7 +37627,12 @@
     "type": "undead",
     "subtype": "shapechanger",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 144,
     "hit_dice": "17d8",
     "hit_points_roll": "17d8+68",
@@ -37551,7 +37867,12 @@
     "type": "undead",
     "subtype": "shapechanger",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 144,
     "hit_dice": "17d8",
     "hit_points_roll": "17d8+68",
@@ -37735,7 +38056,12 @@
     "type": "undead",
     "subtype": "shapechanger",
     "alignment": "lawful evil",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 16
+      }
+    ],
     "hit_points": 144,
     "hit_dice": "17d8",
     "hit_points_roll": "17d8+68",
@@ -37872,7 +38198,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "neutral evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 82,
     "hit_dice": "11d8",
     "hit_points_roll": "11d8+33",
@@ -38545,7 +38876,13 @@
     "size": "Large",
     "type": "undead",
     "alignment": "lawful evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "desc": "barding scraps"
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+6",
@@ -40950,7 +41287,17 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "neutral evil",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 14,
+        "armor": [{
+          "index": "studded-leather-armor",
+          "name": "Studded Leather Armor",
+          "url": "/api/equipment/studded-leather-armor"
+        }]
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8+18",
@@ -41134,7 +41481,12 @@
     "size": "Tiny",
     "type": "undead",
     "alignment": "chaotic evil",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 19
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "9d4",
     "hit_points_roll": "9d4",
@@ -41520,7 +41872,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "neutral evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 67,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+27",
@@ -41638,7 +41995,12 @@
     "size": "Large",
     "type": "dragon",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 110,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+39",
@@ -41793,7 +42155,12 @@
     "size": "Medium",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 19,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 19
+      }
+    ],
     "hit_points": 73,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8+42",
@@ -43872,7 +44239,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "neutral evil",
-    "armor_class": 8,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 8
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+9",

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -34470,7 +34470,7 @@
         "armor": [{
           "index": "leather-armor",
           "name": "Leather Armor",
-          "url": "/api/equipment-categories/leather-armor"
+          "url": "/api/equipment/leather-armor"
         }]
       }
     ],

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -14567,7 +14567,12 @@
     "size": "Small",
     "type": "elemental",
     "alignment": "neutral evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 17,
     "hit_dice": "5d6",
     "hit_points_roll": "5d6",
@@ -21145,7 +21150,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "lawful good",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 127,
     "hit_dice": "15d10",
     "hit_points_roll": "15d10+45",
@@ -22367,7 +22377,21 @@
     "type": "humanoid",
     "subtype": "goblinoid",
     "alignment": "lawful evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 18,
+        "armor": [{
+          "index": "chain-mail",
+          "name": "Chain Mail",
+          "url": "/api/equipment/chain-mail"
+        }, {
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -22459,7 +22483,12 @@
     "size": "Tiny",
     "type": "construct",
     "alignment": "neutral",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "2d4",
     "hit_points_roll": "2d4",
@@ -22812,7 +22841,12 @@
     "size": "Huge",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 172,
     "hit_dice": "15d12",
     "hit_points_roll": "15d12+75",
@@ -23157,7 +23191,12 @@
     "size": "Small",
     "type": "elemental",
     "alignment": "neutral evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 21,
     "hit_dice": "6d6",
     "hit_points_roll": "6d6",
@@ -23443,7 +23482,12 @@
     "size": "Medium",
     "type": "elemental",
     "alignment": "neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 14
+      }
+    ],
     "hit_points": 104,
     "hit_dice": "16d8",
     "hit_points_roll": "16d8+32",
@@ -24034,7 +24078,12 @@
     "type": "humanoid",
     "subtype": "kobold",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6-2",
@@ -24110,7 +24159,12 @@
     "type": "monstrosity",
     "subtype": "titan",
     "alignment": "chaotic evil",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 18
+      }
+    ],
     "hit_points": 472,
     "hit_dice": "27d20",
     "hit_points_roll": "27d20+189",
@@ -24368,7 +24422,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 97,
     "hit_dice": "13d10",
     "hit_points_roll": "13d10+26",
@@ -24679,7 +24738,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "any evil alignment",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 135,
     "hit_dice": "18d8",
     "hit_points_roll": "18d8+54",
@@ -25206,7 +25270,21 @@
     "type": "humanoid",
     "subtype": "lizardfolk",
     "alignment": "neutral",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      },
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+4",
@@ -25643,7 +25721,12 @@
     "size": "Small",
     "type": "elemental",
     "alignment": "neutral evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d6",
     "hit_points_roll": "5d6+5",
@@ -25801,7 +25884,12 @@
     "size": "Small",
     "type": "elemental",
     "alignment": "chaotic neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 9,
     "hit_dice": "2d6",
     "hit_points_roll": "2d6+2",
@@ -25955,7 +26043,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "lawful evil",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 68,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+24",
@@ -26302,7 +26395,12 @@
     "size": "Medium",
     "type": "monstrosity",
     "alignment": "lawful evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 127,
     "hit_dice": "17d8",
     "hit_points_roll": "17d8+51",
@@ -26484,7 +26582,12 @@
     "type": "humanoid",
     "subtype": "merfolk",
     "alignment": "neutral",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -26570,7 +26673,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -26723,7 +26831,12 @@
     "type": "monstrosity",
     "subtype": "shapechanger",
     "alignment": "neutral",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+18",
@@ -26832,7 +26945,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 14
+      }
+    ],
     "hit_points": 76,
     "hit_dice": "9d10",
     "hit_points_roll": "9d10+27",
@@ -27065,7 +27183,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "lawful evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+18",
@@ -27195,7 +27318,12 @@
     "size": "Medium",
     "type": "undead",
     "alignment": "lawful evil",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 17
+      }
+    ],
     "hit_points": 97,
     "hit_dice": "13d8",
     "hit_points_roll": "13d8+39",
@@ -27874,7 +28002,12 @@
     "size": "Large",
     "type": "fiend",
     "alignment": "neutral evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 68,
     "hit_dice": "8d10",
     "hit_points_roll": "8d10+24",
@@ -33695,7 +33828,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "chaotic evil",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 15
+      }
+    ],
     "hit_points": 75,
     "hit_dice": "10d10",
     "hit_points_roll": "10d10+20",
@@ -34125,7 +34263,12 @@
     "size": "Small",
     "type": "elemental",
     "alignment": "neutral evil",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 21,
     "hit_dice": "6d6",
     "hit_points_roll": "6d6",
@@ -38694,7 +38837,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral good",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 135,
     "hit_dice": "18d8",
     "forms": [
@@ -38805,7 +38953,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral good",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 135,
     "hit_dice": "18d8",
     "forms": [
@@ -38900,7 +39053,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral good",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 135,
     "hit_dice": "18d8",
     "forms": [
@@ -39057,7 +39215,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral evil",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 78,
     "hit_dice": "12d8",
     "forms": [
@@ -39151,7 +39314,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral evil",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 78,
     "hit_dice": "12d8",
     "forms": [
@@ -39253,7 +39421,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral evil",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 78,
     "hit_dice": "12d8",
     "forms": [
@@ -39399,7 +39572,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d8",
     "forms": [
@@ -39548,7 +39726,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d8",
     "forms": [
@@ -39746,7 +39929,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "lawful evil",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 33,
     "hit_dice": "6d8",
     "forms": [
@@ -39838,7 +40026,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 120,
     "hit_dice": "16d8",
     "forms": [
@@ -39971,7 +40164,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 120,
     "hit_dice": "16d8",
     "forms": [
@@ -40153,7 +40351,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "neutral",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 120,
     "hit_dice": "16d8",
     "forms": [
@@ -40273,7 +40476,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "forms": [
@@ -40389,7 +40597,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "forms": [
@@ -40504,7 +40717,12 @@
     "type": "humanoid",
     "subtype": "human",
     "alignment": "chaotic evil",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "forms": [

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -214,7 +214,12 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 9,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8",
@@ -6604,7 +6609,20 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }, {
+        "type": "spell",
+        "value": 15,
+        "spell": {
+          "index": "mage-armor",
+          "name": "Mage Armor",
+          "url": "/api/spells/mage-armor"
+        }
+      }
+    ],
     "hit_points": 99,
     "hit_dice": "18d8",
     "hit_points_roll": "18d8+18",
@@ -6875,7 +6893,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-good alignment",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "studded-leather-armor",
+          "name": "Studded Leather Armor",
+          "url": "/api/equipment/studded-leather-armor"
+        }]
+      }
+    ],
     "hit_points": 78,
     "hit_dice": "12d8",
     "hit_points_roll": "12d8+24",
@@ -7690,7 +7718,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-lawful alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 12,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -7756,7 +7794,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-lawful alignment",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "studded-leather-armor",
+          "name": "Studded Leather Armor",
+          "url": "/api/equipment/studded-leather-armor"
+        }]
+      }
+    ],
     "hit_points": 65,
     "hit_dice": "10d8",
     "hit_points_roll": "10d8+20",
@@ -8562,7 +8610,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any chaotic alignment",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "armor": [{
+          "index": "hide-armor",
+          "name": "Hide Armor",
+          "url": "/api/equipment/hide-armor"
+        }]
+      }
+    ],
     "hit_points": 67,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+27",
@@ -11481,7 +11539,12 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 4,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8",
@@ -12154,7 +12217,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-good alignment",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8-5",
@@ -12314,7 +12387,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-good alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 12,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 9,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8",
@@ -14208,7 +14291,20 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }, {
+        "type": "spell",
+        "value": 16,
+        "spell": {
+          "index": "barkskin",
+          "name": "Barkskin",
+          "url": "/api/spells/barkskin"
+        }
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+5",
@@ -19863,7 +19959,21 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [{
+          "index": "studded-leather-armor",
+          "name": "Studded Leather Armor",
+          "url": "/api/equipment/studded-leather-armor"
+        }, {
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 112,
     "hit_dice": "15d8",
     "hit_points_roll": "15d8+45",
@@ -21371,7 +21481,21 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 16,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 16,
+        "armor": [{
+          "index": "chain-shirt",
+          "name": "Chain Shirt",
+          "url": "/api/equipment/chain-shirt"
+        }, {
+          "index": "shield",
+          "name": "Shield",
+          "url": "/api/equipment/shield"
+        }]
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -22167,7 +22291,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -23077,7 +23206,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -23241,7 +23375,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8+1",
@@ -24123,7 +24262,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 3,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6",
@@ -24191,7 +24335,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 90,
     "hit_dice": "12d12",
     "hit_points_roll": "12d12+12",
@@ -24266,7 +24415,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 18,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 18,
+        "armor": [{
+          "index": "plate-armor",
+          "name": "Plate Armor",
+          "url": "/api/equipment/plate-armor"
+        }]
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8+16",
@@ -25415,7 +25574,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 26,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10+4",
@@ -25523,7 +25687,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -25833,7 +26002,20 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }, {
+        "type": "spell",
+        "value": 15,
+        "spell": {
+          "index": "mage-armor",
+          "name": "Mage Armor",
+          "url": "/api/spells/mage-armor"
+        }
+      }
+    ],
     "hit_points": 40,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8",
@@ -26278,7 +26460,12 @@
     "size": "Huge",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 126,
     "hit_dice": "11d12",
     "hit_points_roll": "11d12+55",
@@ -26636,7 +26823,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8+1",
@@ -27434,7 +27626,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -28393,7 +28590,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 15,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 15,
+        "armor": [{
+          "index": "breastplate",
+          "name": "Breastplate",
+          "url": "/api/equipment/breastplate"
+        }]
+      }
+    ],
     "hit_points": 9,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8",
@@ -28589,7 +28796,12 @@
     "size": "Small",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 3,
     "hit_dice": "1d6",
     "hit_points_roll": "1d6",
@@ -29312,7 +29524,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -29492,7 +29709,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8",
@@ -29682,7 +29904,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 32,
     "hit_dice": "5d10",
     "hit_points_roll": "5d10+5",
@@ -30323,7 +30550,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 2,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4",
@@ -30374,7 +30606,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 42,
     "hit_dice": "5d10",
     "hit_points_roll": "5d10+15",
@@ -30471,7 +30708,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -30522,7 +30764,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "armor": [{
+          "index": "chain-shirt",
+          "name": "Chain Shirt",
+          "url": "/api/equipment/chain-shirt"
+        }]
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+5",
@@ -31004,7 +31256,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -31290,7 +31547,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -31346,7 +31608,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -31557,7 +31824,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "4d8",
     "hit_points_roll": "4d8+4",
@@ -31714,7 +31986,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 45,
     "hit_dice": "6d10",
     "hit_points_roll": "6d10+12",
@@ -31769,7 +32046,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 13,
     "hit_dice": "2d10",
     "hit_points_roll": "2d10+2",
@@ -32237,7 +32519,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 52,
     "hit_dice": "7d10",
     "hit_points_roll": "7d10+14",
@@ -32666,7 +32953,17 @@
     "size": "Medium",
     "type": "fey",
     "alignment": "chaotic neutral",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 14,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 31,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8",
@@ -32776,7 +33073,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 11
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -32828,7 +33130,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 13,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 16,
     "hit_dice": "3d8",
     "hit_points_roll": "3d8+3",
@@ -33040,7 +33352,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -34190,7 +34507,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -34465,7 +34787,7 @@
     "alignment": "neutral good",
     "armor_class": [
       {
-        "type": "armo",
+        "type": "armor",
         "value": 15,
         "armor": [{
           "index": "leather-armor",
@@ -34574,7 +34896,12 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 27,
     "hit_dice": "6d8",
     "hit_points_roll": "6d8",
@@ -35589,7 +35916,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -35699,7 +36031,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -35802,7 +36139,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -35904,7 +36246,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -36006,7 +36353,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 14,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 14
+      }
+    ],
     "hit_points": 36,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8",
@@ -36108,7 +36460,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 28,
     "hit_dice": "8d8",
     "hit_points_roll": "8d8-8",
@@ -36218,7 +36575,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 24,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8-7",
@@ -36323,7 +36685,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 24,
     "hit_dice": "7d8",
     "hit_points_roll": "7d8-7",
@@ -36424,7 +36791,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -36533,7 +36905,12 @@
     "size": "Medium",
     "type": "swarm of Tiny beasts",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 12
+      }
+    ],
     "hit_points": 22,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8",
@@ -36926,7 +37303,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any non-good alignment",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 11,
+        "armor": [{
+          "index": "leather-armor",
+          "name": "Leather Armor",
+          "url": "/api/equipment/leather-armor"
+        }]
+      }
+    ],
     "hit_points": 32,
     "hit_dice": "5d8",
     "hit_points_roll": "5d8+10",
@@ -37017,7 +37404,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 12
+      }
+    ],
     "hit_points": 37,
     "hit_dice": "5d10",
     "hit_points_roll": "5d10+10",
@@ -37224,7 +37616,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 12,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 12,
+        "armor": [{
+          "index": "hide-armor",
+          "name": "Hide Armor",
+          "url": "/api/equipment/hide-armor"
+        }]
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -38530,7 +38932,17 @@
     "type": "humanoid",
     "subtype": "any race",
     "alignment": "any alignment",
-    "armor_class": 17,
+    "armor_class": [
+      {
+        "type": "armor",
+        "value": 17,
+        "armor": [{
+          "index": "splint-armor",
+          "name": "Splint Armor",
+          "url": "/api/equipment/splint-armor"
+        }]
+      }
+    ],
     "hit_points": 58,
     "hit_dice": "9d8",
     "hit_points_roll": "9d8+18",
@@ -38916,7 +39328,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 10,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 10
+      }
+    ],
     "hit_points": 5,
     "hit_dice": "1d8",
     "hit_points_roll": "1d8+1",
@@ -38985,7 +39402,12 @@
     "size": "Large",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 11,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 11
+      }
+    ],
     "hit_points": 19,
     "hit_dice": "3d10",
     "hit_points_roll": "3d10+3",
@@ -39265,7 +39687,12 @@
     "size": "Tiny",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "dex",
+        "value": 13
+      }
+    ],
     "hit_points": 1,
     "hit_dice": "1d4",
     "hit_points_roll": "1d4-1",
@@ -41782,7 +42209,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 75,
     "hit_dice": "10d10",
     "hit_points_roll": "10d10+20",
@@ -41893,7 +42325,12 @@
     "size": "Medium",
     "type": "beast",
     "alignment": "unaligned",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 11,
     "hit_dice": "2d8",
     "hit_points_roll": "2d8+2",
@@ -41971,7 +42408,12 @@
     "size": "Large",
     "type": "monstrosity",
     "alignment": "neutral evil",
-    "armor_class": 13,
+    "armor_class": [
+      {
+        "type": "natural",
+        "value": 13
+      }
+    ],
     "hit_points": 26,
     "hit_dice": "4d10",
     "hit_points_roll": "4d10+4",


### PR DESCRIPTION
BREAKING CHANGE: Changes the shape of `armor_class` in monsters

## What does this do?

Changes the shape of `armor_class` in monsters from a number to:
```typescript
type ArmorClass = (ArmorClassDex | ArmorClassNatural | ArmorClassArmor | ArmorClassSpell | ArmorClassCondition)[];
type ArmorClassDex = {
  type: "dex";
  value: number;
  desc?: string;
};
type ArmorClassNatural = {
  type: "natural";
  value: number;
  desc?: string;
}
type ArmorClassArmor = {
  type: "armor";
  value: number;
  armor?: APIReference[]; // Equipment
  desc?: string;
}
type ArmorClassSpell = {
  type: "spell";
  value: number;
  spell: APIReference; // Spell
  desc?: string;
}
type ArmorClassCondition = {
  type: "condition";
  value: number;
  condition: APIReference; // Condition
  desc?: string;
}
```

## How was it tested?

CI

## Is there a Github issue this is resolving?

#280

## Did you update the docs in the API? Please link an associated PR if applicable.

[Yes](https://github.com/5e-bits/5e-srd-api/pull/343)

## Here's a fun image for your troubles

![image](https://user-images.githubusercontent.com/353626/207203199-3b7b2ad0-e3d4-4fb1-aa4c-0bc76c701338.png)
