### PR TITLE
fix(image): Fix image key for black dragon wyrmling thanks to @DMcCallion

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -8926,7 +8926,7 @@
         ]
       }
     ],
-    "images": "/api/images/monsters/black-dragon-wyrmling.png",
+    "image": "/api/images/monsters/black-dragon-wyrmling.png",
     "url": "/api/monsters/black-dragon-wyrmling"
   },
   {


### PR DESCRIPTION
Copied from @DMcCallion #546 

The 'image' key was typo-ed as 'images' for the Black Dragon Wyrmling

## What does this do?

I literally removed one letter, probably the biggest change this repo has ever seen

## How was it tested?

I found it by wondering why my dataframe had image and images columns 

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
