### PR TITLE
feat: Rationalize Equipment Category Schema

### DIFF
--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1406,7 +1406,7 @@
       {
         "index": "donkey",
         "name": "Donkey",
-        "url": "/api/equipment/Donkey"
+        "url": "/api/equipment/donkey"
       },
       {
         "index": "barding-padded",
@@ -3186,7 +3186,7 @@
       {
         "index": "donkey",
         "name": "Donkey",
-        "url": "/api/equipment/Donkey"
+        "url": "/api/equipment/donkey"
       }
     ],
     "url": "/api/equipment-categories/mounts-and-other-animals"

--- a/src/5e-SRD-Equipment-Categories.json
+++ b/src/5e-SRD-Equipment-Categories.json
@@ -1399,6 +1399,16 @@
         "url": "/api/equipment/warhorse"
       },
       {
+        "index": "camel",
+        "name": "Camel",
+        "url": "/api/equipment/camel"
+      },
+      {
+        "index": "donkey",
+        "name": "Donkey",
+        "url": "/api/equipment/Donkey"
+      },
+      {
         "index": "barding-padded",
         "name": "Barding: Padded",
         "url": "/api/equipment/barding-padded"
@@ -3167,6 +3177,16 @@
         "index": "warhorse",
         "name": "Warhorse",
         "url": "/api/equipment/warhorse"
+      },
+      {
+        "index": "camel",
+        "name": "Camel",
+        "url": "/api/equipment/camel"
+      },
+      {
+        "index": "donkey",
+        "name": "Donkey",
+        "url": "/api/equipment/Donkey"
       }
     ],
     "url": "/api/equipment-categories/mounts-and-other-animals"

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -2906,6 +2906,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -2930,6 +2942,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -2955,6 +2979,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -2976,6 +3012,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
+      }
+    ],
     "gear_category": {
       "index": "ammunition",
       "name": "Ammunition",
@@ -2997,6 +3045,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3018,6 +3078,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
+      }
+    ],
     "gear_category": {
       "index": "ammunition",
       "name": "Ammunition",
@@ -3039,6 +3111,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3060,6 +3144,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
+      }
+    ],
     "gear_category": {
       "index": "ammunition",
       "name": "Ammunition",
@@ -3081,6 +3177,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/equipment-categories/ammunition"
+      }
+    ],
     "gear_category": {
       "index": "ammunition",
       "name": "Ammunition",
@@ -3102,6 +3210,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/equipment-categories/holy-symbols"
+      }
+    ],
     "gear_category": {
       "index": "holy-symbols",
       "name": "Holy Symbols",
@@ -3126,6 +3246,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3149,6 +3281,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/equipment-categories/arcane-foci"
+      }
+    ],
     "gear_category": {
       "index": "arcane-foci",
       "name": "Arcane Foci",
@@ -3172,6 +3316,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/equipment-categories/arcane-foci"
+      }
+    ],
     "gear_category": {
       "index": "arcane-foci",
       "name": "Arcane Foci",
@@ -3195,6 +3351,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/equipment-categories/arcane-foci"
+      }
+    ],
     "gear_category": {
       "index": "arcane-foci",
       "name": "Arcane Foci",
@@ -3218,6 +3386,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/equipment-categories/arcane-foci"
+      }
+    ],
     "gear_category": {
       "index": "arcane-foci",
       "name": "Arcane Foci",
@@ -3241,6 +3421,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/equipment-categories/arcane-foci"
+      }
+    ],
     "gear_category": {
       "index": "arcane-foci",
       "name": "Arcane Foci",
@@ -3264,6 +3456,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3284,6 +3488,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3309,6 +3525,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3329,6 +3557,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3349,6 +3589,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3369,6 +3621,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3389,6 +3653,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3409,6 +3685,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3432,6 +3720,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -3019,6 +3019,11 @@
         "url": "/api/equipment-categories/adventuring-gear"
       },
       {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      },
+      {
         "index": "ammunition",
         "name": "Ammunition",
         "url": "/api/equipment-categories/ammunition"
@@ -3083,6 +3088,11 @@
         "index": "adventuring-gear",
         "name": "Adventuring Gear",
         "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
       },
       {
         "index": "ammunition",
@@ -3151,6 +3161,11 @@
         "url": "/api/equipment-categories/adventuring-gear"
       },
       {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      },
+      {
         "index": "ammunition",
         "name": "Ammunition",
         "url": "/api/equipment-categories/ammunition"
@@ -3182,6 +3197,11 @@
         "index": "adventuring-gear",
         "name": "Adventuring Gear",
         "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
       },
       {
         "index": "ammunition",
@@ -7850,9 +7870,9 @@
         "url": "/api/equipment-categories/tools"
       },
       {
-        "index": "artisans-tools",
-        "name": "Artisan's Tools",
-        "url": "/api/equipment-categories/artisans-tools"
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/equipment-categories/gaming-sets"
       }
     ],
     "tool_category": "Gaming Sets",
@@ -8972,6 +8992,11 @@
         "url": "/api/equipment-categories/mounts-and-vehicles"
       },
       {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "url": "/api/equipment-categories/land-vehicles"
+      },
+      {
         "index": "tack-harness-and-drawn-vehicles",
         "name": "Tack, Harness, and Drawn Vehicles",
         "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
@@ -9000,6 +9025,11 @@
         "url": "/api/equipment-categories/mounts-and-vehicles"
       },
       {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "url": "/api/equipment-categories/land-vehicles"
+      },
+      {
         "index": "tack-harness-and-drawn-vehicles",
         "name": "Tack, Harness, and Drawn Vehicles",
         "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
@@ -9026,6 +9056,11 @@
         "index": "mounts-and-vehicles",
         "name": "Mounts and Vehicles",
         "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "url": "/api/equipment-categories/land-vehicles"
       },
       {
         "index": "tack-harness-and-drawn-vehicles",
@@ -9230,6 +9265,11 @@
         "url": "/api/equipment-categories/mounts-and-vehicles"
       },
       {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "url": "/api/equipment-categories/land-vehicles"
+      },
+      {
         "index": "tack-harness-and-drawn-vehicles",
         "name": "Tack, Harness, and Drawn Vehicles",
         "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
@@ -9284,6 +9324,11 @@
         "index": "mounts-and-vehicles",
         "name": "Mounts and Vehicles",
         "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "land-vehicles",
+        "name": "Land Vehicles",
+        "url": "/api/equipment-categories/land-vehicles"
       },
       {
         "index": "tack-harness-and-drawn-vehicles",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -3755,6 +3755,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3775,6 +3787,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3795,6 +3819,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3821,6 +3857,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3844,6 +3892,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3865,6 +3925,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3888,6 +3960,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -3911,6 +3995,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -7,6 +7,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -48,6 +70,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -103,6 +147,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -139,6 +205,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -189,6 +277,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -234,6 +344,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -284,6 +416,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -320,6 +474,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -369,6 +545,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -410,6 +608,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/equipment-categories/simple-melee-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Melee",
     "category_range": "Simple Melee",
@@ -468,6 +688,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/equipment-categories/simple-ranged-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Ranged",
     "category_range": "Simple Ranged",
@@ -515,6 +757,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/equipment-categories/simple-ranged-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Ranged",
     "category_range": "Simple Ranged",
@@ -561,6 +825,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/equipment-categories/simple-ranged-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Ranged",
     "category_range": "Simple Ranged",
@@ -603,6 +889,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/equipment-categories/simple-ranged-weapons"
+      }, 
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/equipment-categories/simple-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Simple",
     "weapon_range": "Ranged",
     "category_range": "Simple Ranged",
@@ -640,6 +948,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -684,6 +1014,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -714,6 +1066,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -760,6 +1134,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -801,6 +1197,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -842,6 +1260,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -888,6 +1328,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -932,6 +1394,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -976,6 +1460,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1017,6 +1523,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1047,6 +1575,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1093,6 +1643,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1129,6 +1701,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1170,6 +1764,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1216,6 +1832,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1269,6 +1907,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1299,6 +1959,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1343,6 +2025,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/equipment-categories/martial-melee-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/equipment-categories/melee-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Melee",
     "category_range": "Martial Melee",
@@ -1384,6 +2088,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/equipment-categories/martial-ranged-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Ranged",
     "category_range": "Martial Ranged",
@@ -1426,6 +2152,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/equipment-categories/martial-ranged-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Ranged",
     "category_range": "Martial Ranged",
@@ -1473,6 +2221,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/equipment-categories/martial-ranged-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Ranged",
     "category_range": "Martial Ranged",
@@ -1525,6 +2295,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/equipment-categories/martial-ranged-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Ranged",
     "category_range": "Martial Ranged",
@@ -1572,6 +2364,28 @@
       "name": "Weapon",
       "url": "/api/equipment-categories/weapon"
     },
+    "equipment_categories": [
+      {
+        "index": "weapon",
+        "name": "Weapon",
+        "url": "/api/equipment-categories/weapon"
+      }, 
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/equipment-categories/martial-ranged-weapons"
+      }, 
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/equipment-categories/martial-weapons"
+      }, 
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/equipment-categories/ranged-weapons"
+      }
+    ],
     "weapon_category": "Martial",
     "weapon_range": "Ranged",
     "category_range": "Martial Ranged",
@@ -1613,6 +2427,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/equipment-categories/light-armor"
+      }
+    ],
     "armor_category": "Light",
     "armor_class": {
       "base": 11,
@@ -1635,6 +2461,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/equipment-categories/light-armor"
+      }
+    ],
     "armor_category": "Light",
     "armor_class": {
       "base": 11,
@@ -1657,6 +2495,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/equipment-categories/light-armor"
+      }
+    ],
     "armor_category": "Light",
     "armor_class": {
       "base": 12,
@@ -1679,6 +2529,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ],
     "armor_category": "Medium",
     "armor_class": {
       "base": 12,
@@ -1702,6 +2564,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ],
     "armor_category": "Medium",
     "armor_class": {
       "base": 13,
@@ -1725,6 +2599,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ],
     "armor_category": "Medium",
     "armor_class": {
       "base": 14,
@@ -1748,6 +2634,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ],
     "armor_category": "Medium",
     "armor_class": {
       "base": 14,
@@ -1771,6 +2669,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/equipment-categories/medium-armor"
+      }
+    ],
     "armor_category": "Medium",
     "armor_class": {
       "base": 15,
@@ -1794,6 +2704,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/equipment-categories/heavy-armor"
+      }
+    ],
     "armor_category": "Heavy",
     "armor_class": {
       "base": 14,
@@ -1816,6 +2738,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/equipment-categories/heavy-armor"
+      }
+    ],
     "armor_category": "Heavy",
     "armor_class": {
       "base": 16,
@@ -1838,6 +2772,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/equipment-categories/heavy-armor"
+      }
+    ],
     "armor_category": "Heavy",
     "armor_class": {
       "base": 17,
@@ -1860,6 +2806,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/equipment-categories/heavy-armor"
+      }
+    ],
     "armor_category": "Heavy",
     "armor_class": {
       "base": 18,
@@ -1882,6 +2840,18 @@
       "name": "Armor",
       "url": "/api/equipment-categories/armor"
     },
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/equipment-categories/armor"
+      }, 
+      {
+        "index": "shields",
+        "name": "Shields",
+        "url": "/api/equipment-categories/shields"
+      }
+    ],
     "armor_category": "Shield",
     "armor_class": {
       "base": 2,
@@ -1904,6 +2874,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",

--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -4027,6 +4027,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4047,6 +4059,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4067,6 +4091,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4087,6 +4123,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4107,6 +4155,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4127,6 +4187,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4150,6 +4222,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4173,6 +4257,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/equipment-categories/druidic-foci"
+      }
+    ],
     "gear_category": {
       "index": "druidic-foci",
       "name": "Druidic Foci",
@@ -4196,6 +4292,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/equipment-categories/druidic-foci"
+      }
+    ],
     "gear_category": {
       "index": "druidic-foci",
       "name": "Druidic Foci",
@@ -4219,6 +4327,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/equipment-categories/druidic-foci"
+      }
+    ],
     "gear_category": {
       "index": "druidic-foci",
       "name": "Druidic Foci",
@@ -4242,6 +4362,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/equipment-categories/druidic-foci"
+      }
+    ],
     "gear_category": {
       "index": "druidic-foci",
       "name": "Druidic Foci",
@@ -4265,6 +4397,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/equipment-categories/holy-symbols"
+      }
+    ],
     "gear_category": {
       "index": "holy-symbols",
       "name": "Holy Symbols",
@@ -4289,6 +4433,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4312,6 +4468,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4332,6 +4500,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4352,6 +4532,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4372,6 +4564,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4392,6 +4596,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4418,6 +4634,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4438,6 +4666,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4463,6 +4703,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4483,6 +4735,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4503,6 +4767,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4523,6 +4799,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4546,6 +4834,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4569,6 +4869,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4592,6 +4904,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4615,6 +4939,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4638,6 +4974,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4661,6 +5009,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "kits",
+        "name": "Kits",
+        "url": "/api/equipment-categories/kits"
+      }
+    ],
     "gear_category": {
       "index": "kits",
       "name": "Kits",
@@ -4684,6 +5044,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4704,6 +5076,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4727,6 +5111,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4750,6 +5146,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4773,6 +5181,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4794,6 +5214,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4817,6 +5249,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4841,6 +5285,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4865,6 +5321,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4885,6 +5353,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4912,6 +5392,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4932,6 +5424,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4952,6 +5456,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4972,6 +5488,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -4992,6 +5520,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5012,6 +5552,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5035,6 +5587,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5055,6 +5619,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5075,6 +5651,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5098,6 +5686,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5119,6 +5719,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5142,6 +5754,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5165,6 +5789,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/equipment-categories/holy-symbols"
+      }
+    ],
     "gear_category": {
       "index": "holy-symbols",
       "name": "Holy Symbols",
@@ -5189,6 +5825,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5209,6 +5857,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5232,6 +5892,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5255,6 +5927,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5275,6 +5959,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5298,6 +5994,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5318,6 +6026,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5338,6 +6058,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5358,6 +6090,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5378,6 +6122,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5399,6 +6155,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5419,6 +6187,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5442,6 +6222,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5462,6 +6254,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5485,6 +6289,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5508,6 +6324,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5529,6 +6357,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5553,6 +6393,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5576,6 +6428,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5597,6 +6461,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5617,6 +6493,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5637,6 +6525,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "standard-gear",
+        "name": "Standard Gear",
+        "url": "/api/equipment-categories/standard-gear"
+      }
+    ],
     "gear_category": {
       "index": "standard-gear",
       "name": "Standard Gear",
@@ -5657,6 +6557,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -5790,6 +6702,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -5899,6 +6823,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -5992,6 +6928,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -6069,6 +7017,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -6154,6 +7114,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -6255,6 +7227,18 @@
       "name": "Adventuring Gear",
       "url": "/api/equipment-categories/adventuring-gear"
     },
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/equipment-categories/equipment-packs"
+      }
+    ],
     "gear_category": {
       "index": "equipment-packs",
       "name": "Equipment Packs",
@@ -6332,6 +7316,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 50,
@@ -6351,6 +7347,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 20,
@@ -6370,6 +7378,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 10,
@@ -6389,6 +7409,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 8,
@@ -6408,6 +7440,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 15,
@@ -6427,6 +7471,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 5,
@@ -6446,6 +7502,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 1,
@@ -6465,6 +7533,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 30,
@@ -6484,6 +7564,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 25,
@@ -6503,6 +7595,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 5,
@@ -6522,6 +7626,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 10,
@@ -6541,6 +7657,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 10,
@@ -6560,6 +7688,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 10,
@@ -6579,6 +7719,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 20,
@@ -6598,6 +7750,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 50,
@@ -6617,6 +7781,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 1,
@@ -6636,6 +7812,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Artisan's Tools",
     "cost": {
       "quantity": 1,
@@ -6655,6 +7843,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/equipment-categories/artisans-tools"
+      }
+    ],
     "tool_category": "Gaming Sets",
     "cost": {
       "quantity": 1,
@@ -6674,6 +7874,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/equipment-categories/gaming-sets"
+      }
+    ],
     "tool_category": "Gaming Sets",
     "cost": {
       "quantity": 5,
@@ -6693,6 +7905,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 30,
@@ -6712,6 +7936,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 6,
@@ -6731,6 +7967,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 25,
@@ -6750,6 +7998,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 2,
@@ -6769,6 +8029,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 35,
@@ -6788,6 +8060,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 30,
@@ -6807,6 +8091,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 3,
@@ -6826,6 +8122,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 12,
@@ -6845,6 +8153,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 2,
@@ -6864,6 +8184,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/equipment-categories/musical-instruments"
+      }
+    ],
     "tool_category": "Musical Instrument",
     "cost": {
       "quantity": 30,
@@ -6883,6 +8215,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+        "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/equipment-categories/other-tools"
+      }
+    ],
     "tool_category": "Other Tools",
     "cost": {
       "quantity": 25,
@@ -6902,6 +8246,18 @@
       "name": "Tools",
       "url": "/api/equipment-categories/tools"
     },
+    "equipment_categories": [
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/equipment-categories/tools"
+      },
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/equipment-categories/other-tools"
+      }
+    ],
     "tool_category": "Other Tools",
     "cost": {
       "quantity": 25,
@@ -6921,6 +8277,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 50,
@@ -6941,6 +8309,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 8,
@@ -6961,6 +8341,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 8,
@@ -6981,6 +8373,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 200,
@@ -7001,6 +8405,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 50,
@@ -7021,6 +8437,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 75,
@@ -7041,6 +8469,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 25,
@@ -7061,6 +8501,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 30,
@@ -7081,6 +8533,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "mounts-and-other-animals",
+        "name": "Mounts and Other Animals",
+        "url": "/api/equipment-categories/mounts-and-other-animals"
+      }
+    ],
     "vehicle_category": "Mounts and Other Animals",
     "cost": {
       "quantity": 400,
@@ -7101,6 +8565,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 20,
@@ -7120,6 +8596,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 40,
@@ -7139,6 +8627,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 180,
@@ -7158,6 +8658,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 40,
@@ -7177,6 +8689,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 200,
@@ -7196,6 +8720,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 200,
@@ -7215,6 +8751,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 1600,
@@ -7234,6 +8782,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 3000,
@@ -7253,6 +8813,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 12,
@@ -7272,6 +8844,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 300,
@@ -7291,6 +8875,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 800,
@@ -7310,6 +8906,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 6000,
@@ -7329,6 +8937,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 2,
@@ -7345,6 +8965,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 100,
@@ -7361,6 +8993,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 15,
@@ -7377,6 +9021,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 250,
@@ -7393,6 +9049,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 5,
@@ -7409,6 +9077,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 60,
@@ -7428,6 +9108,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 20,
@@ -7447,6 +9139,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 5,
@@ -7463,6 +9167,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 10,
@@ -7479,6 +9195,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 4,
@@ -7495,6 +9223,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 20,
@@ -7511,6 +9251,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 5,
@@ -7527,6 +9279,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "tack-harness-and-drawn-vehicles",
+        "name": "Tack, Harness, and Drawn Vehicles",
+        "url": "/api/equipment-categories/tack-harness-and-drawn-vehicles"
+      }
+    ],
     "vehicle_category": "Tack, Harness, and Drawn Vehicles",
     "cost": {
       "quantity": 35,
@@ -7543,6 +9307,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 30000,
@@ -7562,6 +9338,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 3000,
@@ -7584,6 +9372,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 10000,
@@ -7603,6 +9403,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 50,
@@ -7625,6 +9437,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 10000,
@@ -7644,6 +9468,18 @@
       "name": "Mounts and Vehicles",
       "url": "/api/equipment-categories/mounts-and-vehicles"
     },
+    "equipment_categories": [
+      {
+        "index": "mounts-and-vehicles",
+        "name": "Mounts and Vehicles",
+        "url": "/api/equipment-categories/mounts-and-vehicles"
+      },
+      {
+        "index": "waterborne-vehicles",
+        "name": "Waterborne Vehicles",
+        "url": "/api/equipment-categories/waterborne-vehicles"
+      }
+    ],
     "vehicle_category": "Waterborne Vehicles",
     "cost": {
       "quantity": 25000,

--- a/src/tests/validate-equipment-categories.js
+++ b/src/tests/validate-equipment-categories.js
@@ -1,0 +1,49 @@
+const equipment = require('../5e-SRD-Equipment.json');
+const categories = require('../5e-SRD-Equipment-Categories.json');
+let errorFound = false;
+
+//Validates items in the "5e-SRD-Equipment.json" file against the categories of the "5e-SRD-Equipment-Categories.json" file
+equipment.forEach(item => {
+    item.equipment_categories.forEach(itemCategory => {
+        let categoryFound = false;
+        categories.forEach(category => {
+            if (category.index == itemCategory.index) {
+                category.equipment.forEach(piece => {
+                    if (piece.index == item.index) {
+                        categoryFound = true;
+                    }
+                });
+            }
+        });
+        if (!categoryFound) {
+            errorFound = true;
+            console.log(`ERROR: Category "${itemCategory.index}" for "${item.name}" not found in "5e-SRD-Equipment-Categories.json" file`);
+        }
+    });
+});
+
+//Validates categories in the "5e-SRD-Equipment-Categories.json" file against items in the "5e-SRD-Equipment.json" file
+categories.forEach(category => {
+    category.equipment.forEach(piece => {
+        let pieceIsInEquipmentFile = false;
+        equipment.forEach(item => {
+            if (item.index == piece.index) {
+                pieceIsInEquipmentFile = true;
+                let categoryFoundInItem = false;
+                item.equipment_categories.forEach(itemCategory => {
+                    if (itemCategory.index == category.index) {
+                        categoryFoundInItem = true;
+                    }
+                });
+                if (!categoryFoundInItem) {
+                    errorFound = true;
+                    console.log(`ERROR: Category "${category.index}" not found for "${item.name}" in "5e-SRD-Equipment.json" file`);
+                }
+            }
+        });
+    });
+});
+
+if (!errorFound) {
+    console.log("No inconsistencies found between '5e-SRD-Equipment.json' and '5e-SRD-Equipment-Categories.json' files.");
+}


### PR DESCRIPTION
## What does this do?

1. Adds a new "equipment_categories" array for all items within the "5e-SRD-Equipment.json" file.
2. Creates a new script for category validation in src/tests.
3. Adds "Donkey" and "Camel" to "5e-SRD-Equipment-Categories.json". (Previously missing)
4. Adds "standard-gear" to ammunition items in "5e-SRD-Equipment.json". (Present in  "5e-SRD-Equipment-Categories.json", but missing in  "5e-SRD-Equipment.json")
5. Adds "land-vehicles" category to land vehicles in  "5e-SRD-Equipment.json" (Present in  "5e-SRD-Equipment-Categories.json", but missing in  "5e-SRD-Equipment.json")

## How was it tested?

I created a new script in src/tests that validates categories and items between "5e-SRD-Equipment-Categories.json" and "5e-SRD-Equipment.json". This ensures that all items categories in "5e-SRD-Equipment.json" are present  in "5e-SRD-Equipment-Categories.json". It also ensures that all category items in "5e-SRD-Equipment-Categories.json" are present in "5e-SRD-Equipment.json". Using this method, I found that "Donkey" and "Camel" were both missing from "5e-SRD-Equipment-Categories.json". I also found that 'standard-gear' was missing from ammunition items in "5e-SRD-Equipment.json". I also found that there was no reference to the "land-vehicles" category for land vehicles in "5e-SRD-Equipment.json".

## Is there a Github issue this is resolving?

Yes., issue #397 - Equipment category schema rationalization

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
