### PR TITLE
fix: Changed instances of Weapon Attack to Melee Weapon Attack

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -9115,7 +9115,7 @@
     "actions": [
       {
         "name": "Tusk",
-        "desc": "Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage.",
+        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one target. Hit: 4 (1d6 + 1) slashing damage.",
         "attack_bonus": 3,
         "damage": [
           {
@@ -9674,7 +9674,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
+        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 8 (1d8 + 4) piercing damage.",
         "attack_bonus": 5,
         "damage": [
           {
@@ -18287,7 +18287,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 22 (3d10 + 6) piercing damage.",
+        "desc": "Melee Weapon Attack: +9 to hit, reach 5 ft., one target. Hit: 22 (3d10 + 6) piercing damage.",
         "attack_bonus": 9,
         "damage": [
           {
@@ -18672,7 +18672,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage.",
+        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 5 (1d4 + 3) piercing damage.",
         "attack_bonus": 5,
         "damage": [
           {
@@ -18756,7 +18756,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
+        "desc": "Melee Weapon Attack: +3 to hit, reach 5 ft., one creature. Hit: 4 (1d6 + 1) piercing damage, and the target must make a DC 11 Constitution saving throw, taking 7 (2d6) poison damage on a failed save, or half as much damage on a successful one. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned for 1 hour, even after regaining hit points, and is paralyzed while poisoned in this way.",
         "attack_bonus": 3,
         "damage": [
           {
@@ -21142,7 +21142,7 @@
       },
       {
         "name": "Longsword",
-        "desc": "Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.",
+        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 7 (1d8 + 3) slashing damage, or 8 (1d10 + 3) slashing damage if used with two hands.",
         "attack_bonus": 5,
         "damage": [
           {
@@ -22396,7 +22396,7 @@
     "actions": [
       {
         "name": "Bite",
-        "desc": "Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage.",
+        "desc": "Melee Weapon Attack: +2 to hit, reach 5 ft., one target. Hit: 3 (1d6) piercing damage.",
         "attack_bonus": 2,
         "damage": [
           {


### PR DESCRIPTION
## What does this do?

Change instances of "Weapon Attack"  to "Melee Weapon Attack" for consistency with other entries.

## How was it tested?

Only strings are changed - manual tested by reading the changed descriptions.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

Not necessary.

## Here's a fun image for your troubles

![A random tower](https://i.picsum.photos/id/629/400/400.jpg?hmac=BW0lcjCZbZpIVAsNax8HxyHmEsWNoRFNxsJ3Y-Mgpw8)
