### PR TITLE
fix: Giant Centipede xp

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -16989,7 +16989,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
-    "xp": 450,
+    "xp": 50,
     "actions": [
       {
         "name": "Bite",


### PR DESCRIPTION
## What does this do?

Changes the xp value of the Giant Centipede monster to 50 from 450. 

## How was it tested?

For some reason the Docker image wouldn't build locally for me, but I assume an integer change should be ok :)

## Is there a Github issue this is resolving?

This resolves https://github.com/5e-bits/5e-database/issues/519

## Did you update the docs in the API? Please link an associated PR if applicable.

Doesn't require docs update.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/520)
