### PR TITLE
fix: Add druid class to poison spray class list

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -11109,6 +11109,11 @@
         "index": "wizard",
         "name": "Wizard",
         "url": "/api/classes/wizard"
+      },
+      {
+        "index": "druid",
+        "name": "Druid",
+        "url": "/api/classes/druid"
       }
     ],
     "subclasses": [],


### PR DESCRIPTION
Fixing poison spray to include druid class

## What does this do?

It adds the druid class to the poison spray spell, as indicated in the SDR

## How was it tested?

Didn´t test it

## Is there a Github issue this is resolving?

Nope, but I can open one if needed.

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
