### PR TITLE
docs(PR): Swap image link to text so people actually add images

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,4 +16,4 @@
 
 ## Here's a fun image for your troubles
 
-![random photo - update me](https://picsum.photos/200)
+\<Add a fun image here\>


### PR DESCRIPTION
## What does this do?

Swaps PR template from image to text so people actually add images.

## How was it tested?

In other repos.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/35f9c0db-2d63-49ab-8eb1-3e164b7b0c39)

