### PR TITLE
feat: Adding Totem Warrior subclass

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -237,6 +237,11 @@
         "index": "berserker",
         "name": "Berserker",
         "url": "/api/subclasses/berserker"
+      },
+      {
+        "index": "totem-warrior",
+        "name": "Totem Warrior",
+        "url": "/api/subclasses/totem-warrior"
       }
     ],
     "url": "/api/classes/barbarian"


### PR DESCRIPTION
Adding subclass Totem Warrior to Barbarian.

## What does this do?

Its the second path to the barbarian class at 3rd level.

## How was it tested?

In my local application.

## Is there a Github issue this is resolving?
no

