### PR TITLE
feat(2024): Add a bunch of easy tables to 2024

### DIFF
--- a/src/2024/5e-SRD-Ability-Scores.json
+++ b/src/2024/5e-SRD-Ability-Scores.json
@@ -3,9 +3,7 @@
     "index": "str",
     "name": "STR",
     "full_name": "Strength",
-    "description": [
-      "Physical might"
-    ],
+    "description":"Physical might",
     "skills": [
       {
         "name": "Athletics",
@@ -19,9 +17,7 @@
     "index": "dex",
     "name": "DEX",
     "full_name": "Dexterity",
-    "description": [
-      "Agility, reflexes, and balance"
-    ],
+    "description": "Agility, reflexes, and balance",
     "skills": [
       {
         "name": "Acrobatics",
@@ -45,9 +41,7 @@
     "index": "con",
     "name": "CON",
     "full_name": "Constitution",
-    "description": [
-      "Health and stamina"
-    ],
+    "description": "Health and stamina",
     "skills": [],
     "url": "/api/2024/ability-scores/con"
   },
@@ -55,9 +49,7 @@
     "index": "int",
     "name": "INT",
     "full_name": "Intelligence",
-    "description": [
-      "Reasoning and memory"
-    ],
+    "description": "Reasoning and memory",
     "skills": [
       {
         "name": "Arcana",
@@ -91,9 +83,7 @@
     "index": "wis",
     "name": "WIS",
     "full_name": "Wisdom",
-    "description": [
-      "Perceptiveness and mental fortitude"
-    ],
+    "description": "Perceptiveness and mental fortitude",
     "skills": [
       {
         "name": "Animal Handling",
@@ -127,9 +117,7 @@
     "index": "cha",
     "name": "CHA",
     "full_name": "Charisma",
-    "description": [
-      "Confidence, poise, and charm"
-    ],
+    "description": "Confidence, poise, and charm",
     "skills": [
       {
         "name": "Deception",

--- a/src/2024/5e-SRD-Alignments.json
+++ b/src/2024/5e-SRD-Alignments.json
@@ -1,0 +1,72 @@
+[
+  {
+      "index": "lawful-good",
+      "name": "Lawful Good",
+      "abbreviation": "LG",
+      "description": "Lawful Good creatures endeavor to do the right thing as expected by society. Someone who fights injustice and protects the innocent without hesitation is probably Lawful Good.",
+      "url": "/api/2024/alignments/lawful-good"
+  },
+  {
+      "index": "neutral-good",
+      "name": "Neutral Good",
+      "abbreviation": "NG",
+      "description": "Neutral Good creatures do the best they can, working within rules but not feeling bound by them. A kindly person who helps others according to their needs is probably Neutral Good.",
+      "url": "/api/2024/alignments/neutral-good"
+  },
+  {
+      "index": "chaotic-good",
+      "name": "Chaotic Good",
+      "abbreviation": "CG",
+      "description": "Chaotic Good creatures act as their conscience directs with little regard for what others expect. A rebel who waylays a cruel baron's tax collectors and uses the stolen money to help the poor is probably Chaotic Good.",
+      "url": "/api/2024/alignments/chaotic-good"
+  },
+  {
+      "index": "lawful-neutral",
+      "name": "Lawful Neutral",
+      "abbreviation": "LN",
+      "description": "Lawful Neutral individuals act in accordance with law, tradition, or personal codes. Someone who follows a disciplined rule of life—and isn't swayed either by the demands of those in need or by the temptations of evil—is probably Lawful Neutral.",
+      "url": "/api/2024/alignments/lawful-neutral"
+  },
+  {
+      "index": "neutral",
+      "name": "Neutral",
+      "abbreviation": "N",
+      "description": "Neutral is the alignment of those who prefer to avoid moral questions and don't take sides, doing what seems best at the time. Someone who's bored by moral debate is probably Neutral.",
+      "url": "/api/2024/alignments/neutral"
+  },
+  {
+      "index": "chaotic-neutral",
+      "name": "Chaotic Neutral",
+      "abbreviation": "CN",
+      "description": "Chaotic Neutral creatures follow their whims, valuing their personal freedom above all else. A scoundrel who wanders the land living by their wits is probably Chaotic Neutral.",
+      "url": "/api/2024/alignments/chaotic-neutral"
+  },
+  {
+      "index": "lawful-evil",
+      "name": "Lawful Evil",
+      "abbreviation": "LE",
+      "description": "Lawful Evil creatures methodically take what they want within the limits of a code of tradition, loyalty, or order. An aristocrat exploiting citizens while scheming for power is probably Lawful Evil.",
+      "url": "/api/2024/alignments/lawful-evil"
+  },
+  {
+      "index": "neutral-evil",
+      "name": "Neutral Evil",
+      "abbreviation": "NE",
+      "description": "Neutral Evil is the alignment of those who are untroubled by the harm they cause as they pursue their desires. A criminal who robs and murders as they please is probably Neutral Evil.",
+      "url": "/api/2024/alignments/neutral-evil"
+  },
+  {
+      "index": "chaotic-evil",
+      "name": "Chaotic Evil",
+      "abbreviation": "CE",
+      "description": "Chaotic Evil creatures act with arbitrary violence, spurred by their hatred or bloodlust. A villain pursuing schemes of vengeance and havoc is probably Chaotic Evil.",
+      "url": "/api/2024/alignments/chaotic-evil"
+  },
+  {
+    "index": "unaligned",
+    "name": "Unaligned",
+    "abbreviation": "U",
+    "description": "Most creatures that lack the capacity for rational thought don't have alignments; they are unaligned. Sharks are savage predators, for example, but they aren't evil; they are unaligned.",
+    "url": "/api/2024/alignments/unaligned"
+  }
+]

--- a/src/2024/5e-SRD-Conditions.json
+++ b/src/2024/5e-SRD-Conditions.json
@@ -1,0 +1,92 @@
+[
+  {
+    "index": "blinded",
+    "name": "Blinded",
+    "description": "While you have the Blinded condition, you experience the following effects.\n**Can't See.** You can't see and automatically fail any ability check that requires sight.\n**Attacks Affected.** Attack rolls against you have Advantage, and your attack rolls have Disadvantage.",
+    "url": "/api/2024/conditions/blinded"
+  },
+  {
+    "index": "charmed",
+    "name": "Charmed",
+    "description": "While you have the Charmed condition, you experience the following effects.\n**Can't Harm the Charmer.** You can't attack the charmer or target the charmer with damaging abilities or magical effects.\n**Social Advantage.** The charmer has Advantage on ability checks to interact socially with you.",
+    "url": "/api/2024/conditions/charmed"
+  },
+  {
+    "index": "deafened",
+    "name": "Deafened",
+    "description": "While you have the Deafened condition, you experience the following effect.\n**Can't Hear.** You can't hear and automatically fail any ability check that requires hearing.",
+    "url": "/api/2024/conditions/deafened"
+  },
+  {
+    "index": "exhaustion",
+    "name": "Exhaustion",
+    "description": "While you have the Exhaustion condition, you experience the following effects.\n**Exhaustion Levels.** This condition is cumulative. Each time you receive it, you gain 1 Exhaustion level. You die if your Exhaustion level is 6.\n**D20 Tests Affected.** When you make a D20 Test, the roll is reduced by 2 times your Exhaustion level.\n**Speed Reduced.** Your Speed is reduced by a number of feet equal to 5 times your Exhaustion level.\n**Removing Exhaustion Levels.** Finishing a Long Rest removes 1 of your Exhaustion levels. When your Exhaustion level reaches 0, the condition ends.",
+    "url": "/api/2024/conditions/exhaustion"
+  },
+  {
+    "index": "frightened",
+    "name": "Frightened",
+    "description": "While you have the Frightened condition, you experience the following effects.\n**Ability Checks and Attacks Affected.** You have Disadvantage on ability checks and attack rolls while the source of fear is within line of sight.\n**Can't Approach.** You can't willingly move closer to the source of your fear.",
+    "url": "/api/2024/conditions/frightened"
+  },
+  {
+    "index": "grappled",
+    "name": "Grappled",
+    "description": "While you have the Grappled condition, you experience the following effects.\n**Speed 0.** Your Speed is 0 and can't increase.\n**Attacks Affected.** You have Disadvantage on attack rolls against any target other than the grappler.\n**Movable.** The grappler can drag or carry you when it moves, but every foot of movement costs it 1 extra foot unless you are Tiny or two or more sizes smaller.",
+    "url": "/api/2024/conditions/grappled"
+  },
+  {
+    "index": "incapacitated",
+    "name": "Incapacitated",
+    "description": "While you have the Incapacitated condition, you experience the following effects.\n**Inactive.** You can't take any action, Bonus Action, or Reaction.\n**No Concentration.** Your Concentration is broken.\n**Speechless.** You can't speak.\n**Surprised.** If you're Incapacitated when you roll Initiative, you have Disadvantage on the roll.",
+    "url": "/api/2024/conditions/incapacitated"
+  },
+  {
+    "index": "invisible",
+    "name": "Invisible",
+    "description": "While you have the Invisible condition, you experience the following effects.\n**Surprise.** If you're Invisible when you roll Initiative, you have Advantage on the roll.\n**Concealed.** You aren't affected by any effect that requires its target to be seen unless the effect's creator can somehow see you. Any equipment you are wearing or carrying is also concealed.\n**Attacks Affected.** Attack rolls against you have Disadvantage, and your attack rolls have Advantage. If a creature can somehow see you, you don't gain this benefit against that creature.",
+    "url": "/api/2024/conditions/invisible"
+  },
+  {
+    "index": "paralyzed",
+    "name": "Paralyzed",
+    "description": "While you have the Paralyzed condition, you experience the following effects.\n**Incapacitated.** You have the Incapacitated condition.\n**Speed 0.** Your Speed is 0 and can't increase.\n**Saving Throws Affected.** You automatically fail Strength and Dexterity saving throws.\n**Attacks Affected.** Attack rolls against you have Advantage.\n**Automatic Critical Hits.** Any attack roll that hits you is a Critical Hit if the attacker is within 5 feet of you.",
+    "url": "/api/2024/conditions/paralyzed"
+  },
+  {
+    "index": "petrified",
+    "name": "Petrified",
+    "description": "While you have the Petrified condition, you experience the following effects.\n**Turned to Inanimate Substance.** You are transformed, along with any nonmagical objects you are wearing and carrying, into a solid inanimate substance (usually stone). Your weight increases by a factor of ten, and you cease aging.\n**Incapacitated.** You have the Incapacitated condition.\n**Speed 0.** Your Speed is 0 and can't increase.\n**Attacks Affected.** Attack rolls against you have Advantage.\n**Saving Throws Affected.** You automatically fail Strength and Dexterity saving throws.\n**Resist Damage.** You have Resistance to all damage.\n**Poison Immunity.** You have Immunity to the Poisoned condition.\n**Saving Throws Affected.** You automatically fail Strength and Dexterity saving throws.\n**Resist Damage.** You have Resistance to all damage.\n**Poison Immunity.** You have Immunity to the Poisoned condition.",
+    "url": "/api/2024/conditions/petrified"
+  },
+  {
+    "index": "poisoned",
+    "name": "Poisoned",
+    "description": "While you have the Poisoned condition, you experience the following effect.\n**Ability Checks and Attacks Affected.** You have Disadvantage on attack rolls and ability checks.",
+    "url": "/api/2024/conditions/poisoned"
+  },
+  {
+    "index": "prone",
+    "name": "Prone",
+    "description": "While you have the Prone condition, you experience the following effects.\n**Restricted Movement.** Your only movement options are to crawl or to spend an amount of movement equal to half your Speed (round down) to right yourself and thereby end the condition. If your Speed is 0, you can't right yourself.\n**Attacks Affected.** You have Disadvantage on attack rolls. An attack roll against you has Advantage if the attacker is within 5 feet of you. Otherwise, that attack roll has Disadvantage.",
+    "url": "/api/2024/conditions/prone"
+  },
+  {
+    "index": "restrained",
+    "name": "Restrained",
+    "description": "While you have the Restrained condition, you experience the following effects.\n**Speed 0.** Your Speed is 0 and can't increase.\n**Attacks Affected.** Attack rolls against you have Advantage, and your attack rolls have Disadvantage.\n**Saving Throws Affected.** You have Disadvantage on Dexterity saving throws.",
+    "url": "/api/2024/conditions/restrained"
+  },
+  {
+    "index": "stunned",
+    "name": "Stunned",
+    "description": "While you have the Stunned condition, you experience the following effects.\n**Incapacitated.** You have the Incapacitated condition.\n**Saving Throws Affected.** You automatically fail Strength and Dexterity saving throws.\n**Attacks Affected.** Attack rolls against you have Advantage.",
+    "url": "/api/2024/conditions/stunned"
+  },
+  {
+    "index": "unconscious",
+    "name": "Unconscious",
+    "description": "While you have the Unconscious condition, you experience the following effects.\n**Inert.** You have the Incapacitated and Prone conditions, and you drop whatever you're holding.\n**When this condition ends, you remain Prone.\n**Speed 0.** Your Speed is 0 and can't increase.\n**Attacks Affected.** Attack rolls against you have Advantage.\n**Saving Throws Affected.** You automatically fail Strength and Dexterity saving throws.\n**Automatic Critical Hits.** Any attack roll that hits you is a Critical Hit if the attacker is within 5 feet of you.\n**Unaware.** You're unaware of your surroundings.",
+    "url": "/api/2024/conditions/unconscious"
+  }
+]

--- a/src/2024/5e-SRD-Damage-Types.json
+++ b/src/2024/5e-SRD-Damage-Types.json
@@ -1,0 +1,80 @@
+[
+  {
+    "index": "acid",
+    "name": "Acid",
+    "description": "Corrosive liquids, digestive enzymes",
+    "url": "/api/2014/damage-types/acid"
+  },
+  {
+    "index": "bludgeoning",
+    "name": "Bludgeoning",
+    "description": "Blunt objects, constriction, falling",
+    "url": "/api/2014/damage-types/bludgeoning"
+  },
+  {
+    "index": "cold",
+    "name": "Cold",
+    "description": "Freezing water, icy blasts",
+    "url": "/api/2014/damage-types/cold"
+  },
+  {
+    "index": "fire",
+    "name": "Fire",
+    "description": "Flames, unbearable heat",
+    "url": "/api/2014/damage-types/fire"
+  },
+  {
+    "index": "force",
+    "name": "Force",
+    "description": "Pure magical energy",
+    "url": "/api/2014/damage-types/force"
+  },
+  {
+    "index": "lightning",
+    "name": "Lightning",
+    "description": "Electricity",
+    "url": "/api/2014/damage-types/lightning"
+  },
+  {
+    "index": "necrotic",
+    "name": "Necrotic",
+    "description": "Life-draining energy",
+    "url": "/api/2014/damage-types/necrotic"
+  },
+  {
+    "index": "piercing",
+    "name": "Piercing",
+    "description": "Fangs, puncturing objects",
+    "url": "/api/2014/damage-types/piercing"
+  },
+  {
+    "index": "poison",
+    "name": "Poison",
+    "description": "Toxic gas, venom",
+    "url": "/api/2014/damage-types/poison"
+  },
+  {
+    "index": "psychic",
+    "name": "Psychic",
+    "description": "Mind-rending energy",
+    "url": "/api/2014/damage-types/psychic"
+  },
+  {
+    "index": "radiant",
+    "name": "Radiant",
+    "description": "Holy energy, searing radiation",
+    "url": "/api/2014/damage-types/radiant"
+  },
+  {
+    "index": "slashing",
+    "name": "Slashing",
+    "description": "Claws, cutting objects",
+    "url": "/api/2014/damage-types/slashing"
+  },
+  {
+    "index": "thunder",
+    "name": "Thunder",
+    "description": "Concussive sound",
+    "url": "/api/2014/damage-types/thunder"
+  }
+]

--- a/src/2024/5e-SRD-Damage-Types.json
+++ b/src/2024/5e-SRD-Damage-Types.json
@@ -3,78 +3,78 @@
     "index": "acid",
     "name": "Acid",
     "description": "Corrosive liquids, digestive enzymes",
-    "url": "/api/2014/damage-types/acid"
+    "url": "/api/2024/damage-types/acid"
   },
   {
     "index": "bludgeoning",
     "name": "Bludgeoning",
     "description": "Blunt objects, constriction, falling",
-    "url": "/api/2014/damage-types/bludgeoning"
+    "url": "/api/2024/damage-types/bludgeoning"
   },
   {
     "index": "cold",
     "name": "Cold",
     "description": "Freezing water, icy blasts",
-    "url": "/api/2014/damage-types/cold"
+    "url": "/api/2024/damage-types/cold"
   },
   {
     "index": "fire",
     "name": "Fire",
     "description": "Flames, unbearable heat",
-    "url": "/api/2014/damage-types/fire"
+    "url": "/api/2024/damage-types/fire"
   },
   {
     "index": "force",
     "name": "Force",
     "description": "Pure magical energy",
-    "url": "/api/2014/damage-types/force"
+    "url": "/api/2024/damage-types/force"
   },
   {
     "index": "lightning",
     "name": "Lightning",
     "description": "Electricity",
-    "url": "/api/2014/damage-types/lightning"
+    "url": "/api/2024/damage-types/lightning"
   },
   {
     "index": "necrotic",
     "name": "Necrotic",
     "description": "Life-draining energy",
-    "url": "/api/2014/damage-types/necrotic"
+    "url": "/api/2024/damage-types/necrotic"
   },
   {
     "index": "piercing",
     "name": "Piercing",
     "description": "Fangs, puncturing objects",
-    "url": "/api/2014/damage-types/piercing"
+    "url": "/api/2024/damage-types/piercing"
   },
   {
     "index": "poison",
     "name": "Poison",
     "description": "Toxic gas, venom",
-    "url": "/api/2014/damage-types/poison"
+    "url": "/api/2024/damage-types/poison"
   },
   {
     "index": "psychic",
     "name": "Psychic",
     "description": "Mind-rending energy",
-    "url": "/api/2014/damage-types/psychic"
+    "url": "/api/2024/damage-types/psychic"
   },
   {
     "index": "radiant",
     "name": "Radiant",
     "description": "Holy energy, searing radiation",
-    "url": "/api/2014/damage-types/radiant"
+    "url": "/api/2024/damage-types/radiant"
   },
   {
     "index": "slashing",
     "name": "Slashing",
     "description": "Claws, cutting objects",
-    "url": "/api/2014/damage-types/slashing"
+    "url": "/api/2024/damage-types/slashing"
   },
   {
     "index": "thunder",
     "name": "Thunder",
     "description": "Concussive sound",
-    "url": "/api/2014/damage-types/thunder"
+    "url": "/api/2024/damage-types/thunder"
   }
 ]

--- a/src/2024/5e-SRD-Languages.json
+++ b/src/2024/5e-SRD-Languages.json
@@ -1,0 +1,135 @@
+[
+  {
+    "index": "common",
+    "name": "Common",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/common"
+  },
+  {
+    "index": "common-sign-language",
+    "name": "Common Sign Language",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/common-sign-language"
+  },
+  {
+    "index": "draconic",
+    "name": "Draconic",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/draconic"
+  },
+  {
+    "index": "dwarvish",
+    "name": "Dwarvish",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/dwarvish"
+  },
+  {
+    "index": "elvish",
+    "name": "Elvish",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/elvish"
+  },
+  {
+    "index": "giant",
+    "name": "Giant",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/giant"
+  },
+  {
+    "index": "gnomish",
+    "name": "Gnomish",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/gnomish"
+  },
+  {
+    "index": "goblin",
+    "name": "Goblin",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/goblin"
+  },
+  {
+    "index": "halfling",
+    "name": "Halfling",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/halfling"
+  },
+  {
+    "index": "orc",
+    "name": "Orc",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/orc"
+  },
+  {
+    "index": "abyssal",
+    "name": "Abyssal",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/abyssal"
+  },
+  {
+    "index": "celestial",
+    "name": "Celestial",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/celestial"
+  },
+  {
+    "index": "deep-speech",
+    "name": "Deep Speech",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/deep-speech"
+  },
+  {
+    "index": "druidic",
+    "name": "Druidic",
+    "is_rare": false,
+    "note": "",
+    "url": "/api/2024/languages/druidic"
+  },
+  {
+    "index": "infernal",
+    "name": "Infernal",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/infernal"
+  },
+  {
+    "index": "primordial",
+    "name": "Primordial",
+    "is_rare": true,
+    "note": "Primordial includes the Aquan, Auran, Ignan, and Terran dialects. Creatures that know one of these dialects can communicate with those that know a different one.",
+    "url": "/api/2024/languages/primordial"
+  },
+  {
+    "index": "sylvan",
+    "name": "Sylvan",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/sylvan"
+  },
+  {
+    "index": "thieves-cant",
+    "name": "Thieves' Cant",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/thieves-cant"
+  },
+  {
+    "index": "undercommon",
+    "name": "Undercommon",
+    "is_rare": true,
+    "note": "",
+    "url": "/api/2024/languages/undercommon"
+  }
+]

--- a/src/2024/5e-SRD-Magic-Schools.json
+++ b/src/2024/5e-SRD-Magic-Schools.json
@@ -1,0 +1,50 @@
+[
+  {
+    "index": "abjuration",
+    "name": "Abjuration",
+    "desc": "Prevents or reverses harmful effects",
+    "url": "/api/2024/magic-schools/abjuration"
+  },
+  {
+    "index": "conjuration",
+    "name": "Conjuration",
+    "desc": "Transports creatures or objects",
+    "url": "/api/2024/magic-schools/conjuration"
+  },
+  {
+    "index": "divination",
+    "name": "Divination",
+    "desc": "Reveals information",
+    "url": "/api/2024/magic-schools/divination"
+  },
+  {
+    "index": "enchantment",
+    "name": "Enchantment",
+    "desc": "Influences minds",
+    "url": "/api/2024/magic-schools/enchantment"
+  },
+  {
+    "index": "evocation",
+    "name": "Evocation",
+    "desc": "Channels energy to create effects that are often destructive",
+    "url": "/api/2024/magic-schools/evocation"
+  },
+  {
+    "index": "illusion",
+    "name": "Illusion",
+    "desc": "Deceives the mind or senses",
+    "url": "/api/2024/magic-schools/illusion"
+  },
+  {
+    "index": "necromancy",
+    "name": "Necromancy",
+    "desc": "Manipulates life and death",
+    "url": "/api/2024/magic-schools/necromancy"
+  },
+  {
+    "index": "transmutation",
+    "name": "Transmutation",
+    "desc": "Transforms creatures or objects",
+    "url": "/api/2024/magic-schools/transmutation"
+  }
+]

--- a/src/2024/5e-SRD-Magic-Schools.json
+++ b/src/2024/5e-SRD-Magic-Schools.json
@@ -2,49 +2,49 @@
   {
     "index": "abjuration",
     "name": "Abjuration",
-    "desc": "Prevents or reverses harmful effects",
+    "description": "Prevents or reverses harmful effects",
     "url": "/api/2024/magic-schools/abjuration"
   },
   {
     "index": "conjuration",
     "name": "Conjuration",
-    "desc": "Transports creatures or objects",
+    "description": "Transports creatures or objects",
     "url": "/api/2024/magic-schools/conjuration"
   },
   {
     "index": "divination",
     "name": "Divination",
-    "desc": "Reveals information",
+    "description": "Reveals information",
     "url": "/api/2024/magic-schools/divination"
   },
   {
     "index": "enchantment",
     "name": "Enchantment",
-    "desc": "Influences minds",
+    "description": "Influences minds",
     "url": "/api/2024/magic-schools/enchantment"
   },
   {
     "index": "evocation",
     "name": "Evocation",
-    "desc": "Channels energy to create effects that are often destructive",
+    "description": "Channels energy to create effects that are often destructive",
     "url": "/api/2024/magic-schools/evocation"
   },
   {
     "index": "illusion",
     "name": "Illusion",
-    "desc": "Deceives the mind or senses",
+    "description": "Deceives the mind or senses",
     "url": "/api/2024/magic-schools/illusion"
   },
   {
     "index": "necromancy",
     "name": "Necromancy",
-    "desc": "Manipulates life and death",
+    "description": "Manipulates life and death",
     "url": "/api/2024/magic-schools/necromancy"
   },
   {
     "index": "transmutation",
     "name": "Transmutation",
-    "desc": "Transforms creatures or objects",
+    "description": "Transforms creatures or objects",
     "url": "/api/2024/magic-schools/transmutation"
   }
 ]

--- a/src/2024/5e-SRD-Skills.json
+++ b/src/2024/5e-SRD-Skills.json
@@ -2,9 +2,7 @@
   {
     "index": "acrobatics",
     "name": "Acrobatics",
-    "description": [
-      "Stay on your feet in a tricky situation, or perform an acrobatic stunt."
-    ],
+    "description": "Stay on your feet in a tricky situation, or perform an acrobatic stunt.",
     "ability_score": {
       "index": "dex",
       "name": "DEX",
@@ -15,9 +13,7 @@
   {
     "index": "animal-handling",
     "name": "Animal Handling",
-    "description": [
-      "Calm or train an animal, or get an animal to behave in a certain way."
-    ],
+    "description": "Calm or train an animal, or get an animal to behave in a certain way.",
     "ability_score": {
       "index": "wis",
       "name": "WIS",
@@ -28,9 +24,7 @@
   {
     "index": "arcana",
     "name": "Arcana",
-    "description": [
-      "Recall lore about spells, magic items, and the planes of existence."
-    ],
+    "description": "Recall lore about spells, magic items, and the planes of existence.",
     "ability_score": {
       "index": "int",
       "name": "INT",
@@ -41,9 +35,7 @@
   {
     "index": "athletics",
     "name": "Athletics",
-    "description": [
-      "Jump farther than normal, stay afloat in rough water, or break something."
-    ],
+    "description": "Jump farther than normal, stay afloat in rough water, or break something.",
     "ability_score": {
       "index": "str",
       "name": "STR",
@@ -54,9 +46,7 @@
   {
     "index": "deception",
     "name": "Deception",
-    "description": [
-      "Tell a convincing lie, or wear a disguise convincingly."
-    ],
+    "description": "Tell a convincing lie, or wear a disguise convincingly.",
     "ability_score": {
       "index": "cha",
       "name": "CHA",
@@ -67,9 +57,7 @@
   {
     "index": "history",
     "name": "History",
-    "description": [
-      "Recall lore about historical events, people, nations, and cultures."
-    ],
+    "description": "Recall lore about historical events, people, nations, and cultures.",
     "ability_score": {
       "index": "int",
       "name": "INT",
@@ -80,9 +68,7 @@
   {
     "index": "insight",
     "name": "Insight",
-    "description": [
-      "Discern a person’s mood and intentions."
-    ],
+    "description": "Discern a person’s mood and intentions.",
     "ability_score": {
       "index": "wis",
       "name": "WIS",
@@ -93,9 +79,7 @@
   {
     "index": "intimidation",
     "name": "Intimidation",
-    "description": [
-      "Awe or threaten someone into doing what you want."
-    ],
+    "description": "Awe or threaten someone into doing what you want.",
     "ability_score": {
       "index": "cha",
       "name": "CHA",
@@ -106,9 +90,7 @@
   {
     "index": "investigation",
     "name": "Investigation",
-    "description": [
-      "Find obscure information in books, or deduce how something works."
-    ],
+    "description": "Find obscure information in books, or deduce how something works.",
     "ability_score": {
       "index": "int",
       "name": "INT",
@@ -119,9 +101,7 @@
   {
     "index": "medicine",
     "name": "Medicine",
-    "description": [
-      "Diagnose an illness, or determine what killed the recently slain."
-    ],
+    "description": "Diagnose an illness, or determine what killed the recently slain.",
     "ability_score": {
       "index": "wis",
       "name": "WIS",
@@ -132,9 +112,7 @@
   {
     "index": "nature",
     "name": "Nature",
-    "description": [
-      "Recall lore about terrain, plants, animals, and weather."
-    ],
+    "description": "Recall lore about terrain, plants, animals, and weather.",
     "ability_score": {
       "index": "int",
       "name": "INT",
@@ -145,9 +123,7 @@
   {
     "index": "perception",
     "name": "Perception",
-    "description": [
-      "Using a combination of senses, notice something that’s easy to miss."
-    ],
+    "description": "Using a combination of senses, notice something that’s easy to miss.",
     "ability_score": {
       "index": "wis",
       "name": "WIS",
@@ -158,9 +134,7 @@
   {
     "index": "performance",
     "name": "Performance",
-    "description": [
-      "Act, tell a story, perform music, or dance."
-    ],
+    "description": "Act, tell a story, perform music, or dance.",
     "ability_score": {
       "index": "cha",
       "name": "CHA",
@@ -171,9 +145,7 @@
   {
     "index": "persuasion",
     "name": "Persuasion",
-    "description": [
-      "Honestly and graciously convince someone of something."
-    ],
+    "description": "Honestly and graciously convince someone of something.",
     "ability_score": {
       "index": "cha",
       "name": "CHA",
@@ -184,9 +156,7 @@
   {
     "index": "religion",
     "name": "Religion",
-    "description": [
-      "Recall lore about gods, religious rituals, and holy symbols."
-    ],
+    "description": "Recall lore about gods, religious rituals, and holy symbols.",
     "ability_score": {
       "index": "int",
       "name": "INT",
@@ -197,9 +167,7 @@
   {
     "index": "sleight-of-hand",
     "name": "Sleight of Hand",
-    "description": [
-      "Pick a pocket, conceal a handheld object, or perform legerdemain."
-    ],
+    "description": "Pick a pocket, conceal a handheld object, or perform legerdemain.",
     "ability_score": {
       "index": "dex",
       "name": "DEX",
@@ -210,9 +178,7 @@
   {
     "index": "stealth",
     "name": "Stealth",
-    "description": [
-      "Escape notice by moving quietly and hiding behind things."
-    ],
+    "description": "Escape notice by moving quietly and hiding behind things.",
     "ability_score": {
       "index": "dex",
       "name": "DEX",
@@ -223,9 +189,7 @@
   {
     "index": "survival",
     "name": "Survival",
-    "description": [
-      "Follow tracks, forage, find a trail, or avoid natural hazards."
-    ],
+    "description": "Follow tracks, forage, find a trail, or avoid natural hazards.",
     "ability_score": {
       "index": "wis",
       "name": "WIS",

--- a/src/2024/5e-SRD-Weapon-Mastery-Properties.json
+++ b/src/2024/5e-SRD-Weapon-Mastery-Properties.json
@@ -1,0 +1,50 @@
+[
+  {
+    "index": "cleave",
+    "name": "Cleave",
+    "description": "If you hit a creature with a melee attack roll using this weapon, you can make a melee attack roll with the weapon against a second creature within 5 feet of the first that is also within your reach. On a hit, the second creature takes the weapon's damage, but don't add your ability modifier to that damage unless that modifier is negative. You can make this extra attack only once per turn.",
+    "url": "/api/2024/weapon-mastery-properties/cleave"
+  },
+  {
+    "index": "graze",
+    "name": "Graze",
+    "description": "If your attack roll with this weapon misses a creature, you can deal damage to that creature equal to the ability modifier you used to make the attack roll. This damage is the same type dealt by the weapon, and the damage can be increased only by increasing the ability modifier.",
+    "url": "/api/2024/weapon-mastery-properties/graze"
+  },
+  {
+    "index": "nick",
+    "name": "Nick",
+    "description": "When you make the extra attack of the Light property, you can make it as part of the Attack action instead of as a Bonus Action. You can make this extra attack only once per turn.",
+    "url": "/api/2024/weapon-mastery-properties/nick"
+  },
+  {
+    "index": "push",
+    "name": "Push",
+    "description": "If you hit a creature with this weapon, you can push the creature up to 10 feet straight away from yourself if it is Large or smaller.",
+    "url": "/api/2024/weapon-mastery-properties/push"
+  },
+  {
+    "index": "sap",
+    "name": "Sap",
+    "description": "If you hit a creature with this weapon, that creature has Disadvantage on its next attack roll before the start of your next turn.",
+    "url": "/api/2024/weapon-mastery-properties/sap"
+  },
+  {
+    "index": "slow",
+    "name": "Slow",
+    "description": "If you hit a creature with this weapon and deal damage to it, you can reduce its Speed by 10 feet until the start of your next turn. If the creature is hit more than once by weapons that have this property, the Speed reduction doesn't exceed 10 feet.",
+    "url": "/api/2024/weapon-mastery-properties/slow"
+  },
+  {
+    "index": "topple",
+    "name": "Topple",
+    "description": "If you hit a creature with this weapon, you can force the creature to make a Constitution saving throw (DC 8 plus the ability modifier used to make the attack roll and your Proficiency Bonus). On a failed save, the creature has the Prone condition.",
+    "url": "/api/2024/weapon-mastery-properties/topple"
+  },
+  {
+    "index": "vex",
+    "name": "Vex",
+    "description": "If you hit a creature with this weapon and deal damage to the creature, you have Advantage on your next attack roll against that creature before the end of your next turn.",
+    "url": "/api/2024/weapon-mastery-properties/vex"
+  }
+]

--- a/src/2024/5e-SRD-Weapon-Properties.json
+++ b/src/2024/5e-SRD-Weapon-Properties.json
@@ -1,0 +1,62 @@
+[
+  {
+    "index": "ammunition",
+    "name": "Ammunition",
+    "description": "You can use a weapon that has the Ammunition property to make a ranged attack only if you have ammunition to fire from it. The type of ammunition required is specified with the weapon's range. Each attack expends one piece of ammunition. Drawing the ammunition is part of the attack (you need a free hand to load a one-handed weapon). After a fight, you can spend 1 minute to recover half the ammunition (round down) you used in the fight; the rest is lost.",
+    "url": "/api/2024/weapon-properties/ammunition"
+  },
+  {
+    "index": "finesse",
+    "name": "Finesse",
+    "description": "When making an attack with a Finesse weapon, use your choice of your Strength or Dexterity modifier for the attack and damage rolls. You must use the same modifier for both rolls.",
+    "url": "/api/2024/weapon-properties/finesse"
+  },
+  {
+    "index": "heavy",
+    "name": "Heavy",
+    "description": "You have Disadvantage on attack rolls with a Heavy weapon if it's a Melee weapon and your Strength score isn't at least 13 or if it's a Ranged weapon and your Dexterity score isn't at least 13.",
+    "url": "/api/2024/weapon-properties/heavy"
+  },
+  {
+    "index": "light",
+    "name": "Light",
+    "description": "When you take the Attack action on your turn and attack with a Light weapon, you can make one extra attack as a Bonus Action later on the same turn. That extra attack must be made with a different Light weapon, and you don't add your ability modifier to the extra attack's damage unless that modifier is negative. For example, you can attack with a Shortsword in one hand and a Dagger in the other using the Attack action and a Bonus Action, but you don't add your Strength or Dexterity modifier to the damage roll of the Bonus Action unless that modifier is negative.",
+    "url": "/api/2024/weapon-properties/light"
+  },
+  {
+    "index": "loading",
+    "name": "Loading",
+    "description": "You can fire only one piece of ammunition from a Loading weapon when you use an action, a Bonus Action, or a Reaction to fire it, regardless of the number of attacks you can normally make.",
+    "url": "/api/2024/weapon-properties/loading"
+  },
+  {
+    "index": "range",
+    "name": "Range",
+    "description": "A Range weapon has a range in parentheses after the Ammunition or Thrown property. The range lists two numbers. The first is the weapon's normal range in feet, and the second is the weapon's long range. When attacking a target beyond normal range, you have Disadvantage on the attack roll. You can't attack a target beyond the long range.",
+    "url": "/api/2024/weapon-properties/range"
+  },
+  {
+    "index": "reach",
+    "name": "Reach",
+    "description": "A Reach weapon adds 5 feet to your reach when you attack with it, as well as when determining your reach for Opportunity Attacks with it.",
+    "url": "/api/2024/weapon-properties/reach"
+  },
+  {
+    "index": "thrown",
+    "name": "Thrown",
+    "description": "If a weapon has the Thrown property, you can throw the weapon to make a ranged attack, and you can draw that weapon as part of the attack. If the weapon is a Melee weapon, use the same ability modifier for the attack and damage rolls that you use for a melee attack with that weapon.",
+    "url": "/api/2024/weapon-properties/thrown"
+  },
+  {
+    "index": "two-handed",
+    "name": "Two-Handed",
+    "description": "A Two-Handed weapon requires two hands when you attack with it.",
+    "url": "/api/2024/weapon-properties/two-handed"
+  },
+  {
+    "index": "versatile",
+    "name": "Versatile",
+    "description": "A Versatile weapon can be used with one or two hands. A damage value in parentheses appears with the property. The weapon deals that damage when used with two hands to make a melee attack.",
+    "url": "/api/2024/weapon-properties/versatile"
+  }
+]


### PR DESCRIPTION
## What does this do?

Shift all descriptions to be strings and not arrays

Adds the following tables:
* Magic Schools
* Damage types
* Conditions
* Weapon Properties
* Weapon Mastery Properties
* Alignments
* Languages

## How was it tested?

CI

## Is there a Github issue this is resolving?

Nope

## Did you update the docs in the API? Please link an associated PR if applicable.

That will be part of a follow up PR after this gets reviewed.

## Here's a fun image for your troubles

![image](https://github.com/user-attachments/assets/dbaf3a8a-44b8-44de-940b-b82e78b99726)

