### PR TITLE
feat: add enemy type options to Favored Enemy features

### DIFF
--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -3985,6 +3985,32 @@
       "When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.",
       "You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures."
     ],
+    "feature_specific": {
+      "enemy_type_options": {
+        "desc": "one enemy type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "aberrations", 
+            "beasts", 
+            "celestials", 
+            "constructs", 
+            "dragons", 
+            "elementals", 
+            "fey", 
+            "fiends", 
+            "giants", 
+            "monstrosities", 
+            "oozes", 
+            "plants", 
+            "undead",
+            "humanoids"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/favored-enemy-1-type"
   },
   {
@@ -4372,6 +4398,32 @@
       "When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.",
       "You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures."
     ],
+    "feature_specific": {
+      "enemy_type_options": {
+        "desc": "one enemy type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "aberrations", 
+            "beasts", 
+            "celestials", 
+            "constructs", 
+            "dragons", 
+            "elementals", 
+            "fey", 
+            "fiends", 
+            "giants", 
+            "monstrosities", 
+            "oozes", 
+            "plants", 
+            "undead",
+            "humanoids"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/favored-enemy-2-types"
   },
   {
@@ -4727,6 +4779,32 @@
       "When you gain this feature, you also learn one language of your choice that is spoken by your favored enemies, if they speak one at all.",
       "You choose one additional favored enemy, as well as an associated language, at 6th and 14th level. As you gain levels, your choices should reflect the types of monsters you have encountered on your adventures."
     ],
+    "feature_specific": {
+      "enemy_type_options": {
+        "desc": "one enemy type",
+        "choose": 1,
+        "type": "string",
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            "aberrations", 
+            "beasts", 
+            "celestials", 
+            "constructs", 
+            "dragons", 
+            "elementals", 
+            "fey", 
+            "fiends", 
+            "giants", 
+            "monstrosities", 
+            "oozes", 
+            "plants", 
+            "undead",
+            "humanoids"
+          ]
+        }
+      }
+    },
     "url": "/api/2014/features/favored-enemy-3-enemies"
   },
   {


### PR DESCRIPTION
## Summary
- Added feature_specific field with enemy_type_options to favored-enemy-1-type, favored-enemy-2-types, and favored-enemy-3-enemies features
- Used string type in options as discussed in issue #790
- Fixed ranger favored enemy choice options

Related to #790