### PR TITLE
fix: Move Traps, Diseases, Madness from Appendices to Adventuring

### DIFF
--- a/src/5e-SRD-Rules.json
+++ b/src/5e-SRD-Rules.json
@@ -106,6 +106,21 @@
         "url": "/api/rule-sections/the-environment"
       },
       {
+        "name": "Traps",
+        "index": "traps",
+        "url": "/api/rule-sections/traps"
+      },
+      {
+        "name": "Diseases",
+        "index": "diseases",
+        "url": "/api/rule-sections/diseases"
+      },
+      {
+        "name": "Madness",
+        "index": "madness",
+        "url": "/api/rule-sections/madness"
+      },
+      {
         "name": "Resting",
         "index": "resting",
         "url": "/api/rule-sections/resting"
@@ -178,21 +193,6 @@
         "name": "The Planes of Existence",
         "index": "the-planes-of-existence",
         "url": "/api/rule-sections/the-planes-of-existence"
-      },
-      {
-        "name": "Traps",
-        "index": "traps",
-        "url": "/api/rule-sections/traps"
-      },
-      {
-        "name": "Diseases",
-        "index": "diseases",
-        "url": "/api/rule-sections/diseases"
-      },
-      {
-        "name": "Madness",
-        "index": "madness",
-        "url": "/api/rule-sections/madness"
       }
     ],
     "url": "/api/rules/appendix"


### PR DESCRIPTION
## What does this do?

SRD 5.0 added the Conditions appendix before the Traps, Diseases, and Madness sections. SRD 5.1 reorganized these sections and renamed appendices, clarifying that these sections are part of the main adventuring content.

This moves those sections from the Appendix object in `rules` to the Adventuring object.

## How was it tested?

```
docker build -t 5e-database .
docker run -p 27017:27017 -i -t 5e-database:latest
mongo
> use 5e-database
> db['rules'].find({ name: "Appendix" })
{ "_id" : ObjectId("63dd382f512b50f89dfd218c"), "name" : "Appendix", "index" : "appendix", "desc" : "# Appendix\n", "subsections" : [ { "name" : "Fantasy-Historical Pantheons", "index" : "fantasy-historical-pantheons", "url" : "/api/rule-sections/fantasy-historical-pantheons" }, { "name" : "The Planes of Existence", "index" : "the-planes-of-existence", "url" : "/api/rule-sections/the-planes-of-existence" } ], "url" : "/api/rules/appendix" }
> db['rules'].find({ name: "Adventuring" })
{ "_id" : ObjectId("63dd382f512b50f89dfd218d"), "name" : "Adventuring", "index" : "adventuring", "desc" : "# Adventuring\n", "subsections" : [ { "name" : "Time", "index" : "time", "url" : "/api/rule-sections/time" }, { "name" : "Movement", "index" : "movement", "url" : "/api/rule-sections/movement" }, { "name" : "The Environment", "index" : "the-environment", "url" : "/api/rule-sections/the-environment" }, { "name" : "Traps", "index" : "traps", "url" : "/api/rule-sections/traps" }, { "name" : "Diseases", "index" : "diseases", "url" : "/api/rule-sections/diseases" }, { "name" : "Madness", "index" : "madness", "url" : "/api/rule-sections/madness" }, { "name" : "Resting", "index" : "resting", "url" : "/api/rule-sections/resting" }, { "name" : "Between Adventures", "index" : "between-adventures", "url" : "/api/rule-sections/between-adventures" } ], "url" : "/api/rules/adventuring" }
```

Traps, Diseases, Madness are in the correct `subsections`.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

Unsure. I couldn't find any API docs that cover this organization.

## Here's a fun image for your troubles

![random photo - update me](https://pbs.twimg.com/media/FDH394BWEAoaDq-?format=jpg&name=large)
