### PR TITLE
fix: Normalize resistance/immunity/vulnerability strings

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -6705,7 +6705,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "damage from spells",
-      "nonmagical bludgeoning, piercing, and slashing (from stoneskin)"
+      "bludgeoning, piercing, and slashing from nonmagical attacks (from stoneskin)"
     ],
     "damage_immunities": [],
     "condition_immunities": [],
@@ -21385,7 +21385,7 @@
     "proficiencies": [],
     "damage_vulnerabilities": [],
     "damage_resistances": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons"
+      "bludgeoning, piercing, and slashing from nonmagical weapons"
     ],
     "damage_immunities": [],
     "condition_immunities": [],
@@ -24089,7 +24089,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
-      "bludgeoning, piercing, and slashing from nonmagical/nonsilver weapons"
+      "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
     ],
     "damage_immunities": [
       "fire",
@@ -40584,7 +40584,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -40684,7 +40684,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -40792,7 +40792,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -40952,7 +40952,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41107,7 +41107,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41311,7 +41311,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41409,7 +41409,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41548,7 +41548,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41736,7 +41736,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41854,7 +41854,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -41976,7 +41976,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -42097,7 +42097,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing damage from nonmagical weapons that aren't silvered"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {

--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -24089,7 +24089,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [
       "cold",
-      "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "damage_immunities": [
       "fire",
@@ -40204,7 +40204,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -40320,7 +40320,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {
@@ -40422,7 +40422,7 @@
     "damage_vulnerabilities": [],
     "damage_resistances": [],
     "damage_immunities": [
-      "bludgeoning, piercing, and slashing from nonmagical attacks not made with silvered weapons"
+      "bludgeoning, piercing, and slashing from nonmagical weapons that aren't silvered"
     ],
     "condition_immunities": [],
     "senses": {


### PR DESCRIPTION
## What does this do?

Some of these strings would contain "...damage from nonmagical..." or "...from nonmagical...", so this PR removes "damage" from every string to be consistent with the rest.

Also, the Imp had a completely different format of "nonmagical/nonsilver" instead of the usual "nonmagical not made with silver".

Finally, I made the Archmage's resistance from Stoneskin more like the rest of the resistances' formats.

Some strings have "nonmagical attacks not made with silvered weapons" and some have "nonmagical weapons that aren't silvered" and those are unchanged. I wasn't sure if there was a practical difference between them, but if there isn't, I'd be happy to normalize those, too.

Let me know if I missed any!

*Force push was to correct misspelled commit message.*

## How was it tested?

Built locally.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/561)
