### PR TITLE
fix(feats): Add features from several sourcebooks

### DIFF
--- a/src/5e-SRD-Feats.json
+++ b/src/5e-SRD-Feats.json
@@ -886,16 +886,16 @@
     "prerequisites": [
       {
         "ability_score": {
-          "index": "intelligence",
-          "name": "Intelligence",
+          "index": "int",
+          "name": "INT",
           "url": "/api/ability-scores/intelligence"
         },
         "minimum_score": 13
       },
       {
         "ability_score": {
-          "index": "wisdom",
-          "name": "Wisdom",
+          "index": "wis",
+          "name": "WIS",
           "url": "/api/ability-scores/wisdom"
         },
         "minimum_score": 13

--- a/src/5e-SRD-Feats.json
+++ b/src/5e-SRD-Feats.json
@@ -18,5 +18,1209 @@
       "- You can use your action to try to pin a creature Grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both Restrained until the grapple ends."
     ],
     "url": "/api/feats/grappler"
-  }
+  },
+  {
+    "index": "abberrant-dragonmark",
+    "name": "Aberrant Dragonmark",
+    "prerequisites": [
+      {
+        "desc": [
+          "No other dragonmark."
+        ]
+      }
+    ],
+    "desc": [
+      "You have manifested an aberrant dragonmark. Determine its appearance and the flaw associated with it. You gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- You learn a cantrip of your choice from the sorcerer spell list. In addition, choose a 1st-level spell from the sorcerer spell list. You learn that spell and can cast it through your mark. Once you cast it, you must finish a short or long rest before you can cast it again through the mark. Constitution is your spellcasting ability for these spells.",
+      "- When you cast the 1st-level spell through your mark, you can expend one of your Hit Dice and roll it. If you roll an even number, you gain a number of temporary hit points equal to the number rolled. If you roll an odd number, one random creature within 30 feet of you (not including you) takes force damage equal to the number rolled. If no other creatures are in range, you take the damage.",
+      "You also develop a random flaw from the Aberrant Dragonmark Flaws table."
+    ],
+    "url": "/api/feats/abberrant-dragonmark"
+  },
+  {
+    "index": "actor",
+    "name": "Actor",
+    "prerequisites": [],
+    "desc": [
+      "Skilled at mimicry and dramatics, you gain the following benefits:",
+      "- Increase your Charisma score by 1, to a maximum of 20.",
+      "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
+      "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine that the effect is faked."
+    ],
+    "url": "/api/feats/actor"
+  },
+  {
+    "index": "alert",
+    "name": "Alert",
+    "prerequisites": [],
+    "desc": [
+      "Always on the lookout for danger, you gain the following benefits:",
+      "- You gain a +5 bonus to initiative.",
+      "- You can't be surprised while you are conscious.",
+      "- Other creatures don’t gain advantage on attack rolls against you as a result of being unseen by you."
+    ],
+    "url": "/api/feats/alert"
+  },
+  {
+    "index": "artificer-initiate",
+    "name": "Artificer Initiate",
+    "prerequisites": [],
+    "desc": [
+      "You’ve learned some of an artificer’s inventiveness:",
+      "- You learn one cantrip of your choice from the artificer spell list, and you learn one 1st-level spell of your choice from that list. Intelligence is your spellcasting ability for these spells.",
+      "- You can cast this feat’s 1st-level spell without a spell slot, and you must finish a long rest before you can cast it in this way again. You can also cast the spell using any spell slots you have.",
+      "- You gain proficiency with one type of artisan’s tools of your choice, and you can use that type of tool as a spellcasting focus for any spell you cast that uses Intelligence as its spellcasting ability."
+    ],
+    "url": "/api/feats/artificer-initiate"
+  },
+  {
+    "index": "athlete",
+    "name": "Athlete",
+    "prerequisites": [],
+    "desc": [
+      "You have undergone extensive physical training to gain the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- When you are prone, standing up uses only 5 feet of your movement.",
+      "- Climbing doesn't cost you extra movement.",
+      "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
+    ],
+    "url": "/api/feats/athlete"
+  },
+  {
+    "index": "bountiful-luck",
+    "name": "Bountiful Luck",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "halfling",
+          "name": "Halfling",
+          "url": "/api/races/halfling"
+        }
+      }
+    ],
+    "desc": [
+      "Your people have extraordinary luck, which you have learned to mystically lend to your companions when you see them falter. You’re not sure how you do it; you just wish it, and it happens. Surely a sign of fortune’s favor!",
+      "When an ally you can see within 30 feet of you rolls a 1 on the d20 for an attack roll, an ability check, or a saving throw, you can use your reaction to let the ally reroll the die. The ally must use the new roll.",
+      "When you use this ability, you can’t use your Lucky racial trait before the end of your next turn."
+    ],
+    "url": "/api/feats/bountiful-luck"
+  },
+  {
+    "index": "charger",
+    "name": "Charger",
+    "prerequisites": [],
+    "desc": [
+      "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
+      "If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack’s damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
+    ],
+    "url": "/api/feats/charger"
+  },
+  {
+    "index": "chef",
+    "name": "Chef",
+    "prerequisites": [],
+    "desc": [
+      "Time spent mastering the culinary arts has paid off, granting you the following benefits:",
+      "- Increase your Constitution or Wisdom score by 1, to a maximum of 20.",
+      "- You gain proficiency with cook’s utensils if you don’t already have it.",
+      "- As part of a short rest, you can cook special food, provided you have ingredients and cook’s utensils on hand. You can prepare enough of this food for a number of creatures equal to 4 + your proficiency bonus. At the end of the short rest, any creature who eats the food and spends one or more Hit Dice to regain hit points regains an extra 1d8 hit points.",
+      "- With one hour of work or when you finish a long rest, you can cook a number of treats equal to your proficiency bonus. These special treats last 8 hours after being made. A creature can use a bonus action to eat one of those treats to gain temporary hit points equal to your proficiency bonus."
+    ],
+    "url": "/api/feats/chef"
+  },
+  {
+    "index": "crossbow-expert",
+    "name": "Crossbow Expert",
+    "prerequisites": [],
+    "desc": [
+      "Thanks to extensive practice with the crossbow, you gain the following benefits:",
+      "- You ignore the loading property of crossbows with which you are proficient.",
+      "- Being within 5 feet of a hostile creature doesn’t impose disadvantage on your ranged attack rolls.",
+      "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a hand crossbow you are holding."
+    ],
+    "url": "/api/feats/crossbow-expert"
+  },
+  {
+    "index": "crusher",
+    "name": "Crusher",
+    "prerequisites": [],
+    "desc": [
+      "You are practiced in the art of crushing your enemies, granting you the following benefits:",
+      "- Increase your Strength or Constitution by 1, to a maximum of 20.",
+      "- Once per turn, when you hit a creature with an attack that deals bludgeoning damage, you can move it 5 feet to an unoccupied space, provided the target is no more than one size larger than you.",
+      "- When you score a critical hit that deals bludgeoning damage to a creature, attack rolls against that creature are made with advantage until the start of your next turn."
+    ],
+    "url": "/api/feats/crusher"
+  },
+  {
+    "index": "defensive-duelist",
+    "name": "Defensive Duelist",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
+    ],
+    "url": "/api/feats/defensive-duelist"
+  },
+  {
+    "index": "dragon-fear",
+    "name": "Dragon Fear",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dragonborn",
+          "name": "Dragonborn",
+          "url": "/api/races/dragonborn"
+        }
+      }
+    ],
+    "desc": [
+      "When angered, you can radiate menace. You gain the following benefits:",
+      "- Increase your Strength, Constitution, or Charisma score by 1, to a maximum of 20.",
+      "- Instead of exhaling destructive energy, you can expend a use of your Breath Weapon trait to roar, forcing each creature of your choice within 30 feet of you to make a Wisdom saving throw (DC 8 + your proficiency bonus + your Charisma modifier). A target automatically succeeds on the save if it can’t hear or see you. On a failed save, a target becomes frightened of you for 1 minute. If the frightened target takes any damage, it can repeat the saving throw, ending the effect on itself on a success."
+    ],
+    "url": "/api/feats/dragon-fear"
+  },
+  {
+    "index": "dragon-hide",
+    "name": "Dragon Hide",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dragonborn",
+          "name": "Dragonborn",
+          "url": "/api/races/dragonborn"
+        }
+      }
+    ],
+    "desc": [
+      "You manifest scales and claws reminiscent of your draconic ancestors. You gain the following benefits:",
+      "- Increase your Strength, Constitution, or Charisma score by 1, to a maximum of 20.",
+      "- Your scales harden. While you aren’t wearing armor, you can calculate your AC as 13 + your Dexterity modifier. You can use a shield and still gain this benefit.",
+      "- You grow retractable claws from the tips of your fingers. Extending or retracting the claws requires no action. The claws are natural weapons, which you can use to make unarmed strikes. If you hit with them, you deal slashing damage equal to 1d4 + your Strength modifier, instead of the normal bludgeoning damage for an unarmed strike."
+    ],
+    "url": "/api/feats/dragon-hide"
+  },
+  {
+    "index": "drow-high-magic",
+    "name": "Drow High Magic",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "drow",
+          "name": "Drow",
+          "url": "/api/subraces/drow"
+        }
+      }
+    ],
+    "desc": [
+      "You learn more of the magic typical of dark elves. You gain the following benefits:",
+      "- You learn the detect magic spell and can cast it at will, without expending a spell slot.",
+      "- You also learn levitate and dispel magic, each of which you can cast once without expending a spell slot. You regain the ability to cast those two spells in this way when you finish a long rest.",
+      "- Charisma is your spellcasting ability for all three spells."
+    ],
+    "url": "/api/feats/drow-high-magic"
+  },
+  {
+    "index": "dual-wielder",
+    "name": "Dual Wielder",
+    "prerequisites": [],
+    "desc": [
+      "You master fighting with two weapons, gaining the following benefits:",
+      "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
+      "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren't light.",
+      "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
+    ],
+    "url": "/api/feats/dual-wielder"
+  },
+  {
+    "index": "dungeon-delver",
+    "name": "Dungeon Delver",
+    "prerequisites": [],
+    "desc": [
+      "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
+      "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
+      "- You have advantage on saving throws made to avoid or resist traps.",
+      "- You have resistance to the damage dealt by traps.",
+      "- Traveling at a fast pace doesn't impose the normal −5 penalty on your passive Wisdom (Perception) score."
+    ],
+    "url": "/api/feats/dungeon-delver"
+  },
+  {
+    "index": "durable",
+    "name": "Durable",
+    "prerequisites": [],
+    "desc": [
+      "Hardy and resilient, you gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
+    ],
+    "url": "/api/feats/durable"
+  },
+  {
+    "index": "dwarven-fortitude",
+    "name": "Dwarven Fortitude",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dwarf",
+          "name": "Dwarf",
+          "url": "/api/races/dwarf"
+        }
+      }
+    ],
+    "desc": [
+      "You have the blood of dwarf heroes flowing through your veins. You gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- Whenever you take the Dodge action in combat, you can spend one Hit Die to heal yourself. Roll the die, add your Constitution modifier, and regain a number of hit points equal to the total (minimum of 1)."
+    ],
+    "url": "/api/feats/dwarven-fortitude"
+  },
+  {
+    "index": "eldritch-adept",
+    "name": "Eldritch Adept",
+    "prerequisites": [
+      {
+        "features": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/features/spellcasting"
+          },
+          {
+            "index": "pact-magic",
+            "name": "Pact Magic",
+            "url": "/api/features/pact-magic"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "Studying occult lore, you learn one Eldritch Invocation option of your choice from the warlock class. Your spellcasting ability for the invocation is Intelligence, Wisdom, or Charisma (choose when you select this feat). If the invocation has a prerequisite of any kind, you can choose that invocation only if you’re a warlock who meets the prerequisite.",
+      "Whenever you gain a level, you can replace the invocation with another one from the warlock class."
+    ],
+    "url": "/api/feats/eldritch-adept"
+  },
+  {
+    "index": "elemental-adept",
+    "name": "Elemental Adept",
+    "prerequisites": [
+      {
+        "features": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/features/spellcasting"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
+      "Spells you cast ignore resistance to damage of the chosen type. In addition, when you roll damage for a spell you cast that deals damage of that type, you can treat any 1 on a damage die as a 2.",
+      "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
+    ],
+    "url": "/api/feats/elemental-adept"
+  },
+  {
+    "index": "elven-accuracy",
+    "name": "Elven Accuracy",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "elf",
+          "name": "Elf",
+          "url": "/api/races/elf"
+        }
+      },
+      {
+        "race": {
+          "index": "half-elf",
+          "name": "Half-Elf",
+          "url": "/api/races/half-elf"
+        }
+      }
+    ],
+    "desc": [
+      "The accuracy of elves is legendary, especially that of elf archers and spellcasters. You have uncanny aim with attacks that rely on precision rather than brute force. You gain the following benefits:",
+      "- Increase your Dexterity, Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "- Whenever you have advantage on an attack roll using Dexterity, Intelligence, Wisdom, or Charisma, you can reroll one of the dice once."
+    ],
+    "url": "/api/feats/elven-accuracy"
+  },
+  {
+    "index": "fade-away",
+    "name": "Fade Away",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "gnome",
+          "name": "Gnome",
+          "url": "/api/races/gnome"
+        }
+      }
+    ],
+    "desc": [
+      "Your people are clever, with a knack for illusion magic. You have learned a magical trick for fading away when you suffer harm. You gain the following benefits:",
+      "- Increase your Dexterity or Intelligence score by 1, to a maximum of 20.",
+      "- Immediately after you take damage, you can use a reaction to magically become invisible until the end of your next turn or until you attack, deal damage, or force someone to make a saving throw. Once you use this ability, you can’t do so again until you finish a short or long rest."
+    ],
+    "url": "/api/feats/fade-away"
+  },
+  {
+    "index": "fey-teleportation",
+    "name": "Fey Teleportation",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "high-elf",
+          "name": "High Elf",
+          "url": "/api/subraces/high-elf"
+        }
+      }
+    ],
+    "desc": [
+      "Your study of high elven lore has unlocked fey power that few other elves possess, except your eladrin cousins. Drawing on your fey ancestry, you can momentarily stride through the Feywild to shorten your path from one place to another. You gain the following benefits:",
+      "- Increase your Intelligence or Charisma score by 1, to a maximum of 20.",
+      "- You learn to speak, read, and write Sylvan.",
+      "- You learn the misty step spell and can cast it once without expending a spell slot. You regain the ability to cast it in this way when you finish a short or long rest. Intelligence is your spellcasting ability for this spell."
+    ],
+    "url": "/api/feats/fey-teleportation"
+  },
+  {
+    "index": "fey-touched",
+    "name": "Fey Touched",
+    "prerequisites": [],
+    "desc": [
+      "Your exposure to the Feywild’s magic has changed you, granting you the following benefits:",
+      "- Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "- You learn the misty step spell and one 1st-level spell of your choice. The 1st-level spell must be from the divination or enchantment school of magic. You can cast each of these spells without expending a spell slot. Once you cast either of these spells in this way, you can’t cast that spell in this way again until you finish a long rest. You can also cast these spells using spell slots you have of the appropriate level. The spells’ spellcasting ability is the ability increased by this feat."
+    ],
+    "url": "/api/feats/fey-touched"
+  },
+  {
+    "index": "fighting-initiate",
+    "name": "Fighting Initiate",
+    "prerequisites": [
+      {
+        "desc": [
+          "Proficiency with a martial weapon"
+        ]
+      }
+    ],
+    "desc": [
+      "Your martial training has helped you develop a particular style of fighting. As a result, you learn one Fighting Style option of your choice from the fighter class. If you already have a style, the one you choose must be different.",
+      "Whenever you reach a level that grants the Ability Score Improvement feature, you can replace this feat’s fighting style with another one from the fighter class that you don’t have."
+    ],
+    "url": "/api/feats/fighting-initiate"
+  },
+  {
+    "index": "flames-of-phlegethos",
+    "name": "Flames of Phlegethos",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "tiefling",
+          "name": "Tiefling",
+          "url": "/api/races/tiefling"
+        }
+      }
+    ],
+    "desc": [
+      "You learn to call on hellfire to serve your commands. You gain the following benefits:",
+      "- Increase your Intelligence or Charisma score by 1, to a maximum of 20.",
+      "- When you roll fire damage for a spell you cast, you can reroll any roll of 1 on the fire damage dice, but you must use the new roll, even if it is another 1.",
+      "- Whenever you cast a spell that deals fire damage, you can cause flames to wreathe you until the end of your next turn. The flames don’t harm you or your possessions, and they shed bright light out to 30 feet and dim light for an additional 30 feet. While the flames are present, any creature within 5 feet of you that hits you with a melee attack takes 1d4 fire damage."
+    ],
+    "url": "/api/feats/flames-of-phlegethos"
+  },
+  {
+    "index": "gift-of-the-chromatic-dragon",
+    "name": "Gift of the Chromatic Dragon",
+    "prerequisites": [],
+    "desc": [
+      "You’ve manifested some of the power of chromatic dragons, granting you the following benefits:",
+      "- Chromatic Infusion. As a bonus action, you can touch a simple or martial weapon and infuse it with one of the following damage types: acid, cold, fire, lightning, or poison. For the next minute, the weapon deals an extra 1d4 damage of the chosen type when it hits. After you use this bonus action, you can't do so again until you finish a long rest.",
+      "- Reactive Resistance. When you take acid, cold, fire, lightning, or poison damage, you can use your reaction to give yourself resistance to that instance of damage. You can use this reaction a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+    ],
+    "url": "/api/feats/gift-of-the-chromatic-dragon"
+  },
+  {
+    "index": "gift-of-the-gem-dragon",
+    "name": "Gift of the Gem Dragon",
+    "prerequisites": [],
+    "desc": [
+      "You’ve manifested some of the power of gem dragons, granting you the following benefits:",
+      "- Ability Score Increase. Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "- Telekinetic Reprisal. When you take damage from a creature that is within 10 feet of you, you can use your reaction to emanate telekinetic energy. The creature that dealt damage to you must make a Strength saving throw (DC equals 8 + your proficiency bonus + the ability modifier of the score increased by this feat). On a failed save, the creature takes 2d8 force damage and is pushed up to 10 feet away from you. On a successful save, the creature takes half as much damage and isn’t pushed. You can use this reaction a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+    ],
+    "url": "/api/feats/gift-of-the-gem-dragon"
+  },
+  {
+    "index": "gift-of-the-metallic-dragon",
+    "name": "Gift of the Metallic Dragon",
+    "prerequisites": [],
+    "desc": [
+      "You’ve manifested some of the power of metallic dragons, granting you the following benefits:",
+      "- Draconic Healing. You learn the cure wounds spell. You can cast this spell without expending a spell slot. Once you cast this spell in this way, you can’t do so again until you finish a long rest. You can also cast this spell using spell slots you have. The spell’s spellcasting ability is Intelligence, Wisdom, or Charisma when you cast it with this feat (choose when you gain the feat).",
+      "- Protective Wings. You can manifest protective wings that can shield you or others. When you or another creature you can see within 5 feet of you is hit by an attack roll, you can use your reaction to manifest spectral wings from your back for a moment. You grant a bonus to the target’s AC equal to your proficiency bonus against that attack roll, potentially causing it to miss. You can use this reaction a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+    ],
+    "url": "/api/feats/gift-of-the-metallic-dragon"
+  },
+  {
+    "index": "great-weapon-master",
+    "name": "Great Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You've learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+      "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+      "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/feats/great-weapon-master"
+  },
+  {
+    "index": "gunner",
+    "name": "Gunner",
+    "prerequisites": [],
+    "desc": [
+      "You have a quick hand and keen eye when employing firearms, granting you the following benefits:",
+      "- Increase your Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with firearms (see “Firearms” in the Dungeon Master’s Guide).",
+      "- You ignore the loading property of firearms.",
+      "- Being within 5 feet of a hostile creature doesn’t impose disadvantage on your ranged attack rolls."
+    ],
+    "url": "/api/feats/gunner"
+  },
+  {
+    "index": "healer",
+    "name": "Healer",
+    "prerequisites": [],
+    "desc": [
+      "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
+      "- When you use a healer's kit to stabilize a dying creature, that creature also regains 1 hit point.",
+      "- As an action, you can spend one use of a healer's kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature's maximum number of Hit Dice. The creature can't regain hit points from this feat again until it finishes a short or long rest."
+    ],
+    "url": "/api/feats/healer"
+  },
+  {
+    "index": "heavily-armored",
+    "name": "Heavily Armored",
+    "prerequisites": [
+      {
+        "desc": [
+          "Proficiency with medium armor"
+        ]
+      }
+    ],
+    "desc": [
+      "You have trained to master the use of heavy armor, gaining the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- You gain proficiency with heavy armor."
+    ],
+    "url": "/api/feats/heavily-armored"
+  },
+  {
+    "index": "heavy-armor-master",
+    "name": "Heavy Armor Master",
+    "prerequisites": [
+      {
+        "desc": [
+          "Proficiency with heavy armor"
+        ]
+      }
+    ],
+    "desc": [
+      "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical attacks is reduced by 3."
+    ],
+    "url": "/api/feats/heavy-armor-master"
+  },
+  {
+    "index": "infernal-constitution",
+    "name": "Infernal Constitution",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "tiefling",
+          "name": "Tiefling",
+          "url": "/api/races/tiefling"
+        }
+      }
+    ],
+    "desc": [
+      "Fiendish blood runs strong in you, unlocking a resilience akin to that possessed by some fiends. You gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- You have resistance to cold damage and poison damage.",
+      "- You have advantage on saving throws against being poisoned."
+    ],
+    "url": "/api/feats/infernal-constitution"
+  },
+  {
+    "index": "inspiring-leader",
+    "name": "Inspiring Leader",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can't gain temporary hit points from this feat again until it has finished a short or long rest."
+    ],
+    "url": "/api/feats/inspiring-leader"
+  },
+  {
+    "index": "keen-mind",
+    "name": "Keen Mind",
+    "prerequisites": [],
+    "desc": [
+      "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You always know which way is north.",
+      "- You always know the number of hours left before the next sunrise or sunset.",
+      "- You can accurately recall anything you have seen or heard within the past month."
+    ],
+    "url": "/api/feats/keen-mind"
+  },
+  {
+    "index": "lightly-armored",
+    "name": "Lightly Armored",
+    "prerequisites": [],
+    "desc": [
+      "You have trained to master the use of light armor, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with light armor."
+    ],
+    "url": "/api/feats/lightly-armored"
+  },
+  {
+    "index": "linguist",
+    "name": "Linguist",
+    "prerequisites": [],
+    "desc": [
+      "You have studied languages and codes, gaining the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You learn three languages of your choice.",
+      "- You can ably create written ciphers. Others can't decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
+    ],
+    "url": "/api/feats/linguist"
+  },
+  {
+    "index": "lucky",
+    "name": "Lucky",
+    "prerequisites": [],
+    "desc": [
+      "You have inexplicable luck that seems to kick in at just the right moment.",
+      "- You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
+      "- You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker's roll or yours. If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
+      "- You regain your expended luck points when you finish a long rest."
+    ],
+    "url": "/api/feats/lucky"
+  },
+  {
+    "index": "mage-slayer",
+    "name": "Mage Slayer",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
+      "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
+      "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
+      "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
+    ],
+    "url": "/api/feats/mage-slayer"
+  },
+  {
+    "index": "magic-initiate",
+    "name": "Magic Initiate",
+    "prerequisites": [],
+    "desc": [
+      "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class’s spell list.",
+      "In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell once at its lowest level, and you must finish a long rest before you can cast it in this way again.",
+      "Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "url": "/api/feats/magic-initiate"
+  },
+  {
+    "index": "martial-adept",
+    "name": "Martial Adept",
+    "prerequisites": [],
+    "desc": [
+      "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
+      "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver's effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+      "- You gain one superiority die, which is a d6 (this die is added to any superiority dice you have from another source). This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
+    ],
+    "url": "/api/feats/martial-adept"
+  },
+  {
+    "index": "medium-armor-master",
+    "name": "Medium Armor Master",
+    "prerequisites": [
+      {
+        "desc": [
+          "Proficiency with medium armor."
+        ]
+      }
+    ],
+    "desc": [
+      "You have practiced moving in medium armor to gain the following benefits:",
+      "- Wearing medium armor doesn't impose disadvantage on your Dexterity (Stealth) checks.",
+      "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
+    ],
+    "url": "/api/feats/medium-armor-master"
+  },
+  {
+    "index": "metamagic-adept",
+    "name": "Metamagic Adept",
+    "prerequisites": [
+      {
+        "features": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/features/spellcasting"
+          },
+          {
+            "index": "pact-magic",
+            "name": "Pact Magic",
+            "url": "/api/features/pact-magic"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "You’ve learned how to exert your will on your spells to alter how they function:",
+      "- You learn two Metamagic options of your choice from the sorcerer class. You can use only one Metamagic option on a spell when you cast it, unless the option says otherwise. Whenever you reach a level that grants the Ability Score Improvement feature, you can replace one of these Metamagic options with another one from the sorcerer class.",
+      "- You gain 2 sorcery points to spend on Metamagic (these points are added to any sorcery points you have from another source but can be used only on Metamagic). You regain all spent sorcery points when you finish a long rest."
+    ],
+    "url": "/api/feats/metamagic-adept"
+  },
+  {
+    "index": "mobile",
+    "name": "Mobile",
+    "desc": [
+      "You are exceptionally speedy and agile. You gain the following benefits:",
+      "- Your speed increases by 10 feet.",
+      "- When you use the Dash action, difficult terrain doesn't cost you extra movement on that turn.",
+      "- When you make a melee attack against a creature, you don't provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+    ],
+    "url": "/api/feats/mobile"
+  },
+  {
+    "index": "moderately-armored",
+    "name": "Moderately Armored",
+    "prerequisites": [
+      {
+        "desc": [
+          "Proficiency with light armor."
+        ]
+      }
+    ],
+    "desc": [
+      "You have trained to master the use of medium armor and shields, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with medium armor and shields."
+    ],
+    "url": "/api/feats/moderately-armored"
+  },
+  {
+    "index": "mounted-combatant",
+    "name": "Mounted Combatant",
+    "prerequisites": [],
+    "desc": [
+      "You are a dangerous foe to face while mounted. While you are mounted and aren't incapacitated, you gain the following benefits:",
+      "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
+      "- You can force an attack targeted at your mount to target you instead.",
+      "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+    ],
+    "url": "/api/feats/mounted-combatant"
+  },
+  {
+    "index": "observant",
+    "name": "Observant",
+    "prerequisites": [],
+    "desc": [
+      "Quick to notice details of your environment, you gain the following benefits:",
+      "- Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
+      "- If you can see a creature's mouth while it is speaking a language you understand, you can interpret what it's saying by reading its lips.",
+      "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
+    ],
+    "url": "/api/feats/observant"
+  },
+  {
+    "index": "orcish-fury",
+    "name": "Orcish Fury",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "half-orc",
+          "name": "Half-orc",
+          "url": "/api/races/half-orc"
+        }
+      }
+    ],
+    "desc": [
+      "Your inner fury burns tirelessly. You gain the following benefits:",
+      "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
+      "- When you hit with an attack using a simple or martial weapon, you can roll one of the weapon’s damage dice an additional time and add it as extra damage of the weapon’s damage type. Once you use this ability, you can’t use it again until you finish a short or long rest.",
+      "- Immediately after you use your Relentless Endurance trait, you can use your reaction to make one weapon attack."
+    ],
+    "url": "/api/feats/orcish-fury"
+  },
+  {
+    "index": "piercer",
+    "name": "Piercer",
+    "prerequisites": [],
+    "desc": [
+      "You have achieved a penetrating precision in combat, granting you the following benefits:",
+      "- Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "- Once per turn, when you hit a creature with an attack that deals piercing damage, you can reroll one of the attack’s damage dice, and you must use the new roll.",
+      "- When you score a critical hit that deals piercing damage to a creature, you can roll one additional damage die when determining the extra piercing damage the target takes."
+    ],
+    "url": "/api/feats/piercer"
+  },
+  {
+    "index": "poisoner",
+    "name": "Poisoner",
+    "prerequisites": [],
+    "desc": [
+      "You can prepare and deliver deadly poisons, granting you the following benefits:",
+      "- When you make a damage roll that deals poison damage, it ignores resistance to poison damage.",
+      "- You can apply poison to a weapon or piece of ammunition as a bonus action, instead of an action.",
+      "- You gain proficiency with the Poisoner's Kit if you don’t already have it. With one hour of work using a poisoner’s kit and expending 50 gp worth of materials, you can create a number of doses of potent poison equal to your proficiency bonus. Once applied to a weapon or piece of ammunition, the poison retains its potency for 1 minute or until you hit with the weapon or ammunition. When a creature takes damage from the coated weapon or ammunition, that creature must succeed on a DC 14 Constitution saving throw or take 2d8 poison damage and become poisoned until the end of your next turn."
+    ],
+    "url": "/api/feats/poisoner"
+  },
+  {
+    "index": "polearm-master",
+    "name": "Polearm Master",
+    "prerequisites": [],
+    "desc": [
+      "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
+      "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon’s damage die for this attack is a d4, and it deals bludgeoning damage.",
+      "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter the reach you have with that weapon."
+    ],
+    "url": "/api/feats/polearm-master"
+  },
+  {
+    "index": "prodigy",
+    "name": "Prodigy",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "half-elf",
+          "name": "Half-Elf",
+          "url": "/api/races/half-elf"
+        }
+      },
+      {
+        "race": {
+          "index": "half-orc",
+          "name": "Half-Orc",
+          "url": "/api/races/half-orc"
+        }
+      },
+      {
+        "race": {
+          "index": "human",
+          "name": "Human",
+          "url": "/api/races/human"
+        }
+      }
+    ],
+    "desc": [
+      "You have a knack for learning new things. You gain the following benefits:",
+      "- You gain one skill proficiency of your choice, one tool proficiency of your choice, and fluency in one language of your choice.",
+      "- Choose one skill in which you have proficiency. You gain expertise with that skill, which means your proficiency bonus is doubled for any ability check you make with it. The skill you choose must be one that isn’t already benefiting from a feature, such as Expertise, that doubles your proficiency bonus."
+    ],
+    "url": "/api/feats/prodigy"
+  },
+  {
+    "index": "resilient",
+    "name": "Resilient",
+    "prerequisites": [],
+    "desc": [
+      "Choose one ability score. You gain the following benefits:",
+      "- Increase the chosen ability score by 1, to a maximum of 20.",
+      "- You gain proficiency in saving throws using the chosen ability."
+    ],
+    "url": "/api/feats/resilient"
+  },
+  {
+    "index": "revenant-blade",
+    "name": "Revenant Blade",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "elf",
+          "name": "Elf",
+          "url": "/api/races/elf"
+        }
+      }
+    ],
+    "desc": [
+      "You are descended from a master of the double-bladed scimitar, and some of that mastery has passed on to you. You gain the following benefits:",
+      "- Increase your Dexterity or Strength score by 1, to a maximum of 20.",
+      "- While you are holding a double-bladed scimitar with two hands, you gain a +1 bonus to Armor Class.",
+      "- A double-bladed scimitar has the finesse property when you wield it.",
+      "- To gain the weapon benefits of this feat, equip a Revenant Double-Bladed Scimitar or create your own similar weapon."
+    ],
+    "url": "/api/feats/revenant-blade"
+  },
+  {
+    "index": "ritual-caster",
+    "name": "Ritual Caster",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "intelligence",
+          "name": "Intelligence",
+          "url": "/api/ability-scores/intelligence"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "wisdom",
+          "name": "Wisdom",
+          "url": "/api/ability-scores/wisdom"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
+      "When you choose this feat, you acquire a ritual book holding two 1st-level spells of your choice. Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You must choose your spells from that class’s spell list, and the spells you choose must have the ritual tag. The class you choose also determines your spellcasting ability for these spells: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.",
+      "If you come across a spell in written form, such as a magical spell scroll or a wizard’s spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell’s level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it."
+    ],
+    "url": "/api/feats/ritual-caster"
+  },
+  {
+    "index": "savage-attacker",
+    "name": "Savage Attacker",
+    "prerequisites": [],
+    "desc": [
+      "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon’s damage dice and use either total."
+    ],
+    "url": "/api/feats/savage-attacker"
+  },
+  {
+    "index": "second-chance",
+    "name": "Second Chance",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "halfling",
+          "name": "Halfling",
+          "url": "/api/races/halfling"
+        }
+      }
+    ],
+    "desc": [
+      "Fortune favors you when someone tries to strike you. You gain the following benefits:",
+      "- Increase your Dexterity, Constitution, or Charisma score by 1, to a maximum of 20.",
+      "- When a creature you can see hits you with an attack roll, you can use your reaction to force that creature to reroll. Once you use this ability, you can’t use it again until you roll initiative at the start of combat or until you finish a short or long rest."
+    ],
+    "url": "/api/feats/second-chance"
+  },
+  {
+    "index": "sentinel",
+    "name": "Sentinel",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered techniques to take advantage of every drop in any enemy's guard, gaining the following benefits:",
+      "- When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.",
+      "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+      "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn't have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+    ],
+    "url": "/api/feats/sentinel"
+  },
+  {
+    "index": "sentinel",
+    "name": "Sentinel",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered techniques to take advantage of every drop in any enemy's guard, gaining the following benefits:",
+      "- When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.",
+      "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+      "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn't have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+    ],
+    "url": "/api/feats/sentinel"
+  },
+  {
+    "index": "sharpshooter",
+    "name": "Sharpshooter",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
+      "- Attacking at long range doesn't impose disadvantage on your ranged weapon attack rolls.",
+      "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
+      "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/feats/sharpshooter"
+  },
+  {
+    "index": "shield-master",
+    "name": "Shield Master",
+    "prerequisites": [],
+    "desc": [
+      "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
+      "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
+      "- If you aren't incapacitated, you can add your shield's AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
+      "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
+    ],
+    "url": "/api/feats/shield-master"
+  },
+  {
+    "index": "skill-expert",
+    "name": "Skill Expert",
+    "prerequisites": [],
+    "desc": [
+      "You have honed your proficiency with particular skills, granting you the following benefits:",
+      "- Increase one ability score of your choice by 1, to a maximum of 20.",
+      "- You gain proficiency in one skill of your choice.",
+      "- Choose one skill in which you have proficiency. You gain expertise with that skill, which means your proficiency bonus is doubled for any ability check you make with it. The skill you choose must be one that isn’t already benefiting from a feature, such as Expertise, that doubles your proficiency bonus."
+    ],
+    "url": "/api/feats/skill-expert"
+  },
+  {
+    "index": "skilled",
+    "name": "Skilled",
+    "prerequisites": [],
+    "desc": [
+      "You gain proficiency in any combination of three skills or tools of your choice."
+    ],
+    "url": "/api/feats/skilled"
+  },
+  {
+    "index": "skulker",
+    "name": "Skulker",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You are expert at slinking through shadows. You gain the following benefits:",
+      "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
+      "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn't reveal your position.",
+      "- Dim light doesn't impose disadvantage on your Wisdom (Perception) checks relying on sight."
+    ],
+    "url": "/api/feats/skulker"
+  },
+  {
+    "index": "slasher",
+    "name": "Slasher",
+    "prerequisites": [],
+    "desc": [
+      "You’ve learned where to cut to have the greatest results, granting you the following benefits:",
+      "- Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "- Once per turn when you hit a creature with an attack that deals slashing damage, you can reduce the speed of the target by 10 feet until the start of your next turn.",
+      "- When you score a critical hit that deals slashing damage to a creature, you grievously wound it. Until the start of your next turn, the target has disadvantage on all attack rolls."
+    ],
+    "url": "/api/feats/slasher"
+  },
+  {
+    "index": "spell-sniper",
+    "name": "Spell Sniper",
+    "prerequisites": [
+      {
+        "features": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/features/spellcasting"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
+      "- When you cast a spell that requires you to make an attack roll, the spell’s range is doubled.",
+      "- Your ranged spell attacks ignore half cover and three-quarters cover.",
+      "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "url": "/api/feats/spell-sniper"
+  },
+  {
+    "index": "squat-nimbleness",
+    "name": "Squat Nimbleness",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dwarf",
+          "name": "Dwarf",
+          "url": "/api/races/dwarf"
+        }
+      },
+      {
+        "race": {
+          "index": "gnome",
+          "name": "Gnome",
+          "url": "/api/races/gnome"
+        }
+      },
+      {
+        "race": {
+          "index": "halfling",
+          "name": "Halfling",
+          "url": "/api/races/halfling"
+        }
+      }
+    ],
+    "desc": [
+      "You are uncommonly nimble for your race. You gain the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- Increase your walking speed by 5 feet.",
+      "- You gain proficiency in the Acrobatics or Athletics skill (your choice).",
+      "- You have advantage on any Strength (Athletics) or Dexterity (Acrobatics) check you make to escape from being grappled."
+    ],
+    "url": "/api/feats/squat-nimbleness"
+  },
+  {
+    "index": "strixhaven-initiate",
+    "name": "Strixhaven Initiate",
+    "prerequisites": [],
+    "desc": [
+      "You have studied some magical theory and have learned a few spells associated with Strixhaven University.",
+      "Choose one of Strixhaven’s colleges: Lorehold, Prismari, Quandrix, Silverquill, or Witherbloom. You learn two cantrips and one 1st-level spell based on the college you choose, as specified in the Strixhaven Spells table.",
+      "You can cast the chosen 1st-level spell without a spell slot, and you must finish a long rest before you can cast it in this way again. You can also cast the spell using any spell slots you have.",
+      "Your spellcasting ability for this feat’s spells is Intelligence, Wisdom, or Charisma (choose when you select this feat)."
+    ],
+    "url": "/api/feats/strixhaven-initiate"
+  },
+  {
+    "index": "strixhaven-mascot",
+    "name": "Strixhaven Mascot",
+    "prerequisites": [
+      {
+        "feat": {
+          "index": "strixhaven-initiate",
+          "name": "Strixhaven Initiate",
+          "url": "/api/feats/strixhaven-initiate"
+        }
+      }
+    ],
+    "desc": [
+      "You have learned how to summon a Strixhaven mascot to assist you, granting you these benefits:",
+      "- You can cast the find familiar spell as a ritual. Your familiar can take the form of the mascot associated with the college you chose for the Strixhaven Initiate feat: a spirit statue mascot (Lorehold), an art elemental mascot (Prismari), a fractal mascot (Quandrix), an inkling mascot (Silverquill), or a pest mascot (Witherbloom). Stat blocks for these creatures appear in chapter 7.",
+      "- When you take the Attack action on your turn, you can forgo one attack to allow your mascot familiar to make one attack of its own with its reaction.",
+      "- If your mascot familiar is within 60 feet of you, you can teleport as an action, swapping places with the familiar. If your destination space is too small for you to occupy, the teleportation fails and is wasted. Once you teleport in this way, you can’t do so again until you finish a long rest, unless you expend a spell slot of 2nd level or higher to do it again."
+    ],
+    "url": "/api/feats/strixhaven-mascot"
+  },
+  {
+    "index": "tavern-brawler",
+    "name": "Tavern Brawler",
+    "prerequisites": [],
+    "desc": [
+      "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
+      "- Increase your Strength or Constitution score by 1, to a maximum of 20.",
+      "- You are proficient with improvised weapons.",
+      "- Your unarmed strike uses a d4 for damage.",
+      "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
+    ],
+    "url": "/api/feats/tavern-brawler"
+  },
+  {
+    "index": "telekinetic",
+    "name": "Telekinetic",
+    "prerequisites": [],
+    "desc": [
+      "You learn to move things with your mind, granting you the following benefits:",
+      "- Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "- You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is the ability increased by this feat.",
+      "- As a bonus action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, the target must succeed on a Strength saving throw (DC 8 + your proficiency bonus + the ability modifier of the score increased by this feat) or be moved 5 feet toward you or away from you. A creature can willingly fail this save."
+    ],
+    "url": "/api/feats/telekinetic"
+  },
+  {
+    "index": "telepathic",
+    "name": "Telepathic",
+    "prerequisites": [],
+    "desc": [
+      "You awaken the ability to mentally connect with others, granting you the following benefits:",
+      "- Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "- You can speak telepathically to any creature you can see within 60 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn’t give the creature the ability to respond to you telepathically.",
+      "- You can cast the detect thoughts spell, requiring no spell slot or components, and you must finish a long rest before you can cast it this way again. Your spellcasting ability for the spell is the ability increased by this feat. If you have spell slots of 2nd level or higher, you can cast this spell with them."
+    ],
+    "url": "/api/feats/telepathic"
+  },
+  {
+    "index": "tough",
+    "name": "Tough",
+    "prerequisites": [],
+    "desc": [
+      "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
+    ],
+    "url": "/api/feats/tough"
+  },
+  {
+    "index": "war-caster",
+    "name": "War Caster",
+    "prerequisites": [
+      {
+        "features": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/features/spellcasting"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
+      "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
+      "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
+      "- When a hostile creature's movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
+    ],
+    "url": "/api/feats/war-caster"
+  },
+  {
+    "index": "weapon-master",
+    "name": "Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced extensively with a variety of weapons, gaining the following benefits:",
+      "- Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
+    ],
+    "url": "/api/feats/weapon-master"
+  },
+  {
+    "index": "wood-elf-magic",
+    "name": "Wood Elf Magic",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "wood-elf",
+          "name": "Wood Elf",
+          "url": "/api/subraces/wood-elf"
+        }
+      }
+    ],
+    "desc": [
+      "You learn the magic of the primeval woods, which are revered and protected by your people. You learn one druid cantrip of your choice. You also learn the longstrider and pass without trace spells, each of which you can cast once without expending a spell slot. You regain the ability to cast these two spells in this way when you finish a long rest. Wisdom is your spellcasting ability for all three spells."
+    ],
+    "url": "/api/feats/wood-elf-magic"
+  }    
 ]


### PR DESCRIPTION
## What does this do?

\This push aims to add several feats to the API

## How was it tested?

\<It's not clear if I don't update this text with relevant info\>

## Is there a Github issue this is resolving?

\No issue currently

## Did you update the docs in the API? Please link an associated PR if applicable.

\<It's not clear if I don't update this text with relevant info\>

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)

## Notes

- Feat Aberrant Dragonmark has a unique prereq, check key.
- Feats Eldritch Adept, Elemental Adept, Metamagic Adept, Spell Sniper, War Caster contain prereqs for features Spellcater and/or Pact Magic, which are not present in Features
- Feats Fighting Initiate, Heavily Armored, Heavy Armor Master, Medium Armor Master, Moderately Armored require proficiencies, which I was unable to find refs for. Needs review.
- Feats Drow High Magic, Wood Elf Magic point to subraces that have not been populated.
- Missing sourcebooks: Dragonlance: Shadow of the Dragon Queen, Planescape: Adventures in the Multiverse, The Book of Many Things, Bigby Presents: Glory of the Giants,