### PR TITLE
fix(monsters.json): updating to make the count property datatype consistent.

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -103,7 +103,7 @@
         "actions": [
           {
             "action_name": "Tentacle",
-            "count": 3,
+            "count": "3",
             "type": "melee"
           }
         ]
@@ -434,17 +434,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -683,17 +683,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -947,17 +947,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -1225,17 +1225,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -1499,17 +1499,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -1785,17 +1785,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -2085,17 +2085,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -2333,17 +2333,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -2596,17 +2596,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -2867,17 +2867,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -3105,7 +3105,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -3245,17 +3245,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -3494,17 +3494,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -3758,17 +3758,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -4040,17 +4040,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -4318,17 +4318,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -4608,17 +4608,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -4912,17 +4912,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -5160,17 +5160,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -5423,17 +5423,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -5698,17 +5698,17 @@
         "actions": [
           {
             "action_name": "Frightful Presence",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -6068,7 +6068,7 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -6254,7 +6254,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -6418,7 +6418,7 @@
         "actions": [
           {
             "action_name": "Fist",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -6833,7 +6833,7 @@
         "actions": [
           {
             "action_name": "Shortsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -7436,12 +7436,12 @@
         "actions": [
           {
             "action_name": "Longsword",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Whip",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -7655,13 +7655,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Scimitar",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Dagger",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -7669,7 +7669,7 @@
               {
                 "option_type": "action",
                 "action_name": "Dagger",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -7858,13 +7858,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -7872,7 +7872,7 @@
               {
                 "option_type": "action",
                 "action_name": "Hurl Flame",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -8152,12 +8152,12 @@
         "actions": [
           {
             "action_name": "Beard",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Glaive",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -8254,12 +8254,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Constrict",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -8448,12 +8448,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -9235,12 +9235,12 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           },
           {
             "action_name": "Sting",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -9662,12 +9662,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -10079,13 +10079,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Pike",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Hooves",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -10093,7 +10093,7 @@
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -10235,7 +10235,7 @@
         "actions": [
           {
             "action_name": "Chain",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -10342,19 +10342,19 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Horns",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -10365,19 +10365,19 @@
                   {
                     "option_type": "action",
                     "action_name": "Fire Breath",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Horns",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -10388,19 +10388,19 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Fire Breath",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -10558,7 +10558,7 @@
               {
                 "option_type": "action",
                 "action_name": "Pincer",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -10567,13 +10567,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Pincer",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tentacles",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -10710,7 +10710,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -10805,12 +10805,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -11052,7 +11052,7 @@
         "actions": [
           {
             "action_name": "Morningstar",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -11926,7 +11926,7 @@
         "actions": [
           {
             "action_name": "Dagger",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -12164,7 +12164,7 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -12536,7 +12536,7 @@
         "actions": [
           {
             "action_name": "Mace",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -12855,7 +12855,7 @@
         "actions": [
           {
             "action_name": "Scimitar",
-            "count": 3,
+            "count": "3",
             "type": "melee"
           }
         ]
@@ -12995,7 +12995,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -13153,13 +13153,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -13170,13 +13170,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -13313,12 +13313,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -13498,13 +13498,13 @@
               {
                 "option_type": "action",
                 "action_name": "Longsword",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 3,
+                "count": "3",
                 "type": "ranged"
               },
               {
@@ -13513,13 +13513,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Longsword",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -13530,13 +13530,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Longbow",
-                    "count": 2,
+                    "count": "2",
                     "type": "ranged"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -14495,7 +14495,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -14698,13 +14698,13 @@
               {
                 "option_type": "action",
                 "action_name": "Scimitar",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Hurl Flame",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -14994,13 +14994,13 @@
               {
                 "option_type": "action",
                 "action_name": "Longsword",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 3,
+                "count": "3",
                 "type": "ranged"
               },
               {
@@ -15009,13 +15009,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Longsword",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Longbow",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -15026,13 +15026,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Longsword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Longbow",
-                    "count": 2,
+                    "count": "2",
                     "type": "ranged"
                   }
                 ]
@@ -15196,12 +15196,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -15315,12 +15315,12 @@
         "actions": [
           {
             "action_name": "Battleaxe",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Morningstar",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -15467,7 +15467,7 @@
         "actions": [
           {
             "action_name": "Touch",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -15571,7 +15571,7 @@
         "actions": [
           {
             "action_name": "Greatsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -15709,7 +15709,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -16052,7 +16052,7 @@
         "actions": [
           {
             "action_name": "Greataxe",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -16156,12 +16156,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -16704,7 +16704,7 @@
         "actions": [
           {
             "action_name": "Fist",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -16788,12 +16788,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -17204,12 +17204,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -17302,12 +17302,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Talons",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -18144,12 +18144,12 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           },
           {
             "action_name": "Sting",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -18521,12 +18521,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Talons",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -18837,12 +18837,12 @@
         "actions": [
           {
             "action_name": "Bites",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Blinding Spittle",
-            "count": 1,
+            "count": "1",
             "type": "ranged"
           }
         ]
@@ -19053,13 +19053,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Pincer",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Fist",
-                    "count": 2,
+                    "count": "2",
                     "type": "ranged"
                   }
                 ]
@@ -19070,13 +19070,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Pincer",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Innate Spellcasting",
-                    "count": 1,
+                    "count": "1",
                     "type": "magic"
                   }
                 ]
@@ -19215,19 +19215,19 @@
               {
                 "option_type": "action",
                 "action_name": "Spear",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Shield Bash",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Spear",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               },
               {
@@ -19236,13 +19236,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Spear",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Shield Bash",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -19253,13 +19253,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Spear",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Shield Bash",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -20305,12 +20305,12 @@
         "actions": [
           {
             "action_name": "Tentacles",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -20403,12 +20403,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -21050,7 +21050,7 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -21130,12 +21130,12 @@
         "actions": [
           {
             "action_name": "Longsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           },
           {
             "action_name": "Shortsword",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -21276,12 +21276,12 @@
         "actions": [
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Club",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -21592,12 +21592,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -21682,7 +21682,7 @@
         "actions": [
           {
             "action_name": "Greatclub",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -21774,12 +21774,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -22085,13 +22085,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Fork",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -22102,13 +22102,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Fork",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Hurl Flame",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -22119,19 +22119,19 @@
                   {
                     "option_type": "action",
                     "action_name": "Fork",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Hurl Flame",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -22507,17 +22507,17 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -22992,7 +22992,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -23114,13 +23114,13 @@
               {
                 "option_type": "action",
                 "action_name": "Slam",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Sword",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -23129,13 +23129,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Slam",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Sword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -23409,7 +23409,7 @@
         "actions": [
           {
             "action_name": "Greatsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -23656,7 +23656,7 @@
               {
                 "option_type": "action",
                 "action_name": "Tentacle",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               },
               {
@@ -23665,13 +23665,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Tentacle",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Fling",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -23682,13 +23682,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Tentacle",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Fling",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -23696,7 +23696,7 @@
               {
                 "option_type": "action",
                 "action_name": "Fling",
-                "count": 3,
+                "count": "3",
                 "type": "melee"
               }
             ]
@@ -23954,13 +23954,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Dagger",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -23971,13 +23971,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Intoxicating Touch",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   }
                 ]
@@ -24711,13 +24711,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Heavy Club",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -24728,13 +24728,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Javelin",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -24745,13 +24745,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Spiked Shield",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -24762,13 +24762,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Javelin",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Heavy Club",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -24779,13 +24779,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Spiked Shield",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Javelin",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -24796,13 +24796,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Spiked Shield",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Heavy Club",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -25436,13 +25436,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -25450,7 +25450,7 @@
               {
                 "option_type": "action",
                 "action_name": "Tail Spike",
-                "count": 3,
+                "count": "3",
                 "type": "ranged"
               }
             ]
@@ -25605,12 +25605,12 @@
         "actions": [
           {
             "action_name": "Longsword",
-            "count": 6,
+            "count": "6",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -25819,13 +25819,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Snake Hair",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Shortsword",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   }
                 ]
@@ -25833,7 +25833,7 @@
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -26046,13 +26046,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -26063,13 +26063,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Harpoon",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -26080,13 +26080,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Harpoon",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -26567,12 +26567,12 @@
         "actions": [
           {
             "action_name": "Dreadful Glare",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Rotting Fist",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -26851,12 +26851,12 @@
         "actions": [
           {
             "action_name": "Dreadful Glare",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Rotting Fist",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -27033,17 +27033,17 @@
         "actions": [
           {
             "action_name": "Horror Nimbus",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -27967,14 +27967,14 @@
               {
                 "option_type": "action",
                 "action_name": "Glaive",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Claw",
                 "desc": "If in Oni form",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -27984,13 +27984,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Glaive",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -28171,12 +28171,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tentacle",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -28367,12 +28367,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -28822,22 +28822,22 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Mace",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -29109,7 +29109,7 @@
         "actions": [
           {
             "action_name": "Greatsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -29326,12 +29326,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -29739,12 +29739,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail Stinger",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -30145,7 +30145,7 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -30772,12 +30772,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Talons",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -30886,17 +30886,17 @@
         "actions": [
           {
             "action_name": "Tendril",
-            "count": 4,
+            "count": "4",
             "type": "melee"
           },
           {
             "action_name": "Reel",
-            "count": 1,
+            "count": "1",
             "type": "ability"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -31258,13 +31258,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -31275,13 +31275,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Spear",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -31424,12 +31424,12 @@
         "actions": [
           {
             "action_name": "Spear",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -31749,13 +31749,13 @@
               {
                 "option_type": "action",
                 "action_name": "Shortsword",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -32113,12 +32113,12 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           },
           {
             "action_name": "Engulf",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -32227,7 +32227,7 @@
         "actions": [
           {
             "action_name": "Fist",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -32748,7 +32748,7 @@
         "actions": [
           {
             "action_name": "Greatsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -33448,7 +33448,7 @@
         "actions": [
           {
             "action_name": "Shortsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -33766,7 +33766,7 @@
         "actions": [
           {
             "action_name": "Greatclub",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -33898,7 +33898,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -34122,7 +34122,7 @@
         "actions": [
           {
             "action_name": "Greatsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -35496,31 +35496,31 @@
                   {
                     "option_type": "action",
                     "action_name": "Frightful Presence",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Horns",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -35531,32 +35531,32 @@
                   {
                     "option_type": "action",
                     "action_name": "Frightful Presence",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Swallow",
                     "desc": "If the target is grappled",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 2,
+                    "count": "2",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Horns",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tail",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -35714,7 +35714,7 @@
         "actions": [
           {
             "action_name": "Mace",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -35906,7 +35906,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -36158,12 +36158,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -36248,12 +36248,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Tail",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -36428,12 +36428,12 @@
         "actions": [
           {
             "action_name": "Hooves",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Horn",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -36636,13 +36636,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Unarmed Strike (Vampire Form Only)",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite (Bat or Vampire Form Only)",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -36650,7 +36650,7 @@
               {
                 "option_type": "action",
                 "action_name": "Unarmed Strike (Vampire Form Only)",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               }
             ]
@@ -37153,7 +37153,7 @@
               {
                 "option_type": "action",
                 "action_name": "Claws",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -37162,13 +37162,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -37275,12 +37275,12 @@
         "actions": [
           {
             "action_name": "Longsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           },
           {
             "action_name": "Shortsword",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -37523,12 +37523,12 @@
         "actions": [
           {
             "action_name": "Beak",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Talons",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -37882,7 +37882,7 @@
         "actions": [
           {
             "action_name": "Slam",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -38080,7 +38080,7 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -38190,7 +38190,7 @@
         "actions": [
           {
             "action_name": "Greataxe",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -38292,13 +38292,13 @@
               {
                 "option_type": "action",
                 "action_name": "Claw",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Greataxe",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -38307,13 +38307,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Greataxe",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claw",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -38543,7 +38543,7 @@
         "actions": [
           {
             "action_name": "Maul",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -38655,7 +38655,7 @@
               {
                 "option_type": "action",
                 "action_name": "Maul",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
@@ -38664,13 +38664,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Maul",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Tusks",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -38798,13 +38798,13 @@
               {
                 "option_type": "action",
                 "action_name": "Shortsword",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Hand Crossbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               },
               {
@@ -38813,13 +38813,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Shortsword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Hand Crossbow",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -38947,13 +38947,13 @@
               {
                 "option_type": "action",
                 "action_name": "Shortsword",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Hand Crossbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               },
               {
@@ -38962,13 +38962,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Shortsword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Hand Crossbow",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   }
                 ]
@@ -38979,13 +38979,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Shortsword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -38996,13 +38996,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Hand Crossbow",
-                    "count": 1,
+                    "count": "1",
                     "type": "ranged"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -39238,13 +39238,13 @@
               {
                 "option_type": "action",
                 "action_name": "Scimitar",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               }
             ]
@@ -39384,19 +39384,19 @@
               {
                 "option_type": "action",
                 "action_name": "Scimitar",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               },
               {
                 "option_type": "action",
                 "action_name": "Claw",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               }
             ]
@@ -39658,7 +39658,7 @@
         "actions": [
           {
             "action_name": "Spear",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -39774,12 +39774,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claws",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -40125,13 +40125,13 @@
               {
                 "option_type": "action",
                 "action_name": "Longsword",
-                "count": 2,
+                "count": "2",
                 "type": "melee"
               },
               {
                 "option_type": "action",
                 "action_name": "Longbow",
-                "count": 2,
+                "count": "2",
                 "type": "ranged"
               },
               {
@@ -40140,13 +40140,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Life Drain",
-                    "count": 1,
+                    "count": "1",
                     "type": "ability"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Longsword",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -40787,13 +40787,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Stinger",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -40804,13 +40804,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Bite",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -40821,13 +40821,13 @@
                   {
                     "option_type": "action",
                     "action_name": "Stinger",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   },
                   {
                     "option_type": "action",
                     "action_name": "Claws",
-                    "count": 1,
+                    "count": "1",
                     "type": "melee"
                   }
                 ]
@@ -40958,12 +40958,12 @@
         "actions": [
           {
             "action_name": "Claw",
-            "count": 3,
+            "count": "3",
             "type": "melee"
           },
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           }
         ]
@@ -41101,12 +41101,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -41274,12 +41274,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -41454,12 +41454,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -41658,12 +41658,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -41856,12 +41856,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -42068,12 +42068,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -42278,12 +42278,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -42450,12 +42450,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -42637,12 +42637,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]
@@ -42834,12 +42834,12 @@
         "actions": [
           {
             "action_name": "Bite",
-            "count": 1,
+            "count": "1",
             "type": "melee"
           },
           {
             "action_name": "Claw",
-            "count": 2,
+            "count": "2",
             "type": "melee"
           }
         ]


### PR DESCRIPTION

## What does this do?

take 2 on the right repo this time.
This change updates the Monsters.json source file to set the multiattack count properties to a consistent datatype. In 99% of cases the count is an integer. There are however 2(?) instances where the count is a string. This is a pain when parsing with statically typed languages and brakes unmarshaling of the data. I couldn't think of a good way to convert the hydra for instance to a consistent integer so I went and retyped the property throughout.  I'm open to better ideas. 

## How was it tested?

lots of grep statements.

## Is there a Github issue this is resolving?

No, I probably should have created an issue, Sorry.

## Did you update the docs in the API? Please link an associated PR if applicable.

No, I don't think the datatypes are documented anywhere?

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
