### PR TITLE
fix(monsters): unnecessary attack bonus and consistency with similar …

### DIFF
--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -32135,7 +32135,7 @@
       },
       {
         "name": "Fire Breath",
-        "desc": "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC l3 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
+        "desc": "The dragon exhales fire in a 15-foot cone. Each creature in that area must make a DC 13 Dexterity saving throw, taking 24 (7d6) fire damage on a failed save, or half as much damage on a successful one.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -191,7 +191,6 @@
       {
         "name": "Psychic Drain (Costs 2 Actions)",
         "desc": "One creature charmed by the aboleth takes 10 (3d6) psychic damage, and the aboleth regains hit points equal to the damage the creature takes.",
-        "attack_bonus": 0,
         "damage": [
           {
             "damage_type": {
@@ -3939,7 +3938,7 @@
       },
       {
         "name": "Breath Weapons",
-        "desc": "The dragon uses one of the following breath weapons:\nFire Breath. The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+        "desc": "The dragon uses one of the following breath weapons.\nFire Breath. The dragon exhales fire in an 90-foot line that is 10 feet wide. Each creature in that line must make a DC 21 Dexterity saving throw, taking 56 (16d6) fire damage on a failed save, or half as much damage on a successful one.\nSleep Breath. The dragon exhales sleep gas in a 90-foot cone. Each creature in that area must succeed on a DC 21 Constitution saving throw or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",
@@ -8133,7 +8132,6 @@
       {
         "name": "Barbed Hide",
         "desc": "At the start of each of its turns, the barbed devil deals 5 (1d10) piercing damage to any creature grappling it.",
-        "attack_bonus": 0,
         "damage": [
           {
             "damage_type": {
@@ -20340,7 +20338,7 @@
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. and range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.",
+        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack.",
         "attack_bonus": 7,
         "damage": [
           {

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -30503,7 +30503,7 @@
       },
       {
         "name": "Claw",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft. , one target. Hit: 17 (2d8 + 8) slashing damage.",
+        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 17 (2d8 + 8) slashing damage.",
         "attack_bonus": 14,
         "damage": [
           {

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -30518,7 +30518,7 @@
       },
       {
         "name": "Mace",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage.",
+        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 15 (2d6 + 8) bludgeoning damage plus 21 (6d6) fire damage.",
         "attack_bonus": 14,
         "damage": [
           {
@@ -30533,7 +30533,7 @@
       },
       {
         "name": "Tail",
-        "desc": "Melee Weapon Attack: +14 to hit, reach 10ft., one target. Hit: 24 (3d10 + 8) bludgeoning damage.",
+        "desc": "Melee Weapon Attack: +14 to hit, reach 10 ft., one target. Hit: 24 (3d10 + 8) bludgeoning damage.",
         "attack_bonus": 14,
         "damage": [
           {

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -33612,7 +33612,7 @@
       },
       {
         "name": "Longbow",
-        "desc": "Ranged Weapon Attack: +4 to hit, ranged 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
+        "desc": "Ranged Weapon Attack: +4 to hit, range 150/600 ft., one target. Hit: 6 (1d8 + 2) piercing damage.",
         "attack_bonus": 4,
         "damage": [
           {


### PR DESCRIPTION
…strings

## What does this do?

Aboleth and Barbed Devil have an unnecessary attack bonus on some actions. Gladiator and Ancient Brass Dragon have strings in actions inconsistent with similar strings.

## How was it tested?

Not tested.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

\<Add a fun image here\>
