### PR TITLE
fix: Blowgun damage (1d1 -> 1)

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -1392,7 +1392,7 @@
       "unit": "gp"
     },
     "damage": {
-      "damage_dice": "1d1",
+      "damage_dice": "1",
       "damage_type": {
         "index": "piercing",
         "name": "Piercing",


### PR DESCRIPTION
## What does this do?

Changes Blowgun's damage from "1d1" to "1"

## How was it tested?

N/A

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/511)
