### PR TITLE
fix: Add subclass improvements to level features

### DIFF
--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -4075,6 +4075,22 @@
     "url": "/api/2014/features/aura-of-protection"
   },
   {
+    "index": "sacred-oath-improvement-1",
+    "class": {
+      "index": "paladin",
+      "name": "Paladin",
+      "url": "/api/2014/classes/paladin"
+    },
+    "name": "Sacred Oath feature",
+    "level": 7,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you swear the oath that binds you as a paladin forever. Up to this time you have been in a preparatory stage, committed to the path but not yet sworn to it. Now you choose an oath, such as the Oath of Devotion.",
+      "Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature."
+    ],
+    "url": "/api/2014/features/sacred-oath-improvement-1"
+  },
+  {
     "index": "aura-of-devotion",
     "class": {
       "index": "paladin",
@@ -4173,6 +4189,22 @@
     "url": "/api/2014/features/cleansing-touch"
   },
   {
+    "index": "sacred-oath-improvement-2",
+    "class": {
+      "index": "paladin",
+      "name": "Paladin",
+      "url": "/api/2014/classes/paladin"
+    },
+    "name": "Sacred Oath feature",
+    "level": 15,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you swear the oath that binds you as a paladin forever. Up to this time you have been in a preparatory stage, committed to the path but not yet sworn to it. Now you choose an oath, such as the Oath of Devotion.",
+      "Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature."
+    ],
+    "url": "/api/2014/features/sacred-oath-improvement-2"
+  },
+  {
     "index": "purity-of-spirit",
     "class": {
       "index": "paladin",
@@ -4234,6 +4266,22 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/2014/features/paladin-ability-score-improvement-5"
+  },
+  {
+    "index": "sacred-oath-improvement-3",
+    "class": {
+      "index": "paladin",
+      "name": "Paladin",
+      "url": "/api/2014/classes/paladin"
+    },
+    "name": "Sacred Oath feature",
+    "level": 20,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you swear the oath that binds you as a paladin forever. Up to this time you have been in a preparatory stage, committed to the path but not yet sworn to it. Now you choose an oath, such as the Oath of Devotion.",
+      "Your choice grants you features at 3rd level and again at 7th, 15th, and 20th level. Those features include oath spells and the Channel Divinity feature."
+    ],
+    "url": "/api/2014/features/sacred-oath-improvement-3"
   },
   {
     "index": "holy-nimbus",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -166,6 +166,21 @@
     "url": "/api/2014/features/mindless-rage"
   },
   {
+    "index": "primal-path-improvement-1",
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/2014/classes/barbarian"
+    },
+    "name": "Path feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
+    ],
+    "url": "/api/2014/features/primal-path"
+  },
+  {
     "index": "feral-instinct",
     "class": {
       "index": "barbarian",
@@ -233,6 +248,21 @@
     "url": "/api/2014/features/intimidating-presence"
   },
   {
+    "index": "primal-path-improvement-2",
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/2014/classes/barbarian"
+    },
+    "name": "Path feature",
+    "level": 10,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
+    ],
+    "url": "/api/2014/features/primal-path"
+  },
+  {
     "index": "relentless-rage",
     "class": {
       "index": "barbarian",
@@ -297,6 +327,21 @@
       "Starting at 14th level, when you take damage from a creature that is within 5 feet of you, you can use your reaction to make a melee weapon Attack against that creature."
     ],
     "url": "/api/2014/features/retaliation"
+  },
+  {
+    "index": "primal-path-improvement-3",
+    "class": {
+      "index": "barbarian",
+      "name": "Barbarian",
+      "url": "/api/2014/classes/barbarian"
+    },
+    "name": "Path feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
+    ],
+    "url": "/api/2014/features/primal-path"
   },
   {
     "index": "persistent-rage",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -787,6 +787,21 @@
     "url": "/api/2014/features/countercharm"
   },
   {
+    "index": "bard-college-improvement-1",
+    "class": {
+      "index": "bard",
+      "name": "Bard",
+      "url": "/api/2014/classes/bard"
+    },
+    "name": "Bard College feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you delve into the advanced techniques of a bard college of your choice, such as the College of Lore. Your choice grants you features at 3rd level and again at 6th and 14th level."
+    ],
+    "url": "/api/2014/features/bard-college-improvement-1"
+  },
+  {
     "index": "additional-magical-secrets",
     "class": {
       "index": "bard",
@@ -1088,6 +1103,21 @@
       "You learn two additional spells from any class at 14th level and again at 18th level."
     ],
     "url": "/api/2014/features/magical-secrets-2"
+  },
+  {
+    "index": "bard-college-improvement-2",
+    "class": {
+      "index": "bard",
+      "name": "Bard",
+      "url": "/api/2014/classes/bard"
+    },
+    "name": "Bard College feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you delve into the advanced techniques of a bard college of your choice, such as the College of Lore. Your choice grants you features at 3rd level and again at 6th and 14th level."
+    ],
+    "url": "/api/2014/features/bard-college-improvement-2"
   },
   {
     "index": "peerless-skill",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -6151,6 +6151,21 @@
     "url": "/api/2014/features/rogue-ability-score-improvement-2"
   },
   {
+    "index": "roguish-archetype-improvement-1",
+    "class": {
+      "index": "rogue",
+      "name": "Rogue",
+      "url": "/api/2014/classes/rogue"
+    },
+    "name": "Roguish Archetype feature",
+    "level": 9,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you emulate in the exercise of your rogue abilities, such as Thief. Additional archetypes are available in the original source material. Your archetype choice grants you features at 3rd level and then again at 9th, 13th, and 17th level."
+    ],
+    "url": "/api/2014/features/roguish-archetype-improvement-1"
+  },
+  {
     "index": "supreme-sneak",
     "class": {
       "index": "rogue",
@@ -6216,6 +6231,21 @@
     "url": "/api/2014/features/rogue-ability-score-improvement-4"
   },
   {
+    "index": "roguish-archetype-improvement-2",
+    "class": {
+      "index": "rogue",
+      "name": "Rogue",
+      "url": "/api/2014/classes/rogue"
+    },
+    "name": "Roguish Archetype feature",
+    "level": 13,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you emulate in the exercise of your rogue abilities, such as Thief. Additional archetypes are available in the original source material. Your archetype choice grants you features at 3rd level and then again at 9th, 13th, and 17th level."
+    ],
+    "url": "/api/2014/features/roguish-archetype-improvement-2"
+  },
+  {
     "index": "use-magic-device",
     "class": {
       "index": "rogue",
@@ -6279,6 +6309,21 @@
       "When you reach 4th level, and again at 8th, 10th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/2014/features/rogue-ability-score-improvement-5"
+  },
+  {
+    "index": "roguish-archetype-improvement-3",
+    "class": {
+      "index": "rogue",
+      "name": "Rogue",
+      "url": "/api/2014/classes/rogue"
+    },
+    "name": "Roguish Archetype feature",
+    "level": 17,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you emulate in the exercise of your rogue abilities, such as Thief. Additional archetypes are available in the original source material. Your archetype choice grants you features at 3rd level and then again at 9th, 13th, and 17th level."
+    ],
+    "url": "/api/2014/features/roguish-archetype-improvement-3"
   },
   {
     "index": "thiefs-reflexes",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -7129,6 +7129,22 @@
     "url": "/api/2014/features/sorcerer-ability-score-improvement-1"
   },
   {
+    "index": "sorcerous-origin-improvement-1",
+    "class": {
+      "index": "sorcerer",
+      "name": "Sorcerer",
+      "url": "/api/2014/classes/sorcerer"
+    },
+    "name": "Sorcerous Origin feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "Choose a sorcerous origin, which describes the source of your innate magical power, such as Draconic Bloodline.",
+      "Your choice grants you features when you choose it at 1st level and again at 6th, 14th, and 18th level."
+    ],
+    "url": "/api/2014/features/sorcerous-origin-improvement-1"
+  },
+  {
     "index": "elemental-affinity",
     "class": {
       "index": "sorcerer",
@@ -7271,6 +7287,22 @@
     "url": "/api/2014/features/sorcerer-ability-score-improvement-3"
   },
   {
+    "index": "sorcerous-origin-improvement-2",
+    "class": {
+      "index": "sorcerer",
+      "name": "Sorcerer",
+      "url": "/api/2014/classes/sorcerer"
+    },
+    "name": "Sorcerous Origin feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "Choose a sorcerous origin, which describes the source of your innate magical power, such as Draconic Bloodline.",
+      "Your choice grants you features when you choose it at 1st level and again at 6th, 14th, and 18th level."
+    ],
+    "url": "/api/2014/features/sorcerous-origin-improvement-2"
+  },
+  {
     "index": "dragon-wings",
     "class": {
       "index": "sorcerer",
@@ -7396,6 +7428,22 @@
       }
     },
     "url": "/api/2014/features/metamagic-3"
+  },
+  {
+    "index": "sorcerous-origin-improvement-3",
+    "class": {
+      "index": "sorcerer",
+      "name": "Sorcerer",
+      "url": "/api/2014/classes/sorcerer"
+    },
+    "name": "Sorcerous Origin feature",
+    "level": 18,
+    "prerequisites": [],
+    "desc": [
+      "Choose a sorcerous origin, which describes the source of your innate magical power, such as Draconic Bloodline.",
+      "Your choice grants you features when you choose it at 1st level and again at 6th, 14th, and 18th level."
+    ],
+    "url": "/api/2014/features/sorcerous-origin-improvement-3"
   },
   {
     "index": "draconic-presence",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -4825,6 +4825,21 @@
     "url": "/api/2014/features/natural-explorer-2-terrain-types"
   },
   {
+    "index": "ranger-archetype-improvement-1",
+    "class": {
+      "index": "ranger",
+      "name": "Ranger",
+      "url": "/api/2014/classes/ranger"
+    },
+    "name": "Ranger Archetype feature",
+    "level": 7,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate, such as the Hunter. Your choice grants you features at 3rd level and again at 7th, 11th, and 15th level."
+    ],
+    "url": "/api/2014/features/ranger-archetype-improvement-1"
+  },
+  {
     "index": "defensive-tactics",
     "class": {
       "index": "ranger",
@@ -5043,6 +5058,21 @@
     "url": "/api/2014/features/hide-in-plain-sight"
   },
   {
+    "index": "ranger-archetype-improvement-2",
+    "class": {
+      "index": "ranger",
+      "name": "Ranger",
+      "url": "/api/2014/classes/ranger"
+    },
+    "name": "Ranger Archetype feature",
+    "level": 11,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate, such as the Hunter. Your choice grants you features at 3rd level and again at 7th, 11th, and 15th level."
+    ],
+    "url": "/api/2014/features/ranger-archetype-improvement-2"
+  },
+  {
     "index": "multiattack",
     "class": {
       "index": "ranger",
@@ -5215,6 +5245,21 @@
       "Starting at 14th level, you can use the Hide action as a bonus action on your turn. Also, you can't be tracked by nonmagical means, unless you choose to leave a trail."
     ],
     "url": "/api/2014/features/vanish"
+  },
+  {
+    "index": "ranger-archetype-improvement-3",
+    "class": {
+      "index": "ranger",
+      "name": "Ranger",
+      "url": "/api/2014/classes/ranger"
+    },
+    "name": "Ranger Archetype feature",
+    "level": 15,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate, such as the Hunter. Your choice grants you features at 3rd level and again at 7th, 11th, and 15th level."
+    ],
+    "url": "/api/2014/features/ranger-archetype-improvement-3"
   },
   {
     "index": "superior-hunters-defense",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -178,7 +178,7 @@
     "desc": [
       "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
     ],
-    "url": "/api/2014/features/primal-path"
+    "url": "/api/2014/features/primal-path-improvement-1"
   },
   {
     "index": "feral-instinct",
@@ -260,7 +260,7 @@
     "desc": [
       "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
     ],
-    "url": "/api/2014/features/primal-path"
+    "url": "/api/2014/features/primal-path-improvement-2"
   },
   {
     "index": "relentless-rage",
@@ -341,7 +341,7 @@
     "desc": [
       "At 3rd level, you choose a path that shapes the nature of your rage. Choose the Path of the Berserker or the Path of the Totem Warrior, both detailed at the end of the class description. Your choice grants you features at 3rd level and again at 6th, 10th, and 14th levels."
     ],
-    "url": "/api/2014/features/primal-path"
+    "url": "/api/2014/features/primal-path-improvement-3"
   },
   {
     "index": "persistent-rage",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -2829,6 +2829,21 @@
     "url": "/api/2014/features/remarkable-athlete"
   },
   {
+    "index": "martial-archetype-improvement-1",
+    "class": {
+      "index": "fighter",
+      "name": "Fighter",
+      "url": "/api/2014/classes/fighter"
+    },
+    "name": "Martial Archetype feature",
+    "level": 7,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate in your combat styles and techniques, such as Champion. The archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level."
+    ],
+    "url": "/api/2014/features/martial-archetype-improvement-1"
+  },
+  {
     "index": "fighter-ability-score-improvement-3",
     "class": {
       "index": "fighter",
@@ -2938,6 +2953,21 @@
     "url": "/api/2014/features/additional-fighting-style"
   },
   {
+    "index": "martial-archetype-improvement-2",
+    "class": {
+      "index": "fighter",
+      "name": "Fighter",
+      "url": "/api/2014/classes/fighter"
+    },
+    "name": "Martial Archetype feature",
+    "level": 10,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate in your combat styles and techniques, such as Champion. The archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level."
+    ],
+    "url": "/api/2014/features/martial-archetype-improvement-2"
+  },
+  {
     "index": "extra-attack-2",
     "class": {
       "index": "fighter",
@@ -3018,6 +3048,21 @@
     "url": "/api/2014/features/superior-critical"
   },
   {
+    "index": "martial-archetype-improvement-3",
+    "class": {
+      "index": "fighter",
+      "name": "Fighter",
+      "url": "/api/2014/classes/fighter"
+    },
+    "name": "Martial Archetype feature",
+    "level": 15,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate in your combat styles and techniques, such as Champion. The archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level."
+    ],
+    "url": "/api/2014/features/martial-archetype-improvement-3"
+  },
+  {
     "index": "fighter-ability-score-improvement-6",
     "class": {
       "index": "fighter",
@@ -3062,6 +3107,21 @@
       "Beginning at 9th level, you can reroll a saving throw that you fail. If you do so, you must use the new roll, and you can't use this feature again until you finish a long rest. You can use this feature twice between long rests starting at 13th level and three times between long rests starting at 17th level."
     ],
     "url": "/api/2014/features/indomitable-3-uses"
+  },
+  {
+    "index": "martial-archetype-improvement-4",
+    "class": {
+      "index": "fighter",
+      "name": "Fighter",
+      "url": "/api/2014/classes/fighter"
+    },
+    "name": "Martial Archetype feature",
+    "level": 18,
+    "prerequisites": [],
+    "desc": [
+      "At 3rd level, you choose an archetype that you strive to emulate in your combat styles and techniques, such as Champion. The archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level."
+    ],
+    "url": "/api/2014/features/martial-archetype-improvement-4"
   },
   {
     "index": "survivor",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -3418,6 +3418,21 @@
     "url": "/api/2014/features/ki-empowered-strikes"
   },
   {
+    "index": "monastic-tradition-improvement-1",
+    "class": {
+      "index": "monk",
+      "name": "Monk",
+      "url": "/api/2014/classes/monk"
+    },
+    "name": "Monastic Tradition feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you commit yourself to a monastic tradition, such as the Way of the Open Hand. Your tradition grants you features at 3rd level and again at 6th, 11th, and 17th level."
+    ],
+    "url": "/api/2014/features/monastic-tradition-improvement-1"
+  },
+  {
     "index": "wholeness-of-body",
     "class": {
       "index": "monk",
@@ -3514,6 +3529,21 @@
     "url": "/api/2014/features/purity-of-body"
   },
   {
+    "index": "monastic-tradition-improvement-2",
+    "class": {
+      "index": "monk",
+      "name": "Monk",
+      "url": "/api/2014/classes/monk"
+    },
+    "name": "Monastic Tradition feature",
+    "level": 11,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you commit yourself to a monastic tradition, such as the Way of the Open Hand. Your tradition grants you features at 3rd level and again at 6th, 11th, and 17th level."
+    ],
+    "url": "/api/2014/features/monastic-tradition-improvement-2"
+  },
+  {
     "index": "tranquility",
     "class": {
       "index": "monk",
@@ -3608,6 +3638,21 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/2014/features/monk-ability-score-improvement-4"
+  },
+  {
+    "index": "monastic-tradition-improvement-3",
+    "class": {
+      "index": "monk",
+      "name": "Monk",
+      "url": "/api/2014/classes/monk"
+    },
+    "name": "Monastic Tradition feature",
+    "level": 17,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 3rd level, you commit yourself to a monastic tradition, such as the Way of the Open Hand. Your tradition grants you features at 3rd level and again at 6th, 11th, and 17th level."
+    ],
+    "url": "/api/2014/features/monastic-tradition-improvement-3"
   },
   {
     "index": "quivering-palm",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -8173,6 +8173,21 @@
     "url": "/api/2014/features/eldritch-invocation-thirsting-blade"
   },
   {
+    "index": "otherworldly-patron-improvement-1",
+    "class": {
+      "index": "warlock",
+      "name": "Warlock",
+      "url": "/api/2014/classes/warlock"
+    },
+    "name": "Otherworldly Patron feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "At 1st level, you have struck a bargain with an otherworldly being of your choice, such as the Fiend. Your choice grants you features at 1st level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/otherworldly-patron-improvement-1"
+  },
+  {
     "index": "eldritch-invocation-bewitching-whispers",
     "class": {
       "index": "warlock",
@@ -8348,6 +8363,21 @@
     "url": "/api/2014/features/eldritch-invocation-whispers-of-the-grave"
   },
   {
+    "index": "otherworldly-patron-improvement-2",
+    "class": {
+      "index": "warlock",
+      "name": "Warlock",
+      "url": "/api/2014/classes/warlock"
+    },
+    "name": "Otherworldly Patron feature",
+    "level": 10,
+    "prerequisites": [],
+    "desc": [
+      "At 1st level, you have struck a bargain with an otherworldly being of your choice, such as the Fiend. Your choice grants you features at 1st level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/otherworldly-patron-improvement-2"
+  },
+  {
     "index": "eldritch-invocation-lifedrinker",
     "class": {
       "index": "warlock",
@@ -8375,6 +8405,21 @@
       "url": "/api/2014/features/eldritch-invocations"
     },
     "url": "/api/2014/features/eldritch-invocation-lifedrinker"
+  },
+  {
+    "index": "otherworldly-patron-improvement-3",
+    "class": {
+      "index": "warlock",
+      "name": "Warlock",
+      "url": "/api/2014/classes/warlock"
+    },
+    "name": "Otherworldly Patron feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "At 1st level, you have struck a bargain with an otherworldly being of your choice, such as the Fiend. Your choice grants you features at 1st level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/otherworldly-patron-improvement-3"
   },
   {
     "index": "eldritch-invocation-chains-of-carceri",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -1355,6 +1355,22 @@
     "url": "/api/2014/features/channel-divinity-turn-undead"
   },
   {
+    "index": "divine-domain-improvement-1",
+    "class": {
+      "index": "cleric",
+      "name": "Cleric",
+      "url": "/api/2014/classes/cleric"
+    },
+    "name": "Divine Domain feature",
+    "level": 2,
+    "prerequisites": [],
+    "desc": [
+      "Choose one domain related to your deity, such as Knowledge, Life, Light, Nature, Tempest, Trickery, or War. Only the Life domain is detailed in the Open Game Licensed SRD. Additional Domains are described in the official rulebooks or products from other publishers.",
+      "Your domain grants you domain spells and other features when you choose it at 1st level. It also grants you additional ways to use Channel Divinity when you gain that feature at 2nd level, and additional benefits at 6th, 8th, and 17th levels."
+    ],
+    "url": "/api/2014/features/divine-domain-improvement-1"
+  },
+  {
     "index": "channel-divinity-preserve-life",
     "class": {
       "index": "cleric",
@@ -1454,6 +1470,22 @@
     "url": "/api/2014/features/channel-divinity-2-rest"
   },
   {
+    "index": "divine-domain-improvement-2",
+    "class": {
+      "index": "cleric",
+      "name": "Cleric",
+      "url": "/api/2014/classes/cleric"
+    },
+    "name": "Divine Domain feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "Choose one domain related to your deity, such as Knowledge, Life, Light, Nature, Tempest, Trickery, or War. Only the Life domain is detailed in the Open Game Licensed SRD. Additional Domains are described in the official rulebooks or products from other publishers.",
+      "Your domain grants you domain spells and other features when you choose it at 1st level. It also grants you additional ways to use Channel Divinity when you gain that feature at 2nd level, and additional benefits at 6th, 8th, and 17th levels."
+    ],
+    "url": "/api/2014/features/divine-domain-improvement-2"
+  },
+  {
     "index": "blessed-healer",
     "class": {
       "index": "cleric",
@@ -1518,6 +1550,22 @@
       "Starting at 5th level, when an undead fails its saving throw against your Turn Undead feature, the creature is instantly destroyed if its challenge rating is at or below a certain threshold."
     ],
     "url": "/api/2014/features/destroy-undead-cr-1-or-below"
+  },
+  {
+    "index": "divine-domain-improvement-3",
+    "class": {
+      "index": "cleric",
+      "name": "Cleric",
+      "url": "/api/2014/classes/cleric"
+    },
+    "name": "Divine Domain feature",
+    "level": 8,
+    "prerequisites": [],
+    "desc": [
+      "Choose one domain related to your deity, such as Knowledge, Life, Light, Nature, Tempest, Trickery, or War. Only the Life domain is detailed in the Open Game Licensed SRD. Additional Domains are described in the official rulebooks or products from other publishers.",
+      "Your domain grants you domain spells and other features when you choose it at 1st level. It also grants you additional ways to use Channel Divinity when you gain that feature at 2nd level, and additional benefits at 6th, 8th, and 17th levels."
+    ],
+    "url": "/api/2014/features/divine-domain-improvement-3"
   },
   {
     "index": "divine-strike",
@@ -1647,6 +1695,22 @@
       "Starting at 5th level, when an undead fails its saving throw against your Turn Undead feature, the creature is instantly destroyed if its challenge rating is at or below a certain threshold."
     ],
     "url": "/api/2014/features/destroy-undead-cr-4-or-below"
+  },
+  {
+    "index": "divine-domain-improvement-4",
+    "class": {
+      "index": "cleric",
+      "name": "Cleric",
+      "url": "/api/2014/classes/cleric"
+    },
+    "name": "Divine Domain feature",
+    "level": 17,
+    "prerequisites": [],
+    "desc": [
+      "Choose one domain related to your deity, such as Knowledge, Life, Light, Nature, Tempest, Trickery, or War. Only the Life domain is detailed in the Open Game Licensed SRD. Additional Domains are described in the official rulebooks or products from other publishers.",
+      "Your domain grants you domain spells and other features when you choose it at 1st level. It also grants you additional ways to use Channel Divinity when you gain that feature at 2nd level, and additional benefits at 6th, 8th, and 17th levels."
+    ],
+    "url": "/api/2014/features/divine-domain-improvement-4"
   },
   {
     "index": "supreme-healing",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -2227,6 +2227,21 @@
     "url": "/api/2014/features/circle-spells-2"
   },
   {
+    "index": "druid-circle-improvement-1",
+    "class": {
+      "index": "druid",
+      "name": "Druid",
+      "url": "/api/2014/classes/druid"
+    },
+    "name": "Druid Circle feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "At 2nd level, you choose to identify with a circle of druids, such as the Circle of the Land. Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/druid-circle-improvement-1"
+  },
+  {
     "index": "druid-lands-stride",
     "class": {
       "index": "druid",
@@ -2330,6 +2345,21 @@
     "url": "/api/2014/features/circle-spells-4"
   },
   {
+    "index": "druid-circle-improvement-2",
+    "class": {
+      "index": "druid",
+      "name": "Druid",
+      "url": "/api/2014/classes/druid"
+    },
+    "name": "Druid Circle feature",
+    "level": 10,
+    "prerequisites": [],
+    "desc": [
+      "At 2nd level, you choose to identify with a circle of druids, such as the Circle of the Land. Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/druid-circle-improvement-2"
+  },
+  {
     "index": "natures-ward",
     "class": {
       "index": "druid",
@@ -2363,6 +2393,21 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/2014/features/druid-ability-score-improvement-3"
+  },
+  {
+    "index": "druid-circle-improvement-3",
+    "class": {
+      "index": "druid",
+      "name": "Druid",
+      "url": "/api/2014/classes/druid"
+    },
+    "name": "Druid Circle feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "At 2nd level, you choose to identify with a circle of druids, such as the Circle of the Land. Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/druid-circle-improvement-3"
   },
   {
     "index": "natures-sanctuary",

--- a/src/2014/5e-SRD-Features.json
+++ b/src/2014/5e-SRD-Features.json
@@ -8969,6 +8969,22 @@
     "url": "/api/2014/features/wizard-ability-score-improvement-1"
   },
   {
+    "index": "arcane-tradition-improvement-1",
+    "class": {
+      "index": "wizard",
+      "name": "Wizard",
+      "url": "/api/2014/classes/wizard"
+    },
+    "name": "Arcane Tradition feature",
+    "level": 6,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 2nd level, you choose an arcane tradition, shaping your practice of magic through one of eight schools, such as Evocation.",
+      "Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/arcane-tradition-improvement-1"
+  },
+  {
     "index": "potent-cantrip",
     "class": {
       "index": "wizard",
@@ -9004,6 +9020,22 @@
     "url": "/api/2014/features/wizard-ability-score-improvement-2"
   },
   {
+    "index": "arcane-tradition-improvement-2",
+    "class": {
+      "index": "wizard",
+      "name": "Wizard",
+      "url": "/api/2014/classes/wizard"
+    },
+    "name": "Arcane Tradition feature",
+    "level": 10,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 2nd level, you choose an arcane tradition, shaping your practice of magic through one of eight schools, such as Evocation.",
+      "Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/arcane-tradition-improvement-2"
+  },
+  {
     "index": "empowered-evocation",
     "class": {
       "index": "wizard",
@@ -9037,6 +9069,22 @@
       "When you reach 4th level, and again at 8th, 12th, 16th, and 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
     ],
     "url": "/api/2014/features/wizard-ability-score-improvement-3"
+  },
+  {
+    "index": "arcane-tradition-improvement-3",
+    "class": {
+      "index": "wizard",
+      "name": "Wizard",
+      "url": "/api/2014/classes/wizard"
+    },
+    "name": "Arcane Tradition feature",
+    "level": 14,
+    "prerequisites": [],
+    "desc": [
+      "When you reach 2nd level, you choose an arcane tradition, shaping your practice of magic through one of eight schools, such as Evocation.",
+      "Your choice grants you features at 2nd level and again at 6th, 10th, and 14th level."
+    ],
+    "url": "/api/2014/features/arcane-tradition-improvement-3"
   },
   {
     "index": "overchannel",

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -6867,7 +6867,13 @@
     "level": 6,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "otherworldly-patron-improvement-1",
+        "name": "Otherworldly Patron feature",
+        "url": "/api/2014/features/otherworldly-patron-improvement-1"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 3,
       "spells_known": 7,
@@ -7005,7 +7011,13 @@
     "level": 10,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "otherworldly-patron-improvement-2",
+        "name": "Otherworldly Patron feature",
+        "url": "/api/2014/features/otherworldly-patron-improvement-2"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 4,
       "spells_known": 10,
@@ -7155,7 +7167,13 @@
     "level": 14,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "otherworldly-patron-improvement-3",
+        "name": "Otherworldly Patron feature",
+        "url": "/api/2014/features/otherworldly-patron-improvement-3"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 4,
       "spells_known": 12,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -142,7 +142,7 @@
       {
         "index": "primal-path-improvement-1",
         "name": "Path feature",
-        "url": "/api/2014/features/primal-path"
+        "url": "/api/2014/features/primal-path-improvement-1"
       }
     ],
     "class_specific": {
@@ -238,7 +238,7 @@
       {
         "index": "primal-path-improvement-2",
         "name": "Path feature",
-        "url": "/api/2014/features/primal-path"
+        "url": "/api/2014/features/primal-path-improvement-2"
       }
     ],
     "class_specific": {
@@ -334,7 +334,7 @@
       {
         "index": "primal-path-improvement-3",
         "name": "Path feature",
-        "url": "/api/2014/features/primal-path"
+        "url": "/api/2014/features/primal-path-improvement-3"
       }
     ],
     "class_specific": {

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -3406,6 +3406,11 @@
         "index": "ki-empowered-strikes",
         "name": "Ki Empowered Strikes",
         "url": "/api/2014/features/ki-empowered-strikes"
+      },
+      {
+        "index": "monastic-tradition-improvement-1",
+        "name": "Monastic Tradition feature",
+        "url": "/api/2014/features/monastic-tradition-improvement-1"
       }
     ],
     "class_specific": {
@@ -3541,7 +3546,13 @@
     "level": 11,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "monastic-tradition-improvement-2",
+        "name": "Monastic Tradition feature",
+        "url": "/api/2014/features/monastic-tradition-improvement-2"
+      }
+    ],
     "class_specific": {
       "martial_arts": {
         "dice_count": 1,
@@ -3697,7 +3708,13 @@
     "level": 17,
     "ability_score_bonuses": 4,
     "prof_bonus": 6,
-    "features": [],
+    "features": [
+      {
+        "index": "monastic-tradition-improvement-3",
+        "name": "Monastic Tradition feature",
+        "url": "/api/2014/features/monastic-tradition-improvement-3"
+      }
+    ],
     "class_specific": {
       "martial_arts": {
         "dice_count": 1,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -138,7 +138,13 @@
     "level": 6,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "primal-path-improvement-1",
+        "name": "Path feature",
+        "url": "/api/2014/features/primal-path"
+      }
+    ],
     "class_specific": {
       "rage_count": 4,
       "rage_damage_bonus": 2,
@@ -228,7 +234,13 @@
     "level": 10,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "primal-path-improvement-2",
+        "name": "Path feature",
+        "url": "/api/2014/features/primal-path"
+      }
+    ],
     "class_specific": {
       "rage_count": 4,
       "rage_damage_bonus": 3,
@@ -318,7 +330,13 @@
     "level": 14,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "primal-path-improvement-3",
+        "name": "Path feature",
+        "url": "/api/2014/features/primal-path"
+      }
+    ],
     "class_specific": {
       "rage_count": 5,
       "rage_damage_bonus": 3,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -4614,7 +4614,13 @@
     "level": 7,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "ranger-archetype-improvement-1",
+        "name": "Ranger Archetype feature",
+        "url": "/api/2014/features/ranger-archetype-improvement-1"
+      }
+    ],
     "spellcasting": {
       "spells_known": 5,
       "spell_slots_level_1": 4,
@@ -4736,7 +4742,13 @@
     "level": 11,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "ranger-archetype-improvement-2",
+        "name": "Ranger Archetype feature",
+        "url": "/api/2014/features/ranger-archetype-improvement-2"
+      }
+    ],
     "spellcasting": {
       "spells_known": 7,
       "spell_slots_level_1": 4,
@@ -4853,7 +4865,13 @@
     "level": 15,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "ranger-archetype-improvement-3",
+        "name": "Ranger Archetype feature",
+        "url": "/api/2014/features/ranger-archetype-improvement-3"
+      }
+    ],
     "spellcasting": {
       "spells_known": 9,
       "spell_slots_level_1": 4,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -2885,7 +2885,13 @@
     "level": 7,
     "ability_score_bonuses": 2,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "martial-archetype-improvement-1",
+        "name": "Martial Archetype feature",
+        "url": "/api/2014/features/martial-archetype-improvement-1"
+      }
+    ],
     "class_specific": {
       "action_surges": 1,
       "indomitable_uses": 0,
@@ -2951,7 +2957,13 @@
     "level": 10,
     "ability_score_bonuses": 3,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "martial-archetype-improvement-2",
+        "name": "Martial Archetype feature",
+        "url": "/api/2014/features/martial-archetype-improvement-2"
+      }
+    ],
     "class_specific": {
       "action_surges": 1,
       "indomitable_uses": 1,
@@ -3065,7 +3077,13 @@
     "level": 15,
     "ability_score_bonuses": 5,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "martial-archetype-improvement-3",
+        "name": "Martial Archetype feature",
+        "url": "/api/2014/features/martial-archetype-improvement-3"
+      }
+    ],
     "class_specific": {
       "action_surges": 1,
       "indomitable_uses": 2,
@@ -3136,7 +3154,13 @@
     "level": 18,
     "ability_score_bonuses": 6,
     "prof_bonus": 6,
-    "features": [],
+    "features": [
+      {
+        "index": "martial-archetype-improvement-4",
+        "name": "Martial Archetype feature",
+        "url": "/api/2014/features/martial-archetype-improvement-4"
+      }
+    ],
     "class_specific": {
       "action_surges": 2,
       "indomitable_uses": 3,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -718,6 +718,11 @@
         "index": "countercharm",
         "name": "Countercharm",
         "url": "/api/2014/features/countercharm"
+      },
+      {
+        "index": "bard-college-improvement-1",
+        "name": "Bard College feature",
+        "url": "/api/2014/features/bard-college-improvement-1"
       }
     ],
     "spellcasting": {
@@ -1028,6 +1033,11 @@
         "index": "magical-secrets-2",
         "name": "Magical Secrets",
         "url": "/api/2014/features/magical-secrets-2"
+      },
+      {
+        "index": "bard-college-improvement-2",
+        "name": "Bard College feature",
+        "url": "/api/2014/features/bard-college-improvement-2"
       }
     ],
     "spellcasting": {

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -1361,6 +1361,11 @@
         "index": "channel-divinity-turn-undead",
         "name": "Channel Divinity: Turn Undead",
         "url": "/api/2014/features/channel-divinity-turn-undead"
+      },
+      {
+        "index": "divine-domain-improvement-1",
+        "name": "Divine Domain feature",
+        "url": "/api/2014/features/divine-domain-improvement-1"
       }
     ],
     "spellcasting": {
@@ -1506,6 +1511,11 @@
         "index": "channel-divinity-2-rest",
         "name": "Channel Divinity (2/rest)",
         "url": "/api/2014/features/channel-divinity-2-rest"
+      },
+      {
+        "index": "divine-domain-improvement-2",
+        "name": "Divine Domain feature",
+        "url": "/api/2014/features/divine-domain-improvement-2"
       }
     ],
     "spellcasting": {
@@ -1581,6 +1591,11 @@
         "index": "destroy-undead-cr-1-or-below",
         "name": "Destroy Undead (CR 1 or below)",
         "url": "/api/2014/features/destroy-undead-cr-1-or-below"
+      },
+      {
+        "index": "divine-domain-improvement-3",
+        "name": "Divine Domain feature",
+        "url": "/api/2014/features/divine-domain-improvement-3"
       }
     ],
     "spellcasting": {
@@ -1884,6 +1899,11 @@
         "index": "destroy-undead-cr-4-or-below",
         "name": "Destroy Undead (CR 4 or below)",
         "url": "/api/2014/features/destroy-undead-cr-4-or-below"
+      },
+      {
+        "index": "divine-domain-improvement-4",
+        "name": "Divine Domain feature",
+        "url": "/api/2014/features/divine-domain-improvement-4"
       }
     ],
     "spellcasting": {

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -5255,7 +5255,13 @@
     "level": 9,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "roguish-archetype-improvement-1",
+        "name": "Roguish Archetype feature",
+        "url": "/api/2014/features/roguish-archetype-improvement-1"
+      }
+    ],
     "class_specific": {
       "sneak_attack": {
         "dice_count": 5,
@@ -5349,7 +5355,13 @@
     "level": 13,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "roguish-archetype-improvement-2",
+        "name": "Roguish Archetype feature",
+        "url": "/api/2014/features/roguish-archetype-improvement-2"
+      }
+    ],
     "class_specific": {
       "sneak_attack": {
         "dice_count": 7,
@@ -5443,7 +5455,13 @@
     "level": 17,
     "ability_score_bonuses": 4,
     "prof_bonus": 6,
-    "features": [],
+    "features": [
+      {
+        "index": "roguish-archetype-improvement-3",
+        "name": "Roguish Archetype feature",
+        "url": "/api/2014/features/roguish-archetype-improvement-3"
+      }
+    ],
     "class_specific": {
       "sneak_attack": {
         "dice_count": 9,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -5833,7 +5833,13 @@
     "level": 6,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "sorcerous-origin-improvement-1",
+        "name": "Sorcerous Origin feature",
+        "url": "/api/2014/features/sorcerous-origin-improvement-1"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 5,
       "spells_known": 7,
@@ -6267,7 +6273,13 @@
     "level": 14,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "sorcerous-origin-improvement-2",
+        "name": "Sorcerous Origin feature",
+        "url": "/api/2014/features/sorcerous-origin-improvement-2"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 6,
       "spells_known": 13,
@@ -6487,7 +6499,13 @@
     "level": 18,
     "ability_score_bonuses": 4,
     "prof_bonus": 6,
-    "features": [],
+    "features": [
+      {
+        "index": "sorcerous-origin-improvement-3",
+        "name": "Sorcerous Origin feature",
+        "url": "/api/2014/features/sorcerous-origin-improvement-3"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 6,
       "spells_known": 15,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -4020,7 +4020,13 @@
     "level": 7,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "sacred-oath-improvement-1",
+        "name": "Sacred Oath feature",
+        "url": "/api/2014/features/sacred-oath-improvement-1"
+      }
+    ],
     "spellcasting": {
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
@@ -4234,7 +4240,13 @@
     "level": 15,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "sacred-oath-improvement-2",
+        "name": "Sacred Oath feature",
+        "url": "/api/2014/features/sacred-oath-improvement-2"
+      }
+    ],
     "spellcasting": {
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
@@ -4367,7 +4379,13 @@
     "level": 20,
     "ability_score_bonuses": 5,
     "prof_bonus": 6,
-    "features": [],
+    "features": [
+      {
+        "index": "sacred-oath-improvement-3",
+        "name": "Sacred Oath feature",
+        "url": "/api/2014/features/sacred-oath-improvement-3"
+      }
+    ],
     "spellcasting": {
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -2222,7 +2222,13 @@
     "level": 6,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "druid-circle-improvement-1",
+        "name": "Druid Circle feature",
+        "url": "/api/2014/features/druid-circle-improvement-1"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 3,
       "spell_slots_level_1": 4,
@@ -2353,7 +2359,13 @@
     "level": 10,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "druid-circle-improvement-2",
+        "name": "Druid Circle feature",
+        "url": "/api/2014/features/druid-circle-improvement-2"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 4,
       "spell_slots_level_1": 4,
@@ -2479,7 +2491,13 @@
     "level": 14,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "druid-circle-improvement-3",
+        "name": "Druid Circle feature",
+        "url": "/api/2014/features/druid-circle-improvement-3"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 4,
       "spell_slots_level_1": 4,

--- a/src/2014/5e-SRD-Levels.json
+++ b/src/2014/5e-SRD-Levels.json
@@ -7597,7 +7597,13 @@
     "level": 6,
     "ability_score_bonuses": 1,
     "prof_bonus": 3,
-    "features": [],
+    "features": [
+      {
+        "index": "arcane-tradition-improvement-1",
+        "name": "Arcane Tradition feature",
+        "url": "/api/2014/features/arcane-tradition-improvement-1"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 4,
       "spell_slots_level_1": 4,
@@ -7715,7 +7721,13 @@
     "level": 10,
     "ability_score_bonuses": 2,
     "prof_bonus": 4,
-    "features": [],
+    "features": [
+      {
+        "index": "arcane-tradition-improvement-2",
+        "name": "Arcane Tradition feature",
+        "url": "/api/2014/features/arcane-tradition-improvement-2"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 5,
       "spell_slots_level_1": 4,
@@ -7833,7 +7845,13 @@
     "level": 14,
     "ability_score_bonuses": 3,
     "prof_bonus": 5,
-    "features": [],
+    "features": [
+      {
+        "index": "arcane-tradition-improvement-3",
+        "name": "Arcane Tradition feature",
+        "url": "/api/2014/features/arcane-tradition-improvement-3"
+      }
+    ],
     "spellcasting": {
       "cantrips_known": 5,
       "spell_slots_level_1": 4,


### PR DESCRIPTION
## What does this do?

This PR adds features for each of the subclass improvement stages, and adds them to the appropriate level. The intent is that this should make the API data reflect the content of the class table in the SRD document.

The Barbarian Primal Path improvements were added first to ensure that the result is correct before replicating the effort for the remaining classes.

![image](https://github.com/user-attachments/assets/6a6a6729-54f9-4ee9-81ce-6596d6909674)

Work now progresses on the remaining classes.

- [x] Barbarian
- [x] Bard
- [x] Cleric
- [x] Druid
- [x] Fighter
- [x] Monk
- [x] Paladin
- [x] Ranger
- [x] Rogue
- [x] Sorcerer
- [x] Warlock
- [x] Wizard

~~Once complete, the intention is to convert this PR from Draft to a full PR.~~
As all classes are now complete, this PR has been elevated to full PR for further review.

## How was it tested?

Built locally (non-Docker), and resultant tables inspected via MongoDB Compass.

![image](https://github.com/user-attachments/assets/164f82a5-416f-476b-90b9-e2b54810dc9f)

Local tests run and pass successfully.

## Is there a Github issue this is resolving?

Although briefly discussed on Discord, a GitHub Issue has not been raised at this time.

## Did you update the docs in the API? Please link an associated PR if applicable.

No - I don't believe a document update is required, but please correct me if I am wrong.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/b772c8ac-5407-4d4a-bdd4-7a817eb29219)
