### PR TITLE
fix(monsters): unnecessary attack bonus and OCR-related problem

### DIFF
--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -8972,7 +8972,7 @@
       },
       {
         "name": "Acid Breath",
-        "desc": "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (Sd8) acid damage on a failed save, or half as much damage on a successful one.",
+        "desc": "The dragon exhales acid in a 15-foot line that is 5 feet wide. Each creature in that line must make a DC 11 Dexterity saving throw, taking 22 (5d8) acid damage on a failed save, or half as much damage on a successful one.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",
@@ -25134,7 +25134,6 @@
       {
         "name": "Ink Cloud (Costs 3 Actions)",
         "desc": "While underwater, the kraken expels an ink cloud in a 60-foot radius. The cloud spreads around corners, and that area is heavily obscured to creatures other than the kraken. Each creature other than the kraken that ends its turn there must succeed on a DC 23 Constitution saving throw, taking 16 (3d10) poison damage on a failed save, or half as much damage on a successful one. A strong current disperses the cloud, which otherwise disappears at the end of the kraken's next turn.",
-        "attack_bonus": 0,
         "dc": {
           "dc_type": {
             "index": "con",
@@ -36286,7 +36285,6 @@
       {
         "name": "Draining Kiss",
         "desc": "The fiend kisses a creature charmed by it or a willing creature. The target must make a DC 15 Constitution saving throw against this magic, taking 32 (5d10 + 5) psychic damage on a failed save, or half as much damage on a successful one. The target's hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0.",
-        "attack_bonus": 0,
         "damage": [
           {
             "damage_type": {


### PR DESCRIPTION
## What does this do?

Two abilities come with unnecessary attack bonus kv pairs. Sd8 isn't a valid damage expression (probably mistake by OCR software).

## How was it tested?

\<It's not clear if I don't update this text with relevant info\>

## Is there a Github issue this is resolving?

\<It's not clear if I don't update this text with relevant info\>

## Did you update the docs in the API? Please link an associated PR if applicable.

\<It's not clear if I don't update this text with relevant info\>

## Here's a fun image for your troubles

\<Add a fun image here\>
