### PR TITLE
feat(images): Moar images for equipment, magic items, and monsters

### DIFF
--- a/src/2014/5e-SRD-Equipment.json
+++ b/src/2014/5e-SRD-Equipment.json
@@ -1515,6 +1515,7 @@
         "url": "/api/2014/weapon-properties/two-handed"
       }
     ],
+    "image": "/api/2014/images/equipment/crossbow-heavy.png",
     "url": "/api/2014/equipment/crossbow-heavy"
   },
   {
@@ -2317,6 +2318,7 @@
       "A creature moving across the covered area must succeed on a DC 10 Dexterity saving throw or fall prone.",
       "A creature moving through the area at half speed doesn't need to make the save."
     ],
+    "image": "/api/2014/images/equipment/ball-bearings-bag-of-1000.png",
     "url": "/api/2014/equipment/ball-bearings-bag-of-1000"
   },
   {
@@ -5305,6 +5307,7 @@
     "desc": [
       "This item encompasses a wide range of game pieces, including dice and decks of cards (for games such as Three-Dragon Ante). A few common examples appear on the Tools table, but other kinds of gaming sets exist. If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency."
     ],
+    "image": "/api/2014/images/equipment/playing-card-set.png",
     "url": "/api/2014/equipment/playing-card-set"
   },
   {
@@ -5362,6 +5365,7 @@
     "desc": [
       "Several of the most common types of musical instruments are shown on the table as examples. If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument. A bard can use a musical instrument as a spellcasting focus. Each type of musical instrument requires a separate proficiency."
     ],
+    "image": "/api/2014/images/equipment/dulcimer.png",
     "url": "/api/2014/equipment/dulcimer"
   },
   {

--- a/src/2014/5e-SRD-Magic-Items.json
+++ b/src/2014/5e-SRD-Magic-Items.json
@@ -747,6 +747,7 @@
       "You have advantage on Saving Throws against poison, and you have Resistance against poison damage.",
       "You can speak, read, and write Dwarvish."
     ],
+    "image": "/api/2014/images/magic-items/belt-of-dwarvenkind.png",
     "url": "/api/2014/magic-items/belt-of-dwarvenkind"
   },
   {
@@ -947,6 +948,7 @@
       "***Curse.*** This axe is Cursed, and becoming attuned to it extends the curse to you. As long as you remain Cursed, you are unwilling to part with the axe, keeping it within reach at all times. You also have disadvantage on Attack rolls with Weapons other than this one, unless no foe is within 60 feet of you that you can see or hear.",
       "Whenever a Hostile creature damages you while the axe is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. While berserk, you must use your action each round to Attack the creature nearest to you with the axe. If you can make extra attacks as part of the Attack action, you use those extra attacks, moving to Attack the next nearest creature after you fell your current target. If you have multiple possible Targets, you Attack one at random. You are berserk until you start Your Turn with no creatures within 60 feet of you that you can see or hear."
     ],
+    "image": "/api/2014/images/magic-items/berserker-axe.png",
     "url": "/api/2014/magic-items/berserker-axe"
   },
   {
@@ -986,6 +988,7 @@
       "Wondrous item, rare (requires attunement)",
       "While you wear these boots, you can use an action to cast the levitate spell on yourself at will."
     ],
+    "image": "/api/2014/images/magic-items/boots-of-levitation.png",
     "url": "/api/2014/magic-items/boots-of-levitation"
   },
   {
@@ -1006,6 +1009,7 @@
       "While you wear these boots, you can use a bonus action and click the boots' heels together. If you do, the boots double your walking speed, and any creature that makes an opportunity attack against you has disadvantage on the attack roll. If you click your heels together again, you end the effect.",
       "When the boots' property has been used for a total of 10 minutes, the magic ceases to function until you finish a long rest."
     ],
+    "image": "/api/2014/images/magic-items/boots-of-speed.png",
     "url": "/api/2014/magic-items/boots-of-speed"
   },
   {

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -7445,6 +7445,7 @@
         ]
       }
     ],
+    "image": "/api/2014/images/monsters/azer.png",
     "url": "/api/2014/monsters/azer"
   },
   {
@@ -8318,6 +8319,7 @@
         ]
       }
     ],
+    "image": "/api/2014/images/monsters/basilisk.png",
     "url": "/api/2014/monsters/basilisk"
   },
   {
@@ -8525,6 +8527,7 @@
         ]
       }
     ],
+    "image": "/api/2014/images/monsters/bearded-devil.png",
     "url": "/api/2014/monsters/bearded-devil"
   },
   {
@@ -8683,6 +8686,7 @@
         ]
       }
     ],
+    "image": "/api/2014/images/monsters/behir.png",
     "url": "/api/2014/monsters/behir"
   },
   {


### PR DESCRIPTION
## What does this do?

Adds images for:

* Equipment
  * Crossbow, Heavy
  * Bag of Ball Bearings
  * Playing card set
  * Dulcimer
* Magic Items
  * Belt of dwarvenkind
  * Berserker axe
  * Boots of levitation
  * Boots of speed
* Monsters
  * Azer
  * Basilisk
  * Bearded devil
  * Behir

## Here's a fun image for your troubles

![balor](https://github.com/user-attachments/assets/099bf459-fa58-4966-8e41-290f0030f972)
