### PR TITLE
feat: :sparkles: add monster proficiency_bonus field

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -76,6 +76,7 @@
     },
     "languages": "Deep Speech, telepathy 120 ft.",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "special_abilities": [
       {
@@ -259,6 +260,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -426,6 +428,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 14,
+    "proficiency_bonus": 5,
     "xp": 11500,
     "special_abilities": [
       {
@@ -684,6 +687,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 16,
+    "proficiency_bonus": 5,
     "xp": 15000,
     "special_abilities": [
       {
@@ -953,6 +957,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -1232,6 +1237,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 15,
+    "proficiency_bonus": 5,
     "xp": 13000,
     "special_abilities": [
       {
@@ -1515,6 +1521,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 14,
+    "proficiency_bonus": 5,
     "xp": 11500,
     "special_abilities": [
       {
@@ -1802,6 +1809,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 17,
+    "proficiency_bonus": 6,
     "xp": 18000,
     "special_abilities": [
       {
@@ -2107,6 +2115,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 15,
+    "proficiency_bonus": 5,
     "xp": 13000,
     "special_abilities": [
       {
@@ -2364,6 +2373,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 17,
+    "proficiency_bonus": 6,
     "xp": 18000,
     "special_abilities": [
       {
@@ -2632,6 +2642,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 16,
+    "proficiency_bonus": 5,
     "xp": 15000,
     "special_abilities": [
       {
@@ -2904,6 +2915,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -3155,6 +3167,7 @@
     },
     "languages": "Auran",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -3292,6 +3305,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 21,
+    "proficiency_bonus": 7,
     "xp": 33000,
     "special_abilities": [
       {
@@ -3550,6 +3564,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 23,
+    "proficiency_bonus": 7,
     "xp": 50000,
     "special_abilities": [
       {
@@ -3819,6 +3834,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 20,
+    "proficiency_bonus": 6,
     "xp": 25000,
     "special_abilities": [
       {
@@ -4102,6 +4118,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 22,
+    "proficiency_bonus": 7,
     "xp": 41000,
     "special_abilities": [
       {
@@ -4389,6 +4406,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 21,
+    "proficiency_bonus": 7,
     "xp": 33000,
     "special_abilities": [
       {
@@ -4680,6 +4698,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 24,
+    "proficiency_bonus": 7,
     "xp": 62000,
     "special_abilities": [
       {
@@ -4989,6 +5008,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 22,
+    "proficiency_bonus": 7,
     "xp": 41000,
     "special_abilities": [
       {
@@ -5246,6 +5266,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 24,
+    "proficiency_bonus": 7,
     "xp": 62000,
     "special_abilities": [
       {
@@ -5514,6 +5535,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 23,
+    "proficiency_bonus": 7,
     "xp": 50000,
     "special_abilities": [
       {
@@ -5790,6 +5812,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 20,
+    "proficiency_bonus": 6,
     "xp": 25000,
     "special_abilities": [
       {
@@ -6065,6 +6088,7 @@
     },
     "languages": "Common, Sphinx",
     "challenge_rating": 17,
+    "proficiency_bonus": 6,
     "xp": 18000,
     "special_abilities": [
       {
@@ -6360,6 +6384,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -6449,6 +6474,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 250,
     "actions": [
       {
@@ -6558,6 +6584,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "actions": [
       {
@@ -6618,7 +6645,8 @@
       {
         "type": "dex",
         "value": 12
-      }, {
+      },
+      {
         "type": "spell",
         "value": 15,
         "spell": {
@@ -6686,6 +6714,7 @@
     },
     "languages": "any six languages",
     "challenge_rating": 12,
+    "proficiency_bonus": 4,
     "xp": 8400,
     "special_abilities": [
       {
@@ -6984,6 +7013,7 @@
     },
     "languages": "Thieves' cant plus any two languages",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -7077,7 +7107,7 @@
         ]
       }
     ],
-    "image":"/api/images/monsters/assassin.png",
+    "image": "/api/images/monsters/assassin.png",
     "url": "/api/monsters/assassin"
   },
   {
@@ -7119,6 +7149,7 @@
     },
     "languages": "one language known by its creator",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -7143,7 +7174,7 @@
         ]
       }
     ],
-    "image":"/api/images/monsters/awakened-shrub.png",
+    "image": "/api/images/monsters/awakened-shrub.png",
     "url": "/api/monsters/awakened-shrub"
   },
   {
@@ -7186,6 +7217,7 @@
     },
     "languages": "one language known by its creator",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -7210,7 +7242,7 @@
         ]
       }
     ],
-    "image":"/api/images/monsters/awakened-tree.png",
+    "image": "/api/images/monsters/awakened-tree.png",
     "url": "/api/monsters/awakened-tree"
   },
   {
@@ -7248,6 +7280,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -7332,6 +7365,7 @@
     },
     "languages": "Ignan",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -7429,6 +7463,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -7491,6 +7526,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -7600,6 +7636,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 19,
+    "proficiency_bonus": 6,
     "xp": 22000,
     "special_abilities": [
       {
@@ -7762,6 +7799,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -7881,6 +7919,7 @@
     },
     "languages": "any two languages",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -8064,6 +8103,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -8211,6 +8251,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -8290,6 +8331,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -8393,6 +8435,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -8514,6 +8557,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "actions": [
       {
@@ -8658,6 +8702,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -8719,6 +8764,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -8866,6 +8912,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -9001,6 +9048,7 @@
     },
     "languages": "",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -9111,6 +9159,7 @@
     },
     "languages": "Blink Dog, understands Sylvan but can't speak it",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -9191,6 +9240,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -9310,6 +9360,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "actions": [
       {
@@ -9400,6 +9451,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -9537,6 +9589,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "special_abilities": [
       {
@@ -9696,6 +9749,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 100,
     "actions": [
       {
@@ -9859,6 +9913,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -9983,6 +10038,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -10057,7 +10113,8 @@
             "index": "shield",
             "name": "Shield",
             "url": "/api/equipment/shield"
-          }, {
+          },
+          {
             "index": "hide-armor",
             "name": "Hide Armor",
             "url": "/api/equipment/hide-armor"
@@ -10105,6 +10162,7 @@
     },
     "languages": "Common, Goblin",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -10196,6 +10254,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -10260,6 +10319,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -10332,6 +10392,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -10417,6 +10478,7 @@
     },
     "languages": "Elvish, Sylvan",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -10593,6 +10655,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -10706,6 +10769,7 @@
     },
     "languages": "understands Draconic but can't speak",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "actions": [
       {
@@ -10920,6 +10984,7 @@
     },
     "languages": "understands Deep Speech but can't speak",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -11071,6 +11136,7 @@
     },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "special_abilities": [
       {
@@ -11179,6 +11245,7 @@
     },
     "languages": "Deep Speech, Undercommon",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -11344,6 +11411,7 @@
     },
     "languages": "Common, Giant",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "special_abilities": [
       {
@@ -11528,6 +11596,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "actions": [
       {
@@ -11584,6 +11653,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "actions": [
       {
@@ -11640,6 +11710,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -11764,6 +11835,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "actions": [
       {
@@ -11904,6 +11976,7 @@
     },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -12129,6 +12202,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -12199,6 +12273,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -12294,6 +12369,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -12458,6 +12534,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -12529,6 +12606,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -12620,6 +12698,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -12726,6 +12805,7 @@
     },
     "languages": "Gnomish, Terran, Undercommon",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -12859,6 +12939,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "actions": [
       {
@@ -12967,6 +13048,7 @@
     },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "special_abilities": [
       {
@@ -13123,6 +13205,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -13217,6 +13300,7 @@
     },
     "languages": "Auran",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -13480,6 +13564,7 @@
     },
     "languages": "Common",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -13564,6 +13649,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -13647,6 +13733,7 @@
     },
     "languages": "Aquan, Draconic",
     "challenge_rating": 17,
+    "proficiency_bonus": 6,
     "xp": 18000,
     "special_abilities": [
       {
@@ -13827,6 +13914,7 @@
     },
     "languages": "Abyssal, telepathy 60 ft. (works only with creatures that understand Abyssal)",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -13949,6 +14037,7 @@
     },
     "languages": "Elvish, Undercommon",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -14218,6 +14307,7 @@
     },
     "languages": "Elvish, Undercommon",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -14320,7 +14410,8 @@
       {
         "type": "dex",
         "value": 11
-      }, {
+      },
+      {
         "type": "spell",
         "value": 16,
         "spell": {
@@ -14377,6 +14468,7 @@
     },
     "languages": "Druidic plus any two languages",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -14511,7 +14603,8 @@
       {
         "type": "dex",
         "value": 11
-      }, {
+      },
+      {
         "type": "spell",
         "value": 16,
         "spell": {
@@ -14561,6 +14654,7 @@
     },
     "languages": "Elvish, Sylvan",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -14730,6 +14824,7 @@
     },
     "languages": "Dwarvish, Undercommon",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -14860,6 +14955,7 @@
     },
     "languages": "Auran, Terran",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -14984,6 +15080,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -15079,6 +15176,7 @@
     },
     "languages": "Terran",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -15185,6 +15283,7 @@
     },
     "languages": "Ignan",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -15394,6 +15493,7 @@
     },
     "languages": "",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -15469,6 +15569,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -15599,6 +15700,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 12,
+    "proficiency_bonus": 4,
     "xp": 8400,
     "special_abilities": [
       {
@@ -15808,6 +15910,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -15936,6 +16039,7 @@
     },
     "languages": "Giant, Orc",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -16079,6 +16183,7 @@
     },
     "languages": "Ignan",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -16219,6 +16324,7 @@
     },
     "languages": "Giant",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "actions": [
       {
@@ -16336,6 +16442,7 @@
     },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -16432,6 +16539,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -16551,6 +16659,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -16635,6 +16744,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 0,
     "special_abilities": [
       {
@@ -16726,6 +16836,7 @@
     },
     "languages": "Giant",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "actions": [
       {
@@ -16829,6 +16940,7 @@
     },
     "languages": "Terran",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -16953,6 +17065,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -17061,6 +17174,7 @@
     },
     "languages": "Common",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -17208,6 +17322,7 @@
     },
     "languages": "any languages it knew in life",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -17326,6 +17441,7 @@
     },
     "languages": "Common",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "actions": [
       {
@@ -17413,6 +17529,7 @@
     },
     "languages": "",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "actions": [
       {
@@ -17496,6 +17613,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -17590,6 +17708,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -17654,6 +17773,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -17727,6 +17847,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -17792,6 +17913,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -17872,6 +17994,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -17942,6 +18065,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -18045,6 +18169,7 @@
     },
     "languages": "Giant Eagle, understands Common and Auran but can't speak",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -18147,6 +18272,7 @@
     },
     "languages": "Giant Elk, understands Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -18224,6 +18350,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -18303,6 +18430,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -18371,6 +18499,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -18444,6 +18573,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -18507,6 +18637,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -18580,6 +18711,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -18678,6 +18810,7 @@
     },
     "languages": "Giant Owl, understands Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -18753,6 +18886,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -18808,6 +18942,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -18873,6 +19008,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -18938,6 +19074,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "actions": [
       {
@@ -19026,6 +19163,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -19101,6 +19239,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -19178,6 +19317,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -19258,6 +19398,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -19345,6 +19486,7 @@
     },
     "languages": "understands Common but can't speak",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -19443,6 +19585,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "actions": [
       {
@@ -19515,6 +19658,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -19596,6 +19740,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -19672,6 +19817,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -19828,6 +19974,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "special_abilities": [
       {
@@ -20003,7 +20150,8 @@
             "index": "studded-leather-armor",
             "name": "Studded Leather Armor",
             "url": "/api/equipment/studded-leather-armor"
-          }, {
+          },
+          {
             "index": "shield",
             "name": "Shield",
             "url": "/api/equipment/shield"
@@ -20074,6 +20222,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -20260,6 +20409,7 @@
     },
     "languages": "Gnoll",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -20371,6 +20521,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -20417,7 +20568,8 @@
             "index": "leather-armor",
             "name": "Leather Armor",
             "url": "/api/equipment/leather-armor"
-          }, {
+          },
+          {
             "index": "shield",
             "name": "Shield",
             "url": "/api/equipment/shield"
@@ -20457,6 +20609,7 @@
     },
     "languages": "Common, Goblin",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -20588,6 +20741,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -20718,6 +20872,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -20857,6 +21012,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -20994,6 +21150,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -21124,6 +21281,7 @@
     },
     "languages": "Common, Draconic, Sylvan",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -21242,6 +21400,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -21345,6 +21504,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -21470,6 +21630,7 @@
     },
     "languages": "Undercommon",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -21529,7 +21690,8 @@
             "index": "chain-shirt",
             "name": "Chain Shirt",
             "url": "/api/equipment/chain-shirt"
-          }, {
+          },
+          {
             "index": "shield",
             "name": "Shield",
             "url": "/api/equipment/shield"
@@ -21568,6 +21730,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -21698,6 +21861,7 @@
     },
     "languages": "Celestial, Common",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "special_abilities": [
       {
@@ -21916,6 +22080,7 @@
     },
     "languages": "Common, Sphinx",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -22121,6 +22286,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "actions": [
       {
@@ -22272,6 +22438,7 @@
     },
     "languages": "Common",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "actions": [
       {
@@ -22372,6 +22539,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -22444,6 +22612,7 @@
     },
     "languages": "understands Infernal but can't speak it",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -22584,6 +22753,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -22698,6 +22868,7 @@
     },
     "languages": "Giant",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "actions": [
       {
@@ -22789,6 +22960,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -22863,7 +23035,8 @@
             "index": "chain-mail",
             "name": "Chain Mail",
             "url": "/api/equipment/chain-mail"
-          }, {
+          },
+          {
             "index": "shield",
             "name": "Shield",
             "url": "/api/equipment/shield"
@@ -22894,6 +23067,7 @@
     },
     "languages": "Common, Goblin",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -23005,6 +23179,7 @@
     },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -23113,6 +23288,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -23289,6 +23465,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -23364,6 +23541,7 @@
     },
     "languages": "",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -23457,6 +23635,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -23564,6 +23743,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 14,
+    "proficiency_bonus": 5,
     "xp": 11500,
     "special_abilities": [
       {
@@ -23739,6 +23919,7 @@
     },
     "languages": "Aquan, Auran",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -23932,6 +24113,7 @@
     },
     "languages": "Infernal, Common",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -24069,6 +24251,7 @@
     },
     "languages": "Auran, understands Common but doesn't speak it",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -24182,6 +24365,7 @@
     },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 16,
+    "proficiency_bonus": 5,
     "xp": 15000,
     "special_abilities": [
       {
@@ -24349,6 +24533,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -24423,6 +24608,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -24517,6 +24703,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -24623,6 +24810,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -24760,6 +24948,7 @@
     },
     "languages": "understands Abyssal, Celestial, Infernal, and Primordial but can't speak, telepathy 120 ft.",
     "challenge_rating": 23,
+    "proficiency_bonus": 7,
     "xp": 50000,
     "special_abilities": [
       {
@@ -24992,6 +25181,7 @@
     },
     "languages": "Abyssal, Common",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -25218,6 +25408,7 @@
     },
     "languages": "understands infernal but can't speak",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -25373,6 +25564,7 @@
     },
     "languages": "Common plus up to five other languages",
     "challenge_rating": 21,
+    "proficiency_bonus": 7,
     "xp": 33000,
     "special_abilities": [
       {
@@ -25671,6 +25863,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -25769,6 +25962,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "actions": [
       {
@@ -25861,6 +26055,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -26060,7 +26255,8 @@
       {
         "type": "dex",
         "value": 12
-      }, {
+      },
+      {
         "type": "spell",
         "value": 15,
         "spell": {
@@ -26125,6 +26321,7 @@
     },
     "languages": "any four languages",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -26312,6 +26509,7 @@
     },
     "languages": "Ignan, Terran",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -26463,6 +26661,7 @@
     },
     "languages": "Ignan",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -26547,6 +26746,7 @@
     },
     "languages": "",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -26624,6 +26824,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -26799,6 +27000,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 16,
+    "proficiency_bonus": 5,
     "xp": 15000,
     "special_abilities": [
       {
@@ -26919,6 +27121,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -27013,6 +27216,7 @@
     },
     "languages": "Common",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -27176,6 +27380,7 @@
     },
     "languages": "Aquan, Common",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -27259,6 +27464,7 @@
     },
     "languages": "Abyssal, Aquan",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -27433,6 +27639,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -27539,6 +27746,7 @@
     },
     "languages": "Abyssal",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -27638,6 +27846,7 @@
     },
     "languages": "understands Abyssal but can't speak",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -27713,6 +27922,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -27820,6 +28030,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "actions": [
       {
@@ -27994,6 +28205,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 15,
+    "proficiency_bonus": 5,
     "xp": 13000,
     "special_abilities": [
       {
@@ -28290,6 +28502,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -28453,6 +28666,7 @@
     },
     "languages": "Abyssal, Common, Infernal, Primordial",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -28599,6 +28813,7 @@
     },
     "languages": "understands Abyssal, Common, and Infernal but can't speak",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -28709,6 +28924,7 @@
     },
     "languages": "any two languages",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -28807,6 +29023,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -28904,6 +29121,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -28992,6 +29210,7 @@
     },
     "languages": "Common, Giant",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -29079,6 +29298,7 @@
     },
     "languages": "understands Common and Giant but can't speak",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -29205,6 +29425,7 @@
     },
     "languages": "Common, Giant",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "special_abilities": [
       {
@@ -29421,6 +29642,7 @@
     },
     "languages": "Common, Orc",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -29506,6 +29728,7 @@
     },
     "languages": "Otyugh",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -29638,6 +29861,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -29712,6 +29936,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -29822,6 +30047,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -29944,6 +30170,7 @@
     },
     "languages": "understands Celestial, Common, Elvish, and Sylvan but can't speak",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -30010,6 +30237,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -30118,6 +30346,7 @@
     },
     "languages": "Infernal, telepathy 120 ft.",
     "challenge_rating": 20,
+    "proficiency_bonus": 6,
     "xp": 25000,
     "special_abilities": [
       {
@@ -30373,6 +30602,7 @@
     },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 16,
+    "proficiency_bonus": 5,
     "xp": 15000,
     "special_abilities": [
       {
@@ -30585,6 +30815,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -30647,6 +30878,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -30711,6 +30943,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -30803,6 +31036,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -30891,6 +31125,7 @@
     },
     "languages": "any two languages",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -31048,6 +31283,7 @@
     },
     "languages": "understands Common and Draconic but can't speak",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -31151,6 +31387,7 @@
     },
     "languages": "",
     "challenge_rating": 15,
+    "proficiency_bonus": 5,
     "xp": 13000,
     "special_abilities": [
       {
@@ -31267,6 +31504,7 @@
     },
     "languages": "Abyssal, Common",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -31354,6 +31592,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -31440,6 +31679,7 @@
     },
     "languages": "Common, Infernal",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -31645,6 +31885,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -31715,6 +31956,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -31830,6 +32072,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "actions": [
       {
@@ -31931,6 +32174,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -32001,6 +32245,7 @@
     },
     "languages": "",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -32083,6 +32328,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -32143,6 +32389,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -32239,6 +32486,7 @@
     },
     "languages": "",
     "challenge_rating": 11,
+    "proficiency_bonus": 4,
     "xp": 7200,
     "special_abilities": [
       {
@@ -32350,6 +32598,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -32489,6 +32738,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -32548,6 +32798,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -32633,6 +32884,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -32733,6 +32985,7 @@
     },
     "languages": "Sahuagin",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -32907,6 +33160,7 @@
     },
     "languages": "Ignan",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -33082,6 +33336,7 @@
     },
     "languages": "Common, Elvish, Sylvan",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -33173,6 +33428,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "actions": [
       {
@@ -33269,6 +33525,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -33372,6 +33629,7 @@
     },
     "languages": "Aquan, Common, Giant",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -33453,6 +33711,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 0,
     "special_abilities": [
       {
@@ -33559,6 +33818,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -33659,6 +33919,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -33770,6 +34031,7 @@
     },
     "languages": "understands commands given in any language but can't speak",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "special_abilities": [
       {
@@ -33873,6 +34135,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -33976,6 +34239,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -34101,6 +34365,7 @@
     },
     "languages": "understands all languages it spoke in life but can't speak",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -34232,6 +34497,7 @@
     },
     "languages": "all, telepathy 120 ft.",
     "challenge_rating": 21,
+    "proficiency_bonus": 7,
     "xp": 33000,
     "special_abilities": [
       {
@@ -34544,6 +34810,7 @@
     },
     "languages": "understands all languages it knew in life but can't speak",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -34619,6 +34886,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -34734,6 +35002,7 @@
     },
     "languages": "Abyssal, Common",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -34911,6 +35180,7 @@
     },
     "languages": "Common, Elvish, Sylvan",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "actions": [
       {
@@ -35048,6 +35318,7 @@
     },
     "languages": "any two languages",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -35150,6 +35421,7 @@
     },
     "languages": "Aquan, Ignan",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -35294,6 +35566,7 @@
     },
     "languages": "",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "actions": [
       {
@@ -35390,6 +35663,7 @@
     },
     "languages": "Giant",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "special_abilities": [
       {
@@ -35519,6 +35793,7 @@
     },
     "languages": "understands the languages of its creator but can't speak",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "special_abilities": [
       {
@@ -35695,6 +35970,7 @@
     },
     "languages": "Common, Giant",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -35928,6 +36204,7 @@
     },
     "languages": "Abyssal, Common, Infernal, telepathy 60 ft.",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -36071,6 +36348,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -36187,6 +36465,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -36294,6 +36573,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -36401,6 +36681,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -36508,6 +36789,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -36615,6 +36897,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -36729,6 +37012,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -36839,6 +37123,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -36941,6 +37226,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -37060,6 +37346,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -37172,6 +37459,7 @@
     },
     "languages": "",
     "challenge_rating": 30,
+    "proficiency_bonus": 9,
     "xp": 155000,
     "special_abilities": [
       {
@@ -37427,6 +37715,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -37532,6 +37821,7 @@
     },
     "languages": "",
     "challenge_rating": 1,
+    "proficiency_bonus": 2,
     "xp": 200,
     "special_abilities": [
       {
@@ -37625,6 +37915,7 @@
     },
     "languages": "Common, Druidic, Elvish, Sylvan",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "special_abilities": [
       {
@@ -37733,6 +38024,7 @@
     },
     "languages": "any one language",
     "challenge_rating": 0.125,
+    "proficiency_bonus": 2,
     "xp": 25,
     "special_abilities": [
       {
@@ -37814,6 +38106,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -37899,6 +38192,7 @@
     },
     "languages": "Giant",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -38004,6 +38298,7 @@
     },
     "languages": "",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "actions": [
       {
@@ -38109,6 +38404,7 @@
     },
     "languages": "Celestial, Elvish, Sylvan, telepathy 60 ft.",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -38363,6 +38659,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -38604,6 +38901,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -38792,6 +39090,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 13,
+    "proficiency_bonus": 5,
     "xp": 10000,
     "special_abilities": [
       {
@@ -38914,6 +39213,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -39068,6 +39368,7 @@
     },
     "languages": "any one language (usually Common)",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "actions": [
       {
@@ -39207,6 +39508,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -39320,6 +39622,7 @@
     },
     "languages": "Abyssal, telepathy 120 ft.",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -39457,6 +39760,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -39521,6 +39825,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -39599,6 +39904,7 @@
     },
     "languages": "",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "actions": [
       {
@@ -39701,6 +40007,7 @@
     },
     "languages": "Aquan",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -39823,6 +40130,7 @@
     },
     "languages": "",
     "challenge_rating": 0,
+    "proficiency_bonus": 2,
     "xp": 10,
     "special_abilities": [
       {
@@ -39909,6 +40217,7 @@
     },
     "languages": "",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -40024,6 +40333,7 @@
     },
     "languages": "Common",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -40125,6 +40435,7 @@
     },
     "languages": "Common",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -40286,6 +40597,7 @@
     },
     "languages": "",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -40385,6 +40697,7 @@
     },
     "languages": "Common (can't speak in boar form)",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -40492,6 +40805,7 @@
     },
     "languages": "Common",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -40651,6 +40965,7 @@
     },
     "languages": "Common",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -40805,6 +41120,7 @@
     },
     "languages": "Common",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -41009,6 +41325,7 @@
     },
     "languages": "",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -41106,6 +41423,7 @@
     },
     "languages": "Common",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -41244,6 +41562,7 @@
     },
     "languages": "Common",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -41431,6 +41750,7 @@
     },
     "languages": "",
     "challenge_rating": 4,
+    "proficiency_bonus": 2,
     "xp": 1100,
     "special_abilities": [
       {
@@ -41547,6 +41867,7 @@
     },
     "languages": "Common",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -41668,6 +41989,7 @@
     },
     "languages": "Common",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -41788,6 +42110,7 @@
     },
     "languages": "",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -41908,6 +42231,7 @@
     },
     "languages": "Draconic",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "actions": [
       {
@@ -42039,6 +42363,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -42243,6 +42568,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 2,
+    "proficiency_bonus": 2,
     "xp": 450,
     "special_abilities": [
       {
@@ -42349,6 +42675,7 @@
     },
     "languages": "Common, Giant, Winter Wolf",
     "challenge_rating": 3,
+    "proficiency_bonus": 2,
     "xp": 700,
     "special_abilities": [
       {
@@ -42463,6 +42790,7 @@
     },
     "languages": "",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {
@@ -42539,6 +42867,7 @@
     },
     "languages": "Goblin, Worg",
     "challenge_rating": 0.5,
+    "proficiency_bonus": 2,
     "xp": 100,
     "special_abilities": [
       {
@@ -42654,6 +42983,7 @@
     },
     "languages": "the languages it knew in life",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -42734,6 +43064,7 @@
     },
     "languages": "",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "actions": [
       {
@@ -42905,6 +43236,7 @@
     },
     "languages": "Terran",
     "challenge_rating": 5,
+    "proficiency_bonus": 3,
     "xp": 1800,
     "special_abilities": [
       {
@@ -43061,6 +43393,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "special_abilities": [
       {
@@ -43245,6 +43578,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "actions": [
       {
@@ -43430,6 +43764,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "actions": [
       {
@@ -43633,6 +43968,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -43842,6 +44178,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 7,
+    "proficiency_bonus": 3,
     "xp": 2900,
     "actions": [
       {
@@ -44053,6 +44390,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "special_abilities": [
       {
@@ -44268,6 +44606,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 8,
+    "proficiency_bonus": 3,
     "xp": 3900,
     "special_abilities": [
       {
@@ -44451,6 +44790,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 10,
+    "proficiency_bonus": 4,
     "xp": 5900,
     "actions": [
       {
@@ -44643,6 +44983,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 9,
+    "proficiency_bonus": 4,
     "xp": 5000,
     "actions": [
       {
@@ -44839,6 +45180,7 @@
     },
     "languages": "Common, Draconic",
     "challenge_rating": 6,
+    "proficiency_bonus": 3,
     "xp": 2300,
     "special_abilities": [
       {
@@ -44985,6 +45327,7 @@
     },
     "languages": "understands all languages it spoke in life but can't speak",
     "challenge_rating": 0.25,
+    "proficiency_bonus": 2,
     "xp": 50,
     "special_abilities": [
       {


### PR DESCRIPTION
## What does this do?

Adds a `proficiency_bonus` field to Monster documents.

## How was it tested?

Built image locally & tested ad-hoc.

## Is there a Github issue this is resolving?

Will resolve #550, alongside API/Docs changes.

## Did you update the docs in the API? Please link an associated PR if applicable.

[Yes](https://github.com/5e-bits/5e-srd-api/pull/370)

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
