### PR TITLE
feat: Adding Totem Warrior levels

### DIFF
--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -7944,6 +7944,99 @@
     "level": 3,
     "features": [
       {
+        "index": "spirit-seeker",
+        "name": "Spirit Seeker",
+        "url": "/api/features/spirit-seeker"
+      },
+      {
+        "index": "totem-spirit",
+        "name": "Totem Spirit",
+        "url": "/api/features/totem-spirit"
+      }
+    ],
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/classes/barbarian"
+    },
+    "subclass": {
+      "index": "totem-warrior",
+      "name": "Totem Warrior",
+      "url": "/api/subclasses/totem-warrior"
+    },
+    "url": "/api/subclasses/totem-warrior/levels/3",
+    "index": "totem-warrior-3"
+  },
+  {
+    "level": 6,
+    "features": [
+      {
+        "index": "aspect-of-the-beast",
+        "name": "Aspect of the Beast",
+        "url": "/api/features/aspect-of-the-beast"
+      }
+    ],
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/classes/barbarian"
+    },
+    "subclass": {
+      "index": "totem-warrior",
+      "name": "Totem Warrior",
+      "url": "/api/subclasses/totem-warrior"
+    },
+    "url": "/api/subclasses/totem-warrior/levels/6",
+    "index": "totem-warrior-6"
+  },
+  {
+    "level": 10,
+    "features": [
+      {
+        "index": "spirit-walker",
+        "name": "Spirit Walker",
+        "url": "/api/features/spirit-walker"
+      }
+    ],
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/classes/barbarian"
+    },
+    "subclass": {
+      "index": "totem-warrior",
+      "name": "Totem Warrior",
+      "url": "/api/subclasses/totem-warrior"
+    },
+    "url": "/api/subclasses/totem-warrior/levels/10",
+    "index": "totem-warrior-10"
+  },
+  {
+    "level": 14,
+    "features": [
+      {
+        "index": "totemic-attunement",
+        "name": "Totemic Attunement",
+        "url": "/api/features/totemic-attunement"
+      }
+    ],
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/classes/barbarian"
+    },
+    "subclass": {
+      "index": "totem-warrior",
+      "name": "Totem Warrior",
+      "url": "/api/subclasses/totem-warrior"
+    },
+    "url": "/api/subclasses/totem-warrior/levels/14",
+    "index": "totem-warrior-14"
+  },
+  {
+    "level": 3,
+    "features": [
+      {
         "index": "bonus-proficiencies",
         "name": "Bonus Proficiencies",
         "url": "/api/features/bonus-proficiencies"


### PR DESCRIPTION
Adding subclass Totem Warrior to Barbarian.

What does this do?
Its the second path to the barbarian class at 3rd level.

How was it tested?
In my local application.

Is there a Github issue this is resolving?
no

https://github.com/5e-bits/5e-database/pull/543
https://github.com/5e-bits/5e-database/pull/542