### PR TITLE
feat: Add Subraces

### DIFF
--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -679,6 +679,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "url": "/api/proficiencies/shortbows",
@@ -835,6 +840,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "url": "/api/proficiencies/longswords",
@@ -952,6 +962,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "url": "/api/proficiencies/shortswords",
@@ -1079,6 +1094,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "url": "/api/proficiencies/longbows",

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -909,7 +909,13 @@
         "url": "/api/classes/rogue"
       }
     ],
-    "races": [],
+    "races": [
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
+      }
+    ],
     "url": "/api/proficiencies/rapiers",
     "reference": {
       "index": "rapier",
@@ -967,6 +973,11 @@
         "index": "wood-elf",
         "name": "Wood Elf",
         "url": "/api/subraces/wood-elf"
+      },
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
       }
     ],
     "url": "/api/proficiencies/shortswords",
@@ -1063,7 +1074,13 @@
         "url": "/api/classes/rogue"
       }
     ],
-    "races": [],
+    "races": [
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
+      }
+    ],
     "url": "/api/proficiencies/hand-crossbows",
     "reference": {
       "index": "crossbow-hand",

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -197,6 +197,11 @@
         "index": "wood-elf",
         "name": "Wood Elf",
         "url": "/api/subraces/wood-elf"
+      },
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
       }
     ],
     "url": "/api/races/elf"

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -260,6 +260,11 @@
         "index": "lightfoot-halfling",
         "name": "Lightfoot Halfling",
         "url": "/api/subraces/lightfoot-halfling"
+      },
+      {
+        "index": "stout-halfling",
+        "name": "Stout Halfling",
+        "url": "/api/subraces/stout-halfling"
       }
     ],
     "url": "/api/races/halfling"

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -118,6 +118,11 @@
         "index": "hill-dwarf",
         "name": "Hill Dwarf",
         "url": "/api/subraces/hill-dwarf"
+      },
+      {
+        "index": "mountain-dwarf",
+        "name": "Mountain Dwarf",
+        "url": "/api/subraces/mountain-dwarf"
       }
     ],
     "url": "/api/races/dwarf"

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -192,6 +192,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "url": "/api/races/elf"

--- a/src/5e-SRD-Races.json
+++ b/src/5e-SRD-Races.json
@@ -578,6 +578,11 @@
         "index": "rock-gnome",
         "name": "Rock Gnome",
         "url": "/api/subraces/rock-gnome"
+      },
+      {
+        "index": "forest-gnome",
+        "name": "Forest Gnome",
+        "url": "/api/subraces/forest-gnome"
       }
     ],
     "url": "/api/races/gnome"

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -424,6 +424,183 @@
     "url": "/api/subraces/wood-elf"
   },
   {
+    "index": "dark-elf",
+    "name": "Dark Elf",
+    "race": {
+      "index": "elf",
+      "name": "Elf",
+      "url": "/api/races/elf"
+    },
+    "desc": "As a drow, you are infused with the magic of the Underdark, and underground real of wonders and horrors rarely seen on the surface above.",
+    "ability_bonuses": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/ability-scores/cha"
+        },
+        "bonus": 1
+      }
+    ],
+    "starting_proficiencies": [
+      {
+        "index": "rapiers",
+        "name": "Rapiers",
+        "url": "/api/proficiencies/rapiers"
+      },
+      {
+        "index": "shortswords",
+        "name": "Shortswords",
+        "url": "/api/proficiencies/shortswords"
+      },
+      {
+        "index": "crossbow-hand",
+        "name": "Hand Crossbows",
+        "url": "/api/proficiencies/crossbow-hand"
+      }
+    ],
+    "languages": [],
+    "language_options": {
+      "choose": 1,
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      },
+      "type": "language"
+    },
+    "racial_traits": [
+      {
+        "index": "superior-darkvision",
+        "name": "Superior Darkvision",
+        "url": "/api/traits/superior-darkvision"
+      },
+      {
+        "index": "sunlight-sensitivity",
+        "name": "Sunlight Sensitivity",
+        "url": "/api/traits/sunlight-sensitivity"
+      },
+      {
+        "index": "drow-magic",
+        "name": "Drow Magic",
+        "url": "/api/traits/drow-magic"
+      }
+    ],
+    "url": "/api/subraces/dark-elf"
+  },
+  {
     "index": "lightfoot-halfling",
     "name": "Lightfoot Halfling",
     "race": {

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -30,6 +30,36 @@
     "url": "/api/subraces/hill-dwarf"
   },
   {
+    "index": "mountain-dwarf",
+    "name": "Mountain Dwarf",
+    "race": {
+      "index": "dwarf",
+      "name": "Dwarf",
+      "url": "/api/races/dwarf"
+    },
+    "desc": "As a mountain dwarf, you're strong and hardy, accustomed to a difficult life in rugged terrain.",
+    "ability_bonuses": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/ability-scores/str"
+        },
+        "bonus": 2
+      }
+    ],
+    "starting_proficiencies": [],
+    "languages": [],
+    "racial_traits": [
+      {
+        "index": "dwarven-armor-training",
+        "name": "Dwarven Armor Training",
+        "url": "/api/traits/dwarven-armor-training"
+      }
+    ],
+    "url": "/api/subraces/mountain-dwarf"
+  },
+  {
     "index": "high-elf",
     "name": "High Elf",
     "race": {

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -631,6 +631,36 @@
     "url": "/api/subraces/lightfoot-halfling"
   },
   {
+    "index": "stout-halfling",
+    "name": "Stout Halfling",
+    "race": {
+      "index": "halfling",
+      "name": "Halfling",
+      "url": "/api/races/halfling"
+    },
+    "desc": "As a stout halfling, you're hardier than average an have some resistance to poison. Some say that stouts have dwarven blood. in the Forgotten Realms, these halflings are called stronghearts, adn they're most common in the south.",
+    "ability_bonuses": [
+      {
+        "ability_score": {
+          "index": "con",
+          "name": "CON",
+          "url": "/api/ability-scores/con"
+        },
+        "bonus": 1
+      }
+    ],
+    "starting_proficiencies": [],
+    "languages": [],
+    "racial_traits": [
+      {
+        "index": "stout-resilience",
+        "name": "Stout Resilience",
+        "url": "/api/traits/stout-resilience"
+      }
+    ],
+    "url": "/api/subraces/stout-halfling"
+  },
+  {
     "index": "rock-gnome",
     "name": "Rock Gnome",
     "race": {

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -242,6 +242,188 @@
     "url": "/api/subraces/high-elf"
   },
   {
+    "index": "wood-elf",
+    "name": "Wood Elf",
+    "race": {
+      "index": "elf",
+      "name": "Elf",
+      "url": "/api/races/elf"
+    },
+    "desc": "As a wood elf, you have keen sense and intuition, and your fleet feet carry you quickly and stealthily through your native forests.",
+    "ability_bonuses": [
+      {
+        "ability_score": {
+          "index": "wis",
+          "name": "WIS",
+          "url": "/api/ability-scores/wis"
+        },
+        "bonus": 1
+      }
+    ],
+    "starting_proficiencies": [
+      {
+        "index": "longswords",
+        "name": "Longswords",
+        "url": "/api/proficiencies/longswords"
+      },
+      {
+        "index": "shortswords",
+        "name": "Shortswords",
+        "url": "/api/proficiencies/shortswords"
+      },
+      {
+        "index": "shortbows",
+        "name": "Shortbows",
+        "url": "/api/proficiencies/shortbows"
+      },
+      {
+        "index": "longbows",
+        "name": "Longbows",
+        "url": "/api/proficiencies/longbows"
+      }
+    ],
+    "languages": [],
+    "language_options": {
+      "choose": 1,
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      },
+      "type": "language"
+    },
+    "racial_traits": [
+      {
+        "index": "elf-weapon-training",
+        "name": "Elf Weapon Training",
+        "url": "/api/traits/elf-weapon-training"
+      },
+      {
+        "index": "fleet-of-foot",
+        "name": "Fleet of Foot",
+        "url": "/api/traits/fleet-of-foot"
+      },
+      {
+        "index": "mask-of-wild",
+        "name": "Mask of the Wild",
+        "url": "/api/traits/mask-of-wild"
+      }
+    ],
+    "url": "/api/subraces/wood-elf"
+  },
+  {
     "index": "lightfoot-halfling",
     "name": "Lightfoot Halfling",
     "race": {

--- a/src/5e-SRD-Subraces.json
+++ b/src/5e-SRD-Subraces.json
@@ -700,5 +700,40 @@
       }
     ],
     "url": "/api/subraces/rock-gnome"
+  },
+  {
+    "index": "forest-gnome",
+    "name": "Forest Gnome",
+    "race": {
+      "index": "gnome",
+      "name": "Gnome",
+      "url": "/api/races/gnome"
+    },
+    "desc": "As a forest gnome, you have a natural knack for illusion and inherent quickness and stealth.",
+    "ability_bonuses": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/ability-scores/dex"
+        },
+        "bonus": 1
+      }
+    ],
+    "starting_proficiencies": [],
+    "languages": [],
+    "racial_traits": [
+      {
+        "index": "natural-illusionist",
+        "name": "Natural Illusionist",
+        "url": "/api/traits/natural-illusionist"
+      },
+      {
+        "index": "speak-with-small-beasts",
+        "name": "Speak with Small Beasts",
+        "url": "/api/traits/speak-with-small-beasts"
+      }
+    ],
+    "url": "/api/subraces/forest-gnome"
   }
 ]

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -2191,6 +2191,40 @@
     "url": "/api/traits/tinker"
   },
   {
+    "index": "natural-illusionist",
+    "races": [],
+    "subraces": [
+      {
+        "index": "forest-gnome",
+        "name": "Forest Gnome",
+        "url": "/api/subraces/forest-gnome"
+      }
+    ],
+    "name": "Natural Illusionist",
+    "desc": [
+      "You know the minor illusion cantrip. Intelligence is your spellcasting ability for it."
+    ],
+    "proficiencies": [],
+    "url": "/api/traits/natural-illusionist"
+  },
+  {
+    "index": "speak-with-small-beasts",
+    "races": [],
+    "subraces": [
+      {
+        "index": "forest-gnome",
+        "name": "Forest Gnome",
+        "url": "/api/subraces/forest-gnome"
+      }
+    ],
+    "name": "Speak with Small Beasts",
+    "desc": [
+      "Through sounds and gestures, you can communicate simple ideas with Small or smaller beasts. Forest gnomes love animals and often keep squirrels, badgers, rabbits, moles, woodpeckers, and other creatures as beloved pets."
+    ],
+    "proficiencies": [],
+    "url": "/api/traits/speak-with-small-beasts"
+  },
+  {
     "index": "skill-versatility",
     "races": [
       {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -851,6 +851,418 @@
     "url": "/api/traits/mask-of-wild"
   },
   {
+    "index": "superior-darkvision",
+    "races": [],
+    "subraces": [
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
+      }
+    ],
+    "name": "Superior Darkvision",
+    "desc": ["Your darkvision has a radius of 120 feet."],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/traits/superior-darkvision"
+  },
+  {
+    "index": "sunlight-sensitivity",
+    "races": [],
+    "subraces": [
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
+      }
+    ],
+    "name": "Sunlight Sensitivity",
+    "desc": [
+      "You have disadvantage on attack rolls and on Wisdom (Perception) checks that rely on sight when you, the target of your attack, or whatever you are trying to perceive is in direct sunlight."
+    ],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/traits/sunlight-sensitivity"
+  },
+  {
+    "index": "drow-magic",
+    "races": [],
+    "subraces": [
+      {
+        "index": "dark-elf",
+        "name": "Dark Elf",
+        "url": "/api/subraces/dark-elf"
+      }
+    ],
+    "name": "Drow Magic",
+    "desc": [
+      "you know the dancing lights cantrip. When you reach 3rd level, you can cast the faerie fire spell once with this trait and regain the abilith to do so when you finish a long rest. When you reach 5th level, you can cast the darkness spell once with this trait and regain ithe ability to do so when you finish a long rest. Charisma is your spellcasting ability fofr these spells."
+    ],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/traits/drow-magic"
+  },
+  {
     "index": "lucky",
     "races": [
       {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -181,6 +181,21 @@
     "url": "/api/traits/dwarven-toughness"
   },
   {
+    "index": "dwarven-armor-training",
+    "races": [],
+    "subraces": [
+      {
+        "index": "mountain-dwarf",
+        "name": "Mountain Dwarf",
+        "url": "/api/subraces/mountain-dwarf"
+      }
+    ],
+    "name": "Dwarven Armor Training",
+    "desc": ["You have proficiency with light and medium armor."],
+    "proficiencies": [],
+    "url": "/api/traits/dwarven-toughness"
+  },
+  {
     "index": "keen-senses",
     "races": [
       {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -1329,6 +1329,23 @@
     "url": "/api/traits/naturally-stealthy"
   },
   {
+    "index": "stout-resilience",
+    "races": [],
+    "subraces": [
+      {
+        "index": "stout-halfling",
+        "name": "Stout Halfling",
+        "url": "/api/subraces/stout-halfling"
+      }
+    ],
+    "name": "Stout Resilience",
+    "desc": [
+      "You have advantage on saving throws against poison, and you have resistance against poison damage."
+    ],
+    "proficiencies": [],
+    "url": "/api/traits/stout-resilience"
+  },
+  {
     "index": "draconic-ancestry",
     "races": [
       {

--- a/src/5e-SRD-Traits.json
+++ b/src/5e-SRD-Traits.json
@@ -263,6 +263,11 @@
         "index": "high-elf",
         "name": "High Elf",
         "url": "/api/subraces/high-elf"
+      },
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
       }
     ],
     "name": "Elf Weapon Training",
@@ -570,6 +575,280 @@
       }
     },
     "url": "/api/traits/extra-language"
+  },
+  {
+    "index": "fleet-of-foot",
+    "races": [],
+    "subraces": [
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
+      }
+    ],
+    "name": "Fleet of Foot",
+    "desc": ["Your base walking speed increases to 35."],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/traits/fleet-of-foot"
+  },
+  {
+    "index": "mask-of-wild",
+    "races": [],
+    "subraces": [
+      {
+        "index": "wood-elf",
+        "name": "Wood Elf",
+        "url": "/api/subraces/wood-elf"
+      }
+    ],
+    "name": "Mask of the Wild",
+    "desc": [
+      "You can attempt to hide even when you are only lightly obscured by foliage, heavy rain, falling snow, mist, and other natural phenomena."
+    ],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Dwarvish",
+              "url": "/api/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Giant",
+              "url": "/api/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnomish",
+              "url": "/api/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Goblin",
+              "url": "/api/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfling",
+              "url": "/api/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Celestial",
+              "url": "/api/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconic",
+              "url": "/api/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Deep Speech",
+              "url": "/api/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvan",
+              "url": "/api/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Undercommon",
+              "url": "/api/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/traits/mask-of-wild"
   },
   {
     "index": "lucky",


### PR DESCRIPTION
## What does this do?

Add the following subraces with associated traits and proficiencies:

- Mountain Dwarf
- Wood Elf
- Dark Elf
- Stout Halfling
- Forest Gnome

## How was it tested?

Per README:

1. Run local Docker image:
```
docker build -t 5e-database .
docker run -i -t 5e-database:latest
```

2. Build with Docker:
```
docker-compose up --build
```

3. Test response at `localhost:3000`

## Is there a Github issue this is resolving?
No

## Did you update the docs in the API? Please link an associated PR if applicable.

https://github.com/5e-bits/5e-srd-api/pull/353

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/id/29/400/200)
