### PR TITLE
feat: Removing a wrong space.

### DIFF
--- a/src/5e-SRD-Equipment.json
+++ b/src/5e-SRD-Equipment.json
@@ -2760,7 +2760,7 @@
     },
     "weight": 2,
     "desc": [
-      " A component pouch is a small, watertight leather belt pouch that has compartments to hold all the material components and other special items you need to cast your spells, except for those components that have a specific cost (as indicated in a spell's description)."
+      "A component pouch is a small, watertight leather belt pouch that has compartments to hold all the material components and other special items you need to cast your spells, except for those components that have a specific cost (as indicated in a spell's description)."
     ],
     "url": "/api/equipment/component-pouch"
   },


### PR DESCRIPTION
## What does this do?
This PR fixes a minor formatting issue by removing an unnecessary space in the text describing the "component pouch." It ensures the text is more readable and consistent.

## How was it tested?
As this is a textual adjustment with no code impact, no specific testing was required. Visual inspection confirmed the formatting is now correct.

## Is there a Github issue this is resolving?
No, this adjustment was identified and resolved independently, with no associated issue.

## Did you update the docs in the API? Please link an associated PR if applicable.
No updates to the API documentation were necessary, as this is a textual correction with no effect on functionality.
