### PR TITLE
fix: :bug: cleric spell list includes Animal Friendship

### DIFF
--- a/src/5e-SRD-Spells.json
+++ b/src/5e-SRD-Spells.json
@@ -296,11 +296,6 @@
         "url": "/api/classes/bard"
       },
       {
-        "index": "cleric",
-        "name": "Cleric",
-        "url": "/api/classes/cleric"
-      },
-      {
         "index": "druid",
         "name": "Druid",
         "url": "/api/classes/druid"


### PR DESCRIPTION
## What does this do?

Removes `Animal Friendship` from the Cleric spell list.

## How was it tested?

Requested `/api/classes/cleric/spells` locally.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![image](https://github.com/5e-bits/5e-database/assets/6972523/bef7fd4a-6898-4500-a27f-2657c56c8de1)
