### PR TITLE
fix: Bone Devil CR, XP, passive perception

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -9533,11 +9533,11 @@
     ],
     "senses": {
       "darkvision": "120 ft.",
-      "passive_perception": 9
+      "passive_perception": 12
     },
     "languages": "Infernal, telepathy 120 ft.",
-    "challenge_rating": 12,
-    "xp": 8400,
+    "challenge_rating": 9,
+    "xp": 5000,
     "special_abilities": [
       {
         "name": "Devil's Sight",
@@ -9583,7 +9583,7 @@
       },
       {
         "name": "Sting",
-        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success .",
+        "desc": "Melee Weapon Attack: +8 to hit, reach 10 ft., one target. Hit: 13 (2d8 + 4) piercing damage plus 17 (5d6) poison damage, and the target must succeed on a DC 14 Constitution saving throw or become poisoned for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
         "attack_bonus": 8,
         "damage": [
           {


### PR DESCRIPTION
## What does this do?

Fix transposed numbers on the Bone Devil monster entry, and a typo.

## How was it tested?

```
docker build -t 5e-database . && docker run -p 27017:27017 -i -t 5e-database:latest
mongo 5e-database
> db['monsters'].find({ name: "Bone Devil" }, { xp: 1, challenge_rating: 1, senses: 1 }).pretty()
{
	"_id" : ObjectId("63de93d1149d54c9ff6c774f"),
	"senses" : {
		"darkvision" : "120 ft.",
		"passive_perception" : 12
	},
	"challenge_rating" : 9,
	"xp" : 5000
}
```

## Is there a Github issue this is resolving?

Fixes #530.

## Did you update the docs in the API? Please link an associated PR if applicable.

Couldn't find any docs that needed changing.

## Here's a fun image for your troubles

![66620fc15fe7583871a59eb87e520d0f--peanut-butter-snacks-drake-cake](https://user-images.githubusercontent.com/19192104/216781153-19bf3505-28b1-4fdb-b6bd-ed568f11ea8f.jpg)

