### PR TITLE
fix(ci): Upgrade to v4 correctly for Semantic Release action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,12 @@ jobs:
           fetch-depth: 0
       - name: Semantic Release
         id: semantic
-        uses: cycjimmy/semantic-release-action@v3
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          extra_plugins: |
+            @semantic-release/commit-analyzer
+            @semantic-release/release-notes-generator
+            @semantic-release/github
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What does this do?

Tries to correctly upgrade to `semantic-release-action@v4` by specifying the packages used

## How was it tested?

It's going to have to be live.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
