### PR TITLE
fix(magic-item): Add image to the correct magic item

### DIFF
--- a/src/5e-SRD-Magic-Items.json
+++ b/src/5e-SRD-Magic-Items.json
@@ -16,6 +16,7 @@
       "Armor (medium or heavy, but not hide), uncommon",
       "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit."
     ],
+    "image": "/api/images/magic-items/adamantine-armor.png",
     "url": "/api/magic-items/adamantine-armor"
   },
   {
@@ -51,7 +52,6 @@
       "Weapon (any ammunition), uncommon (+1), rare (+2), or very rare (+3)",
       "You have a bonus to attack and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical."
     ],
-    "image": "/api/images/magic-items/adamantine-armor.png",
     "url": "/api/magic-items/ammunition"
   },
   {


### PR DESCRIPTION
## What does this do?

Adamantine Armor image was on Ammunition by mistake.

## Here's a fun image for your troubles

![random photo - update me](https://picsum.photos/200)
