### PR TITLE
fix: :bug: duplicate "blinded" condition in Black Pudding immunities

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -8975,11 +8975,6 @@
         "url": "/api/conditions/charmed"
       },
       {
-        "index": "blinded",
-        "name": "Blinded",
-        "url": "/api/conditions/blinded"
-      },
-      {
         "index": "exhaustion",
         "name": "Exhaustion",
         "url": "/api/conditions/exhaustion"


### PR DESCRIPTION
## What does this do?

Removes a duplicated APIReference to the Blinded condition in the Black Pudding's `condition_immunities` list.

## How was it tested?

Data change, N/A.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![image](https://github.com/5e-bits/5e-database/assets/6972523/66241db9-4c2d-4cfd-bc17-6d8753ade952)
