### PR TITLE
fix: Add usage dict to recharge 6 actions

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6336,8 +6336,13 @@
         ]
       },
       {
-        "name": "Acid Spray (Recharge 6)",
+        "name": "Acid Spray",
         "desc": "The ankheg spits acid in a line that is 30 ft. long and 5 ft. wide, provided that it has no creature grappled. Each creature in that line must make a DC 13 Dexterity saving throw, taking 10 (3d6) acid damage on a failed save, or half as much damage on a successful one.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -14332,8 +14337,13 @@
         ]
       },
       {
-        "name": "Blinding Breath (Recharge 6)",
+        "name": "Blinding Breath",
         "desc": "The mephit exhales a 15-foot cone of blinding dust. Each creature in that area must succeed on a DC 10 Dexterity saving throw or be blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -16550,8 +16560,13 @@
         }
       },
       {
-        "name": "Possession (Recharge 6)",
+        "name": "Possession",
         "desc": "One humanoid that the ghost can see within 5 ft. of it must succeed on a DC 13 Charisma saving throw or be possessed by the ghost; the ghost then disappears, and the target is incapacitated and loses control of its body. The ghost now controls the body but doesn't deprive the target of awareness. The ghost can't be targeted by any attack, spell, or other effect, except ones that turn undead, and it retains its alignment, Intelligence, Wisdom, Charisma, and immunity to being charmed and frightened. It otherwise uses the possessed target's statistics, but doesn't gain access to the target's knowledge, class features, or proficiencies.\nThe possession lasts until the body drops to 0 hit points, the ghost ends it as a bonus action, or the ghost is turned or forced out by an effect like the dispel evil and good spell. When the possession ends, the ghost reappears in an unoccupied space within 5 ft. of the body. The target is immune to this ghost's Possession for 24 hours after succeeding on the saving throw or after the possession ends.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "cha",
@@ -22739,8 +22754,13 @@
         ]
       },
       {
-        "name": "Frost Breath (Recharge 6)",
+        "name": "Frost Breath",
         "desc": "The mephit exhales a 15-foot cone of cold air. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 5 (2d4) cold damage on a failed save, or half as much damage on a successful one.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -25202,8 +25222,13 @@
         ]
       },
       {
-        "name": "Fire Breath (Recharge 6)",
+        "name": "Fire Breath",
         "desc": "The mephit exhales a 15-foot cone of fire. Each creature in that area must make a DC 11 Dexterity saving throw, taking 7 (2d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -33604,8 +33629,13 @@
         ]
       },
       {
-        "name": "Steam Breath (Recharge 6)",
+        "name": "Steam Breath",
         "desc": "The mephit exhales a 15-foot cone of scalding steam. Each creature in that area must succeed on a DC 10 Dexterity saving throw, taking 4 (1d8) fire damage on a failed save, or half as much damage on a successful one.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -37564,8 +37594,13 @@
         ]
       },
       {
-        "name": "Spores (Recharge 6)",
+        "name": "Spores",
         "desc": "A 15-foot-radius cloud of toxic spores extends out from the vrock. The spores spread around corners. Each creature in that area must succeed on a DC 14 Constitution saving throw or become poisoned. While poisoned in this way, a target takes 5 (1d10) poison damage at the start of each of its turns. A target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Emptying a vial of holy water on the target also ends the effect on it.",
+        "usage": {
+          "type": "recharge on roll",
+          "dice": "1d6",
+          "min_value": 6
+        },
         "dc": {
           "dc_type": {
             "index": "con",


### PR DESCRIPTION
## What does this do?

This adds the following "usage" dict to the 7 actions with (Recharge 6) in their name and removes (Recharge 6) from the action name. I'm not sure if this was left out on purpose, or maybe I'm misunderstanding the Recharge rule, so feel free to close this if it's not applicable.
```json
"usage": {
  "type": "recharge on roll",
  "dice": "1d6",
  "min_value": 6
}
```

This may be a breaking change?

## How was it tested?

N/A

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/526)
