### PR TITLE
fix(monsters): Fix Badger damage type

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -7542,9 +7542,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/damage-types/piercing"
             },
             "damage_dice": "1"
           }


### PR DESCRIPTION
## What does this do?

Fixes badger's attack damage type to match the string.

## How was it tested?

CI

## Is there a Github issue this is resolving?

Issue raised in Discord

## Here's a fun image for your troubles

![image](https://github.com/5e-bits/5e-database/assets/353626/8e93a165-40c2-4992-ab91-56e45ef5ffd2)
