### PR TITLE
feat: add terrain type options to Natural Explorer features

### DIFF
--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -4008,6 +4008,25 @@
       "- While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.",
       "You choose additional favored terrain types at 6th and 10th level."
     ],
+    "feature_specific": {
+      "terrain_type_options": {
+        "desc": "one terrain type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "arctic", 
+            "coast", 
+            "desert", 
+            "forest", 
+            "grassland", 
+            "mountain", 
+            "swamp"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/natural-explorer-1-terrain-type"
   },
   {
@@ -4395,6 +4414,25 @@
       "- While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.",
       "You choose additional favored terrain types at 6th and 10th level."
     ],
+    "feature_specific": {
+      "terrain_type_options": {
+        "desc": "one terrain type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "arctic", 
+            "coast", 
+            "desert", 
+            "forest", 
+            "grassland", 
+            "mountain", 
+            "swamp"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/natural-explorer-2-terrain-types"
   },
   {
@@ -4578,6 +4616,25 @@
       "- While tracking other creatures, you also learn their exact number, their sizes, and how long ago they passed through the area.",
       "You choose additional favored terrain types at 6th and 10th level."
     ],
+    "feature_specific": {
+      "terrain_type_options": {
+        "desc": "one terrain type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "arctic", 
+            "coast", 
+            "desert", 
+            "forest", 
+            "grassland", 
+            "mountain", 
+            "swamp"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/natural-explorer-3-terrain-types"
   },
   {


### PR DESCRIPTION
## Summary
- Added feature_specific field with terrain_type_options to natural-explorer-1-terrain-type, natural-explorer-2-terrain-types, and natural-explorer-3-terrain-types features
- Used string type in options as discussed in issue #790
- Fixed ranger natural explorer terrain type choices

Closes #790