### PR TITLE
feat: Adding Totem Warrior subclass

### DIFF
--- a/src/5e-SRD-Subclasses.json
+++ b/src/5e-SRD-Subclasses.json
@@ -15,6 +15,21 @@
     "url": "/api/subclasses/berserker"
   },
   {
+    "index": "totem-warrior",
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/classes/barbarian"
+    },
+    "name": "Totem Warrior",
+    "subclass_flavor": "Primal Path",
+    "desc": [
+      "The Path of the Totem Warrior is a spiritual journey, as the barbarian accepts a spirit animal as guide, protector, and inspiration. In battle, your totem spirit fills you with supernatural might, adding magical fuel to your barbarian rage. Most barbarian tribes consider a totem animal to be kin to a particular clan. In such cases, it is unusual for an individual to have more than one totem animal spirit, though exceptions exist."
+    ],
+    "subclass_levels": "/api/subclasses/totem-warrior/levels",
+    "url": "/api/subclasses/totem-warrior"
+  },
+  {
     "index": "lore",
     "class": {
       "index": "bard",


### PR DESCRIPTION
Adding subclass Totem Warrior to Barbarian.

What does this do?
Its the second path to the barbarian class at 3rd level.

How was it tested?
In my local application.

Is there a Github issue this is resolving?
no