### PR TITLE
feat(2024): Add 2024 ability scores and skills tables

### DIFF
--- a/scripts/dbRefresh.ts
+++ b/scripts/dbRefresh.ts
@@ -194,6 +194,9 @@ async function main() {
     console.log('\nUploading 2014 tables...');
     await uploadTablesFromFolder(db, 'src/2014', '2014-');
 
+    console.log('\nUploading 2024 tables...');
+    await uploadTablesFromFolder(db, 'src/2024', '2024-');
+
     // Add calls for other directories if needed, e.g.:
     // console.log('\nUploading root src tables...');
     // await uploadTablesFromFolder(db, 'src/');

--- a/src/2024/5e-SRD-Ability-Scores.json
+++ b/src/2024/5e-SRD-Ability-Scores.json
@@ -1,0 +1,157 @@
+[
+  {
+    "index": "str",
+    "name": "STR",
+    "full_name": "Strength",
+    "description": [
+      "Physical might"
+    ],
+    "skills": [
+      {
+        "name": "Athletics",
+        "index": "athletics",
+        "url": "/api/2014/skills/athletics"
+      }
+    ],
+    "url": "/api/2014/ability-scores/str"
+  },
+  {
+    "index": "dex",
+    "name": "DEX",
+    "full_name": "Dexterity",
+    "description": [
+      "Agility, reflexes, and balance"
+    ],
+    "skills": [
+      {
+        "name": "Acrobatics",
+        "index": "acrobatics",
+        "url": "/api/2014/skills/acrobatics"
+      },
+      {
+        "name": "Sleight of Hand",
+        "index": "sleight-of-hand",
+        "url": "/api/2014/skills/sleight-of-hand"
+      },
+      {
+        "name": "Stealth",
+        "index": "stealth",
+        "url": "/api/2014/skills/stealth"
+      }
+    ],
+    "url": "/api/2014/ability-scores/dex"
+  },
+  {
+    "index": "con",
+    "name": "CON",
+    "full_name": "Constitution",
+    "description": [
+      "Health and stamina"
+    ],
+    "skills": [],
+    "url": "/api/2014/ability-scores/con"
+  },
+  {
+    "index": "int",
+    "name": "INT",
+    "full_name": "Intelligence",
+    "description": [
+      "Reasoning and memory"
+    ],
+    "skills": [
+      {
+        "name": "Arcana",
+        "index": "arcana",
+        "url": "/api/2014/skills/arcana"
+      },
+      {
+        "name": "History",
+        "index": "history",
+        "url": "/api/2014/skills/history"
+      },
+      {
+        "name": "Investigation",
+        "index": "investigation",
+        "url": "/api/2014/skills/investigation"
+      },
+      {
+        "name": "Nature",
+        "index": "nature",
+        "url": "/api/2014/skills/nature"
+      },
+      {
+        "name": "Religion",
+        "index": "religion",
+        "url": "/api/2014/skills/religion"
+      }
+    ],
+    "url": "/api/2014/ability-scores/int"
+  },
+  {
+    "index": "wis",
+    "name": "WIS",
+    "full_name": "Wisdom",
+    "description": [
+      "Perceptiveness and mental fortitude"
+    ],
+    "skills": [
+      {
+        "name": "Animal Handling",
+        "index": "animal-handling",
+        "url": "/api/2014/skills/animal-handling"
+      },
+      {
+        "name": "Insight",
+        "index": "insight",
+        "url": "/api/2014/skills/insight"
+      },
+      {
+        "name": "Medicine",
+        "index": "medicine",
+        "url": "/api/2014/skills/medicine"
+      },
+      {
+        "name": "Perception",
+        "index": "perception",
+        "url": "/api/2014/skills/perception"
+      },
+      {
+        "name": "Survival",
+        "index": "survival",
+        "url": "/api/2014/skills/survival"
+      }
+    ],
+    "url": "/api/2014/ability-scores/wis"
+  },
+  {
+    "index": "cha",
+    "name": "CHA",
+    "full_name": "Charisma",
+    "description": [
+      "Confidence, poise, and charm"
+    ],
+    "skills": [
+      {
+        "name": "Deception",
+        "index": "deception",
+        "url": "/api/2014/skills/deception"
+      },
+      {
+        "name": "Intimidation",
+        "index": "intimidation",
+        "url": "/api/2014/skills/intimidation"
+      },
+      {
+        "name": "Performance",
+        "index": "performance",
+        "url": "/api/2014/skills/performance"
+      },
+      {
+        "name": "Persuasion",
+        "index": "persuasion",
+        "url": "/api/2014/skills/persuasion"
+      }
+    ],
+    "url": "/api/2014/ability-scores/cha"
+  }
+]

--- a/src/2024/5e-SRD-Ability-Scores.json
+++ b/src/2024/5e-SRD-Ability-Scores.json
@@ -10,10 +10,10 @@
       {
         "name": "Athletics",
         "index": "athletics",
-        "url": "/api/2014/skills/athletics"
+        "url": "/api/2024/skills/athletics"
       }
     ],
-    "url": "/api/2014/ability-scores/str"
+    "url": "/api/2024/ability-scores/str"
   },
   {
     "index": "dex",
@@ -26,20 +26,20 @@
       {
         "name": "Acrobatics",
         "index": "acrobatics",
-        "url": "/api/2014/skills/acrobatics"
+        "url": "/api/2024/skills/acrobatics"
       },
       {
         "name": "Sleight of Hand",
         "index": "sleight-of-hand",
-        "url": "/api/2014/skills/sleight-of-hand"
+        "url": "/api/2024/skills/sleight-of-hand"
       },
       {
         "name": "Stealth",
         "index": "stealth",
-        "url": "/api/2014/skills/stealth"
+        "url": "/api/2024/skills/stealth"
       }
     ],
-    "url": "/api/2014/ability-scores/dex"
+    "url": "/api/2024/ability-scores/dex"
   },
   {
     "index": "con",
@@ -49,7 +49,7 @@
       "Health and stamina"
     ],
     "skills": [],
-    "url": "/api/2014/ability-scores/con"
+    "url": "/api/2024/ability-scores/con"
   },
   {
     "index": "int",
@@ -62,30 +62,30 @@
       {
         "name": "Arcana",
         "index": "arcana",
-        "url": "/api/2014/skills/arcana"
+        "url": "/api/2024/skills/arcana"
       },
       {
         "name": "History",
         "index": "history",
-        "url": "/api/2014/skills/history"
+        "url": "/api/2024/skills/history"
       },
       {
         "name": "Investigation",
         "index": "investigation",
-        "url": "/api/2014/skills/investigation"
+        "url": "/api/2024/skills/investigation"
       },
       {
         "name": "Nature",
         "index": "nature",
-        "url": "/api/2014/skills/nature"
+        "url": "/api/2024/skills/nature"
       },
       {
         "name": "Religion",
         "index": "religion",
-        "url": "/api/2014/skills/religion"
+        "url": "/api/2024/skills/religion"
       }
     ],
-    "url": "/api/2014/ability-scores/int"
+    "url": "/api/2024/ability-scores/int"
   },
   {
     "index": "wis",
@@ -98,30 +98,30 @@
       {
         "name": "Animal Handling",
         "index": "animal-handling",
-        "url": "/api/2014/skills/animal-handling"
+        "url": "/api/2024/skills/animal-handling"
       },
       {
         "name": "Insight",
         "index": "insight",
-        "url": "/api/2014/skills/insight"
+        "url": "/api/2024/skills/insight"
       },
       {
         "name": "Medicine",
         "index": "medicine",
-        "url": "/api/2014/skills/medicine"
+        "url": "/api/2024/skills/medicine"
       },
       {
         "name": "Perception",
         "index": "perception",
-        "url": "/api/2014/skills/perception"
+        "url": "/api/2024/skills/perception"
       },
       {
         "name": "Survival",
         "index": "survival",
-        "url": "/api/2014/skills/survival"
+        "url": "/api/2024/skills/survival"
       }
     ],
-    "url": "/api/2014/ability-scores/wis"
+    "url": "/api/2024/ability-scores/wis"
   },
   {
     "index": "cha",
@@ -134,24 +134,24 @@
       {
         "name": "Deception",
         "index": "deception",
-        "url": "/api/2014/skills/deception"
+        "url": "/api/2024/skills/deception"
       },
       {
         "name": "Intimidation",
         "index": "intimidation",
-        "url": "/api/2014/skills/intimidation"
+        "url": "/api/2024/skills/intimidation"
       },
       {
         "name": "Performance",
         "index": "performance",
-        "url": "/api/2014/skills/performance"
+        "url": "/api/2024/skills/performance"
       },
       {
         "name": "Persuasion",
         "index": "persuasion",
-        "url": "/api/2014/skills/persuasion"
+        "url": "/api/2024/skills/persuasion"
       }
     ],
-    "url": "/api/2014/ability-scores/cha"
+    "url": "/api/2024/ability-scores/cha"
   }
 ]

--- a/src/2024/5e-SRD-Skills.json
+++ b/src/2024/5e-SRD-Skills.json
@@ -1,0 +1,236 @@
+[
+  {
+    "index": "acrobatics",
+    "name": "Acrobatics",
+    "description": [
+      "Stay on your feet in a tricky situation, or perform an acrobatic stunt."
+    ],
+    "ability_score": {
+      "index": "dex",
+      "name": "DEX",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "url": "/api/2024/skills/acrobatics"
+  },
+  {
+    "index": "animal-handling",
+    "name": "Animal Handling",
+    "description": [
+      "Calm or train an animal, or get an animal to behave in a certain way."
+    ],
+    "ability_score": {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "url": "/api/2024/skills/animal-handling"
+  },
+  {
+    "index": "arcana",
+    "name": "Arcana",
+    "description": [
+      "Recall lore about spells, magic items, and the planes of existence."
+    ],
+    "ability_score": {
+      "index": "int",
+      "name": "INT",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "url": "/api/2024/skills/arcana"
+  },
+  {
+    "index": "athletics",
+    "name": "Athletics",
+    "description": [
+      "Jump farther than normal, stay afloat in rough water, or break something."
+    ],
+    "ability_score": {
+      "index": "str",
+      "name": "STR",
+      "url": "/api/2024/ability-scores/str"
+    },
+    "url": "/api/2024/skills/athletics"
+  },
+  {
+    "index": "deception",
+    "name": "Deception",
+    "description": [
+      "Tell a convincing lie, or wear a disguise convincingly."
+    ],
+    "ability_score": {
+      "index": "cha",
+      "name": "CHA",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "url": "/api/2024/skills/deception"
+  },
+  {
+    "index": "history",
+    "name": "History",
+    "description": [
+      "Recall lore about historical events, people, nations, and cultures."
+    ],
+    "ability_score": {
+      "index": "int",
+      "name": "INT",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "url": "/api/2024/skills/history"
+  },
+  {
+    "index": "insight",
+    "name": "Insight",
+    "description": [
+      "Discern a person’s mood and intentions."
+    ],
+    "ability_score": {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "url": "/api/2024/skills/insight"
+  },
+  {
+    "index": "intimidation",
+    "name": "Intimidation",
+    "description": [
+      "Awe or threaten someone into doing what you want."
+    ],
+    "ability_score": {
+      "index": "cha",
+      "name": "CHA",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "url": "/api/2024/skills/intimidation"
+  },
+  {
+    "index": "investigation",
+    "name": "Investigation",
+    "description": [
+      "Find obscure information in books, or deduce how something works."
+    ],
+    "ability_score": {
+      "index": "int",
+      "name": "INT",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "url": "/api/2024/skills/investigation"
+  },
+  {
+    "index": "medicine",
+    "name": "Medicine",
+    "description": [
+      "Diagnose an illness, or determine what killed the recently slain."
+    ],
+    "ability_score": {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "url": "/api/2024/skills/medicine"
+  },
+  {
+    "index": "nature",
+    "name": "Nature",
+    "description": [
+      "Recall lore about terrain, plants, animals, and weather."
+    ],
+    "ability_score": {
+      "index": "int",
+      "name": "INT",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "url": "/api/2024/skills/nature"
+  },
+  {
+    "index": "perception",
+    "name": "Perception",
+    "description": [
+      "Using a combination of senses, notice something that’s easy to miss."
+    ],
+    "ability_score": {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "url": "/api/2024/skills/perception"
+  },
+  {
+    "index": "performance",
+    "name": "Performance",
+    "description": [
+      "Act, tell a story, perform music, or dance."
+    ],
+    "ability_score": {
+      "index": "cha",
+      "name": "CHA",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "url": "/api/2024/skills/performance"
+  },
+  {
+    "index": "persuasion",
+    "name": "Persuasion",
+    "description": [
+      "Honestly and graciously convince someone of something."
+    ],
+    "ability_score": {
+      "index": "cha",
+      "name": "CHA",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "url": "/api/2024/skills/persuasion"
+  },
+  {
+    "index": "religion",
+    "name": "Religion",
+    "description": [
+      "Recall lore about gods, religious rituals, and holy symbols."
+    ],
+    "ability_score": {
+      "index": "int",
+      "name": "INT",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "url": "/api/2024/skills/religion"
+  },
+  {
+    "index": "sleight-of-hand",
+    "name": "Sleight of Hand",
+    "description": [
+      "Pick a pocket, conceal a handheld object, or perform legerdemain."
+    ],
+    "ability_score": {
+      "index": "dex",
+      "name": "DEX",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "url": "/api/2024/skills/sleight-of-hand"
+  },
+  {
+    "index": "stealth",
+    "name": "Stealth",
+    "description": [
+      "Escape notice by moving quietly and hiding behind things."
+    ],
+    "ability_score": {
+      "index": "dex",
+      "name": "DEX",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "url": "/api/2024/skills/stealth"
+  },
+  {
+    "index": "survival",
+    "name": "Survival",
+    "description": [
+      "Follow tracks, forage, find a trail, or avoid natural hazards."
+    ],
+    "ability_score": {
+      "index": "wis",
+      "name": "WIS",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "url": "/api/2024/skills/survival"
+  }
+]

--- a/src/2024/tests/tables.test.js
+++ b/src/2024/tests/tables.test.js
@@ -1,0 +1,99 @@
+const fs = require('fs');
+const glob = require('glob');
+
+describe('duplicate indices', () => {
+  it('should contain unique indices', () => {
+    let errors = [];
+    const fileIndices = {};
+
+    forEachFileEntry((filename, entry) => {
+      if (filename in fileIndices === false) {
+        fileIndices[filename] = new Set();
+      }
+
+      if (fileIndices[filename].has(entry.index)) {
+        errors.push(`${filename}: Index '${entry.index}' already exists.`);
+      }
+
+      fileIndices[filename].add(entry.index);
+    });
+
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('api references', () => {
+  it('should not contain broken links', () => {
+    let errors = [];
+    let resources = {};
+
+    forEachFileEntry((filename, entry) => {
+      if (entry.url === undefined) return;
+
+      if (entry.index === undefined) {
+        errors.push(`${filename}: Entry with URL '${entry.url}' should have an index.`);
+      }
+
+      resources[entry.url] = { index: entry.index, name: entry.name };
+    });
+
+    forEachFileEntry((filename, topLevelEntry) => {
+      recurseIntoObject(topLevelEntry, (subEntry) => {
+        if (!subEntry.hasOwnProperty('url')) return; // eslint-disable-line no-prototype-builtins
+
+        if (resources[subEntry.url] === undefined) {
+          errors.push(`${filename}: URL '${subEntry.url}' not found.`);
+        } else {
+          if (
+            resources[subEntry.url].name !== undefined &&
+            resources[subEntry.url].name !== subEntry.name
+          ) {
+            errors.push(
+              `${filename}: Name mismatch for reference to '${subEntry.url}', '${subEntry.name}' should be '${resources[subEntry.url].name}'`
+            );
+          }
+
+          if (subEntry.index !== undefined && resources[subEntry.url].index !== subEntry.index) {
+            errors.push(
+              `${filename}: Index mismatch for reference to '${subEntry.url}', '${subEntry.index}' should be '${resources[subEntry.url].index}'`
+            );
+          }
+        }
+      });
+    });
+
+    expect(errors).toEqual([]);
+  });
+});
+
+/**
+ * Calls the callback for top-level objects/arrays in all JSON files.
+ *
+ * @param (function(string, object)) callback Called with filename and each
+ *     top-level entry.
+ */
+const forEachFileEntry = (callback) => {
+  let filenames = glob.sync('src/2014/*.json');
+
+  for (const filename of filenames) {
+    const fileText = fs.readFileSync(filename, 'utf8');
+    const fileJSON = JSON.parse(fileText);
+    fileJSON.forEach((entry) => callback(filename, entry));
+  }
+};
+
+/**
+ * Calls the callback recursivelly for all objects/arrays contained in the
+ * passed object.
+ *
+ * @param (object) object The object to recurse into.
+ * @param (function(object)) callback Called with each sub-top-level entry.
+ */
+const recurseIntoObject = (object, callback) => {
+  for (const property in object) {
+    if (typeof object[property] === 'object' && object[property] !== null) {
+      callback(object[property]);
+      recurseIntoObject(object[property], callback);
+    }
+  }
+};

--- a/src/2024/tests/tables.test.js
+++ b/src/2024/tests/tables.test.js
@@ -73,7 +73,7 @@ describe('api references', () => {
  *     top-level entry.
  */
 const forEachFileEntry = (callback) => {
-  let filenames = glob.sync('src/2014/*.json');
+  let filenames = glob.sync('src/2024/*.json');
 
   for (const filename of filenames) {
     const fileText = fs.readFileSync(filename, 'utf8');


### PR DESCRIPTION
## What does this do?

* Adds 2024 Ability Scores table based on SRD v5.2
* Adds 2024 Skills table based on SRD v5.2
* Hooks up `dbRefresh.ts` to pull in 2024 tables (necessary for docker images)
* Copies the tests

## How was it tested?

Ran tests and linter locally

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/3430ad20-b11d-48dc-8b57-2229a2e8a5b1)
