### PR TITLE
feat(images): Redirect image urls to new image urls

### DIFF
--- a/src/2014/5e-SRD-Equipment.json
+++ b/src/2014/5e-SRD-Equipment.json
@@ -1515,7 +1515,7 @@
         "url": "/api/2014/weapon-properties/two-handed"
       }
     ],
-    "image": "/api/2014/images/equipment/crossbow-heavy.png",
+    "image": "/api/images/equipment/crossbow-heavy.png",
     "url": "/api/2014/equipment/crossbow-heavy"
   },
   {
@@ -2318,7 +2318,7 @@
       "A creature moving across the covered area must succeed on a DC 10 Dexterity saving throw or fall prone.",
       "A creature moving through the area at half speed doesn't need to make the save."
     ],
-    "image": "/api/2014/images/equipment/ball-bearings-bag-of-1000.png",
+    "image": "/api/images/equipment/ball-bearings-bag-of-1000.png",
     "url": "/api/2014/equipment/ball-bearings-bag-of-1000"
   },
   {
@@ -5307,7 +5307,7 @@
     "desc": [
       "This item encompasses a wide range of game pieces, including dice and decks of cards (for games such as Three-Dragon Ante). A few common examples appear on the Tools table, but other kinds of gaming sets exist. If you are proficient with a gaming set, you can add your proficiency bonus to ability checks you make to play a game with that set. Each type of gaming set requires a separate proficiency."
     ],
-    "image": "/api/2014/images/equipment/playing-card-set.png",
+    "image": "/api/images/equipment/playing-card-set.png",
     "url": "/api/2014/equipment/playing-card-set"
   },
   {
@@ -5365,7 +5365,7 @@
     "desc": [
       "Several of the most common types of musical instruments are shown on the table as examples. If you have proficiency with a given musical instrument, you can add your proficiency bonus to any ability checks you make to play music with the instrument. A bard can use a musical instrument as a spellcasting focus. Each type of musical instrument requires a separate proficiency."
     ],
-    "image": "/api/2014/images/equipment/dulcimer.png",
+    "image": "/api/images/equipment/dulcimer.png",
     "url": "/api/2014/equipment/dulcimer"
   },
   {

--- a/src/2014/5e-SRD-Magic-Items.json
+++ b/src/2014/5e-SRD-Magic-Items.json
@@ -16,7 +16,7 @@
       "Armor (medium or heavy, but not hide), uncommon",
       "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit."
     ],
-    "image": "/api/2014/images/magic-items/adamantine-armor.png",
+    "image": "/api/images/magic-items/adamantine-armor.png",
     "url": "/api/2014/magic-items/adamantine-armor"
   },
   {
@@ -52,7 +52,7 @@
       "Weapon (any ammunition), uncommon (+1), rare (+2), or very rare (+3)",
       "You have a bonus to attack and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical."
     ],
-    "image": "/api/2014/images/magic-items/ammunition.png",
+    "image": "/api/images/magic-items/ammunition.png",
     "url": "/api/2014/magic-items/ammunition"
   },
   {
@@ -72,7 +72,7 @@
       "Weapon (any ammunition), uncommon",
       "You have a +1 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
     ],
-    "image": "/api/2014/images/magic-items/ammunition.png",
+    "image": "/api/images/magic-items/ammunition.png",
     "url": "/api/2014/magic-items/ammunition-1"
   },
   {
@@ -92,7 +92,7 @@
       "Weapon (any ammunition), rare",
       "You have a +2 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
     ],
-    "image": "/api/2014/images/magic-items/ammunition.png",
+    "image": "/api/images/magic-items/ammunition.png",
     "url": "/api/2014/magic-items/ammunition-2"
   },
   {
@@ -112,7 +112,7 @@
       "Weapon (any ammunition), very rare",
       "You have a +3 bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical."
     ],
-    "image": "/api/2014/images/magic-items/ammunition.png",
+    "image": "/api/images/magic-items/ammunition.png",
     "url": "/api/2014/magic-items/ammunition-3"
   },
   {
@@ -132,7 +132,7 @@
       "Wondrous item, rare (requires attunement)",
       "Your Constitution score is 19 while you wear this amulet. It has no effect on you if your Constitution is already 19 or higher"
     ],
-    "image": "/api/2014/images/magic-items/amulet-of-health.png",
+    "image": "/api/images/magic-items/amulet-of-health.png",
     "url": "/api/2014/magic-items/amulet-of-health"
   },
   {
@@ -152,7 +152,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "While wearing this amulet, you are hidden from divination magic. You can't be targeted by such magic or perceived through magical scrying sensors."
     ],
-    "image": "/api/2014/images/magic-items/amulet-of-proof-against-detection-and-location.png",
+    "image": "/api/images/magic-items/amulet-of-proof-against-detection-and-location.png",
     "url": "/api/2014/magic-items/amulet-of-proof-against-detection-and-location"
   },
   {
@@ -172,7 +172,7 @@
       "Wondrous item, very rare (requires attunement)",
       "While wearing this amulet, you can use an action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence check. On a successful check, you cast the plane shift spell. On a failure, you and each creature and object within 15 feet of you travel to a random destination. Roll a d100. On a 1-60, you travel to a random location on the plane you named. On a 61-100, you travel to a randomly determined plane of existence."
     ],
-    "image": "/api/2014/images/magic-items/amulet-of-the-planes.png",
+    "image": "/api/images/magic-items/amulet-of-the-planes.png",
     "url": "/api/2014/magic-items/amulet-of-the-planes"
   },
   {
@@ -192,7 +192,7 @@
       "Armor (shield), very rare (requires attunement)",
       "While holding this shield, you can speak its command word as a bonus action to cause it to animate. The shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The shield remains animated for 1 minute, until you use a bonus action to end this effect, or until you are incapacitated or die, at which point the shield falls to the ground or into your hand if you have one free."
     ],
-    "image": "/api/2014/images/magic-items/animated-shield.png",
+    "image": "/api/images/magic-items/animated-shield.png",
     "url": "/api/2014/magic-items/animated-shield"
   },
   {
@@ -233,7 +233,7 @@
       "| 9 | The apparatus sinks as much as 20 feet in liquid. | The apparatus rises up to 20 feet in liquid. |",
       "| 10 | The rear hatch unseals and opens. |  The rear hatch closes and seals. |"
     ],
-    "image": "/api/2014/images/magic-items/apparatus-of-the-crab.png",
+    "image": "/api/images/magic-items/apparatus-of-the-crab.png",
     "url": "/api/2014/magic-items/apparatus-of-the-crab"
   },
   {
@@ -269,7 +269,7 @@
       "Armor (light, medium, or heavy), rare (+1), very rare (+2), or legendary (+3)",
       "You have a bonus to AC while wearing this armor. The bonus is determined by its rarity."
     ],
-    "image": "/api/2014/images/magic-items/armor.png",
+    "image": "/api/images/magic-items/armor.png",
     "url": "/api/2014/magic-items/armor"
   },
   {
@@ -289,7 +289,7 @@
       "Armor (light, medium, or heavy), rare",
       "You have a +1 bonus to AC while wearing this armor."
     ],
-    "image": "/api/2014/images/magic-items/armor.png",
+    "image": "/api/images/magic-items/armor.png",
     "url": "/api/2014/magic-items/armor-1"
   },
   {
@@ -309,7 +309,7 @@
       "Armor (light, medium, or heavy), very rare",
       "You have a +2 bonus to AC while wearing this armor."
     ],
-    "image": "/api/2014/images/magic-items/armor-2.png",
+    "image": "/api/images/magic-items/armor-2.png",
     "url": "/api/2014/magic-items/armor-2"
   },
   {
@@ -329,7 +329,7 @@
       "Armor (light, medium, or heavy), legendary",
       "You have a +3 bonus to AC while wearing this armor."
     ],
-    "image": "/api/2014/images/magic-items/armor-3.png",
+    "image": "/api/images/magic-items/armor-3.png",
     "url": "/api/2014/magic-items/armor-3"
   },
   {
@@ -349,7 +349,7 @@
       "Armor (plate), legendary (requires attunement)",
       "You have resistance to nonmagical damage while you wear this armor. Additionally, you can use an action to make yourself immune to nonmagical damage for 10 minutes or until you are no longer wearing the armor. Once this special action is used, it can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/armor-of-invulnerability.png",
+    "image": "/api/images/magic-items/armor-of-invulnerability.png",
     "url": "/api/2014/magic-items/armor-of-invulnerability"
   },
   {
@@ -381,7 +381,7 @@
       "| 9 | Radiant |",
       "| 10 | Thunder |"
     ],
-    "image": "/api/2014/images/magic-items/armor-of-resistance.png",
+    "image": "/api/images/magic-items/armor-of-resistance.png",
     "url": "/api/2014/magic-items/armor-of-resistance"
   },
   {
@@ -402,7 +402,7 @@
       "While wearing this armor, you have resistance to  one of the following damage types: bludgeoning, piercing, or slashing. The GM chooses the type or determines it randomly.",
       "***Curse.*** This armor is cursed, a fact that is revealed only when an identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by the remove curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have vulnerability to two of the three damage types associated with the armor (not the one to which it grants resistance)."
     ],
-    "image": "/api/2014/images/magic-items/armor-of-vulnerability.png",
+    "image": "/api/images/magic-items/armor-of-vulnerability.png",
     "url": "/api/2014/magic-items/armor-of-vulnerability"
   },
   {
@@ -422,7 +422,7 @@
       "Armor (shield), rare (requires attunement)",
       "You gain a +2 bonus to AC against ranged attacks while you wield this shield. This bonus is in addition to the shield's normal bonus to AC. In addition, whenever an attacker makes a ranged attack against a target within 5 feet of you, you can use your reaction to become the target of the attack instead."
     ],
-    "image": "/api/2014/images/magic-items/arrow-catching-shield.png",
+    "image": "/api/images/magic-items/arrow-catching-shield.png",
     "url": "/api/2014/magic-items/arrow-catching-shield"
   },
   {
@@ -444,7 +444,7 @@
       "Once an arrow of slaying deals its extra damage to a creature, it becomes a nonmagical arrow.",
       "Other types of magic ammunition of this kind exist, such as bolts of slaying meant for a crossbow, though arrows are most common."
     ],
-    "image": "/api/2014/images/magic-items/arrow-of-slaying.png",
+    "image": "/api/images/magic-items/arrow-of-slaying.png",
     "url": "/api/2014/magic-items/arrow-of-slaying"
   },
   {
@@ -480,7 +480,7 @@
       "| 91-99 | A pyramid with a 60-foot-square base bursts upward. Inside is a sarcophagus containing a mummy lord. The pyramid is treated as the mummy lord's lair, and its sarcophagus contains treasure of the GM's choice. |",
       "| 100 | A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or a different plane of existence. |"
     ],
-    "image": "/api/2014/images/magic-items/bag-of-beans.png",
+    "image": "/api/images/magic-items/bag-of-beans.png",
     "url": "/api/2014/magic-items/bag-of-beans"
   },
   {
@@ -503,7 +503,7 @@
       "Inanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.",
       "If the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
     ],
-    "image": "/api/2014/images/magic-items/bag-of-devouring.png",
+    "image": "/api/images/magic-items/bag-of-devouring.png",
     "url": "/api/2014/magic-items/bag-of-devouring"
   },
   {
@@ -525,7 +525,7 @@
       "If the bag is overloaded, pierced, or torn, it ruptures and is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth, unharmed, but the bag must be put right before it can be used again. Breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.",
       "Placing a bag of holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
     ],
-    "image": "/api/2014/images/magic-items/bag-of-holding.png",
+    "image": "/api/images/magic-items/bag-of-holding.png",
     "url": "/api/2014/magic-items/bag-of-holding"
   },
   {
@@ -597,7 +597,7 @@
       "| 07 | Giant Hyena |",
       "| 08 | Tiger |"
     ],
-    "image": "/api/2014/images/magic-items/bag-of-tricks.png",
+    "image": "/api/images/magic-items/bag-of-tricks.png",
     "url": "/api/2014/magic-items/bag-of-tricks"
   },
   {
@@ -631,7 +631,7 @@
       "| 07 | Dire Wolf |",
       "| 08 | Giant Elk |"
     ],
-    "image": "/api/2014/images/magic-items/bag-of-tricks.png",
+    "image": "/api/images/magic-items/bag-of-tricks.png",
     "url": "/api/2014/magic-items/bag-of-tricks-gray"
   },
   {
@@ -665,7 +665,7 @@
       "| 07 | Lion |",
       "| 08 | Brown Bear |"
     ],
-    "image": "/api/2014/images/magic-items/bag-of-tricks.png",
+    "image": "/api/images/magic-items/bag-of-tricks.png",
     "url": "/api/2014/magic-items/bag-of-tricks-rust"
   },
   {
@@ -699,7 +699,7 @@
       "| 07 | Giant Hyena |",
       "| 08 | Tiger |"
     ],
-    "image": "/api/2014/images/magic-items/bag-of-tricks.png",
+    "image": "/api/images/magic-items/bag-of-tricks.png",
     "url": "/api/2014/magic-items/bag-of-tricks-tan"
   },
   {
@@ -721,7 +721,7 @@
       "You can use an action to throw the bead up to 60 feet. The bead explodes on impact and is destroyed. Each creature within a 10-foot radius of where the bead landed must succeed on a DC 15 Dexterity saving throw or take 5d4 force damage. A Sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this Sphere. Creatures that succeeded on the save, or are partially within the area, are pushed away from the center of the Sphere until they are no longer inside it. Only breathable air can pass through the sphere's wall. No Attack or other Effect can.",
       "An enclosed creature can use its action to push against the sphere's wall, moving the Sphere up to half the creature's walking speed. The Sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
     ],
-    "image": "/api/2014/images/magic-items/bead-of-force.png",
+    "image": "/api/images/magic-items/bead-of-force.png",
     "url": "/api/2014/magic-items/bead-of-force"
   },
   {
@@ -747,7 +747,7 @@
       "You have advantage on Saving Throws against poison, and you have Resistance against poison damage.",
       "You can speak, read, and write Dwarvish."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-dwarvenkind.png",
+    "image": "/api/images/magic-items/belt-of-dwarvenkind.png",
     "url": "/api/2014/magic-items/belt-of-dwarvenkind"
   },
   {
@@ -806,7 +806,7 @@
       "| Cloud Giant | 27 | Legendary |",
       "| Storm Giant | 29 | Legendary |"
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength"
   },
   {
@@ -826,7 +826,7 @@
       "Wondrous item, rare (requires attunement)",
       "While wearing this belt, your Strength score changes to a 21. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-hill"
   },
   {
@@ -846,7 +846,7 @@
       "Wondrous item, very rare (requires attunement)",
       "While wearing this belt, your Strength score changes to a 23. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-stone"
   },
   {
@@ -866,7 +866,7 @@
       "Wondrous item, very rare (requires attunement)",
       "While wearing this belt, your Strength score changes to 23. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-frost"
   },
   {
@@ -886,7 +886,7 @@
       "Wondrous item, very rare (requires attunement)",
       "While wearing this belt, your Strength score changes to 25. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-fire"
   },
   {
@@ -906,7 +906,7 @@
       "Wondrous item, legendary (requires attunement)",
       "While wearing this belt, your Strength score changes to 27. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-cloud"
   },
   {
@@ -926,7 +926,7 @@
       "Wondrous item, legendary (requires attunement)",
       "While wearing this belt, your Strength score changes to 29. If your Strength is already equal to or greater than the belt's score, the item has no Effect on you."
     ],
-    "image": "/api/2014/images/magic-items/belt-of-giant-strength.png",
+    "image": "/api/images/magic-items/belt-of-giant-strength.png",
     "url": "/api/2014/magic-items/belt-of-giant-strength-storm"
   },
   {
@@ -948,7 +948,7 @@
       "***Curse.*** This axe is Cursed, and becoming attuned to it extends the curse to you. As long as you remain Cursed, you are unwilling to part with the axe, keeping it within reach at all times. You also have disadvantage on Attack rolls with Weapons other than this one, unless no foe is within 60 feet of you that you can see or hear.",
       "Whenever a Hostile creature damages you while the axe is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. While berserk, you must use your action each round to Attack the creature nearest to you with the axe. If you can make extra attacks as part of the Attack action, you use those extra attacks, moving to Attack the next nearest creature after you fell your current target. If you have multiple possible Targets, you Attack one at random. You are berserk until you start Your Turn with no creatures within 60 feet of you that you can see or hear."
     ],
-    "image": "/api/2014/images/magic-items/berserker-axe.png",
+    "image": "/api/images/magic-items/berserker-axe.png",
     "url": "/api/2014/magic-items/berserker-axe"
   },
   {
@@ -968,7 +968,7 @@
       "Wondrous item, uncommon",
       "While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have advantage on Dexterity (Stealth) checks that rely on moving silently."
     ],
-    "image": "/api/2014/images/magic-items/boots-of-elvenkind.png",
+    "image": "/api/images/magic-items/boots-of-elvenkind.png",
     "url": "/api/2014/magic-items/boots-of-elvenkind"
   },
   {
@@ -988,7 +988,7 @@
       "Wondrous item, rare (requires attunement)",
       "While you wear these boots, you can use an action to cast the levitate spell on yourself at will."
     ],
-    "image": "/api/2014/images/magic-items/boots-of-levitation.png",
+    "image": "/api/images/magic-items/boots-of-levitation.png",
     "url": "/api/2014/magic-items/boots-of-levitation"
   },
   {
@@ -1009,7 +1009,7 @@
       "While you wear these boots, you can use a bonus action and click the boots' heels together. If you do, the boots double your walking speed, and any creature that makes an opportunity attack against you has disadvantage on the attack roll. If you click your heels together again, you end the effect.",
       "When the boots' property has been used for a total of 10 minutes, the magic ceases to function until you finish a long rest."
     ],
-    "image": "/api/2014/images/magic-items/boots-of-speed.png",
+    "image": "/api/images/magic-items/boots-of-speed.png",
     "url": "/api/2014/magic-items/boots-of-speed"
   },
   {
@@ -1029,7 +1029,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "While you wear these boots, your walking speed becomes 30 feet, unless your walking speed is higher, and your speed isn't reduced if you are encumbered or wearing heavy armor. In addition, you can jump three times the normal distance, though you can't jump farther than your remaining movement would allow."
     ],
-    "image": "/api/2014/images/magic-items/boots-of-striding-and-springing.png",
+    "image": "/api/images/magic-items/boots-of-striding-and-springing.png",
     "url": "/api/2014/magic-items/boots-of-striding-and-springing"
   },
   {
@@ -1052,7 +1052,7 @@
       "* You ignore difficult terrain created by ice or snow.",
       "* You can tolerate temperatures as low as -50 degrees Fahrenheit without any additional protection. If you wear heavy clothes, you can tolerate temperatures as low as -100 degrees Fahrenheit."
     ],
-    "image": "/api/2014/images/magic-items/boots-of-the-winterlands.png",
+    "image": "/api/images/magic-items/boots-of-the-winterlands.png",
     "url": "/api/2014/magic-items/boots-of-the-winterlands"
   },
   {
@@ -1092,7 +1092,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "While wearing these bracers, you have proficiency with the longbow and shortbow, and you gain a +2 bonus to damage rolls on ranged attacks made with such weapons."
     ],
-    "image": "/api/2014/images/magic-items/bracers-of-archery.png",
+    "image": "/api/images/magic-items/bracers-of-archery.png",
     "url": "/api/2014/magic-items/bracers-of-archery"
   },
   {
@@ -1112,7 +1112,7 @@
       "Wondous item, rare (requires attunement)",
       "While wearing these bracers, you gain a +2 bonus to AC if you are wearing no armor and using no shield."
     ],
-    "image": "/api/2014/images/magic-items/bracers-of-defense.png",
+    "image": "/api/images/magic-items/bracers-of-defense.png",
     "url": "/api/2014/magic-items/bracers-of-defense"
   },
   {
@@ -1133,7 +1133,7 @@
       "While a fire burns in this brass brazier, you can use an action to speak the brazier's command word and summon a fire elemental, as if you had cast the conjure elemental spell. The brazier can't be used this way again until the next dawn.",
       "The brazier weighs 5 pounds."
     ],
-    "image": "/api/2014/images/magic-items/brazier-of-commanding-fire-elementals.png",
+    "image": "/api/images/magic-items/brazier-of-commanding-fire-elementals.png",
     "url": "/api/2014/magic-items/brazier-of-commanding-fire-elementals"
   },
   {
@@ -1153,7 +1153,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "While wearing this brooch, you have resistance to force damage, and you have immunity to damage from the magic missile spell."
     ],
-    "image": "/api/2014/images/magic-items/brooch-of-shielding.png",
+    "image": "/api/images/magic-items/brooch-of-shielding.png",
     "url": "/api/2014/magic-items/brooch-of-shielding"
   },
   {
@@ -1174,7 +1174,7 @@
       "This wooden broom, which weighs 3 pounds, functions like a mundane broom until you stand astride it and speak its command word. It then hovers beneath you and can be ridden in the air. It has a flying speed of 50 feet. It can carry up to 400 pounds, but its flying speed becomes 30 feet while carrying over 200 pounds. The broom stops hovering when you land.",
       "You can send the broom to travel alone to a destination within 1 mile of you if you speak the command word, name the location, and are familiar with that place. The broom comes back to you when you speak another command word, provided that the broom is still within 1 mile of you."
     ],
-    "image": "/api/2014/images/magic-items/broom-of-flying.png",
+    "image": "/api/images/magic-items/broom-of-flying.png",
     "url": "/api/2014/magic-items/broom-of-flying"
   },
   {
@@ -1208,7 +1208,7 @@
       "While lit, the candle sheds dim light in a 30-foot radius. Any creature within that light whose alignment matches that of the candle makes attack rolls, saving throws, and ability checks with advantage. In addition, a cleric or druid in the light whose alignment matches the candle's can cast 1stlevel spells he or she has prepared without expending spell slots, though the spell's effect is as if cast with a 1st-level slot.",
       "Alternatively, when you light the candle for the first time, you can cast the gate spell with it. Doing so destroys the candle."
     ],
-    "image": "/api/2014/images/magic-items/candle-of-invocation.png",
+    "image": "/api/images/magic-items/candle-of-invocation.png",
     "url": "/api/2014/magic-items/candle-of-invocation"
   },
   {
@@ -1229,7 +1229,7 @@
       "This cape smells faintly of brimstone. While wearing it, you can use it to cast the dimension door spell as an action. This property of the cape can't be used again until the next dawn.",
       "When you disappear, you leave behind a cloud of smoke, and you appear in a similar cloud of smoke at your destination. The smoke lightly obscures the space you left and the space you appear in, and it dissipates at the end of your next turn. A light or stronger wind disperses the smoke."
     ],
-    "image": "/api/2014/images/magic-items/cape-of-the-mountebank.png",
+    "image": "/api/images/magic-items/cape-of-the-mountebank.png",
     "url": "/api/2014/magic-items/cape-of-the-mountebank"
   },
   {
@@ -1278,7 +1278,7 @@
       "| 81-100 | 6 ft. × 9 ft. | 800 lb. | 30 feet |",
       "A carpet can carry up to twice the weight shown on the table, but it flies at half speed if it carries more than its normal capacity."
     ],
-    "image": "/api/2014/images/magic-items/carpet-of-flying.png",
+    "image": "/api/images/magic-items/carpet-of-flying.png",
     "url": "/api/2014/magic-items/carpet-of-flying"
   },
   {
@@ -1299,7 +1299,7 @@
       "You can speak the carpet's command word as an  action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.",
       "This carpet is 3 feet by 5 feet and has a flying speed of 80 feet. It can carry up to 400 pounds, but its flying speed becomes 40 feet while carrying over 200 pounds."
     ],
-    "image": "/api/2014/images/magic-items/carpet-of-flying.png",
+    "image": "/api/images/magic-items/carpet-of-flying.png",
     "url": "/api/2014/magic-items/carpet-of-flying-3x5"
   },
   {
@@ -1320,7 +1320,7 @@
       "You can speak the carpet's command word as an  action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.",
       "This carpet is 4 feet by 6 feet and has a flying speed of 60 feet. It can carry up to 800 pounds, but its flying speed becomes 30 feet while carrying over 400 pounds."
     ],
-    "image": "/api/2014/images/magic-items/carpet-of-flying.png",
+    "image": "/api/images/magic-items/carpet-of-flying.png",
     "url": "/api/2014/magic-items/carpet-of-flying-4x6"
   },
   {
@@ -1341,7 +1341,7 @@
       "You can speak the carpet's command word as an  action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.",
       "This carpet is 5 feet by 7 feet and has a flying speed of 40 feet. It can carry up to 1200 pounds, but its flying speed becomes 20 feet while carrying over 600 pounds."
     ],
-    "image": "/api/2014/images/magic-items/carpet-of-flying.png",
+    "image": "/api/images/magic-items/carpet-of-flying.png",
     "url": "/api/2014/magic-items/carpet-of-flying-5x7"
   },
   {
@@ -1362,7 +1362,7 @@
       "You can speak the carpet's command word as an  action to make the carpet hover and fly. It moves according to your spoken directions, provided that you are within 30 feet of it.",
       "This carpet is 6 feet by 9 feet and has a flying speed of 30 feet. It can carry up to 1600 pounds, but its flying speed becomes 15 feet while carrying over 800 pounds."
     ],
-    "image": "/api/2014/images/magic-items/carpet-of-flying.png",
+    "image": "/api/images/magic-items/carpet-of-flying.png",
     "url": "/api/2014/magic-items/carpet-of-flying-6x9"
   },
   {
@@ -1383,7 +1383,7 @@
       "While incense is burning in this censer, you can use an action to speak the censer's command word and summon an air elemental, as if you had cast the conjure elemental spell. The censer can't be used this way again until the next dawn.",
       "This 6-inch-wide, 1-foot-high vessel resembles a chalice with a decorated lid. It weighs 1 pound."
     ],
-    "image": "/api/2014/images/magic-items/censer-of-controlling-air-elementals.png",
+    "image": "/api/images/magic-items/censer-of-controlling-air-elementals.png",
     "url": "/api/2014/magic-items/censer-of-controlling-air-elementals"
   },
   {
@@ -1404,7 +1404,7 @@
       "This hollow metal tube measures about 1 foot long and weighs 1 pound. You can strike it as an action, pointing it at an object within 120 feet of you that can be opened, such as a door, lid, or lock. The chime issues a clear tone, and one lock or latch on the object opens unless the sound can't reach the object. If no locks or latches remain, the object itself opens.",
       "The chime can be used ten times. After the tenth time, it cracks and becomes useless."
     ],
-    "image": "/api/2014/images/magic-items/chime-of-opening.png",
+    "image": "/api/images/magic-items/chime-of-opening.png",
     "url": "/api/2014/magic-items/chime-of-opening"
   },
   {
@@ -1424,7 +1424,7 @@
       "Wondrous item, uncommon",
       "While wearing this circlet, you can use an action to cast the scorching ray spell with it. When you make the spell's attacks, you do so with an attack bonus of +5. The circlet can't be used this way again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/circlet-of-blasting.png",
+    "image": "/api/images/magic-items/circlet-of-blasting.png",
     "url": "/api/2014/magic-items/circlet-of-blasting"
   },
   {
@@ -1449,7 +1449,7 @@
       "* You can't be caught in webs of any sort and can move through webs as if they were difficult terrain.",
       "* You can use an action to cast the web spell (save DC 13). The web created by the spell fills twice its normal area. Once used, this property of the cloak can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-arachnida.png",
+    "image": "/api/images/magic-items/cloak-of-arachnida.png",
     "url": "/api/2014/magic-items/cloak-of-arachnida"
   },
   {
@@ -1469,7 +1469,7 @@
       "Wondrous item, rare (requires attunement)",
       "While you wear this cloak, it projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while you are incapacitated, restrained, or otherwise unable to move."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-displacement.png",
+    "image": "/api/images/magic-items/cloak-of-displacement.png",
     "url": "/api/2014/magic-items/cloak-of-displacement"
   },
   {
@@ -1489,7 +1489,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "While you wear this cloak with its hood up, Wisdom (Perception) checks made to see you have disadvantage, and you have advantage on Dexterity (Stealth) checks made to hide, as the cloak's color shifts to camouflage you. Pulling the hood up or down requires an action."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-elvenkind.png",
+    "image": "/api/images/magic-items/cloak-of-elvenkind.png",
     "url": "/api/2014/magic-items/cloak-of-elvenkind"
   },
   {
@@ -1509,7 +1509,7 @@
       "Wondrous item, uncommon (requires attunement)",
       "You gain a +1 bonus to AC and saving throws while you wear this cloak."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-protection.png",
+    "image": "/api/images/magic-items/cloak-of-protection.png",
     "url": "/api/2014/magic-items/cloak-of-protection"
   },
   {
@@ -1530,7 +1530,7 @@
       "While wearing this cloak, you have advantage on Dexterity (Stealth) checks. In an area of dim light or darkness, you can grip the edges of the cloak with both hands and use it to fly at a speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in dim light or darkness, you lose this flying speed.",
       "While wearing the cloak in an area of dim light or darkness, you can use your action to cast polymorph on yourself, transforming into a bat. While you are in the form of the bat, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-the-bat.png",
+    "image": "/api/images/magic-items/cloak-of-the-bat.png",
     "url": "/api/2014/magic-items/cloak-of-the-bat"
   },
   {
@@ -1550,7 +1550,7 @@
       "Wondrous item, uncommon",
       "While wearing this cloak with its hood up, you can breathe underwater, and you have a swimming speed of 60 feet. Pulling the hood up or down requires an action."
     ],
-    "image": "/api/2014/images/magic-items/cloak-of-the-manta-ray.png",
+    "image": "/api/images/magic-items/cloak-of-the-manta-ray.png",
     "url": "/api/2014/magic-items/cloak-of-the-manta-ray"
   },
   {
@@ -1590,7 +1590,7 @@
       "***Crystal Ball of Telepathy.*** While scrying with the crystal ball, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also use an action to cast the suggestion spell (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this suggestion to maintain it during its duration, but it ends if scrying ends. Once used, the suggestion power of the crystal ball can't be used again until the next dawn.",
       "***Crystal Ball of True Seeing.*** While scrying with the crystal ball, you have truesight with a radius of 120 feet centered on the spell's sensor."
     ],
-    "image": "/api/2014/images/magic-items/crystal-ball.png",
+    "image": "/api/images/magic-items/crystal-ball.png",
     "url": "/api/2014/magic-items/crystal-ball"
   },
   {
@@ -1611,7 +1611,7 @@
       "The crystal ball is about 6 inches in diameter. While touching it, you can cast the scrying spell (save DC 17) with it.",
       "***Crystal Ball of Mind Reading.*** You can use an action to cast the detect thoughts spell (save DC 17) while you are scrying with the crystal ball, targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this detect thoughts to maintain it during its duration, but it ends if scrying ends."
     ],
-    "image": "/api/2014/images/magic-items/crystal-ball-of-mind-reading.png",
+    "image": "/api/images/magic-items/crystal-ball-of-mind-reading.png",
     "url": "/api/2014/magic-items/crystal-ball-of-mind-reading"
   },
   {
@@ -1632,7 +1632,7 @@
       "The crystal ball is about 6 inches in diameter. While touching it, you can cast the scrying spell (save DC 17) with it.",
       "***Crystal Ball of Telepathy.*** While scrying with the crystal ball, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also use an action to cast the suggestion spell (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this suggestion to maintain it during its duration, but it ends if scrying ends. Once used, the suggestion power of the crystal ball can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/crystal-ball-of-telepathy.png",
+    "image": "/api/images/magic-items/crystal-ball-of-telepathy.png",
     "url": "/api/2014/magic-items/crystal-ball-of-telepathy"
   },
   {
@@ -1653,7 +1653,7 @@
       "The crystal ball is about 6 inches in diameter. While touching it, you can cast the scrying spell (save DC 17) with it.",
       "***Crystal Ball of True Seeing.*** While scrying with the crystal ball, you have truesight with a radius of 120 feet centered on the spell's sensor."
     ],
-    "image": "/api/2014/images/magic-items/crystal-ball-of-true-seeing.png",
+    "image": "/api/images/magic-items/crystal-ball-of-true-seeing.png",
     "url": "/api/2014/magic-items/crystal-ball-of-true-seeing"
   },
   {
@@ -1692,7 +1692,7 @@
       "| Prismatic spray | 1d20 |",
       "| Wall of fire | 1d4 |"
     ],
-    "image": "/api/2014/images/magic-items/cube-of-force.png",
+    "image": "/api/images/magic-items/cube-of-force.png",
     "url": "/api/2014/magic-items/cube-of-force"
   },
   {
@@ -1714,7 +1714,7 @@
       "You can use an action to press one side of the cube to cast the gate spell with it, opening a portal to the plane keyed to that side. Alternatively, if you use an action to press one side twice, you can cast the plane shift spell (save DC 17) with the cube and transport the targets to the plane keyed to that side.",
       "The cube has 3 charges. Each use of the cube expends 1 charge. The cube regains 1d3 expended charges daily at dawn."
     ],
-    "image": "/api/2014/images/magic-items/cubic-gate.png",
+    "image": "/api/images/magic-items/cubic-gate.png",
     "url": "/api/2014/magic-items/cubic-gate"
   },
   {
@@ -1735,7 +1735,7 @@
       "You gain a +1 bonus to attack and damage rolls made with this magic weapon.",
       "You can use an action to cause thick, black poison to coat the blade. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 poison damage and become poisoned for 1 minute. The dagger can't be used this way again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dagger-of-venom.png",
+    "image": "/api/images/magic-items/dagger-of-venom.png",
     "url": "/api/2014/magic-items/dagger-of-venom"
   },
   {
@@ -1757,7 +1757,7 @@
       "While the sword hovers, you can use a bonus action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same bonus action, you can cause the sword to attack one creature within 5 feet of it.",
       "After the hovering sword attacks for the fourth time, it flies up to 30 feet and tries to return to your hand. If you have no hand free, it falls to the ground at your feet. If the sword has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or move more than 30 feet away from it."
     ],
-    "image": "/api/2014/images/magic-items/dancing-sword.png",
+    "image": "/api/images/magic-items/dancing-sword.png",
     "url": "/api/2014/magic-items/dancing-sword"
   },
   {
@@ -1781,7 +1781,7 @@
       "\"Fountain\" produces 5 gallons of water.",
       "\"Geyser\" produces 30 gallons of water that gushes forth in a geyser 30 feet long and 1 foot wide. As a bonus action while holding the decanter, you can aim the geyser at a creature you can see within 30 feet of you. The target must succeed on a DC 13 Strength saving throw or take 1d4 bludgeoning damage and fall prone. Instead of a creature, you can target an object that isn't being worn or carried and that weighs no more than 200 pounds. The object is either knocked over or pushed up to 15 feet away from you."
     ],
-    "image": "/api/2014/images/magic-items/decanter-of-endless-water.png",
+    "image": "/api/images/magic-items/decanter-of-endless-water.png",
     "url": "/api/2014/magic-items/decanter-of-endless-water"
   },
   {
@@ -1839,7 +1839,7 @@
       "| Two of clubs | Kobold |",
       "| Jokers (2) | You (the deck's owner) |"
     ],
-    "image": "/api/2014/images/magic-items/deck-of-illusions.png",
+    "image": "/api/images/magic-items/deck-of-illusions.png",
     "url": "/api/2014/magic-items/deck-of-illusions"
   },
   {
@@ -1902,7 +1902,7 @@
       "***Ruin.*** All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.",
       "***Skull.*** You summon an avatar of death-a ghostly humanoid skeleton clad in a tattered black robe and carrying a spectral scythe. It appears in a space of the GM's choice within 10 feet of you and attacks you, warning all others that you must win the battle alone. The avatar fights until you die or it drops to 0 hit points, whereupon it disappears. If anyone tries to help you, the helper summons its own avatar of death. A creature slain by an avatar of death can't be restored to life."
     ],
-    "image": "/api/2014/images/magic-items/deck-of-many-things.png",
+    "image": "/api/images/magic-items/deck-of-many-things.png",
     "url": "/api/2014/magic-items/deck-of-many-things"
   },
   {
@@ -1923,7 +1923,7 @@
       "You gain a +3 bonus to attack and damage rolls made with this magic weapon.",
       "The first time you attack with the sword on each of your turns, you can transfer some or all of the sword's bonus to your Armor Class, instead of using the bonus on any attacks that turn. For example, you could reduce the bonus to your attack and damage rolls to +1 and gain a +2 bonus to AC. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the sword to gain a bonus to AC from it."
     ],
-    "image": "/api/2014/images/magic-items/defender.png",
+    "image": "/api/images/magic-items/defender.png",
     "url": "/api/2014/magic-items/defender"
   },
   {
@@ -1944,7 +1944,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, and you can understand and speak Abyssal. In addition, the armor's clawed gauntlets turn unarmed strikes with your hands into magic weapons that deal slashing damage, with a +1 bonus to attack rolls and damage rolls and a damage die of 1d8.",
       "***Curse.*** Once you don this cursed armor, you can't doff it unless you are targeted by the remove curse spell or similar magic. While wearing the armor, you have disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
     ],
-    "image": "/api/2014/images/magic-items/demon-armor.png",
+    "image": "/api/images/magic-items/demon-armor.png",
     "url": "/api/2014/magic-items/demon-armor"
   },
   {
@@ -1965,7 +1965,7 @@
       "You can use an action to place these shackles on an incapacitated creature. The shackles adjust to fit a creature of Small to Large size. In addition to serving as mundane manacles, the shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.",
       "You and any creature you designate when you use the shackles can use an action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a success, the creature breaks free and destroys the shackles."
     ],
-    "image": "/api/2014/images/magic-items/dimensional-shackles.png",
+    "image": "/api/images/magic-items/dimensional-shackles.png",
     "url": "/api/2014/magic-items/dimensional-shackles"
   },
   {
@@ -2050,7 +2050,7 @@
       "| Silver | Cold |",
       "| White | Cold |"
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail.png",
+    "image": "/api/images/magic-items/dragon-scale-mail.png",
     "url": "/api/2014/magic-items/dragon-scale-mail"
   },
   {
@@ -2072,7 +2072,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest black dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-black.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-black.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-black"
   },
   {
@@ -2094,7 +2094,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest blue dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-blue.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-blue.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-blue"
   },
   {
@@ -2116,7 +2116,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest brass dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-brass.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-brass.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-brass"
   },
   {
@@ -2138,7 +2138,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to lightning damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest bronze dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-bronze.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-bronze.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-bronze"
   },
   {
@@ -2160,7 +2160,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to acid damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest copper dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-copper.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-copper.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-copper"
   },
   {
@@ -2182,7 +2182,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest gold dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-gold.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-gold.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-gold"
   },
   {
@@ -2204,7 +2204,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to poison damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest green dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-green.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-green.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-green"
   },
   {
@@ -2226,7 +2226,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to fire damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest red dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-red.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-red.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-red"
   },
   {
@@ -2248,7 +2248,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest silver dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-silver.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-silver.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-silver"
   },
   {
@@ -2270,7 +2270,7 @@
       "While wearing this armor, you gain a +1 bonus to AC, you have advantage on saving throws against the Frightful Presence and breath weapons of dragons, and you have resistance to cold damage.",
       "Additionally, you can focus your senses as an action to magically discern the distance and direction to the closest white dragon within 30 miles of you. This special action can't be used again until the next dawn."
     ],
-    "image": "/api/2014/images/magic-items/dragon-scale-mail-white.png",
+    "image": "/api/images/magic-items/dragon-scale-mail-white.png",
     "url": "/api/2014/magic-items/dragon-scale-mail-white"
   },
   {
@@ -2291,7 +2291,7 @@
       "You gain a +1 bonus to attack and damage rolls made with this magic weapon.",
       "When you hit a dragon with this weapon, the dragon takes an extra 3d6 damage of the weapon's type. For the purpose of this weapon, \"dragon\" refers to any creature with the dragon type, including dragon turtles and wyverns."
     ],
-    "image": "/api/2014/images/magic-items/dragon-slayer.png",
+    "image": "/api/images/magic-items/dragon-slayer.png",
     "url": "/api/2014/magic-items/dragon-slayer"
   },
   {
@@ -2311,7 +2311,7 @@
       "Wondrous item, uncommon",
       "Found in a small packet, this powder resembles very fine sand. There is enough of it for one use. When you use an action to throw the dust into the air, you and each creature and object within 10 feet of you become invisible for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. If a creature affected by the dust attacks or casts a spell, the invisibility ends for that creature."
     ],
-    "image": "/api/2014/images/magic-items/dust-of-disappearance.png",
+    "image": "/api/images/magic-items/dust-of-disappearance.png",
     "url": "/api/2014/magic-items/dust-of-disappearance"
   },
   {
@@ -2333,7 +2333,7 @@
       "Someone can use an action to smash the pellet against a hard surface, causing the pellet to shatter and release the water the dust absorbed. Doing so ends that pellet's magic.",
       "An elemental composed mostly of water that is exposed to a pinch of the dust must make a DC 13 Constitution saving throw, taking 10d6 necrotic damage on a failed save, or half as much damage on a successful one."
     ],
-    "image": "/api/2014/images/magic-items/dust-of-dryness.png",
+    "image": "/api/images/magic-items/dust-of-dryness.png",
     "url": "/api/2014/magic-items/dust-of-dryness"
   },
   {
@@ -2354,7 +2354,7 @@
       "Found in a small container, this powder resembles very fine sand. It appears to be dust of disappearance, and an identify spell reveals it to be such. There is enough of it for one use.",
       "When you use an action to throw a handful of the dust into the air, you and each creature that needs to breathe within 30 feet of you must succeed on a DC 15 Constitution saving throw or become unable to breathe, while sneezing uncontrollably. A creature affected in this way is incapacitated and suffocating. As long as it is conscious, a creature can repeat the saving throw at the end of each of its turns, ending the effect on it on a success. The lesser restoration spell can also end the effect on a creature."
     ],
-    "image": "/api/2014/images/magic-items/dust-of-sneezing-and-choking.png",
+    "image": "/api/images/magic-items/dust-of-sneezing-and-choking.png",
     "url": "/api/2014/magic-items/dust-of-sneezing-and-choking"
   },
   {
@@ -2374,7 +2374,7 @@
       "Armor (plate), very rare",
       "While wearing this armor, you gain a +2 bonus to AC. In addition, if an effect moves you against your will along the ground, you can use your reaction to reduce the distance you are moved by up to 10 feet."
     ],
-    "image": "/api/2014/images/magic-items/dwarven-plate.png",
+    "image": "/api/images/magic-items/dwarven-plate.png",
     "url": "/api/2014/magic-items/dwarven-plate"
   },
   {
@@ -2394,7 +2394,7 @@
       "Weapon (warhammer), very rare (requires attunement by a dwarf)",
       "You gain a +3 bonus to attack and damage rolls made with this magic weapon. It has the thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 damage or, if the target is a giant, 2d8 damage. Immediately after the attack, the weapon flies back to your hand."
     ],
-    "image": "/api/2014/images/magic-items/dwarven-thrower.png",
+    "image": "/api/images/magic-items/dwarven-thrower.png",
     "url": "/api/2014/magic-items/dwarven-thrower"
   },
   {
@@ -2415,7 +2415,7 @@
       "Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to sixty arrows, bolts, or similar objects. The midsize compartment holds up to eighteen javelins or similar objects. The longest compartment holds up to six long objects, such as bows, quarterstaffs, or spears.",
       "You can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
     ],
-    "image": "/api/2014/images/magic-items/efficient-quiver.png",
+    "image": "/api/images/magic-items/efficient-quiver.png",
     "url": "/api/2014/magic-items/efficient-quiver"
   },
   {
@@ -2441,7 +2441,7 @@
       "| 11-90 | The efreeti serves you for 1 hour, doing as you command. Then the efreeti returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic. |",
       "| 91-100 | The efreeti can cast the wish spell three times for you. It disappears when it grants the final wish or after 1 hour, and the bottle loses its magic. |"
     ],
-    "image": "/api/2014/images/magic-items/efreeti-bottle.png",
+    "image": "/api/images/magic-items/efreeti-bottle.png",
     "url": "/api/2014/magic-items/efreeti-bottle"
   },
   {
@@ -2488,7 +2488,7 @@
       "| Red corundum | Fire elemental |",
       "| Emerald | Water elemental |"
     ],
-    "image": "/api/2014/images/magic-items/elemental-gem.png",
+    "image": "/api/images/magic-items/elemental-gem.png",
     "url": "/api/2014/magic-items/elemental-gem"
   },
   {
@@ -2508,7 +2508,7 @@
       "Wondrous item, uncommon",
       "This blue sapphire contains a mote of elemental energy. When you use an action to break the gem, an air elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost."
     ],
-    "image": "/api/2014/images/magic-items/elemental-gem-air.png",
+    "image": "/api/images/magic-items/elemental-gem-air.png",
     "url": "/api/2014/magic-items/elemental-gem-air"
   },
   {
@@ -2528,7 +2528,7 @@
       "Wondrous item, uncommon",
       "This yellow diamond contains a mote of elemental energy. When you use an action to break the gem, an earth elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost."
     ],
-    "image": "/api/2014/images/magic-items/elemental-gem-earth.png",
+    "image": "/api/images/magic-items/elemental-gem-earth.png",
     "url": "/api/2014/magic-items/elemental-gem-earth"
   },
   {
@@ -2548,7 +2548,7 @@
       "Wondrous item, uncommon",
       "This red corundum contains a mote of elemental energy. When you use an action to break the gem, a fire elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost."
     ],
-    "image": "/api/2014/images/magic-items/elemental-gem-fire.png",
+    "image": "/api/images/magic-items/elemental-gem-fire.png",
     "url": "/api/2014/magic-items/elemental-gem-fire"
   },
   {
@@ -2568,7 +2568,7 @@
       "Wondrous item, uncommon",
       "This emerald contains a mote of elemental energy. When you use an action to break the gem, a water elemental is summoned as if you had cast the conjure elemental spell, and the gem's magic is lost."
     ],
-    "image": "/api/2014/images/magic-items/elemental-gem-water.png",
+    "image": "/api/images/magic-items/elemental-gem-water.png",
     "url": "/api/2014/magic-items/elemental-gem-water"
   },
   {

--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -203,7 +203,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/aboleth.png",
+    "image": "/api/images/monsters/aboleth.png",
     "url": "/api/2014/monsters/aboleth"
   },
   {
@@ -335,7 +335,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/acolyte.png",
+    "image": "/api/images/monsters/acolyte.png",
     "url": "/api/2014/monsters/acolyte"
   },
   {
@@ -594,7 +594,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-black-dragon.png",
+    "image": "/api/images/monsters/adult-black-dragon.png",
     "url": "/api/2014/monsters/adult-black-dragon"
   },
   {
@@ -849,7 +849,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-blue-dragon.png",
+    "image": "/api/images/monsters/adult-blue-dragon.png",
     "url": "/api/2014/monsters/adult-blue-dragon"
   },
   {
@@ -1138,7 +1138,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-brass-dragon.png",
+    "image": "/api/images/monsters/adult-brass-dragon.png",
     "url": "/api/2014/monsters/adult-brass-dragon"
   },
   {
@@ -1423,7 +1423,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-bronze-dragon.png",
+    "image": "/api/images/monsters/adult-bronze-dragon.png",
     "url": "/api/2014/monsters/adult-bronze-dragon"
   },
   {
@@ -1704,7 +1704,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-copper-dragon.png",
+    "image": "/api/images/monsters/adult-copper-dragon.png",
     "url": "/api/2014/monsters/adult-copper-dragon"
   },
   {
@@ -1997,7 +1997,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-gold-dragon.png",
+    "image": "/api/images/monsters/adult-gold-dragon.png",
     "url": "/api/2014/monsters/adult-gold-dragon"
   },
   {
@@ -2286,7 +2286,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-green-dragon.png",
+    "image": "/api/images/monsters/adult-green-dragon.png",
     "url": "/api/2014/monsters/adult-green-dragon"
   },
   {
@@ -2541,7 +2541,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-red-dragon.png",
+    "image": "/api/images/monsters/adult-red-dragon.png",
     "url": "/api/2014/monsters/adult-red-dragon"
   },
   {
@@ -2829,7 +2829,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-silver-dragon.png",
+    "image": "/api/images/monsters/adult-silver-dragon.png",
     "url": "/api/2014/monsters/adult-silver-dragon"
   },
   {
@@ -3089,7 +3089,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/adult-white-dragon.png",
+    "image": "/api/images/monsters/adult-white-dragon.png",
     "url": "/api/2014/monsters/adult-white-dragon"
   },
   {
@@ -3221,7 +3221,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/air-elemental.png",
+    "image": "/api/images/monsters/air-elemental.png",
     "url": "/api/2014/monsters/air-elemental"
   },
   {
@@ -3480,7 +3480,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-black-dragon.png",
+    "image": "/api/images/monsters/ancient-black-dragon.png",
     "url": "/api/2014/monsters/ancient-black-dragon"
   },
   {
@@ -3735,7 +3735,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-blue-dragon.png",
+    "image": "/api/images/monsters/ancient-blue-dragon.png",
     "url": "/api/2014/monsters/ancient-blue-dragon"
   },
   {
@@ -4028,7 +4028,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-brass-dragon.png",
+    "image": "/api/images/monsters/ancient-brass-dragon.png",
     "url": "/api/2014/monsters/ancient-brass-dragon"
   },
   {
@@ -4317,7 +4317,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-bronze-dragon.png",
+    "image": "/api/images/monsters/ancient-bronze-dragon.png",
     "url": "/api/2014/monsters/ancient-bronze-dragon"
   },
   {
@@ -4602,7 +4602,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-copper-dragon.png",
+    "image": "/api/images/monsters/ancient-copper-dragon.png",
     "url": "/api/2014/monsters/ancient-copper-dragon"
   },
   {
@@ -4899,7 +4899,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-gold-dragon.png",
+    "image": "/api/images/monsters/ancient-gold-dragon.png",
     "url": "/api/2014/monsters/ancient-gold-dragon"
   },
   {
@@ -5188,7 +5188,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-green-dragon.png",
+    "image": "/api/images/monsters/ancient-green-dragon.png",
     "url": "/api/2014/monsters/ancient-green-dragon"
   },
   {
@@ -5443,7 +5443,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-red-dragon.png",
+    "image": "/api/images/monsters/ancient-red-dragon.png",
     "url": "/api/2014/monsters/ancient-red-dragon"
   },
   {
@@ -5735,7 +5735,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-silver-dragon.png",
+    "image": "/api/images/monsters/ancient-silver-dragon.png",
     "url": "/api/2014/monsters/ancient-silver-dragon"
   },
   {
@@ -5995,7 +5995,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ancient-white-dragon.png",
+    "image": "/api/images/monsters/ancient-white-dragon.png",
     "url": "/api/2014/monsters/ancient-white-dragon"
   },
   {
@@ -6320,7 +6320,7 @@
         "desc": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
       }
     ],
-    "image": "/api/2014/images/monsters/androsphinx.png",
+    "image": "/api/images/monsters/androsphinx.png",
     "url": "/api/2014/monsters/androsphinx"
   },
   {
@@ -6443,7 +6443,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/animated-armor.png",
+    "image": "/api/images/monsters/animated-armor.png",
     "url": "/api/2014/monsters/animated-armor"
   },
   {
@@ -6547,7 +6547,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ankheg.png",
+    "image": "/api/images/monsters/ankheg.png",
     "url": "/api/2014/monsters/ankheg"
   },
   {
@@ -6648,7 +6648,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ape.png",
+    "image": "/api/images/monsters/ape.png",
     "url": "/api/2014/monsters/ape"
   },
   {
@@ -6934,7 +6934,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/archmage.png",
+    "image": "/api/images/monsters/archmage.png",
     "url": "/api/2014/monsters/archmage"
   },
   {
@@ -7125,7 +7125,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/assassin.png",
+    "image": "/api/images/monsters/assassin.png",
     "url": "/api/2014/monsters/assassin"
   },
   {
@@ -7192,7 +7192,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/awakened-shrub.png",
+    "image": "/api/images/monsters/awakened-shrub.png",
     "url": "/api/2014/monsters/awakened-shrub"
   },
   {
@@ -7260,7 +7260,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/awakened-tree.png",
+    "image": "/api/images/monsters/awakened-tree.png",
     "url": "/api/2014/monsters/awakened-tree"
   },
   {
@@ -7317,7 +7317,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/axe-beak.png",
+    "image": "/api/images/monsters/axe-beak.png",
     "url": "/api/2014/monsters/axe-beak"
   },
   {
@@ -7444,7 +7444,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/azer.png",
+    "image": "/api/images/monsters/azer.png",
     "url": "/api/2014/monsters/azer"
   },
   {
@@ -7507,7 +7507,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/baboon.png",
+    "image": "/api/images/monsters/baboon.png",
     "url": "/api/2014/monsters/baboon"
   },
   {
@@ -7571,7 +7571,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/badger.png",
+    "image": "/api/images/monsters/badger.png",
     "url": "/api/2014/monsters/badger"
   },
   {
@@ -7775,7 +7775,7 @@
         "desc": "The balor magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
       }
     ],
-    "image": "/api/2014/images/monsters/balor.png",
+    "image": "/api/images/monsters/balor.png",
     "url": "/api/2014/monsters/balor"
   },
   {
@@ -7855,7 +7855,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/bandit.png",
+    "image": "/api/images/monsters/bandit.png",
     "url": "/api/2014/monsters/bandit"
   },
   {
@@ -8019,7 +8019,7 @@
         "desc": "The captain adds 2 to its AC against one melee attack that would hit it. To do so, the captain must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/bandit-captain.png",
+    "image": "/api/images/monsters/bandit-captain.png",
     "url": "/api/2014/monsters/bandit-captain"
   },
   {
@@ -8237,7 +8237,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/barbed-devil.png",
+    "image": "/api/images/monsters/barbed-devil.png",
     "url": "/api/2014/monsters/barbed-devil"
   },
   {
@@ -8317,7 +8317,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/basilisk.png",
+    "image": "/api/images/monsters/basilisk.png",
     "url": "/api/2014/monsters/basilisk"
   },
   {
@@ -8385,7 +8385,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/bat.png",
+    "image": "/api/images/monsters/bat.png",
     "url": "/api/2014/monsters/bat"
   },
   {
@@ -8526,7 +8526,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/bearded-devil.png",
+    "image": "/api/images/monsters/bearded-devil.png",
     "url": "/api/2014/monsters/bearded-devil"
   },
   {
@@ -8685,7 +8685,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/behir.png",
+    "image": "/api/images/monsters/behir.png",
     "url": "/api/2014/monsters/behir"
   },
   {
@@ -8755,7 +8755,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/berserker.png",
+    "image": "/api/images/monsters/berserker.png",
     "url": "/api/2014/monsters/berserker"
   },
   {
@@ -8850,7 +8850,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/black-bear.png",
+    "image": "/api/images/monsters/black-bear.png",
     "url": "/api/2014/monsters/black-bear"
   },
   {
@@ -9003,7 +9003,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/black-dragon-wyrmling.png",
+    "image": "/api/images/monsters/black-dragon-wyrmling.png",
     "url": "/api/2014/monsters/black-dragon-wyrmling"
   },
   {
@@ -9130,7 +9130,7 @@
         "desc": "When a pudding that is Medium or larger is subjected to lightning or slashing damage, it splits into two new puddings if it has at least 10 hit points. Each new pudding has hit points equal to half the original pudding's, rounded down. New puddings are one size smaller than the original pudding."
       }
     ],
-    "image": "/api/2014/images/monsters/black-pudding.png",
+    "image": "/api/images/monsters/black-pudding.png",
     "url": "/api/2014/monsters/black-pudding"
   },
   {
@@ -9219,7 +9219,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/blink-dog.png",
+    "image": "/api/images/monsters/blink-dog.png",
     "url": "/api/2014/monsters/blink-dog"
   },
   {
@@ -9296,7 +9296,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/blood-hawk.png",
+    "image": "/api/images/monsters/blood-hawk.png",
     "url": "/api/2014/monsters/blood-hawk"
   },
   {
@@ -9443,7 +9443,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/blue-dragon-wyrmling.png",
+    "image": "/api/images/monsters/blue-dragon-wyrmling.png",
     "url": "/api/2014/monsters/blue-dragon-wyrmling"
   },
   {
@@ -9526,7 +9526,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/boar.png",
+    "image": "/api/images/monsters/boar.png",
     "url": "/api/2014/monsters/boar"
   },
   {
@@ -9688,7 +9688,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/bone-devil.png",
+    "image": "/api/images/monsters/bone-devil.png",
     "url": "/api/2014/monsters/bone-devil"
   },
   {
@@ -9853,7 +9853,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/brass-dragon-wyrmling.png",
+    "image": "/api/images/monsters/brass-dragon-wyrmling.png",
     "url": "/api/2014/monsters/brass-dragon-wyrmling"
   },
   {
@@ -10024,7 +10024,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/bronze-dragon-wyrmling.png",
+    "image": "/api/images/monsters/bronze-dragon-wyrmling.png",
     "url": "/api/2014/monsters/bronze-dragon-wyrmling"
   },
   {
@@ -10128,7 +10128,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/brown-bear.png",
+    "image": "/api/images/monsters/brown-bear.png",
     "url": "/api/2014/monsters/brown-bear"
   },
   {
@@ -10240,7 +10240,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/bugbear.png",
+    "image": "/api/images/monsters/bugbear.png",
     "url": "/api/2014/monsters/bugbear"
   },
   {
@@ -10318,7 +10318,7 @@
         "desc": "If the bulette jumps at least 15 ft. as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a DC 16 Strength or Dexterity saving throw (target's choice) or be knocked prone and take 14 (3d6 + 4) bludgeoning damage plus 14 (3d6 + 4) slashing damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 ft. out of the bulette's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the bulette's space."
       }
     ],
-    "image": "/api/2014/images/monsters/bulette.png",
+    "image": "/api/images/monsters/bulette.png",
     "url": "/api/2014/monsters/bulette"
   },
   {
@@ -10374,7 +10374,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/camel.png",
+    "image": "/api/images/monsters/camel.png",
     "url": "/api/2014/monsters/camel"
   },
   {
@@ -10454,7 +10454,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/cat.png",
+    "image": "/api/images/monsters/cat.png",
     "url": "/api/2014/monsters/cat"
   },
   {
@@ -10618,7 +10618,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/centaur.png",
+    "image": "/api/images/monsters/centaur.png",
     "url": "/api/2014/monsters/centaur"
   },
   {
@@ -10761,7 +10761,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/chain-devil.png",
+    "image": "/api/images/monsters/chain-devil.png",
     "url": "/api/2014/monsters/chain-devil"
   },
   {
@@ -10969,7 +10969,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/chimera.png",
+    "image": "/api/images/monsters/chimera.png",
     "url": "/api/2014/monsters/chimera"
   },
   {
@@ -11104,7 +11104,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/chuul.png",
+    "image": "/api/images/monsters/chuul.png",
     "url": "/api/2014/monsters/chuul"
   },
   {
@@ -11240,7 +11240,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/clay-golem.png",
+    "image": "/api/images/monsters/clay-golem.png",
     "url": "/api/2014/monsters/clay-golem"
   },
   {
@@ -11377,7 +11377,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/cloaker.png",
+    "image": "/api/images/monsters/cloaker.png",
     "url": "/api/2014/monsters/cloaker"
   },
   {
@@ -11602,7 +11602,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/cloud-giant.png",
+    "image": "/api/images/monsters/cloud-giant.png",
     "url": "/api/2014/monsters/cloud-giant"
   },
   {
@@ -11660,7 +11660,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/cockatrice.png",
+    "image": "/api/images/monsters/cockatrice.png",
     "url": "/api/2014/monsters/cockatrice"
   },
   {
@@ -11718,7 +11718,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/commoner.png",
+    "image": "/api/images/monsters/commoner.png",
     "url": "/api/2014/monsters/commoner"
   },
   {
@@ -11791,7 +11791,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/constrictor-snake.png",
+    "image": "/api/images/monsters/constrictor-snake.png",
     "url": "/api/2014/monsters/constrictor-snake"
   },
   {
@@ -11956,7 +11956,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/copper-dragon-wyrmling.png",
+    "image": "/api/images/monsters/copper-dragon-wyrmling.png",
     "url": "/api/2014/monsters/copper-dragon-wyrmling"
   },
   {
@@ -12204,7 +12204,7 @@
         "desc": "The couatl magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the couatl's choice).\nIn a new form, the couatl retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and other actions are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks. If the new form has a bite attack, the couatl can use its bite in that form."
       }
     ],
-    "image": "/api/2014/images/monsters/couatl.png",
+    "image": "/api/images/monsters/couatl.png",
     "url": "/api/2014/monsters/couatl"
   },
   {
@@ -12277,7 +12277,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/crab.png",
+    "image": "/api/images/monsters/crab.png",
     "url": "/api/2014/monsters/crab"
   },
   {
@@ -12349,7 +12349,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/crocodile.png",
+    "image": "/api/images/monsters/crocodile.png",
     "url": "/api/2014/monsters/crocodile"
   },
   {
@@ -12523,7 +12523,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/cult-fanatic.png",
+    "image": "/api/images/monsters/cult-fanatic.png",
     "url": "/api/2014/monsters/cult-fanatic"
   },
   {
@@ -12611,7 +12611,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/cultist.png",
+    "image": "/api/images/monsters/cultist.png",
     "url": "/api/2014/monsters/cultist"
   },
   {
@@ -12696,7 +12696,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/darkmantle.png",
+    "image": "/api/images/monsters/darkmantle.png",
     "url": "/api/2014/monsters/darkmantle"
   },
   {
@@ -12789,7 +12789,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/death-dog.png",
+    "image": "/api/images/monsters/death-dog.png",
     "url": "/api/2014/monsters/death-dog"
   },
   {
@@ -12958,7 +12958,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/deep-gnome-svirfneblin.png",
+    "image": "/api/images/monsters/deep-gnome-svirfneblin.png",
     "url": "/api/2014/monsters/deep-gnome-svirfneblin"
   },
   {
@@ -13014,7 +13014,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/deer.png",
+    "image": "/api/images/monsters/deer.png",
     "url": "/api/2014/monsters/deer"
   },
   {
@@ -13209,7 +13209,7 @@
         "desc": "The deva magically polymorphs into a humanoid or beast that has a challenge rating equal to or less than its own, or back into its true form. It reverts to its true form if it dies. Any equipment it is wearing or carrying is absorbed or borne by the new form (the deva's choice).\nIn a new form, the deva retains its game statistics and ability to speak, but its AC, movement modes, Strength, Dexterity, and special senses are replaced by those of the new form, and it gains any statistics and capabilities (except class features, legendary actions, and lair actions) that the new form has but that it lacks."
       }
     ],
-    "image": "/api/2014/images/monsters/deva.png",
+    "image": "/api/images/monsters/deva.png",
     "url": "/api/2014/monsters/deva"
   },
   {
@@ -13292,7 +13292,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/dire-wolf.png",
+    "image": "/api/images/monsters/dire-wolf.png",
     "url": "/api/2014/monsters/dire-wolf"
   },
   {
@@ -13562,7 +13562,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/djinni.png",
+    "image": "/api/images/monsters/djinni.png",
     "url": "/api/2014/monsters/djinni"
   },
   {
@@ -13673,7 +13673,7 @@
         "desc": "The doppelganger magically reads the surface thoughts of one creature within 60 ft. of it. The effect can penetrate barriers, but 3 ft. of wood or dirt, 2 ft. of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, the doppelganger can continue reading its thoughts, as long as the doppelganger's concentration isn't broken (as if concentrating on a spell). While reading the target's mind, the doppelganger has advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) checks against the target."
       }
     ],
-    "image": "/api/2014/images/monsters/doppelganger.png",
+    "image": "/api/images/monsters/doppelganger.png",
     "url": "/api/2014/monsters/doppelganger"
   },
   {
@@ -13729,7 +13729,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/draft-horse.png",
+    "image": "/api/images/monsters/draft-horse.png",
     "url": "/api/2014/monsters/draft-horse"
   },
   {
@@ -13926,7 +13926,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/dragon-turtle.png",
+    "image": "/api/images/monsters/dragon-turtle.png",
     "url": "/api/2014/monsters/dragon-turtle"
   },
   {
@@ -14045,7 +14045,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/dretch.png",
+    "image": "/api/images/monsters/dretch.png",
     "url": "/api/2014/monsters/dretch"
   },
   {
@@ -14309,7 +14309,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/drider.png",
+    "image": "/api/images/monsters/drider.png",
     "url": "/api/2014/monsters/drider"
   },
   {
@@ -14461,7 +14461,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/drow.png",
+    "image": "/api/images/monsters/drow.png",
     "url": "/api/2014/monsters/drow"
   },
   {
@@ -14657,7 +14657,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/druid.png",
+    "image": "/api/images/monsters/druid.png",
     "url": "/api/2014/monsters/druid"
   },
   {
@@ -14838,7 +14838,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/dryad.png",
+    "image": "/api/images/monsters/dryad.png",
     "url": "/api/2014/monsters/dryad"
   },
   {
@@ -14957,7 +14957,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/duergar.png",
+    "image": "/api/images/monsters/duergar.png",
     "url": "/api/2014/monsters/duergar"
   },
   {
@@ -15102,7 +15102,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/dust-mephit.png",
+    "image": "/api/images/monsters/dust-mephit.png",
     "url": "/api/2014/monsters/dust-mephit"
   },
   {
@@ -15174,7 +15174,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/eagle.png",
+    "image": "/api/images/monsters/eagle.png",
     "url": "/api/2014/monsters/eagle"
   },
   {
@@ -15287,7 +15287,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/earth-elemental.png",
+    "image": "/api/images/monsters/earth-elemental.png",
     "url": "/api/2014/monsters/earth-elemental"
   },
   {
@@ -15527,7 +15527,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/efreeti.png",
+    "image": "/api/images/monsters/efreeti.png",
     "url": "/api/2014/monsters/efreeti"
   },
   {
@@ -15604,7 +15604,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/elephant.png",
+    "image": "/api/images/monsters/elephant.png",
     "url": "/api/2014/monsters/elephant"
   },
   {
@@ -15681,7 +15681,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/elk.png",
+    "image": "/api/images/monsters/elk.png",
     "url": "/api/2014/monsters/elk"
   },
   {
@@ -15920,7 +15920,7 @@
         "desc": "The erinyes adds 4 to its AC against one melee attack that would hit it. To do so, the erinyes must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/erinyes.png",
+    "image": "/api/images/monsters/erinyes.png",
     "url": "/api/2014/monsters/erinyes"
   },
   {
@@ -16067,7 +16067,7 @@
         "attack_bonus": 4
       }
     ],
-    "image": "/api/2014/images/monsters/ettercap.png",
+    "image": "/api/images/monsters/ettercap.png",
     "url": "/api/2014/monsters/ettercap"
   },
   {
@@ -16175,7 +16175,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ettin.png",
+    "image": "/api/images/monsters/ettin.png",
     "url": "/api/2014/monsters/ettin"
   },
   {
@@ -16314,7 +16314,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/fire-elemental.png",
+    "image": "/api/images/monsters/fire-elemental.png",
     "url": "/api/2014/monsters/fire-elemental"
   },
   {
@@ -16447,7 +16447,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/fire-giant.png",
+    "image": "/api/images/monsters/fire-giant.png",
     "url": "/api/2014/monsters/fire-giant"
   },
   {
@@ -16577,7 +16577,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/flesh-golem.png",
+    "image": "/api/images/monsters/flesh-golem.png",
     "url": "/api/2014/monsters/flesh-golem"
   },
   {
@@ -16651,7 +16651,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/flying-snake.png",
+    "image": "/api/images/monsters/flying-snake.png",
     "url": "/api/2014/monsters/flying-snake"
   },
   {
@@ -16768,7 +16768,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/flying-sword.png",
+    "image": "/api/images/monsters/flying-sword.png",
     "url": "/api/2014/monsters/flying-sword"
   },
   {
@@ -16837,7 +16837,7 @@
         "desc": "The frog's long jump is up to 10 ft. and its high jump is up to 5 ft., with or without a running start."
       }
     ],
-    "image": "/api/2014/images/monsters/frog.png",
+    "image": "/api/images/monsters/frog.png",
     "url": "/api/2014/monsters/frog"
   },
   {
@@ -16964,7 +16964,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/frost-giant.png",
+    "image": "/api/images/monsters/frost-giant.png",
     "url": "/api/2014/monsters/frost-giant"
   },
   {
@@ -17080,7 +17080,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/gargoyle.png",
+    "image": "/api/images/monsters/gargoyle.png",
     "url": "/api/2014/monsters/gargoyle"
   },
   {
@@ -17201,7 +17201,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/gelatinous-cube.png",
+    "image": "/api/images/monsters/gelatinous-cube.png",
     "url": "/api/2014/monsters/gelatinous-cube"
   },
   {
@@ -17312,7 +17312,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ghast.png",
+    "image": "/api/images/monsters/ghast.png",
     "url": "/api/2014/monsters/ghast"
   },
   {
@@ -17472,7 +17472,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/ghost.png",
+    "image": "/api/images/monsters/ghost.png",
     "url": "/api/2014/monsters/ghost"
   },
   {
@@ -17562,7 +17562,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ghoul.png",
+    "image": "/api/images/monsters/ghoul.png",
     "url": "/api/2014/monsters/ghoul"
   },
   {
@@ -17663,7 +17663,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-ape.png",
+    "image": "/api/images/monsters/giant-ape.png",
     "url": "/api/2014/monsters/giant-ape"
   },
   {
@@ -17759,7 +17759,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-badger.png",
+    "image": "/api/images/monsters/giant-badger.png",
     "url": "/api/2014/monsters/giant-badger"
   },
   {
@@ -17827,7 +17827,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-bat.png",
+    "image": "/api/images/monsters/giant-bat.png",
     "url": "/api/2014/monsters/giant-bat"
   },
   {
@@ -17900,7 +17900,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-boar.png",
+    "image": "/api/images/monsters/giant-boar.png",
     "url": "/api/2014/monsters/giant-boar"
   },
   {
@@ -17958,7 +17958,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-centipede.png",
+    "image": "/api/images/monsters/giant-centipede.png",
     "url": "/api/2014/monsters/giant-centipede"
   },
   {
@@ -18040,7 +18040,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-constrictor-snake.png",
+    "image": "/api/images/monsters/giant-constrictor-snake.png",
     "url": "/api/2014/monsters/giant-constrictor-snake"
   },
   {
@@ -18113,7 +18113,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-crab.png",
+    "image": "/api/images/monsters/giant-crab.png",
     "url": "/api/2014/monsters/giant-crab"
   },
   {
@@ -18217,7 +18217,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-crocodile.png",
+    "image": "/api/images/monsters/giant-crocodile.png",
     "url": "/api/2014/monsters/giant-crocodile"
   },
   {
@@ -18322,7 +18322,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-eagle.png",
+    "image": "/api/images/monsters/giant-eagle.png",
     "url": "/api/2014/monsters/giant-eagle"
   },
   {
@@ -18409,7 +18409,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-elk.png",
+    "image": "/api/images/monsters/giant-elk.png",
     "url": "/api/2014/monsters/giant-elk"
   },
   {
@@ -18473,7 +18473,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-fire-beetle.png",
+    "image": "/api/images/monsters/giant-fire-beetle.png",
     "url": "/api/2014/monsters/giant-fire-beetle"
   },
   {
@@ -18562,7 +18562,7 @@
         "desc": "The frog makes one bite attack against a Small or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 5 (2d4) acid damage at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 ft. of movement, exiting prone."
       }
     ],
-    "image": "/api/2014/images/monsters/giant-frog.png",
+    "image": "/api/images/monsters/giant-frog.png",
     "url": "/api/2014/monsters/giant-frog"
   },
   {
@@ -18628,7 +18628,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-goat.png",
+    "image": "/api/images/monsters/giant-goat.png",
     "url": "/api/2014/monsters/giant-goat"
   },
   {
@@ -18699,7 +18699,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-hyena.png",
+    "image": "/api/images/monsters/giant-hyena.png",
     "url": "/api/2014/monsters/giant-hyena"
   },
   {
@@ -18758,7 +18758,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-lizard.png",
+    "image": "/api/images/monsters/giant-lizard.png",
     "url": "/api/2014/monsters/giant-lizard"
   },
   {
@@ -18858,7 +18858,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/giant-octopus.png",
+    "image": "/api/images/monsters/giant-octopus.png",
     "url": "/api/2014/monsters/giant-octopus"
   },
   {
@@ -18943,7 +18943,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-owl.png",
+    "image": "/api/images/monsters/giant-owl.png",
     "url": "/api/2014/monsters/giant-owl"
   },
   {
@@ -19010,7 +19010,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-poisonous-snake.png",
+    "image": "/api/images/monsters/giant-poisonous-snake.png",
     "url": "/api/2014/monsters/giant-poisonous-snake"
   },
   {
@@ -19077,7 +19077,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-rat.png",
+    "image": "/api/images/monsters/giant-rat.png",
     "url": "/api/2014/monsters/giant-rat"
   },
   {
@@ -19144,7 +19144,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-rat-diseased.png",
+    "image": "/api/images/monsters/giant-rat-diseased.png",
     "url": "/api/2014/monsters/giant-rat-diseased"
   },
   {
@@ -19233,7 +19233,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-scorpion.png",
+    "image": "/api/images/monsters/giant-scorpion.png",
     "url": "/api/2014/monsters/giant-scorpion"
   },
   {
@@ -19301,7 +19301,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-sea-horse.png",
+    "image": "/api/images/monsters/giant-sea-horse.png",
     "url": "/api/2014/monsters/giant-sea-horse"
   },
   {
@@ -19378,7 +19378,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-shark.png",
+    "image": "/api/images/monsters/giant-shark.png",
     "url": "/api/2014/monsters/giant-shark"
   },
   {
@@ -19471,7 +19471,7 @@
         "attack_bonus": 5
       }
     ],
-    "image": "/api/2014/images/monsters/giant-spider.png",
+    "image": "/api/images/monsters/giant-spider.png",
     "url": "/api/2014/monsters/giant-spider"
   },
   {
@@ -19551,7 +19551,7 @@
         "desc": "The toad makes one bite attack against a Medium or smaller target it is grappling. If the attack hits, the target is swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the toad, and it takes 10 (3d6) acid damage at the start of each of the toad's turns. The toad can have only one target swallowed at a time.\nIf the toad dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
       }
     ],
-    "image": "/api/2014/images/monsters/giant-toad.png",
+    "image": "/api/images/monsters/giant-toad.png",
     "url": "/api/2014/monsters/giant-toad"
   },
   {
@@ -19660,7 +19660,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-vulture.png",
+    "image": "/api/images/monsters/giant-vulture.png",
     "url": "/api/2014/monsters/giant-vulture"
   },
   {
@@ -19718,7 +19718,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-wasp.png",
+    "image": "/api/images/monsters/giant-wasp.png",
     "url": "/api/2014/monsters/giant-wasp"
   },
   {
@@ -19798,7 +19798,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-weasel.png",
+    "image": "/api/images/monsters/giant-weasel.png",
     "url": "/api/2014/monsters/giant-weasel"
   },
   {
@@ -19889,7 +19889,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/giant-wolf-spider.png",
+    "image": "/api/images/monsters/giant-wolf-spider.png",
     "url": "/api/2014/monsters/giant-wolf-spider"
   },
   {
@@ -20007,7 +20007,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/gibbering-mouther.png",
+    "image": "/api/images/monsters/gibbering-mouther.png",
     "url": "/api/2014/monsters/gibbering-mouther"
   },
   {
@@ -20249,7 +20249,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/glabrezu.png",
+    "image": "/api/images/monsters/glabrezu.png",
     "url": "/api/2014/monsters/glabrezu"
   },
   {
@@ -20478,7 +20478,7 @@
         "desc": "The gladiator adds 3 to its AC against one melee attack that would hit it. To do so, the gladiator must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/gladiator.png",
+    "image": "/api/images/monsters/gladiator.png",
     "url": "/api/2014/monsters/gladiator"
   },
   {
@@ -20605,7 +20605,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/gnoll.png",
+    "image": "/api/images/monsters/gnoll.png",
     "url": "/api/2014/monsters/gnoll"
   },
   {
@@ -20671,7 +20671,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/goat.png",
+    "image": "/api/images/monsters/goat.png",
     "url": "/api/2014/monsters/goat"
   },
   {
@@ -20771,7 +20771,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/goblin.png",
+    "image": "/api/images/monsters/goblin.png",
     "url": "/api/2014/monsters/goblin"
   },
   {
@@ -20942,7 +20942,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/gold-dragon-wyrmling.png",
+    "image": "/api/images/monsters/gold-dragon-wyrmling.png",
     "url": "/api/2014/monsters/gold-dragon-wyrmling"
   },
   {
@@ -21053,7 +21053,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/gorgon.png",
+    "image": "/api/images/monsters/gorgon.png",
     "url": "/api/2014/monsters/gorgon"
   },
   {
@@ -21177,7 +21177,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/gray-ooze.png",
+    "image": "/api/images/monsters/gray-ooze.png",
     "url": "/api/2014/monsters/gray-ooze"
   },
   {
@@ -21336,7 +21336,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/green-dragon-wyrmling.png",
+    "image": "/api/images/monsters/green-dragon-wyrmling.png",
     "url": "/api/2014/monsters/green-dragon-wyrmling"
   },
   {
@@ -21486,7 +21486,7 @@
         "desc": "The hag magically turns invisible until she attacks or casts a spell, or until her concentration ends (as if concentrating on a spell). While invisible, she leaves no physical evidence of her passage, so she can be tracked only by magic. Any equipment she wears or carries is invisible with her."
       }
     ],
-    "image": "/api/2014/images/monsters/green-hag.png",
+    "image": "/api/images/monsters/green-hag.png",
     "url": "/api/2014/monsters/green-hag"
   },
   {
@@ -21584,7 +21584,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/grick.png",
+    "image": "/api/images/monsters/grick.png",
     "url": "/api/2014/monsters/grick"
   },
   {
@@ -21689,7 +21689,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/griffon.png",
+    "image": "/api/images/monsters/griffon.png",
     "url": "/api/2014/monsters/griffon"
   },
   {
@@ -21800,7 +21800,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/grimlock.png",
+    "image": "/api/images/monsters/grimlock.png",
     "url": "/api/2014/monsters/grimlock"
   },
   {
@@ -21900,7 +21900,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/guard.png",
+    "image": "/api/images/monsters/guard.png",
     "url": "/api/2014/monsters/guard"
   },
   {
@@ -22125,7 +22125,7 @@
         "attack_bonus": 8
       }
     ],
-    "image": "/api/2014/images/monsters/guardian-naga.png",
+    "image": "/api/images/monsters/guardian-naga.png",
     "url": "/api/2014/monsters/guardian-naga"
   },
   {
@@ -22370,7 +22370,7 @@
         "desc": "The sphinx casts a spell from its list of prepared spells, using a spell slot as normal."
       }
     ],
-    "image": "/api/2014/images/monsters/gynosphinx.png",
+    "image": "/api/images/monsters/gynosphinx.png",
     "url": "/api/2014/monsters/gynosphinx"
   },
   {
@@ -22534,7 +22534,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/half-red-dragon-veteran.png",
+    "image": "/api/images/monsters/half-red-dragon-veteran.png",
     "url": "/api/2014/monsters/half-red-dragon-veteran"
   },
   {
@@ -22627,7 +22627,7 @@
         "desc": "The harpy sings a magical melody. Every humanoid and giant within 300 ft. of the harpy that can hear the song must succeed on a DC 11 Wisdom saving throw or be charmed until the song ends. The harpy must take a bonus action on its subsequent turns to continue singing. It can stop singing at any time. The song ends if the harpy is incapacitated.\nWhile charmed by the harpy, a target is incapacitated and ignores the songs of other harpies. If the charmed target is more than 5 ft. away from the harpy, the must move on its turn toward the harpy by the most direct route. It doesn't avoid opportunity attacks, but before moving into damaging terrain, such as lava or a pit, and whenever it takes damage from a source other than the harpy, a target can repeat the saving throw. A creature can also repeat the saving throw at the end of each of its turns. If a creature's saving throw is successful, the effect ends on it.\nA target that successfully saves is immune to this harpy's song for the next 24 hours."
       }
     ],
-    "image": "/api/2014/images/monsters/harpy.png",
+    "image": "/api/images/monsters/harpy.png",
     "url": "/api/2014/monsters/harpy"
   },
   {
@@ -22699,7 +22699,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hawk.png",
+    "image": "/api/images/monsters/hawk.png",
     "url": "/api/2014/monsters/hawk"
   },
   {
@@ -22813,7 +22813,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hell-hound.png",
+    "image": "/api/images/monsters/hell-hound.png",
     "url": "/api/2014/monsters/hell-hound"
   },
   {
@@ -22960,7 +22960,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hezrou.png",
+    "image": "/api/images/monsters/hezrou.png",
     "url": "/api/2014/monsters/hezrou"
   },
   {
@@ -23052,7 +23052,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hill-giant.png",
+    "image": "/api/images/monsters/hill-giant.png",
     "url": "/api/2014/monsters/hill-giant"
   },
   {
@@ -23156,7 +23156,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hippogriff.png",
+    "image": "/api/images/monsters/hippogriff.png",
     "url": "/api/2014/monsters/hippogriff"
   },
   {
@@ -23268,7 +23268,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hobgoblin.png",
+    "image": "/api/images/monsters/hobgoblin.png",
     "url": "/api/2014/monsters/hobgoblin"
   },
   {
@@ -23345,7 +23345,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/homunculus.png",
+    "image": "/api/images/monsters/homunculus.png",
     "url": "/api/2014/monsters/homunculus"
   },
   {
@@ -23560,7 +23560,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/horned-devil.png",
+    "image": "/api/images/monsters/horned-devil.png",
     "url": "/api/2014/monsters/horned-devil"
   },
   {
@@ -23637,7 +23637,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hunter-shark.png",
+    "image": "/api/images/monsters/hunter-shark.png",
     "url": "/api/2014/monsters/hunter-shark"
   },
   {
@@ -23734,7 +23734,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hydra.png",
+    "image": "/api/images/monsters/hydra.png",
     "url": "/api/2014/monsters/hydra"
   },
   {
@@ -23805,7 +23805,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/hyena.png",
+    "image": "/api/images/monsters/hyena.png",
     "url": "/api/2014/monsters/hyena"
   },
   {
@@ -23998,7 +23998,7 @@
         "desc": "The devil magically forms an opaque wall of ice on a solid surface it can see within 60 feet of it. The wall is 1 foot thick and up to 30 feet long and 10 feet high, or it's a hemispherical dome up to 20 feet in diameter.\nWhen the wall appears, each creature in its space is pushed out of it by the shortest route. The creature chooses which side of the wall to end up on, unless the creature is incapacitated. The creature then makes a DC 17 Dexterity saving throw, taking 35 (10d6) cold damage on a failed save, or half as much damage on a successful one.\nThe wall lasts for 1 minute or until the devil is incapacitated or dies. The wall can be damaged and breached; each 10-foot section has AC 5, 30 hit points, vulnerability to fire damage, and immunity to acid, cold, necrotic, poison, and psychic damage. If a section is destroyed, it leaves behind a sheet of frigid air in the space the wall occupied. Whenever a creature finishes moving through the frigid air on a turn, willingly or otherwise, the creature must make a DC 17 Constitution saving throw, taking 17 (5d6) cold damage on a failed save, or half as much damage on a successful one. The frigid air dissipates when the rest of the wall vanishes."
       }
     ],
-    "image": "/api/2014/images/monsters/ice-devil.png",
+    "image": "/api/images/monsters/ice-devil.png",
     "url": "/api/2014/monsters/ice-devil"
   },
   {
@@ -24176,7 +24176,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ice-mephit.png",
+    "image": "/api/images/monsters/ice-mephit.png",
     "url": "/api/2014/monsters/ice-mephit"
   },
   {
@@ -24298,7 +24298,7 @@
         "desc": "The imp magically turns invisible until it attacks, or until its concentration ends (as if concentrating on a spell). Any equipment the imp wears or carries is invisible with it."
       }
     ],
-    "image": "/api/2014/images/monsters/imp.png",
+    "image": "/api/images/monsters/imp.png",
     "url": "/api/2014/monsters/imp"
   },
   {
@@ -24441,7 +24441,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/invisible-stalker.png",
+    "image": "/api/images/monsters/invisible-stalker.png",
     "url": "/api/2014/monsters/invisible-stalker"
   },
   {
@@ -24638,7 +24638,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/iron-golem.png",
+    "image": "/api/images/monsters/iron-golem.png",
     "url": "/api/2014/monsters/iron-golem"
   },
   {
@@ -24713,7 +24713,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/jackal.png",
+    "image": "/api/images/monsters/jackal.png",
     "url": "/api/2014/monsters/jackal"
   },
   {
@@ -24793,7 +24793,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/killer-whale.png",
+    "image": "/api/images/monsters/killer-whale.png",
     "url": "/api/2014/monsters/killer-whale"
   },
   {
@@ -24925,7 +24925,7 @@
         "desc": "The knight adds 2 to its AC against one melee attack that would hit it. To do so, the knight must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/knight.png",
+    "image": "/api/images/monsters/knight.png",
     "url": "/api/2014/monsters/knight"
   },
   {
@@ -25008,7 +25008,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/kobold.png",
+    "image": "/api/images/monsters/kobold.png",
     "url": "/api/2014/monsters/kobold"
   },
   {
@@ -25273,7 +25273,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/kraken.png",
+    "image": "/api/images/monsters/kraken.png",
     "url": "/api/2014/monsters/kraken"
   },
   {
@@ -25505,7 +25505,7 @@
         "attack_bonus": 5
       }
     ],
-    "image": "/api/2014/images/monsters/lamia.png",
+    "image": "/api/images/monsters/lamia.png",
     "url": "/api/2014/monsters/lamia"
   },
   {
@@ -25594,7 +25594,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/lemure.png",
+    "image": "/api/images/monsters/lemure.png",
     "url": "/api/2014/monsters/lemure"
   },
   {
@@ -25968,7 +25968,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/lich.png",
+    "image": "/api/images/monsters/lich.png",
     "url": "/api/2014/monsters/lich"
   },
   {
@@ -26083,7 +26083,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/lion.png",
+    "image": "/api/images/monsters/lion.png",
     "url": "/api/2014/monsters/lion"
   },
   {
@@ -26141,7 +26141,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/lizard.png",
+    "image": "/api/images/monsters/lizard.png",
     "url": "/api/2014/monsters/lizard"
   },
   {
@@ -26402,7 +26402,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/lizardfolk.png",
+    "image": "/api/images/monsters/lizardfolk.png",
     "url": "/api/2014/monsters/lizardfolk"
   },
   {
@@ -26613,7 +26613,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/mage.png",
+    "image": "/api/images/monsters/mage.png",
     "url": "/api/2014/monsters/mage"
   },
   {
@@ -26783,7 +26783,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/magma-mephit.png",
+    "image": "/api/images/monsters/magma-mephit.png",
     "url": "/api/2014/monsters/magma-mephit"
   },
   {
@@ -26873,7 +26873,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/magmin.png",
+    "image": "/api/images/monsters/magmin.png",
     "url": "/api/2014/monsters/magmin"
   },
   {
@@ -26951,7 +26951,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/mammoth.png",
+    "image": "/api/images/monsters/mammoth.png",
     "url": "/api/2014/monsters/mammoth"
   },
   {
@@ -27082,7 +27082,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/manticore.png",
+    "image": "/api/images/monsters/manticore.png",
     "url": "/api/2014/monsters/manticore"
   },
   {
@@ -27242,7 +27242,7 @@
         "desc": "The marilith adds 5 to its AC against one melee attack that would hit it. To do so, the marilith must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/marilith.png",
+    "image": "/api/images/monsters/marilith.png",
     "url": "/api/2014/monsters/marilith"
   },
   {
@@ -27314,7 +27314,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/mastiff.png",
+    "image": "/api/images/monsters/mastiff.png",
     "url": "/api/2014/monsters/mastiff"
   },
   {
@@ -27502,7 +27502,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/medusa.png",
+    "image": "/api/images/monsters/medusa.png",
     "url": "/api/2014/monsters/medusa"
   },
   {
@@ -27596,7 +27596,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/merfolk.png",
+    "image": "/api/images/monsters/merfolk.png",
     "url": "/api/2014/monsters/merfolk"
   },
   {
@@ -27755,7 +27755,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/merrow.png",
+    "image": "/api/images/monsters/merrow.png",
     "url": "/api/2014/monsters/merrow"
   },
   {
@@ -27871,7 +27871,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/mimic.png",
+    "image": "/api/images/monsters/mimic.png",
     "url": "/api/2014/monsters/mimic"
   },
   {
@@ -27966,7 +27966,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/minotaur.png",
+    "image": "/api/images/monsters/minotaur.png",
     "url": "/api/2014/monsters/minotaur"
   },
   {
@@ -28059,7 +28059,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/minotaur-skeleton.png",
+    "image": "/api/images/monsters/minotaur-skeleton.png",
     "url": "/api/2014/monsters/minotaur-skeleton"
   },
   {
@@ -28125,7 +28125,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/mule.png",
+    "image": "/api/images/monsters/mule.png",
     "url": "/api/2014/monsters/mule"
   },
   {
@@ -28262,7 +28262,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/mummy.png",
+    "image": "/api/images/monsters/mummy.png",
     "url": "/api/2014/monsters/mummy"
   },
   {
@@ -28593,7 +28593,7 @@
         "desc": "The mummy lord magically transforms into a whirlwind of sand, moves up to 60 feet, and reverts to its normal form. While in whirlwind form, the mummy lord is immune to all damage, and it can't be grappled, petrified, knocked prone, restrained, or stunned. Equipment worn or carried by the mummy lord remain in its possession."
       }
     ],
-    "image": "/api/2014/images/monsters/mummy-lord.png",
+    "image": "/api/images/monsters/mummy-lord.png",
     "url": "/api/2014/monsters/mummy-lord"
   },
   {
@@ -28763,7 +28763,7 @@
         "desc": "The nalfeshnee magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
       }
     ],
-    "image": "/api/2014/images/monsters/nalfeshnee.png",
+    "image": "/api/images/monsters/nalfeshnee.png",
     "url": "/api/2014/monsters/nalfeshnee"
   },
   {
@@ -28952,7 +28952,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/night-hag.png",
+    "image": "/api/images/monsters/night-hag.png",
     "url": "/api/2014/monsters/night-hag"
   },
   {
@@ -29033,7 +29033,7 @@
         "desc": "The nightmare and up to three willing creatures within 5 feet of it magically enter the Ethereal Plane from the Material Plane, or vice versa."
       }
     ],
-    "image": "/api/2014/images/monsters/nightmare.png",
+    "image": "/api/images/monsters/nightmare.png",
     "url": "/api/2014/monsters/nightmare"
   },
   {
@@ -29129,7 +29129,7 @@
         "desc": "The noble adds 2 to its AC against one melee attack that would hit it. To do so, the noble must see the attacker and be wielding a melee weapon."
       }
     ],
-    "image": "/api/2014/images/monsters/noble.png",
+    "image": "/api/images/monsters/noble.png",
     "url": "/api/2014/monsters/noble"
   },
   {
@@ -29247,7 +29247,7 @@
         "desc": "When a jelly that is Medium or larger is subjected to lightning or slashing damage, it splits into two new jellies if it has at least 10 hit points. Each new jelly has hit points equal to half the original jelly's, rounded down. New jellies are one size smaller than the original jelly."
       }
     ],
-    "image": "/api/2014/images/monsters/ochre-jelly.png",
+    "image": "/api/images/monsters/ochre-jelly.png",
     "url": "/api/2014/monsters/ochre-jelly"
   },
   {
@@ -29348,7 +29348,7 @@
         "attack_bonus": 0
       }
     ],
-    "image": "/api/2014/images/monsters/octopus.png",
+    "image": "/api/images/monsters/octopus.png",
     "url": "/api/2014/monsters/octopus"
   },
   {
@@ -29427,7 +29427,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ogre.png",
+    "image": "/api/images/monsters/ogre.png",
     "url": "/api/2014/monsters/ogre"
   },
   {
@@ -29507,7 +29507,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/ogre-zombie.png",
+    "image": "/api/images/monsters/ogre-zombie.png",
     "url": "/api/2014/monsters/ogre-zombie"
   },
   {
@@ -29773,7 +29773,7 @@
         "desc": "The oni magically polymorphs into a Small or Medium humanoid, into a Large giant, or back into its true form. Other than its size, its statistics are the same in each form. The only equipment that is transformed is its glaive, which shrinks so that it can be wielded in humanoid form. If the oni dies, it reverts to its true form, and its glaive reverts to its normal size."
       }
     ],
-    "image": "/api/2014/images/monsters/oni.png",
+    "image": "/api/images/monsters/oni.png",
     "url": "/api/2014/monsters/oni"
   },
   {
@@ -29868,7 +29868,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/orc.png",
+    "image": "/api/images/monsters/orc.png",
     "url": "/api/2014/monsters/orc"
   },
   {
@@ -29993,7 +29993,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/otyugh.png",
+    "image": "/api/images/monsters/otyugh.png",
     "url": "/api/2014/monsters/otyugh"
   },
   {
@@ -30078,7 +30078,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/owl.png",
+    "image": "/api/images/monsters/owl.png",
     "url": "/api/2014/monsters/owl"
   },
   {
@@ -30182,7 +30182,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/owlbear.png",
+    "image": "/api/images/monsters/owlbear.png",
     "url": "/api/2014/monsters/owlbear"
   },
   {
@@ -30290,7 +30290,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/panther.png",
+    "image": "/api/images/monsters/panther.png",
     "url": "/api/2014/monsters/panther"
   },
   {
@@ -30380,7 +30380,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/pegasus.png",
+    "image": "/api/images/monsters/pegasus.png",
     "url": "/api/2014/monsters/pegasus"
   },
   {
@@ -30462,7 +30462,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/phase-spider.png",
+    "image": "/api/images/monsters/phase-spider.png",
     "url": "/api/2014/monsters/phase-spider"
   },
   {
@@ -30705,7 +30705,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/pit-fiend.png",
+    "image": "/api/images/monsters/pit-fiend.png",
     "url": "/api/2014/monsters/pit-fiend"
   },
   {
@@ -30955,7 +30955,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/planetar.png",
+    "image": "/api/images/monsters/planetar.png",
     "url": "/api/2014/monsters/planetar"
   },
   {
@@ -31035,7 +31035,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/plesiosaurus.png",
+    "image": "/api/images/monsters/plesiosaurus.png",
     "url": "/api/2014/monsters/plesiosaurus"
   },
   {
@@ -31093,7 +31093,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/poisonous-snake.png",
+    "image": "/api/images/monsters/poisonous-snake.png",
     "url": "/api/2014/monsters/poisonous-snake"
   },
   {
@@ -31197,7 +31197,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/polar-bear.png",
+    "image": "/api/images/monsters/polar-bear.png",
     "url": "/api/2014/monsters/polar-bear"
   },
   {
@@ -31253,7 +31253,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/pony.png",
+    "image": "/api/images/monsters/pony.png",
     "url": "/api/2014/monsters/pony"
   },
   {
@@ -31426,7 +31426,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/priest.png",
+    "image": "/api/images/monsters/priest.png",
     "url": "/api/2014/monsters/priest"
   },
   {
@@ -31531,7 +31531,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/pseudodragon.png",
+    "image": "/api/images/monsters/pseudodragon.png",
     "url": "/api/2014/monsters/pseudodragon"
   },
   {
@@ -31645,7 +31645,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/purple-worm.png",
+    "image": "/api/images/monsters/purple-worm.png",
     "url": "/api/2014/monsters/purple-worm"
   },
   {
@@ -31756,7 +31756,7 @@
         "desc": "The quasit magically turns invisible until it attacks or uses Scare, or until its concentration ends (as if concentrating on a spell). Any equipment the quasit wears or carries is invisible with it."
       }
     ],
-    "image": "/api/2014/images/monsters/quasit.png",
+    "image": "/api/images/monsters/quasit.png",
     "url": "/api/2014/monsters/quasit"
   },
   {
@@ -31824,7 +31824,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/quipper.png",
+    "image": "/api/images/monsters/quipper.png",
     "url": "/api/2014/monsters/quipper"
   },
   {
@@ -32052,7 +32052,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/rakshasa.png",
+    "image": "/api/images/monsters/rakshasa.png",
     "url": "/api/2014/monsters/rakshasa"
   },
   {
@@ -32115,7 +32115,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/rat.png",
+    "image": "/api/images/monsters/rat.png",
     "url": "/api/2014/monsters/rat"
   },
   {
@@ -32187,7 +32187,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/raven.png",
+    "image": "/api/images/monsters/raven.png",
     "url": "/api/2014/monsters/raven"
   },
   {
@@ -32334,7 +32334,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/red-dragon-wyrmling.png",
+    "image": "/api/images/monsters/red-dragon-wyrmling.png",
     "url": "/api/2014/monsters/red-dragon-wyrmling"
   },
   {
@@ -32411,7 +32411,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/reef-shark.png",
+    "image": "/api/images/monsters/reef-shark.png",
     "url": "/api/2014/monsters/reef-shark"
   },
   {
@@ -32501,7 +32501,7 @@
         "desc": "The remorhaz makes one bite attack against a Medium or smaller creature it is grappling. If the attack hits, that creature takes the bite's damage and is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the remorhaz, and it takes 21 (6d6) acid damage at the start of each of the remorhaz's turns.\nIf the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the remorhaz. If the remorhaz dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 15 feet of movement, exiting prone."
       }
     ],
-    "image": "/api/2014/images/monsters/remorhaz.png",
+    "image": "/api/images/monsters/remorhaz.png",
     "url": "/api/2014/monsters/remorhaz"
   },
   {
@@ -32563,7 +32563,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/rhinoceros.png",
+    "image": "/api/images/monsters/rhinoceros.png",
     "url": "/api/2014/monsters/rhinoceros"
   },
   {
@@ -32619,7 +32619,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/riding-horse.png",
+    "image": "/api/images/monsters/riding-horse.png",
     "url": "/api/2014/monsters/riding-horse"
   },
   {
@@ -32755,7 +32755,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/roc.png",
+    "image": "/api/images/monsters/roc.png",
     "url": "/api/2014/monsters/roc"
   },
   {
@@ -32875,7 +32875,7 @@
         "desc": "The roper pulls each creature grappled by it up to 25 ft. straight toward it."
       }
     ],
-    "image": "/api/2014/images/monsters/roper.png",
+    "image": "/api/images/monsters/roper.png",
     "url": "/api/2014/monsters/roper"
   },
   {
@@ -32975,7 +32975,7 @@
         "attack_bonus": 5
       }
     ],
-    "image": "/api/2014/images/monsters/rug-of-smothering.png",
+    "image": "/api/images/monsters/rug-of-smothering.png",
     "url": "/api/2014/monsters/rug-of-smothering"
   },
   {
@@ -33046,7 +33046,7 @@
         "desc": "The rust monster corrodes a nonmagical ferrous metal object it can see within 5 feet of it. If the object isn't being worn or carried, the touch destroys a 1-foot cube of it. If the object is being worn or carried by a creature, the creature can make a DC 11 Dexterity saving throw to avoid the rust monster's touch.\nIf the object touched is either metal armor or a metal shield being worn or carried, its takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed. If the object touched is a held metal weapon, it rusts as described in the Rust Metal trait."
       }
     ],
-    "image": "/api/2014/images/monsters/rust-monster.png",
+    "image": "/api/images/monsters/rust-monster.png",
     "url": "/api/2014/monsters/rust-monster"
   },
   {
@@ -33153,7 +33153,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/saber-toothed-tiger.png",
+    "image": "/api/images/monsters/saber-toothed-tiger.png",
     "url": "/api/2014/monsters/saber-toothed-tiger"
   },
   {
@@ -33334,7 +33334,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/sahuagin.png",
+    "image": "/api/images/monsters/sahuagin.png",
     "url": "/api/2014/monsters/sahuagin"
   },
   {
@@ -33486,7 +33486,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/salamander.png",
+    "image": "/api/images/monsters/salamander.png",
     "url": "/api/2014/monsters/salamander"
   },
   {
@@ -33610,7 +33610,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/satyr.png",
+    "image": "/api/images/monsters/satyr.png",
     "url": "/api/2014/monsters/satyr"
   },
   {
@@ -33667,7 +33667,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/scorpion.png",
+    "image": "/api/images/monsters/scorpion.png",
     "url": "/api/2014/monsters/scorpion"
   },
   {
@@ -33812,7 +33812,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/scout.png",
+    "image": "/api/images/monsters/scout.png",
     "url": "/api/2014/monsters/scout"
   },
   {
@@ -33897,7 +33897,7 @@
         "desc": "The hag covers herself and anything she is wearing or carrying with a magical illusion that makes her look like an ugly creature of her general size and humanoid shape. The effect ends if the hag takes a bonus action to end it or if she dies.\nThe changes wrought by this effect fail to hold up to physical inspection. For example, the hag could appear to have no claws, but someone touching her hand might feel the claws. Otherwise, a creature must take an action to visually inspect the illusion and succeed on a DC 16 Intelligence (Investigation) check to discern that the hag is disguised."
       }
     ],
-    "image": "/api/2014/images/monsters/sea-hag.png",
+    "image": "/api/images/monsters/sea-hag.png",
     "url": "/api/2014/monsters/sea-hag"
   },
   {
@@ -33942,7 +33942,7 @@
         "desc": "The sea horse can breathe only underwater."
       }
     ],
-    "image": "/api/2014/images/monsters/sea-horse.png",
+    "image": "/api/images/monsters/sea-horse.png",
     "url": "/api/2014/monsters/sea-horse"
   },
   {
@@ -34075,7 +34075,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/shadow.png",
+    "image": "/api/images/monsters/shadow.png",
     "url": "/api/2014/monsters/shadow"
   },
   {
@@ -34190,7 +34190,7 @@
         "desc": "The shambling mound engulfs a Medium or smaller creature grappled by it. The engulfed target is blinded, restrained, and unable to breathe, and it must succeed on a DC 14 Constitution saving throw at the start of each of the mound's turns or take 13 (2d8 + 4) bludgeoning damage. If the mound moves, the engulfed target moves with it. The mound can have only one creature engulfed at a time."
       }
     ],
-    "image": "/api/2014/images/monsters/shambling-mound.png",
+    "image": "/api/images/monsters/shambling-mound.png",
     "url": "/api/2014/monsters/shambling-mound"
   },
   {
@@ -34308,7 +34308,7 @@
         "desc": "When a creature makes an attack against the wearer of the guardian's amulet, the guardian grants a +2 bonus to the wearer's AC if the guardian is within 5 feet of the wearer."
       }
     ],
-    "image": "/api/2014/images/monsters/shield-guardian.png",
+    "image": "/api/images/monsters/shield-guardian.png",
     "url": "/api/2014/monsters/shield-guardian"
   },
   {
@@ -34376,7 +34376,7 @@
         "desc": "When bright light or a creature is within 30 feet of the shrieker, it emits a shriek audible within 300 feet of it. The shrieker continues to shriek until the disturbance moves out of range and for 1d4 of the shrieker's turns afterward"
       }
     ],
-    "image": "/api/2014/images/monsters/shrieker.png",
+    "image": "/api/images/monsters/shrieker.png",
     "url": "/api/2014/monsters/shrieker"
   },
   {
@@ -34540,7 +34540,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/silver-dragon-wyrmling.png",
+    "image": "/api/images/monsters/silver-dragon-wyrmling.png",
     "url": "/api/2014/monsters/silver-dragon-wyrmling"
   },
   {
@@ -34628,7 +34628,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/skeleton.png",
+    "image": "/api/images/monsters/skeleton.png",
     "url": "/api/2014/monsters/skeleton"
   },
   {
@@ -34945,7 +34945,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/solar.png",
+    "image": "/api/images/monsters/solar.png",
     "url": "/api/2014/monsters/solar"
   },
   {
@@ -35070,7 +35070,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/specter.png",
+    "image": "/api/images/monsters/specter.png",
     "url": "/api/2014/monsters/specter"
   },
   {
@@ -35151,7 +35151,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/spider.png",
+    "image": "/api/images/monsters/spider.png",
     "url": "/api/2014/monsters/spider"
   },
   {
@@ -35352,7 +35352,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/spirit-naga.png",
+    "image": "/api/images/monsters/spirit-naga.png",
     "url": "/api/2014/monsters/spirit-naga"
   },
   {
@@ -35465,7 +35465,7 @@
         "desc": "The sprite magically turns invisible until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). Any equipment the sprite wears or carries is invisible with it."
       }
     ],
-    "image": "/api/2014/images/monsters/sprite.png",
+    "image": "/api/images/monsters/sprite.png",
     "url": "/api/2014/monsters/sprite"
   },
   {
@@ -35609,7 +35609,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/spy.png",
+    "image": "/api/images/monsters/spy.png",
     "url": "/api/2014/monsters/spy"
   },
   {
@@ -35764,7 +35764,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/steam-mephit.png",
+    "image": "/api/images/monsters/steam-mephit.png",
     "url": "/api/2014/monsters/steam-mephit"
   },
   {
@@ -35822,7 +35822,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/stirge.png",
+    "image": "/api/images/monsters/stirge.png",
     "url": "/api/2014/monsters/stirge"
   },
   {
@@ -35959,7 +35959,7 @@
         "desc": "If a rock or similar object is hurled at the giant, the giant can, with a successful DC 10 Dexterity saving throw, catch the missile and take no bludgeoning damage from it."
       }
     ],
-    "image": "/api/2014/images/monsters/stone-giant.png",
+    "image": "/api/images/monsters/stone-giant.png",
     "url": "/api/2014/monsters/stone-giant"
   },
   {
@@ -36095,7 +36095,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/stone-golem.png",
+    "image": "/api/images/monsters/stone-golem.png",
     "url": "/api/2014/monsters/stone-golem"
   },
   {
@@ -36358,7 +36358,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/storm-giant.png",
+    "image": "/api/images/monsters/storm-giant.png",
     "url": "/api/2014/monsters/storm-giant"
   },
   {
@@ -36505,7 +36505,7 @@
         "desc": "The fiend magically enters the Ethereal Plane from the Material Plane, or vice versa."
       }
     ],
-    "image": "/api/2014/images/monsters/succubus-incubus.png",
+    "image": "/api/images/monsters/succubus-incubus.png",
     "url": "/api/2014/monsters/succubus-incubus"
   },
   {
@@ -36622,7 +36622,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-bats.png",
+    "image": "/api/images/monsters/swarm-of-bats.png",
     "url": "/api/2014/monsters/swarm-of-bats"
   },
   {
@@ -36732,7 +36732,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-beetles.png",
+    "image": "/api/images/monsters/swarm-of-beetles.png",
     "url": "/api/2014/monsters/swarm-of-beetles"
   },
   {
@@ -36841,7 +36841,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-centipedes.png",
+    "image": "/api/images/monsters/swarm-of-centipedes.png",
     "url": "/api/2014/monsters/swarm-of-centipedes"
   },
   {
@@ -36950,7 +36950,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-insects.png",
+    "image": "/api/images/monsters/swarm-of-insects.png",
     "url": "/api/2014/monsters/swarm-of-insects"
   },
   {
@@ -37059,7 +37059,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-poisonous-snakes.png",
+    "image": "/api/images/monsters/swarm-of-poisonous-snakes.png",
     "url": "/api/2014/monsters/swarm-of-poisonous-snakes"
   },
   {
@@ -37176,7 +37176,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-quippers.png",
+    "image": "/api/images/monsters/swarm-of-quippers.png",
     "url": "/api/2014/monsters/swarm-of-quippers"
   },
   {
@@ -37288,7 +37288,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-rats.png",
+    "image": "/api/images/monsters/swarm-of-rats.png",
     "url": "/api/2014/monsters/swarm-of-rats"
   },
   {
@@ -37396,7 +37396,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-ravens.png",
+    "image": "/api/images/monsters/swarm-of-ravens.png",
     "url": "/api/2014/monsters/swarm-of-ravens"
   },
   {
@@ -37512,7 +37512,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-spiders.png",
+    "image": "/api/images/monsters/swarm-of-spiders.png",
     "url": "/api/2014/monsters/swarm-of-spiders"
   },
   {
@@ -37621,7 +37621,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/swarm-of-wasps.png",
+    "image": "/api/images/monsters/swarm-of-wasps.png",
     "url": "/api/2014/monsters/swarm-of-wasps"
   },
   {
@@ -37912,7 +37912,7 @@
         "desc": "The tarrasque makes one bite attack or uses its Swallow."
       }
     ],
-    "image": "/api/2014/images/monsters/tarrasque.png",
+    "image": "/api/images/monsters/tarrasque.png",
     "url": "/api/2014/monsters/tarrasque"
   },
   {
@@ -38019,7 +38019,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/thug.png",
+    "image": "/api/images/monsters/thug.png",
     "url": "/api/2014/monsters/thug"
   },
   {
@@ -38127,7 +38127,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/tiger.png",
+    "image": "/api/images/monsters/tiger.png",
     "url": "/api/2014/monsters/tiger"
   },
   {
@@ -38233,7 +38233,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/treant.png",
+    "image": "/api/images/monsters/treant.png",
     "url": "/api/2014/monsters/treant"
   },
   {
@@ -38325,7 +38325,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/tribal-warrior.png",
+    "image": "/api/images/monsters/tribal-warrior.png",
     "url": "/api/2014/monsters/tribal-warrior"
   },
   {
@@ -38402,7 +38402,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/triceratops.png",
+    "image": "/api/images/monsters/triceratops.png",
     "url": "/api/2014/monsters/triceratops"
   },
   {
@@ -38510,7 +38510,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/troll.png",
+    "image": "/api/images/monsters/troll.png",
     "url": "/api/2014/monsters/troll"
   },
   {
@@ -38607,7 +38607,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/tyrannosaurus-rex.png",
+    "image": "/api/images/monsters/tyrannosaurus-rex.png",
     "url": "/api/2014/monsters/tyrannosaurus-rex"
   },
   {
@@ -38824,7 +38824,7 @@
         "desc": "The unicorn magically regains 11 (2d8 + 2) hit points."
       }
     ],
-    "image": "/api/2014/images/monsters/unicorn.png",
+    "image": "/api/images/monsters/unicorn.png",
     "url": "/api/2014/monsters/unicorn"
   },
   {
@@ -39066,7 +39066,7 @@
         "attack_bonus": 0
       }
     ],
-    "image": "/api/2014/images/monsters/vampire-vampire.png",
+    "image": "/api/images/monsters/vampire-vampire.png",
     "url": "/api/2014/monsters/vampire-vampire"
   },
   {
@@ -39257,7 +39257,7 @@
         "attack_bonus": 0
       }
     ],
-    "image": "/api/2014/images/monsters/vampire-bat.png",
+    "image": "/api/images/monsters/vampire-bat.png",
     "url": "/api/2014/monsters/vampire-bat"
   },
   {
@@ -39402,7 +39402,7 @@
         "attack_bonus": 0
       }
     ],
-    "image": "/api/2014/images/monsters/vampire-mist.png",
+    "image": "/api/images/monsters/vampire-mist.png",
     "url": "/api/2014/monsters/vampire-mist"
   },
   {
@@ -39569,7 +39569,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/vampire-spawn.png",
+    "image": "/api/images/monsters/vampire-spawn.png",
     "url": "/api/2014/monsters/vampire-spawn"
   },
   {
@@ -39719,7 +39719,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/veteran.png",
+    "image": "/api/images/monsters/veteran.png",
     "url": "/api/2014/monsters/veteran"
   },
   {
@@ -39810,7 +39810,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/violet-fungus.png",
+    "image": "/api/images/monsters/violet-fungus.png",
     "url": "/api/2014/monsters/violet-fungus"
   },
   {
@@ -39980,7 +39980,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/vrock.png",
+    "image": "/api/images/monsters/vrock.png",
     "url": "/api/2014/monsters/vrock"
   },
   {
@@ -40056,7 +40056,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/vulture.png",
+    "image": "/api/images/monsters/vulture.png",
     "url": "/api/2014/monsters/vulture"
   },
   {
@@ -40118,7 +40118,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/warhorse.png",
+    "image": "/api/images/monsters/warhorse.png",
     "url": "/api/2014/monsters/warhorse"
   },
   {
@@ -40191,7 +40191,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/warhorse-skeleton.png",
+    "image": "/api/images/monsters/warhorse-skeleton.png",
     "url": "/api/2014/monsters/warhorse-skeleton"
   },
   {
@@ -40345,7 +40345,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/water-elemental.png",
+    "image": "/api/images/monsters/water-elemental.png",
     "url": "/api/2014/monsters/water-elemental"
   },
   {
@@ -40424,7 +40424,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/weasel.png",
+    "image": "/api/images/monsters/weasel.png",
     "url": "/api/2014/monsters/weasel"
   },
   {
@@ -40542,7 +40542,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werebear-bear.png",
+    "image": "/api/images/monsters/werebear-bear.png",
     "url": "/api/2014/monsters/werebear-bear"
   },
   {
@@ -40644,7 +40644,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werebear-human.png",
+    "image": "/api/images/monsters/werebear-human.png",
     "url": "/api/2014/monsters/werebear-human"
   },
   {
@@ -40808,7 +40808,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werebear-hybrid.png",
+    "image": "/api/images/monsters/werebear-hybrid.png",
     "url": "/api/2014/monsters/werebear-hybrid"
   },
   {
@@ -40909,7 +40909,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wereboar-boar.png",
+    "image": "/api/images/monsters/wereboar-boar.png",
     "url": "/api/2014/monsters/wereboar-boar"
   },
   {
@@ -41018,7 +41018,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wereboar-human.png",
+    "image": "/api/images/monsters/wereboar-human.png",
     "url": "/api/2014/monsters/wereboar-human"
   },
   {
@@ -41171,7 +41171,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wereboar-hybrid.png",
+    "image": "/api/images/monsters/wereboar-hybrid.png",
     "url": "/api/2014/monsters/wereboar-hybrid"
   },
   {
@@ -41327,7 +41327,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wererat-human.png",
+    "image": "/api/images/monsters/wererat-human.png",
     "url": "/api/2014/monsters/wererat-human"
   },
   {
@@ -41532,7 +41532,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wererat-hybrid.png",
+    "image": "/api/images/monsters/wererat-hybrid.png",
     "url": "/api/2014/monsters/wererat-hybrid"
   },
   {
@@ -41631,7 +41631,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wererat-rat.png",
+    "image": "/api/images/monsters/wererat-rat.png",
     "url": "/api/2014/monsters/wererat-rat"
   },
   {
@@ -41771,7 +41771,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/weretiger-human.png",
+    "image": "/api/images/monsters/weretiger-human.png",
     "url": "/api/2014/monsters/weretiger-human"
   },
   {
@@ -41960,7 +41960,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/weretiger-hybrid.png",
+    "image": "/api/images/monsters/weretiger-hybrid.png",
     "url": "/api/2014/monsters/weretiger-hybrid"
   },
   {
@@ -42087,7 +42087,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/weretiger-tiger.png",
+    "image": "/api/images/monsters/weretiger-tiger.png",
     "url": "/api/2014/monsters/weretiger-tiger"
   },
   {
@@ -42210,7 +42210,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werewolf-human.png",
+    "image": "/api/images/monsters/werewolf-human.png",
     "url": "/api/2014/monsters/werewolf-human"
   },
   {
@@ -42332,7 +42332,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werewolf-hybrid.png",
+    "image": "/api/images/monsters/werewolf-hybrid.png",
     "url": "/api/2014/monsters/werewolf-hybrid"
   },
   {
@@ -42422,7 +42422,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/werewolf-wolf.png",
+    "image": "/api/images/monsters/werewolf-wolf.png",
     "url": "/api/2014/monsters/werewolf-wolf"
   },
   {
@@ -42570,7 +42570,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/white-dragon-wyrmling.png",
+    "image": "/api/images/monsters/white-dragon-wyrmling.png",
     "url": "/api/2014/monsters/white-dragon-wyrmling"
   },
   {
@@ -42767,7 +42767,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wight.png",
+    "image": "/api/images/monsters/wight.png",
     "url": "/api/2014/monsters/wight"
   },
   {
@@ -42903,7 +42903,7 @@
         "desc": "The will-o'-wisp and its light magically become invisible until it attacks or uses its Consume Life, or until its concentration ends (as if concentrating on a spell)."
       }
     ],
-    "image": "/api/2014/images/monsters/will-o-wisp.png",
+    "image": "/api/images/monsters/will-o-wisp.png",
     "url": "/api/2014/monsters/will-o-wisp"
   },
   {
@@ -43021,7 +43021,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/winter-wolf.png",
+    "image": "/api/images/monsters/winter-wolf.png",
     "url": "/api/2014/monsters/winter-wolf"
   },
   {
@@ -43104,7 +43104,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wolf.png",
+    "image": "/api/images/monsters/wolf.png",
     "url": "/api/2014/monsters/wolf"
   },
   {
@@ -43177,7 +43177,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/worg.png",
+    "image": "/api/images/monsters/worg.png",
     "url": "/api/2014/monsters/worg"
   },
   {
@@ -43301,7 +43301,7 @@
         "desc": "The wraith targets a humanoid within 10 feet of it that has been dead for no longer than 1 minute and died violently. The target's spirit rises as a specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith's control. The wraith can have no more than seven specters under its control at one time."
       }
     ],
-    "image": "/api/2014/images/monsters/wraith.png",
+    "image": "/api/images/monsters/wraith.png",
     "url": "/api/2014/monsters/wraith"
   },
   {
@@ -43463,7 +43463,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/wyvern.png",
+    "image": "/api/images/monsters/wyvern.png",
     "url": "/api/2014/monsters/wyvern"
   },
   {
@@ -43587,7 +43587,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/xorn.png",
+    "image": "/api/images/monsters/xorn.png",
     "url": "/api/2014/monsters/xorn"
   },
   {
@@ -43772,7 +43772,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/young-black-dragon.png",
+    "image": "/api/images/monsters/young-black-dragon.png",
     "url": "/api/2014/monsters/young-black-dragon"
   },
   {
@@ -43951,7 +43951,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/young-blue-dragon.png",
+    "image": "/api/images/monsters/young-blue-dragon.png",
     "url": "/api/2014/monsters/young-blue-dragon"
   },
   {
@@ -44156,7 +44156,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/young-brass-dragon.png",
+    "image": "/api/images/monsters/young-brass-dragon.png",
     "url": "/api/2014/monsters/young-brass-dragon"
   },
   {
@@ -44367,7 +44367,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/young-bronze-dragon.png",
+    "image": "/api/images/monsters/young-bronze-dragon.png",
     "url": "/api/2014/monsters/young-bronze-dragon"
   },
   {
@@ -44572,7 +44572,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/young-copper-dragon.png",
+    "image": "/api/images/monsters/young-copper-dragon.png",
     "url": "/api/2014/monsters/young-copper-dragon"
   },
   {
@@ -44791,7 +44791,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/young-gold-dragon.png",
+    "image": "/api/images/monsters/young-gold-dragon.png",
     "url": "/api/2014/monsters/young-gold-dragon"
   },
   {
@@ -44990,7 +44990,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/young-green-dragon.png",
+    "image": "/api/images/monsters/young-green-dragon.png",
     "url": "/api/2014/monsters/young-green-dragon"
   },
   {
@@ -45169,7 +45169,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/young-red-dragon.png",
+    "image": "/api/images/monsters/young-red-dragon.png",
     "url": "/api/2014/monsters/young-red-dragon"
   },
   {
@@ -45381,7 +45381,7 @@
         }
       }
     ],
-    "image": "/api/2014/images/monsters/young-silver-dragon.png",
+    "image": "/api/images/monsters/young-silver-dragon.png",
     "url": "/api/2014/monsters/young-silver-dragon"
   },
   {
@@ -45567,7 +45567,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/young-white-dragon.png",
+    "image": "/api/images/monsters/young-white-dragon.png",
     "url": "/api/2014/monsters/young-white-dragon"
   },
   {
@@ -45647,7 +45647,7 @@
         ]
       }
     ],
-    "image": "/api/2014/images/monsters/zombie.png",
+    "image": "/api/images/monsters/zombie.png",
     "url": "/api/2014/monsters/zombie"
   }
 ]


### PR DESCRIPTION
## What does this do?

Changes all `"image"` to use the new endpoint for the API which drops `2014` from the path.

## How was it tested?

Locally.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/89082d4b-e09a-4ed9-bcc8-2d14b4e05e9d)
