### PR TITLE
fix(monsters): Change burrow speed for young-blue-dragon to 20 ft. (from 40 ft.)

### DIFF
--- a/src/5e-SRD-Monsters.json
+++ b/src/5e-SRD-Monsters.json
@@ -43502,7 +43502,7 @@
     "hit_points_roll": "16d10+64",
     "speed": {
       "walk": "40 ft.",
-      "burrow": "40 ft.",
+      "burrow": "20 ft.",
       "fly": "80 ft."
     },
     "strength": 21,


### PR DESCRIPTION
As compared to 5E Monster Manual; also Ancient and Adult Blue Dragon burrow speed is 40ft and 30ft respectively

## What does this do?

Simple change of JSON data in 5e-SRD-Monsters.json

## How was it tested?

Using diff

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
