### PR TITLE
Added all 2014 and 2024 feats

### DIFF
--- a/src/2014/5e-SRD-Feats.json
+++ b/src/2014/5e-SRD-Feats.json
@@ -1,5 +1,131 @@
 [
   {
+    "index": "actor",
+    "name": "Actor",
+    "prerequisites": [],
+    "desc": [
+      "Skilled at mimicry and dramatics, you gain the following benefits:",
+      "- Increase your Charisma score by 1, to a maximum of 20.",
+      "- You have advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
+      "- You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine that the effect is faked."
+    ],
+    "url": "/api/2014/feats/actor"
+  },
+  {
+    "index": "alert",
+    "name": "Alert",
+    "prerequisites": [],
+    "desc": [
+      "Always on the lookout for danger, you gain the following benefits:",
+      "- You gain a +5 bonus to initiative.",
+      "- You can't be surprised while you are conscious.",
+      "- Other creatures don't gain advantage on attack rolls against you as a result of being unseen by you."
+    ],
+    "url": "/api/2014/feats/alert"
+  },
+  {
+    "index": "athlete",
+    "name": "Athlete",
+    "prerequisites": [],
+    "desc": [
+      "You have undergone extensive physical training to gain the following benefits:",
+      "- Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "- When you are prone, standing up uses only 5 feet of your movement.",
+      "- Climbing doesn't cost you extra movement.",
+      "- You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
+    ],
+    "url": "/api/2014/feats/athlete"
+  },
+  {
+    "index": "charger",
+    "name": "Charger",
+    "prerequisites": [],
+    "desc": [
+      "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
+      "If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack's damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
+    ],
+    "url": "/api/2014/feats/charger"
+  },
+  {
+    "index": "crossbow-expert",
+    "name": "Crossbow Expert",
+    "prerequisites": [],
+    "desc": [
+      "Thanks to extensive practice with the crossbow, you gain the following benefits:",
+      "- You ignore the loading quality of crossbows with which you are proficient.",
+      "- Being within 5 feet of a hostile creature doesn't impose disadvantage on your ranged attack rolls.",
+      "- When you use the Attack action and attack with a one-handed weapon, you can use a bonus action to attack with a hand crossbow you are holding."
+    ],
+    "url": "/api/2014/feats/crossbow-expert"
+  },
+  {
+    "index": "defensive-duelist",
+    "name": "Defensive Duelist",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2014/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
+    ],
+    "url": "/api/2014/feats/defensive-duelist"
+  },
+  {
+    "index": "dual-wielder",
+    "name": "Dual Wielder",
+    "prerequisites": [],
+    "desc": [
+      "You master fighting with two weapons, gaining the following benefits:",
+      "- You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
+      "- You can use two-weapon fighting even when the one-handed melee weapons you are wielding aren't light.",
+      "- You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
+    ],
+    "url": "/api/2014/feats/dual-wielder"
+  },
+  {
+    "index": "dungeon-delver",
+    "name": "Dungeon Delver",
+    "prerequisites": [],
+    "desc": [
+      "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
+      "- You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
+      "- You have advantage on saving throws made to avoid or resist traps.",
+      "- You have resistance to the damage dealt by traps.",
+      "- Traveling at a fast pace doesn't impose the normal -5 penalty on your passive Wisdom (Perception) score."
+    ],
+    "url": "/api/2014/feats/dungeon-delver"
+  },
+  {
+    "index": "durable",
+    "name": "Durable",
+    "prerequisites": [],
+    "desc": [
+      "Hardy and resilient, you gain the following benefits:",
+      "- Increase your Constitution score by 1, to a maximum of 20.",
+      "- When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
+    ],
+    "url": "/api/2014/feats/durable"
+  },
+  {
+    "index": "elemental-adept",
+    "name": "Elemental Adept",
+    "prerequisites": [],
+    "desc": [
+      "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
+      "Spells you cast ignore resistance to damage of the chosen type. In addition, when you roll damage for a spell you cast that deals damage of that type, you can treat any 1 on a damage die as a 2.",
+      "You can select this feat multiple times. Each time you do so, you must choose a different damage type.",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: special = 'The ability to cast at least one spell'"
+    ],
+    "url": "/api/2014/feats/elemental-adept"
+  },
+  {
     "index": "grappler",
     "name": "Grappler",
     "prerequisites": [
@@ -13,10 +139,408 @@
       }
     ],
     "desc": [
-      "You’ve developed the Skills necessary to hold your own in close--quarters Grappling. You gain the following benefits:",
-      "- You have advantage on Attack Rolls against a creature you are Grappling.",
-      "- You can use your action to try to pin a creature Grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both Restrained until the grapple ends."
+      "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
+      "- You have advantage on attack rolls against a creature you are grappling.",
+      "- You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
     ],
     "url": "/api/2014/feats/grappler"
+  },
+  {
+    "index": "great-weapon-master",
+    "name": "Great Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You've learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+      "- On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+      "- Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/2014/feats/great-weapon-master"
+  },
+  {
+    "index": "healer",
+    "name": "Healer",
+    "prerequisites": [],
+    "desc": [
+      "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
+      "- When you use a healer's kit to stabilize a dying creature, that creature also regains 1 hit point.",
+      "- As an action, you can spend one use of a healer's kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature's maximum number of Hit Dice. The creature can't regain hit points from this feat again until it finishes a short or long rest."
+    ],
+    "url": "/api/2014/feats/healer"
+  },
+  {
+    "index": "heavily-armored",
+    "name": "Heavily Armored",
+    "prerequisites": [],
+    "desc": [
+      "You have trained to master the use of heavy armor, gaining the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- You gain proficiency with heavy armor.",
+      "PREREQ: armor-training = 'medium-armor'",
+      "PREREQ: feat = 'moderately-armored'"
+    ],
+    "url": "/api/2014/feats/heavily-armored"
+  },
+  {
+    "index": "heavy-armor-master",
+    "name": "Heavy Armor Master",
+    "prerequisites": [],
+    "desc": [
+      "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
+      "- Increase your Strength score by 1, to a maximum of 20.",
+      "- While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical attacks is reduced by 3.",
+      "PREREQ: armor-training = 'heavy-armor'",
+      "PREREQ: feat = 'heavily-armored'"
+    ],
+    "url": "/api/2014/feats/heavy-armor-master"
+  },
+  {
+    "index": "inspiring-leader",
+    "name": "Inspiring Leader",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/2014/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can't gain temporary hit points from this feat again until it has finished a short or long rest."
+    ],
+    "url": "/api/2014/feats/inspiring-leader"
+  },
+  {
+    "index": "keen-mind",
+    "name": "Keen Mind",
+    "prerequisites": [],
+    "desc": [
+      "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You always know which way is north.",
+      "- You always know the number of hours left before the next sunrise or sunset.",
+      "- You can accurately recall anything you have seen or heard within the past month."
+    ],
+    "url": "/api/2014/feats/keen-mind"
+  },
+  {
+    "index": "lightly-armored",
+    "name": "Lightly Armored",
+    "prerequisites": [],
+    "desc": [
+      "You have trained to master the use of light armor, gaining the following benefits:",
+      "- Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "- You gain proficiency with light armor.",
+      "PREREQ: armor-training = 'light-armor'",
+      "PREREQ: feat = 'lightly-armored'"
+    ],
+    "url": "/api/2014/feats/lightly-armored"
+  },
+  {
+    "index": "linguist",
+    "name": "Linguist",
+    "prerequisites": [],
+    "desc": [
+      "You have studied languages and codes, gaining the following benefits:",
+      "- Increase your Intelligence score by 1, to a maximum of 20.",
+      "- You learn three languages of your choice.",
+      "- You can ably create written ciphers. Others can't decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
+    ],
+    "url": "/api/2014/feats/linguist"
+  },
+  {
+    "index": "lucky",
+    "name": "Lucky",
+    "prerequisites": [],
+    "desc": [
+      "You have inexplicable luck that seems to kick in at just the right moment.",
+      "You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
+      "You can also spend one luck point when an attack roll is made against you. Roll a d20, and then choose whether the attack uses the attacker's roll or yours. If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
+      "You regain your expended luck points when you finish a long rest."
+    ],
+    "url": "/api/2014/feats/lucky"
+  },
+  {
+    "index": "mage-slayer",
+    "name": "Mage Slayer",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced techniques useful in melee combat against spellcasters, gaining the following benefits:",
+      "- When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
+      "- When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
+      "- You have advantage on saving throws against spells cast by creatures within 5 feet of you."
+    ],
+    "url": "/api/2014/feats/mage-slayer"
+  },
+  {
+    "index": "magic-initiate",
+    "name": "Magic Initiate",
+    "prerequisites": [],
+    "desc": [
+      "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class's spell list.",
+      "In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell once at its lowest level, and you must finish a long rest before you can cast it in this way again.",
+      "Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "url": "/api/2014/feats/magic-initiate"
+  },
+  {
+    "index": "martial-adept",
+    "name": "Martial Adept",
+    "prerequisites": [],
+    "desc": [
+      "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
+      "- You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver's effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+      "- You gain one superiority die, which is a d6 (this die is added to any superiority dice you have from another source). This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
+    ],
+    "url": "/api/2014/feats/martial-adept"
+  },
+  {
+    "index": "medium-armor-master",
+    "name": "Medium Armor Master",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced moving in medium armor to gain the following benefits:",
+      "- Wearing medium armor doesn't impose disadvantage on your Dexterity (Stealth) checks.",
+      "- When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher.",
+      "PREREQ: armor-training = 'medium-armor'",
+      "PREREQ: feat = 'moderately-armored'"
+    ],
+    "url": "/api/2014/feats/medium-armor-master"
+  },
+  {
+    "index": "mobile",
+    "name": "Mobile",
+    "prerequisites": [],
+    "desc": [
+      "You are exceptionally speedy and agile. You gain the following benefits:",
+      "- Your speed increases by 10 feet.",
+      "- When you use the Dash action, difficult terrain doesn't cost you extra movement on that turn.",
+      "- When you make a melee attack against a creature, you don't provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+    ],
+    "url": "/api/2014/feats/mobile"
+  },
+  {
+    "index": "moderately-armored",
+    "name": "Moderately Armored",
+    "prerequisites": [],
+    "desc": [
+      "You have trained to master the use of medium armor and shields, gaining the following benefits:",
+      "Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "You gain proficiency with medium armor and shields.",
+      "PREREQ: armor-training = 'light-armor'",
+      "PREREQ: feat = 'lightly-armored'"
+    ],
+    "url": "/api/2014/feats/moderately-armored"
+  },
+  {
+    "index": "mounted-combatant",
+    "name": "Mounted Combatant",
+    "prerequisites": [],
+    "desc": [
+      "You are a dangerous foe to face while mounted. While you are mounted and aren't incapacitated, you gain the following benefits:",
+      "- You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
+      "- You can force an attack targeted at your mount to target you instead.",
+      "- If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+    ],
+    "url": "/api/2014/feats/mounted-combatant"
+  },
+  {
+    "index": "observant",
+    "name": "Observant",
+    "prerequisites": [],
+    "desc": [
+      "Quick to notice details of your environment, you gain the following benefits:",
+      "- Increase your Intelligence or Wisdom by 1, to a maximum of 20.",
+      "- If you can see a creature's mouth while it is speaking a language you understand, you can interpret what it's saying by reading its lips.",
+      "- You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
+    ],
+    "url": "/api/2014/feats/observant"
+  },
+  {
+    "index": "polearm-master",
+    "name": "Polearm Master",
+    "prerequisites": [],
+    "desc": [
+      "You can keep your enemies at bay with reach weapons. You gain the following benefits:",
+      "- When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon; this attack uses the same ability modifier as the primary attack. The weapon's damage die for this attack is a d4, and the attack deals bludgeoning damage.",
+      "- While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter the reach you have with that weapon."
+    ],
+    "url": "/api/2014/feats/polearm-master"
+  },
+  {
+    "index": "resilient",
+    "name": "Resilient",
+    "prerequisites": [],
+    "desc": [
+      "Choose one ability score. You gain the following benefits:",
+      "- Increase the chosen ability score by 1, to a maximum of 20.",
+      "- You gain proficiency in saving throws using the chosen ability."
+    ],
+    "url": "/api/2014/feats/resilient"
+  },
+  {
+    "index": "ritual-caster",
+    "name": "Ritual Caster",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "int",
+          "name": "INT",
+          "url": "/api/2014/ability-scores/int"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "wis",
+          "name": "WIS",
+          "url": "/api/2014/ability-scores/wis"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
+      "When you choose this feat, you acquire a ritual book holding two 1st-level spells of your choice. Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You must choose your spells from that class's spell list, and the spells you choose must have the ritual tag. The class you choose also determines your spellcasting ability for these spells: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.",
+      "If you come across a spell in written form, such as a magical spell scroll or a wizard's spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell's level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it."
+    ],
+    "url": "/api/2014/feats/ritual-caster"
+  },
+  {
+    "index": "savage-attacker",
+    "name": "Savage Attacker",
+    "prerequisites": [],
+    "desc": [
+      "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon's damage dice and use either total."
+    ],
+    "url": "/api/2014/feats/savage-attacker"
+  },
+  {
+    "index": "sentinel",
+    "name": "Sentinel",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered techniques to take advantage of every drop in any enemy's guard, gaining the following benefits:",
+      "- When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.",
+      "- Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+      "- When a creature within 5 feet of you makes an attack against a target other than you (and that target doesn't have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+    ],
+    "url": "/api/2014/feats/sentinel"
+  },
+  {
+    "index": "sharpshooter",
+    "name": "Sharpshooter",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
+      "- Attacking at long range doesn't impose disadvantage on your ranged weapon attack rolls.",
+      "- Your ranged weapon attacks ignore half cover and three-quarters cover.",
+      "- Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/2014/feats/sharpshooter"
+  },
+  {
+    "index": "shield-master",
+    "name": "Shield Master",
+    "prerequisites": [],
+    "desc": [
+      "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
+      "- If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
+      "- If you aren't incapacitated, you can add your shield's AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
+      "- If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
+    ],
+    "url": "/api/2014/feats/shield-master"
+  },
+  {
+    "index": "skilled",
+    "name": "Skilled",
+    "prerequisites": [],
+    "desc": [
+      "You gain proficiency in any combination of three skills or tools of your choice."
+    ],
+    "url": "/api/2014/feats/skilled"
+  },
+  {
+    "index": "skulker",
+    "name": "Skulker",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2014/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You are expert at slinking through shadows. You gain the following benefits:",
+      "- You can try to hide when you are lightly obscured from the creature from which you are hiding.",
+      "- When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn't reveal your position.",
+      "- Dim light doesn't impose disadvantage on your Wisdom (Perception) checks relying on sight."
+    ],
+    "url": "/api/2014/feats/skulker"
+  },
+  {
+    "index": "spell-sniper",
+    "name": "Spell Sniper",
+    "prerequisites": [],
+    "desc": [
+      "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
+      "- When you cast a spell that requires you to make an attack roll, the spell's range is doubled.",
+      "- Your ranged spell attacks ignore half cover and three-quarters cover.",
+      "- You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: special = 'The ability to cast at least one spell'"
+    ],
+    "url": "/api/2014/feats/spell-sniper"
+  },
+  {
+    "index": "tavern-brawler",
+    "name": "Tavern Brawler",
+    "prerequisites": [],
+    "desc": [
+      "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
+      "- Increase your Strength or Constitution by 1, to a maximum of 20.",
+      "- You are proficient with improvised weapons.",
+      "- Your unarmed strike uses a d4 for damage.",
+      "- When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
+    ],
+    "url": "/api/2014/feats/tavern-brawler"
+  },
+  {
+    "index": "tough",
+    "name": "Tough",
+    "prerequisites": [],
+    "desc": [
+      "Your hit point maximum increases by an amount equal to twice your level when you gain this feat. Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
+    ],
+    "url": "/api/2014/feats/tough"
+  },
+  {
+    "index": "war-caster",
+    "name": "War Caster",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
+      "- You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
+      "- You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
+      "- When a hostile creature's movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature.",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: special = 'The ability to cast at least one spell'"
+    ],
+    "url": "/api/2014/feats/war-caster"
+  },
+  {
+    "index": "weapon-master",
+    "name": "Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced extensively with a variety of weapons, gaining the following benefits:",
+      "- Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "- You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
+    ],
+    "url": "/api/2014/feats/weapon-master"
   }
 ]

--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -1,0 +1,1228 @@
+[
+  {
+    "index": "ability-score-improvement",
+    "name": "Ability Score Improvement",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "Increase one ability score of your choice by 2, or increase two ability scores of your choice by 1. This feat can't increase an ability score above 20.",
+      "**Repeatable**. You can take this feat more than once.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/ability-score-improvement"
+  },
+  {
+    "index": "actor",
+    "name": "Actor",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/2024/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "You gain the following benefits.",
+      "**Ability Score Increase.** Increase your Charisma score by 1, to a maximum of 20.",
+      "**Impersonation.** While you're disguised as a real or fictional person, you have Advantage on Charisma (Deception or Performance) checks to convince others that you are that person.",
+      "**Mimicry.** You can mimic the sounds of other creatures, including speech. A creature that hears the mimicry must succeed on a Wisdom (Insight) check to determine the effect is faked (DC 8 plus your Charisma modifier and Proficiency Bonus).",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/actor"
+  },
+  {
+    "index": "alert",
+    "name": "Alert",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Initiative Proficiency.** When you roll Initiative, you can add your Proficiency Bonus to the roll.",
+      "**Initiative Swap.** Immediately after you roll Initiative, you can swap your Initiative with the Initiative of one willing ally in the same combat. You can't make this swap if you or the ally has the Incapacitated condition."
+    ],
+    "url": "/api/2024/feats/alert"
+  },
+  {
+    "index": "archery",
+    "name": "Archery",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "You gain a +2 bonus to attack rolls you make with Ranged weapons.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/archery"
+  },
+  {
+    "index": "athlete",
+    "name": "Athlete",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Climb Speed.** You gain a Climb Speed equal to your Speed.",
+      "**Hop Up.** When you have the Prone condition, you can right yourself with only 5 feet of movement.",
+      "**Jumping.** You can make a running Long or High Jump after moving only 5 feet.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/athlete"
+  },
+  {
+    "index": "blessed-warrior",
+    "name": "Blessed Warrior",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "You learn two Cleric cantrips of your choice. Guidance and Sacred Flame are recommended. The chosen cantrips count as Paladin spells for you, and Charisma is your spellcasting ability for them. Whenever you gain a Paladin level, you can replace one of these cantrips with another Cleric cantrip.",
+      "PREREQ: feature = 'fighting-style'",
+      "PREREQ: special = 'When Gaining the Level 2 Paladin \"Fighting Style\" Feature'"
+    ],
+    "url": "/api/2024/feats/blessed-warrior"
+  },
+  {
+    "index": "blind-fighting",
+    "name": "Blind Fighting",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "You have Blindsight with a range of 10 feet.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/blind-fighting"
+  },
+  {
+    "index": "boon-of-combat-prowess",
+    "name": "Boon of Combat Prowess",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Peerless Aim.** When you miss with an attack roll, you can hit instead. Once you use this benefit, you can't use it again until the start of your next turn.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-combat-prowess"
+  },
+  {
+    "index": "boon-of-dimensional-travel",
+    "name": "Boon of Dimensional Travel",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Blink Steps.** Immediately after you take the Attack action or the Magic action, you can teleport up to 30 feet to an unoccupied space you can see.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-dimensional-travel"
+  },
+  {
+    "index": "boon-of-energy-resistance",
+    "name": "Boon of Energy Resistance",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Energy Resistances.** You gain Resistance to two of the following damage types of your choice: Acid, Cold, Fire, Lightning, Necrotic, Poison, Psychic, Radiant, or Thunder. Whenever you finish a Long Rest, you can change your choices.",
+      "**Energy Redirection.** When you take damage of one of the types chosen for the Energy Resistances benefit, you can take a Reaction to direct damage of the same type toward another creature you can see within 60 feet of yourself that isn't behind Total Cover. If you do so, that creature must succeed on a Dexterity saving throw (DC 8 plus your Constitution modifier and Proficiency Bonus) or take damage equal to 2d12 plus your Constitution modifier.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-energy-resistance"
+  },
+  {
+    "index": "boon-of-fate",
+    "name": "Boon of Fate",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Improve Fate.** When you or another creature within 60 feet of you succeeds on or fails a D20 Test, you can roll 2d4 and apply the total rolled as a bonus or penalty to the d20 roll. Once you use this benefit, you can't use it again until you roll Initiative or finish a Short or Long Rest.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-fate"
+  },
+  {
+    "index": "boon-of-fortitude",
+    "name": "Boon of Fortitude",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Fortified Health.** Your Hit Point maximum increases by 40. In addition, whenever you regain Hit Points, you can regain additional Hit Points equal to your Constitution modifier. Once you've regained these additional Hit Points, you can't do so again until the start of your next turn.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-fortitude"
+  },
+  {
+    "index": "boon-of-irresistible-offense",
+    "name": "Boon of Irresistible Offense",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 30.",
+      "**Overcome Defenses.** The Bludgeoning, Piercing, and Slashing damage you deal always ignores Resistance.",
+      "**Overwhelming Strike.** When you roll a 20 on the d20 for an attack roll, you can deal extra damage to the target equal to the ability score increased by this feat. The extra damage's type is the same as the attack's type.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-irresistible-offense"
+  },
+  {
+    "index": "boon-of-recovery",
+    "name": "Boon of Recovery",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Last Stand.** When you would be reduced to 0 Hit Points, you can drop to 1 Hit Point instead and regain a number of Hit Points equal to half your Hit Point maximum. Once you use this benefit, you can't use it again until you finish a Long Rest.",
+      "**Recover Vitality.** You have a pool of ten d10s. As a Bonus Action, you can expend dice from the pool, roll those dice, and regain a number of Hit Points equal to the roll's total. You regain all the expended dice when you finish a Long Rest.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-recovery"
+  },
+  {
+    "index": "boon-of-skill",
+    "name": "Boon of Skill",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**All-Around Adept.** You gain proficiency in all skills.",
+      "**Expertise.** Choose one skill in which you lack Expertise. You gain Expertise in that skill.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-skill"
+  },
+  {
+    "index": "boon-of-speed",
+    "name": "Boon of Speed",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Escape Artist.** As a Bonus Action, you can take the Disengage action, which also ends the Grappled condition on you.",
+      "**Quickness.** Your Speed increases by 30 feet.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-speed"
+  },
+  {
+    "index": "boon-of-spell-recall",
+    "name": "Boon of Spell Recall",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 30.",
+      "**Free Casting.** Whenever you cast a spell with a level 1-4 spell slot, roll 1d4. If the number you roll is the same as the slot's level, the slot isn't expended.",
+      "PREREQ: level = 19",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: feature = 'pact-magic'",
+      "PREREQ: special = 'Spellcasting or Pact Magic Feature'"
+    ],
+    "url": "/api/2024/feats/boon-of-spell-recall"
+  },
+  {
+    "index": "boon-of-the-night-spirit",
+    "name": "Boon of the Night Spirit",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Merge with Shadows.** While within Dim Light or Darkness, you can give yourself the Invisible condition as a Bonus Action. The condition ends on you immediately after you take an action, a Bonus Action, or a Reaction.",
+      "**Shadowy Form.** While within Dim Light or Darkness, you have Resistance to all damage except Psychic and Radiant.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-the-night-spirit"
+  },
+  {
+    "index": "boon-of-truesight",
+    "name": "Boon of Truesight",
+    "prerequisites": [],
+    "desc": [
+      "Epic Boon Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.",
+      "**Truesight.** You have Truesight with a range of 60 feet.",
+      "PREREQ: level = 19"
+    ],
+    "url": "/api/2024/feats/boon-of-truesight"
+  },
+  {
+    "index": "charger",
+    "name": "Charger",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Improved Dash.** When you take the Dash action, your Speed increases by 10 feet for that action.",
+      "**Charge Attack.** If you move at least 10 feet in a straight line toward a target immediately before hitting it with a melee attack roll as part of the Attack action, choose one of the following effects: gain a 1d8 bonus to the attack's damage roll, or push the target up to 10 feet away if it is no more than one size larger than you. You can use this benefit only once on each of your turns.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/charger"
+  },
+  {
+    "index": "chef",
+    "name": "Chef",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Constitution or Wisdom by 1, to a maximum of 20.",
+      "**Cook's Utensils.** You gain proficiency with Cook's Utensils if you don't already have it.",
+      "**Replenishing Meal.** As part of a Short Rest, you can cook special food if you have ingredients and Cook's Utensils on hand. You can prepare enough of this food for a number of creatures equal to 4 plus your Proficiency Bonus. At the end of the Short Rest, any creature who eats the food and spends one or more Hit Dice to regain Hit Points regains an extra 1d8 Hit Points.",
+      "**Bolstering Treats.** With 1 hour of work or when you finish a Long Rest, you can cook a number of treats equal to your Proficiency Bonus if you have ingredients and Cook's Utensils on hand. These special treats last 8 hours after being made. A creature can use a Bonus Action to eat one of those treats to gain a number of Temporary Hit Points equal to your Proficiency Bonus.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/chef"
+  },
+  {
+    "index": "crafter",
+    "name": "Crafter",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Tool Proficiency.** You gain proficiency with three different Artisan's Tools of your choice from the Fast Crafting table.",
+      "**Discount.** Whenever you buy a nonmagical item, you receive a 20 percent discount on it.",
+      "**Fast Crafting.** When you finish a Long Rest, you can craft one piece of gear from the Fast Crafting table, provided you have the Artisan's Tools associated with that item and have proficiency with those tools. The item lasts until you finish another Long Rest, at which point the item falls apart.",
+      "###Fast Crafting###",
+      "| Artisan's Tools       | Crafted Gear                                              |",
+      "| --------------------- | --------------------------------------------------------- |",
+      "| Carpenter's Tools     | Ladder, Torch                                             |",
+      "| Leatherworker's Tools | Crossbow Bolt Case, Map or Scroll Case, Pouch             |",
+      "| Mason's Tools         | Block and Tackle                                          |",
+      "| Potter's Tools        | Jug, Lamp                                                 |",
+      "| Smith's Tools         | Ball Bearings, Bucket, Caltrops, Grappling Hook, Iron Pot |",
+      "| Tinker's Tools        | Bell, Shovel, Tinderbox                                   |",
+      "| Weaver's Tools        | Basket, Rope, Net, Tent                                   |",
+      "| Woodcarver's Tools    | Club, Greatclub, Quarterstaff                             |"
+    ],
+    "url": "/api/2024/feats/crafter"
+  },
+  {
+    "index": "crossbow-expert",
+    "name": "Crossbow Expert",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity score by 1, to a maximum of 20.",
+      "**Ignore Loading.** You ignore the Loading property of the Hand Crossbow, Heavy Crossbow, and Light Crossbow (all called crossbows elsewhere in this feat). If you're holding one of them, you can load a piece of ammunition into it even if you lack a free hand.",
+      "**Firing in Melee.** Being within 5 feet of an enemy doesn't impose Disadvantage on your attack rolls with crossbows.",
+      "**Dual Wielding.** When you make the extra attack of the Light property, you can add your ability modifier to the damage of the extra attack if that attack is with a crossbow that has the Light property and you aren't already adding that modifier to the damage.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/crossbow-expert"
+  },
+  {
+    "index": "crusher",
+    "name": "Crusher",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Constitution by 1, to a maximum of 20.",
+      "**Push.** Once per turn, when you hit a creature with an attack that deals Bludgeoning damage, you can move it 5 feet to an unoccupied space if the target is no more than one size larger than you.",
+      "**Enhanced Critical.** When you score a Critical Hit that deals Bludgeoning damage to a creature, attack rolls against that creature have Advantage until the start of your next turn.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/crusher"
+  },
+  {
+    "index": "defense",
+    "name": "Defense",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "While you're wearing Light, Medium, or Heavy armor, you gain a +1 bonus to Armor Class.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/defense"
+  },
+  {
+    "index": "defensive-duelist",
+    "name": "Defensive Duelist",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity score by 1, to a maximum of 20.",
+      "**Parry.** If you're holding a Finesse weapon and another creature hits you with a melee attack, you can take a Reaction to add your Proficiency Bonus to your Armor Class, potentially causing the attack to miss you. You gain this bonus to your AC against melee attacks until the start of your next turn.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/defensive-duelist"
+  },
+  {
+    "index": "druidic-warrior",
+    "name": "Druidic Warrior",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "You learn two Druid cantrips of your choice. Guidance and Starry Wisp are recommended. The chosen cantrips count as Ranger spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a Ranger level, you can replace one of these cantrips with another Druid cantrip.",
+      "PREREQ: feature = 'fighting-style'",
+      "PREREQ: special = 'When Gaining the Level 2 Ranger \"Fighting Style\" Feature'"
+    ],
+    "url": "/api/2024/feats/druidic-warrior"
+  },
+  {
+    "index": "dual-wielder",
+    "name": "Dual Wielder",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Enhanced Dual Wielding.** When you take the Attack action on your turn and attack with a weapon that has the Light property, you can make one extra attack as a Bonus Action later on the same turn with a different weapon, which must be a Melee weapon that lacks the Two-Handed property. You don't add your ability modifier to the extra attack's damage unless that modifier is negative.",
+      "**Quick Draw.** You can draw or stow two weapons that lack the Two-Handed property when you would normally be able to draw or stow only one.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/dual-wielder"
+  },
+  {
+    "index": "dueling",
+    "name": "Dueling",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When you're holding a Melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/dueling"
+  },
+  {
+    "index": "durable",
+    "name": "Durable",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Constitution score by 1, to a maximum of 20.",
+      "**Defy Death.** You have Advantage on Death Saving Throws.",
+      "**Speedy Recovery.** As a Bonus Action, you can expend one of your Hit Point Dice, roll the die, and regain a number of Hit Points equal to the roll.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/durable"
+  },
+  {
+    "index": "elemental-adept",
+    "name": "Elemental Adept",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Energy Mastery.** Choose one of the following damage types: Acid, Cold, Fire, Lightning, or Thunder. Spells you cast ignore Resistance to damage of the chosen type. In addition, when you roll damage for a spell you cast that deals damage of that type, you can treat any 1 on a damage die as a 2.",
+      "**Repeatable.** You can take this feat more than once, but you must choose a different damage type each time for Energy Mastery.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: feature = 'pact-magic'",
+      "PREREQ: special = 'Spellcasting or Pact Magic Feature'"
+    ],
+    "url": "/api/2024/feats/elemental-adept"
+  },
+  {
+    "index": "fey-touched",
+    "name": "Fey-Touched",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "Your exposure to the Feywild's magic grants you the following benefits.",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Fey Magic.** Choose one level 1 spell from the Divination or Enchantment school of magic. You always have that spell and the Misty Step spell prepared. You can cast each of these spells without expending a spell slot. Once you cast either spell in this way, you can't cast that spell in this way again until you finish a Long Rest. You can also cast these spells using spell slots you have of the appropriate level. The spells' spellcasting ability is the ability increased by this feat.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/fey-touched"
+  },
+  {
+    "index": "grappler",
+    "name": "Grappler",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Punch and Grab.** When you hit a creature with an Unarmed Strike as part of the Attack action on your turn, you can use both the Damage and the Grapple option. You can use this benefit only once per turn.",
+      "**Attack Advantage.** You have Advantage on attack rolls against a creature Grappled by you.",
+      "**Fast Wrestler.** You don't have to spend extra movement to move a creature Grappled by you if the creature is your size or smaller.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/grappler"
+  },
+  {
+    "index": "great-weapon-fighting",
+    "name": "Great Weapon Fighting",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When you roll damage for an attack you make with a Melee weapon that you are holding with two hands, you can treat any 1 or 2 on a damage die as a 3. The weapon must have the Two-Handed or Versatile property to gain this benefit.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/great-weapon-fighting"
+  },
+  {
+    "index": "great-weapon-master",
+    "name": "Great Weapon Master",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength score by 1, to a maximum of 20.",
+      "**Heavy Weapon Mastery.** When you hit a creature with a weapon that has the Heavy property as part of the Attack action on your turn, you can cause the weapon to deal extra damage to the target. The extra damage equals your Proficiency Bonus.",
+      "**Hew.** Immediately after you score a Critical Hit with a Melee weapon or reduce a creature to 0 Hit Points with one, you can make one attack with the same weapon as a Bonus Action.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/great-weapon-master"
+  },
+  {
+    "index": "healer",
+    "name": "Healer",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Battle Medic.** If you have a Healer's Kit, you can expend one use of it and tend to a creature within 5 feet of yourself as a Utilize action. That creature can expend one of its Hit Point Dice, and you then roll that die. The creature regains a number of Hit Points equal to the roll plus your Proficiency Bonus.",
+      "**Healing Rerolls.** Whenever you roll a die to determine the number of Hit Points you restore with a spell or with this feat's Battle Medic benefit, you can reroll the die if it rolls a 1, and you must use the new roll."
+    ],
+    "url": "/api/2024/feats/healer"
+  },
+  {
+    "index": "heavily-armored",
+    "name": "Heavily Armored",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Constitution or Strength by 1, to a maximum of 20.",
+      "**Armor Training.** You gain training with Heavy armor.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'medium-armor-training'"
+    ],
+    "url": "/api/2024/feats/heavily-armored"
+  },
+  {
+    "index": "heavy-armor-master",
+    "name": "Heavy Armor Master",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Constitution or Strength by 1, to a maximum of 20.",
+      "**Damage Reduction.** When you're hit by an attack while you're wearing Heavy armor, any Bludgeoning, Piercing, and Slashing damage dealt to you by that attack is reduced by an amount equal to your Proficiency Bonus.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'heavy-armor-training'"
+    ],
+    "url": "/api/2024/feats/heavy-armor-master"
+  },
+  {
+    "index": "inspiring-leader",
+    "name": "Inspiring Leader",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "wis",
+          "name": "WIS",
+          "url": "/api/2024/ability-scores/wis"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/2024/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Wisdom or Charisma by 1, to a maximum of 20.",
+      "**Bolstering Performance.** When you finish a Short or Long Rest, you can give an inspiring performance: a speech, song, or dance. When you do so, choose up to six allies (which can include yourself) within 30 feet of yourself who witness the performance. The chosen creatures each gain Temporary Hit Points equal to your character level plus the modifier of the ability you increased with this feat.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/inspiring-leader"
+  },
+  {
+    "index": "interception",
+    "name": "Interception",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When a creature you can see hits another creature within 5 feet of you with an attack roll, you can take a Reaction to reduce the damage dealt to the target by 1d10 plus your Proficiency Bonus. You must be holding a Shield or a Simple or Martial weapon to use this Reaction.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/interception"
+  },
+  {
+    "index": "keen-mind",
+    "name": "Keen Mind",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "int",
+          "name": "INT",
+          "url": "/api/2024/ability-scores/int"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence score by 1, to a maximum of 20.",
+      "**Lore Knowledge.** Choose one of the following skills: Arcana, History, Investigation, Nature, or Religion. If you lack proficiency in the chosen skill, you gain proficiency in it, and if you already have proficiency in it, you gain Expertise in it.",
+      "**Quick Study.** You can take the Study action as a Bonus Action.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/keen-mind"
+  },
+  {
+    "index": "lightly-armored",
+    "name": "Lightly Armored",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Armor Training.** You gain training with Light armor and Shields.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/lightly-armored"
+  },
+  {
+    "index": "lucky",
+    "name": "Lucky",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Luck Points.** You have a number of Luck Points equal to your Proficiency Bonus and can spend the points on the benefits below. You regain your expended Luck Points when you finish a Long Rest.",
+      "**Advantage.** When you roll a d20 for a D20 Test, you can spend 1 Luck Point to give yourself Advantage on the roll.",
+      "**Disadvantage.** When a creature rolls a d20 for an attack roll against you, you can spend 1 Luck Point to impose Disadvantage on that roll."
+    ],
+    "url": "/api/2024/feats/lucky"
+  },
+  {
+    "index": "mage-slayer",
+    "name": "Mage Slayer",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Concentration Breaker.** When you damage a creature that is Concentrating, it has Disadvantage on the saving throw it makes to maintain Concentration.",
+      "**Guarded Mind.** If you fail an Intelligence, a Wisdom, or a Charisma saving throw, you can cause yourself to succeed instead. Once you use this benefit, you can't use it again until you finish a Short or Long Rest.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/mage-slayer"
+  },
+  {
+    "index": "magic-initiate",
+    "name": "Magic Initiate",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Two Cantrips.** You learn two cantrips of your choice from the Cleric, Druid, or Wizard spell list. Intelligence, Wisdom, or Charisma is your spellcasting ability for this feat's spells (choose when you select this feat).",
+      "**Level 1 Spell.** Choose a level 1 spell from the same list you selected for this feat's cantrips. You always have that spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a Long Rest. You can also cast the spell using any spell slots you have.",
+      "**Spell Change.** Whenever you gain a new level, you can replace one of the spells you chose for this feat with a different spell of the same level from the chosen spell list.",
+      "**Repeatable.** You can take this feat more than once, but you must choose a different spell list each time."
+    ],
+    "url": "/api/2024/feats/magic-initiate"
+  },
+  {
+    "index": "martial-weapon-training",
+    "name": "Martial Weapon Training",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Weapon Proficiency.** You gain proficiency with Martial weapons.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/martial-weapon-training"
+  },
+  {
+    "index": "medium-armor-master",
+    "name": "Medium Armor Master",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Dexterous Wearer.** While you're wearing Medium armor, you can add 3, rather than 2 to your AC if you have a Dexterity score of 16 or higher.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'medium-armor-training'"
+    ],
+    "url": "/api/2024/feats/medium-armor-master"
+  },
+  {
+    "index": "moderately-armored",
+    "name": "Moderately Armored",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Armor Training.** You gain training with Medium armor.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'light-armor-training'"
+    ],
+    "url": "/api/2024/feats/moderately-armored"
+  },
+  {
+    "index": "mounted-combatant",
+    "name": "Mounted Combatant",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength, Dexterity, or Wisdom by 1, to a maximum of 20.",
+      "**Mounted Strike.** While mounted, you have Advantage on attack rolls against any unmounted creature within 5 feet of your mount that is at least one size smaller than the mount.",
+      "**Leap Aside.** If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw and only half damage if it fails. For your mount to gain this benefit, you must be riding it, and neither of you can have the Incapacitated condition.",
+      "**Veer.** While mounted, you can force an attack that hits your mount to hit you instead if you don't have the Incapacitated condition.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/mounted-combatant"
+  },
+  {
+    "index": "musician",
+    "name": "Musician",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Instrument Training.** You gain proficiency with three Musical Instruments of your choice.",
+      "**Encouraging Song.** As you finish a Short or Long Rest, you can play a song on a Musical Instrument with which you have proficiency and give Heroic Inspiration to allies who hear the song. The number of allies you can affect in this way equals your Proficiency Bonus."
+    ],
+    "url": "/api/2024/feats/musician"
+  },
+  {
+    "index": "observant",
+    "name": "Observant",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "int",
+          "name": "INT",
+          "url": "/api/2024/ability-scores/int"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence or Wisdom by 1, to a maximum of 20.",
+      "**Keen Observer.** Choose one of the following skills: Insight, Investigation, or Perception. If you lack proficiency with the chosen skill, you gain proficiency in it, and if you already have proficiency in it, you gain Expertise in it.",
+      "**Quick Search.** You can take the Search action as a Bonus Action.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/observant"
+  },
+  {
+    "index": "piercer",
+    "name": "Piercer",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Puncture.** Once per turn, when you hit a creature with an attack that deals Piercing damage, you can reroll one of the attack's damage dice, and you must use the new roll.",
+      "**Enhanced Critical.** When you score a Critical Hit that deals Piercing damage to a creature, you can roll one additional damage die when determining the extra Piercing damage the target takes.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/piercer"
+  },
+  {
+    "index": "poisoner",
+    "name": "Poisoner",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity or Intelligence by 1, to a maximum of 20.",
+      "**Potent Poison.** When you make a damage roll that deals Poison damage, it ignores Resistance to Poison damage.",
+      "**Brew Poison.** You gain proficiency with the Poisoner's Kit. With 1 hour of work using such a kit and expending 50 GP worth of materials, you can create a number of poison doses equal to your Proficiency Bonus. As a Bonus Action, you can apply a poison dose to a weapon or piece of ammunition. Once applied, the poison retains its potency for 1 minute or until you deal damage with the poisoned item, whichever is shorter. When a creature takes damage from the poisoned item, that creature must succeed on a Constitution saving throw (DC 8 plus the modifier of the ability increased by this feat and your Proficiency Bonus) or take 2d8 Poison damage and have the Poisoned condition until the end of your next turn.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/poisoner"
+  },
+  {
+    "index": "polearm-master",
+    "name": "Polearm Master",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity or Strength by 1, to a maximum of 20.",
+      "**Pole Strike.** Immediately after you take the Attack action and attack with a Quarterstaff, a Spear, or a weapon that has the Heavy and Reach properties, you can use a Bonus Action to make a melee attack with the opposite end of the weapon. The weapon deals Bludgeoning damage, and the weapon's damage die for this attack is a d4.",
+      "**Reactive Strike.** While you're holding a Quarterstaff, a Spear, or a weapon that has the Heavy and Reach properties, you can take a Reaction to make one melee attack against a creature that enters the reach you have with that weapon.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/polearm-master"
+  },
+  {
+    "index": "protection",
+    "name": "Protection",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When a creature you can see attacks a target other than you that is within 5 feet of you, you can take a Reaction to interpose your Shield if you're holding one. You impose Disadvantage on the triggering attack roll and all other attack rolls against the target until the start of your next turn if you remain within 5 feet of the target.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/protection"
+  },
+  {
+    "index": "resilient",
+    "name": "Resilient",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Choose one ability in which you lack saving throw proficiency. Increase the chosen ability score by 1, to a maximum of 20.",
+      "**Saving Throw Proficiency.** You gain saving throw proficiency with the chosen ability.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/resilient"
+  },
+  {
+    "index": "ritual-caster",
+    "name": "Ritual Caster",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "int",
+          "name": "INT",
+          "url": "/api/2024/ability-scores/int"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "wis",
+          "name": "WIS",
+          "url": "/api/2024/ability-scores/wis"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/2024/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Ritual Spells.** Choose a number of level 1 spells equal to your Proficiency Bonus that have the Ritual tag. You always have those spells prepared, and you can cast them with any spell slots you have. The spells' spellcasting ability is the ability increased by this feat. Whenever your Proficiency Bonus increases thereafter, you can add an additional level 1 spell with the Ritual tag to the spells always prepared with this feature.",
+      "**Quick Ritual.** With this benefit, you can cast a Ritual spell that you have prepared using its regular casting time rather than the extended time for a Ritual. Doing so doesn't require a spell slot. Once you cast the spell in this way, you can't use this benefit again until you finish a Long Rest.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/ritual-caster"
+  },
+  {
+    "index": "savage-attacker",
+    "name": "Savage Attacker",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "You've trained to deal particularly damaging strikes. Once per turn when you hit a target with a weapon, you can roll the weapon's damage dice twice and use either roll against the target."
+    ],
+    "url": "/api/2024/feats/savage-attacker"
+  },
+  {
+    "index": "sentinel",
+    "name": "Sentinel",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "str",
+          "name": "STR",
+          "url": "/api/2024/ability-scores/str"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Guardian.** Immediately after a creature within 5 feet of you takes the Disengage action or hits a target other than you with an attack, you can make an Opportunity Attack against that creature.",
+      "**Halt.** When you hit a creature with an Opportunity Attack, the creature's Speed becomes 0 for the rest of the current turn.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/sentinel"
+  },
+  {
+    "index": "shadow-touched",
+    "name": "Shadow-Touched",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Shadow Magic.** Choose one level 1 spell from the Illusion or Necromancy school of magic. You always have that spell and the Invisibility spell prepared. You can cast each of these spells without expending a spell slot. Once you cast either spell in this way, you can't cast that spell in this way again until you finish a Long Rest. You can also cast these spells using spell slots you have of the appropriate level. The spells' spellcasting ability is the ability increased by this feat.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/shadow-touched"
+  },
+  {
+    "index": "sharpshooter",
+    "name": "Sharpshooter",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity score by 1, to a maximum of 20.",
+      "**Bypass Cover.** Your ranged attacks with weapons ignore Half Cover and Three-Quarters Cover.",
+      "**Firing in Melee.** Being within 5 feet of an enemy doesn't impose Disadvantage on your attack rolls with Ranged weapons.",
+      "**Long Shots.** Attacking at long range doesn't impose Disadvantage on your attack rolls with Ranged weapons.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/sharpshooter"
+  },
+  {
+    "index": "shield-master",
+    "name": "Shield Master",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength score by 1, to a maximum of 20.",
+      "**Shield Bash.** If you attack a creature within 5 feet of you as part of the Attack action and hit with a Melee weapon, you can immediately bash the target with your Shield if it's equipped, forcing the target to make a Strength saving throw (DC 8 plus your Strength modifier and Proficiency Bonus). On a failed save, you either push the target 5 feet from you or cause it to have the Prone condition (your choice). You can use this benefit only once on each of your turns.",
+      "**Interpose Shield.** If you're subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can take a Reaction to take no damage if you succeed on the saving throw and are holding a Shield.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'shield-training'"
+    ],
+    "url": "/api/2024/feats/shield-master"
+  },
+  {
+    "index": "skill-expert",
+    "name": "Skill Expert",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 20.",
+      "**Skill Proficiency.** You gain proficiency in one skill of your choice.",
+      "**Expertise.** Choose one skill in which you have proficiency but lack Expertise. You gain Expertise with that skill.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/skill-expert"
+  },
+  {
+    "index": "skilled",
+    "name": "Skilled",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "You gain proficiency in any combination of three skills or tools of your choice.",
+      "**Repeatable.** You can take this feat more than once."
+    ],
+    "url": "/api/2024/feats/skilled"
+  },
+  {
+    "index": "skulker",
+    "name": "Skulker",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity score by 1, to a maximum of 20.",
+      "**Blindsight.** You have Blindsight with a range of 10 feet.",
+      "**Fog of War.** You exploit the distractions of battle, gaining Advantage on any Dexterity (Stealth) check you make as part of the Hide action during combat.",
+      "**Sniper.** If you make an attack roll while hidden and the roll misses, making the attack roll doesn't reveal your location.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/skulker"
+  },
+  {
+    "index": "slasher",
+    "name": "Slasher",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Hamstring.** Once per turn when you hit a creature with an attack that deals Slashing damage, you can reduce the Speed of that creature by 10 feet until the start of your next turn.",
+      "**Enhanced Critical.** When you score a Critical Hit that deals Slashing damage to a creature, it has Disadvantage on attack rolls until the start of your next turn.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/slasher"
+  },
+  {
+    "index": "speedy",
+    "name": "Speedy",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2024/ability-scores/dex"
+        },
+        "minimum_score": 13
+      },
+      {
+        "ability_score": {
+          "index": "con",
+          "name": "CON",
+          "url": "/api/2024/ability-scores/con"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Dexterity or Constitution by 1, to a maximum of 20.",
+      "**Speed Increase.** Your Speed increases by 10 feet.",
+      "**Dash over Difficult Terrain.** When you take the Dash action on your turn, Difficult Terrain doesn't cost you extra movement for the rest of that turn.",
+      "**Agile Movement.** Opportunity Attacks have Disadvantage against you.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/speedy"
+  },
+  {
+    "index": "spell-sniper",
+    "name": "Spell Sniper",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Bypass Cover.** Your attack rolls for spells ignore Half Cover and Three-Quarters Cover.",
+      "**Casting in Melee.** Being within 5 feet of an enemy doesn't impose Disadvantage on your attack rolls with spells.",
+      "**Increased Range.** When you cast a spell that has a range of at least 10 feet and requires you to make an attack roll, you can increase the spell's range by 60 feet.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: feature = 'pact-magic'",
+      "PREREQ: special = 'Spellcasting or Pact Magic Feature'"
+    ],
+    "url": "/api/2024/feats/spell-sniper"
+  },
+  {
+    "index": "tavern-brawler",
+    "name": "Tavern Brawler",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "**Enhanced Unarmed Strike.** When you hit with your Unarmed Strike and deal damage, you can deal Bludgeoning damage equal to 1d4 plus your Strength modifier instead of the normal damage of an Unarmed Strike.",
+      "**Damage Rerolls.** Whenever you roll a damage die for your Unarmed Strike, you can reroll the die if it rolls a 1, and you must use the new roll.",
+      "**Improvised Weaponry.** You have proficiency with improvised weapons.",
+      "**Push.** When you hit a creature with an Unarmed Strike as part of the Attack action on your turn, you can deal damage to the target and also push it 5 feet away from you. You can use this benefit only once per turn."
+    ],
+    "url": "/api/2024/feats/tavern-brawler"
+  },
+  {
+    "index": "telekinetic",
+    "name": "Telekinetic",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Minor Telekinesis.** You learn the Mage Hand spell. You can cast it without Verbal or Somatic components, you can make the spectral hand Invisible, and its range and the distance it can be away from you both increase by 30 feet when you cast it. The spell's spellcasting ability is the ability increased by this feat.",
+      "**Telekinetic Shove.** As a Bonus Action, you can telekinetically shove one creature you can see within 30 feet of yourself. When you do so, the target must succeed on a Strength saving throw (DC 8 plus the ability modifier of the score increased by this feat and your Proficiency Bonus) or be moved 5 feet toward or away from you.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/telekinetic"
+  },
+  {
+    "index": "telepathic",
+    "name": "Telepathic",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Telepathic Utterance.** You can speak telepathically to any creature you can see within 60 feet of yourself. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn't give the creature the ability to respond to you telepathically.",
+      "**Detect Thoughts.** You always have the Detect Thoughts spell prepared. You can cast it without a spell slot or spell components, and you must finish a Long Rest before you can cast it in this way again. You can also cast it using spell slots you have of the appropriate level. Your spellcasting ability for the spell is the ability increased by this feat.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/telepathic"
+  },
+  {
+    "index": "thrown-weapon-fighting",
+    "name": "Thrown Weapon Fighting",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When you hit with a ranged attack roll using a weapon that has the Thrown property, you gain a +2 bonus to the damage roll.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/thrown-weapon-fighting"
+  },
+  {
+    "index": "tough",
+    "name": "Tough",
+    "prerequisites": [],
+    "desc": [
+      "Origin Feat",
+      "Your Hit Point maximum increases by an amount equal to twice your character level when you gain this feat. Whenever you gain a character level thereafter, your Hit Point maximum increases by an additional 2 Hit Points."
+    ],
+    "url": "/api/2024/feats/tough"
+  },
+  {
+    "index": "two-weapon-fighting",
+    "name": "Two-Weapon Fighting",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When you make an extra attack as a result of using a weapon that has the Light property, you can add your ability modifier to the damage of that attack if you aren't already adding it to the damage.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/two-weapon-fighting"
+  },
+  {
+    "index": "unarmed-fighting",
+    "name": "Unarmed Fighting",
+    "prerequisites": [],
+    "desc": [
+      "Fighting Style Feat",
+      "When you hit with your Unarmed Strike and deal damage, you can deal Bludgeoning damage equal to 1d6 plus your Strength modifier instead of the normal damage of an Unarmed Strike. If you aren't holding any weapons or a Shield when you make the attack roll, the d6 becomes a d8.",
+      "At the start of each of your turns, you can deal 1d4 Bludgeoning damage to one creature Grappled by you.",
+      "PREREQ: feature = 'fighting-style'"
+    ],
+    "url": "/api/2024/feats/unarmed-fighting"
+  },
+  {
+    "index": "war-caster",
+    "name": "War Caster",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Intelligence, Wisdom, or Charisma by 1, to a maximum of 20.",
+      "**Concentration.** You have Advantage on Constitution saving throws that you make to maintain Concentration.",
+      "**Reactive Spell.** When a creature provokes an Opportunity Attack from you by leaving your reach, you can take a Reaction to cast a spell at the creature rather than making an Opportunity Attack. The spell must have a casting time of one action and must target only that creature.",
+      "**Somatic Components.** You can perform the Somatic components of spells even when you have weapons or a Shield in one or both hands.",
+      "PREREQ: level = 4",
+      "PREREQ: feature = 'spell-casting'",
+      "PREREQ: feature = 'pact-magic'",
+      "PREREQ: special = 'Spellcasting or Pact Magic Feature'"
+    ],
+    "url": "/api/2024/feats/war-caster"
+  },
+  {
+    "index": "weapon-master",
+    "name": "Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "General Feat",
+      "**Ability Score Increase.** Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "**Mastery Property.** Your training with weapons allows you to use the mastery property of one kind of Simple or Martial weapon of your choice, provided you have proficiency with it. Whenever you finish a Long Rest, you can change the kind of weapon to another eligible kind.",
+      "PREREQ: level = 4"
+    ],
+    "url": "/api/2024/feats/weapon-master"
+  }
+]


### PR DESCRIPTION
## What does this do?

I've added all of the 2014 and 2024 feats to the JSON files. Please note, the feats class was only setup to display ability score prerequisites. the 2014 feats also has spellcasting and armor training prerequisites, and 2024 has those as well as level prereqs. Because there was no plase to add those, I simply added them to the bottom of the description. I will create a feature request to add those also. Once it is ready, I can easily go back update the JSON files to include those.

## How was it tested?

I ran `npm run test` and all tests passed.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

![image](https://preview.redd.it/wmjz4vsnxi721.jpg?width=640&crop=smart&auto=webp&s=d35a2b5f9d8d9def719607e7037490dbf96d2236)