### PR TITLE
feat(2024): Adding equipment and equipment categories

### DIFF
--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -4,9 +4,239 @@
     "name": "Adventuring Gear",
     "equipment": [
       {
+        "index": "acid",
+        "name": "Acid",
+        "url": "/api/2024/equipment/acid"
+      },
+      {
+        "index": "alchemists-fire",
+        "name": "Alchemist's Fire",
+        "url": "/api/2024/equipment/alchemists-fire"
+      },
+      {
+        "index": "antitoxin",
+        "name": "Antitoxin",
+        "url": "/api/2024/equipment/antitoxin"
+      },
+      {
+        "index": "backpack",
+        "name": "Backpack",
+        "url": "/api/2024/equipment/backpack"
+      },
+      {
+        "index": "ball-bearings",
+        "name": "Ball Bearings",
+        "url": "/api/2024/equipment/ball-bearings"
+      },
+      {
+        "index": "barrel",
+        "name": "Barrel",
+        "url": "/api/2024/equipment/barrel"
+      },
+      {
+        "index": "basket",
+        "name": "Basket",
+        "url": "/api/2024/equipment/basket"
+      },
+      {
+        "index": "bedroll",
+        "name": "Bedroll",
+        "url": "/api/2024/equipment/bedroll"
+      },
+      {
+        "index": "bell",
+        "name": "Bell",
+        "url": "/api/2024/equipment/bell"
+      },
+      {
+        "index": "blanket",
+        "name": "Blanket",
+        "url": "/api/2024/equipment/blanket"
+      },
+      {
+        "index": "block-and-tackle",
+        "name": "Block and Tackle",
+        "url": "/api/2024/equipment/block-and-tackle"
+      },
+      {
+        "index": "book",
+        "name": "Book",
+        "url": "/api/2024/equipment/book"
+      },
+      {
+        "index": "bottle-glass",
+        "name": "Bottle, Glass",
+        "url": "/api/2024/equipment/bottle-glass"
+      },
+      {
+        "index": "bucket",
+        "name": "Bucket",
+        "url": "/api/2024/equipment/bucket"
+      },
+      {
+        "index": "burglars-pack",
+        "name": "Burglar's Pack",
+        "url": "/api/2024/equipment/burglars-pack"
+      },
+      {
+        "index": "caltrops",
+        "name": "Caltrops",
+        "url": "/api/2024/equipment/caltrops"
+      },
+      {
+        "index": "candle",
+        "name": "Candle",
+        "url": "/api/2024/equipment/candle"
+      },
+      {
         "index": "case-crossbow-bolt",
         "name": "Case, Crossbow Bolt",
         "url": "/api/2024/equipment/case-crossbow-bolt"
+      },
+      {
+        "index": "case-map-or-scroll",
+        "name": "Case, Map or Scroll",
+        "url": "/api/2024/equipment/case-map-or-scroll"
+      },
+      {
+        "index": "chain",
+        "name": "Chain",
+        "url": "/api/2024/equipment/chain"
+      },
+      {
+        "index": "chest",
+        "name": "Chest",
+        "url": "/api/2024/equipment/chest"
+      },
+      {
+        "index": "climbers-kit",
+        "name": "Climber's Kit",
+        "url": "/api/2024/equipment/climbers-kit"
+      },
+      {
+        "index": "clothes-fine",
+        "name": "Clothes, Fine",
+        "url": "/api/2024/equipment/clothes-fine"
+      },
+      {
+        "index": "clothes-travelers",
+        "name": "Clothes, Traveler's",
+        "url": "/api/2024/equipment/clothes-travelers"
+      },
+      {
+        "index": "component-pouch",
+        "name": "Component Pouch",
+        "url": "/api/2024/equipment/component-pouch"
+      },
+      {
+        "index": "costume",
+        "name": "Costume",
+        "url": "/api/2024/equipment/costume"
+      },
+      {
+        "index": "crystal",
+        "name": "Crystal",
+        "url": "/api/2024/equipment/crystal"
+      },
+      {
+        "index": "diplomat-pack",
+        "name": "Diplomat's Pack",
+        "url": "/api/2024/equipment/diplomat-pack"
+      },
+      {
+        "index": "dungeoneer-pack",
+        "name": "Dungeoneer's Pack",
+        "url": "/api/2024/equipment/dungeoneer-pack"
+      },
+      {
+        "index": "ink",
+        "name": "Ink",
+        "url": "/api/2024/equipment/ink"
+      },
+      {
+        "index": "ink-pen",
+        "name": "Ink Pen",
+        "url": "/api/2024/equipment/ink-pen"
+      },
+      {
+        "index": "jug",
+        "name": "Jug",
+        "url": "/api/2024/equipment/jug"
+      },
+      {
+        "index": "ladder",
+        "name": "Ladder",
+        "url": "/api/2024/equipment/ladder"
+      },
+      {
+        "index": "lantern-bullseye",
+        "name": "Lantern, Bullseye",
+        "url": "/api/2024/equipment/lantern-bullseye"
+      },
+      {
+        "index": "lantern-hooded",
+        "name": "Lantern, Hooded",
+        "url": "/api/2024/equipment/lantern-hooded"
+      },
+      {
+        "index": "lock",
+        "name": "Lock",
+        "url": "/api/2024/equipment/lock"
+      },
+      {
+        "index": "magnifying-glass",
+        "name": "Magnifying Glass",
+        "url": "/api/2024/equipment/magnifying-glass"
+      },
+      {
+        "index": "manacles",
+        "name": "Manacles",
+        "url": "/api/2024/equipment/manacles"
+      },
+      {
+        "index": "map",
+        "name": "Map",
+        "url": "/api/2024/equipment/map"
+      },
+      {
+        "index": "mirror",
+        "name": "Mirror",
+        "url": "/api/2024/equipment/mirror"
+      },
+      {
+        "index": "net",
+        "name": "Net",
+        "url": "/api/2024/equipment/net"
+      },
+      {
+        "index": "oil",
+        "name": "Oil",
+        "url": "/api/2024/equipment/oil"
+      },
+      {
+        "index": "orb",
+        "name": "Orb",
+        "url": "/api/2024/equipment/orb"
+      },
+      {
+        "index": "paper",
+        "name": "Paper",
+        "url": "/api/2024/equipment/paper"
+      },
+      {
+        "index": "parchment",
+        "name": "Parchment",
+        "url": "/api/2024/equipment/parchment"
+      },
+      {
+        "index": "perfume",
+        "name": "Perfume",
+        "url": "/api/2024/equipment/perfume"
+      },
+      {
+        "index": "poison-basic",
+        "name": "Poison, Basic",
+        "url": "/api/2024/equipment/poison-basic"
       },
       {
         "index": "pouch",
@@ -14,9 +244,144 @@
         "url": "/api/2024/equipment/pouch"
       },
       {
+        "index": "pole",
+        "name": "Pole",
+        "url": "/api/2024/equipment/pole"
+      },
+      {
+        "index": "pot-iron",
+        "name": "Pot, Iron",
+        "url": "/api/2024/equipment/pot-iron"
+      },
+      {
+        "index": "potion-of-healing",
+        "name": "Potion of Healing",
+        "url": "/api/2024/equipment/potion-of-healing"
+      },
+      {
+        "index": "priests-pack",
+        "name": "Priest's Pack",
+        "url": "/api/2024/equipment/priests-pack"
+      },
+      {
         "index": "quiver",
         "name": "Quiver",
         "url": "/api/2024/equipment/quiver"
+      },
+      {
+        "index": "ram-portable",
+        "name": "Ram, Portable",
+        "url": "/api/2024/equipment/ram-portable"
+      },
+      {
+        "index": "rations",
+        "name": "Rations",
+        "url": "/api/2024/equipment/rations"
+      },
+      {
+        "index": "robe",
+        "name": "Robe",
+        "url": "/api/2024/equipment/robe"
+      },
+      {
+        "index": "rod",
+        "name": "Rod",
+        "url": "/api/2024/equipment/rod"
+      },
+      {
+        "index": "rope",
+        "name": "Rope",
+        "url": "/api/2024/equipment/rope"
+      },
+      {
+        "index": "sack",
+        "name": "Sack",
+        "url": "/api/2024/equipment/sack"
+      },
+      {
+        "index": "scholars-pack",
+        "name": "Scholar's Pack",
+        "url": "/api/2024/equipment/scholars-pack"
+      },
+      {
+        "index": "shovel",
+        "name": "Shovel",
+        "url": "/api/2024/equipment/shovel"
+      },
+      {
+        "index": "signal-whistle",
+        "name": "Signal Whistle",
+        "url": "/api/2024/equipment/signal-whistle"
+      },
+      {
+        "index": "spell-scroll-cantrip",
+        "name": "Spell Scroll, Cantrip",
+        "url": "/api/2024/equipment/spell-scroll-cantrip"
+      },
+      {
+        "index": "spell-scroll-level-1",
+        "name": "Spell Scroll, Level 1",
+        "url": "/api/2024/equipment/spell-scroll-level-1"
+      },
+      {
+        "index": "spikes-iron",
+        "name": "Spikes, Iron",
+        "url": "/api/2024/equipment/spikes-iron"
+      },
+      {
+        "index": "sprig-of-mistletoe",
+        "name": "Sprig of Mistletoe",
+        "url": "/api/2024/equipment/sprig-of-mistletoe"
+      },
+      {
+        "index": "spyglass",
+        "name": "Spyglass",
+        "url": "/api/2024/equipment/spyglass"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "string",
+        "name": "String",
+        "url": "/api/2024/equipment/string"
+      },
+      {
+        "index": "tent",
+        "name": "Tent",
+        "url": "/api/2024/equipment/tent"
+      },
+      {
+        "index": "tinderbox",
+        "name": "Tinderbox",
+        "url": "/api/2024/equipment/tinderbox"
+      },
+      {
+        "index": "torch",
+        "name": "Torch",
+        "url": "/api/2024/equipment/torch"
+      },
+      {
+        "index": "vial",
+        "name": "Vial",
+        "url": "/api/2024/equipment/vial"
+      },
+      {
+        "index": "wand",
+        "name": "Wand",
+        "url": "/api/2024/equipment/wand"
+      },
+      {
+        "index": "waterskin",
+        "name": "Waterskin",
+        "url": "/api/2024/equipment/waterskin"
+      },
+      {
+        "index": "yew-wand",
+        "name": "Yew Wand",
+        "url": "/api/2024/equipment/yew-wand"
       }
     ],
     "url": "/api/2024/equipment-categories/adventuring-gear"
@@ -52,6 +417,43 @@
       }
     ],
     "url": "/api/2024/equipment-categories/ammunition"
+  },
+  {
+    "index": "arcane-foci",
+    "name": "Arcane Foci",
+    "equipment": [
+      {
+        "index": "crystal",
+        "name": "Crystal",
+        "url": "/api/2024/equipment/crystal"
+      },
+      {
+        "index": "orb",
+        "name": "Orb",
+        "url": "/api/2024/equipment/orb"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "rod",
+        "name": "Rod",
+        "url": "/api/2024/equipment/rod"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "wand",
+        "name": "Wand",
+        "url": "/api/2024/equipment/wand"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/arcane-foci"
   },
   {
     "index": "armor",
@@ -124,6 +526,55 @@
       }
     ],
     "url": "/api/2024/equipment-categories/armor"
+  },
+  {
+    "index": "druidic-foci",
+    "name": "Druidic Foci",
+    "equipment": [
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "sprig-of-mistletoe",
+        "name": "Sprig of Mistletoe",
+        "url": "/api/2024/equipment/sprig-of-mistletoe"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "yew-wand",
+        "name": "Yew Wand",
+        "url": "/api/2024/equipment/yew-wand"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/druidic-foci"
+  },
+  {
+    "index": "equipment-packs",
+    "name": "Equipment Packs",
+    "equipment": [
+      {
+        "index": "burglars-pack",
+        "name": "Burglar's Pack",
+        "url": "/api/2024/equipment/burglars-pack"
+      },
+      {
+        "index": "diplomat-pack",
+        "name": "Diplomat's Pack",
+        "url": "/api/2024/equipment/diplomat-pack"
+      },
+      {
+        "index": "dungeoneer-pack",
+        "name": "Dungeoneer's Pack",
+        "url": "/api/2024/equipment/dungeoneer-pack"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/equipment-packs"
   },
   {
     "index": "heavy-armor",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -54,6 +54,127 @@
     "url": "/api/2024/equipment-categories/ammunition"
   },
   {
+    "index": "armor",
+    "name": "Armor",
+    "equipment": [
+      {
+        "index": "breastplate",
+        "name": "Breastplate",
+        "url": "/api/2024/equipment/breastplate"
+      },
+      {
+        "index": "chain-mail",
+        "name": "Chain Mail",
+        "url": "/api/2024/equipment/chain-mail"
+      },
+      {
+        "index": "chain-shirt",
+        "name": "Chain Shirt",
+        "url": "/api/2024/equipment/chain-shirt"
+      },
+      {
+        "index": "half-plate-armor",
+        "name": "Half-Plate Armor",
+        "url": "/api/2024/equipment/half-plate-armor"
+      },
+      {
+        "index": "hide-armor",
+        "name": "Hide Armor",
+        "url": "/api/2024/equipment/hide-armor"
+      },
+      {
+        "index": "leather-armor",
+        "name": "Leather Armor",
+        "url": "/api/2024/equipment/leather-armor"
+      },
+      {
+        "index": "padded-armor",
+        "name": "Padded Armor",
+        "url": "/api/2024/equipment/padded-armor"
+      },
+      {
+        "index": "plate-armor",
+        "name": "Plate Armor",
+        "url": "/api/2024/equipment/plate-armor"
+      },
+      {
+        "index": "ring-mail",
+        "name": "Ring Mail",
+        "url": "/api/2024/equipment/ring-mail"
+      },
+      {
+        "index": "scale-mail",
+        "name": "Scale Mail",
+        "url": "/api/2024/equipment/scale-mail"
+      },
+      {
+        "index": "shield",
+        "name": "Shield",
+        "url": "/api/2024/equipment/shield"
+      },
+      {
+        "index": "splint-armor",
+        "name": "Splint Armor",
+        "url": "/api/2024/equipment/splint-armor"
+      },
+      {
+        "index": "studded-leather-armor",
+        "name": "Studded Leather Armor",
+        "url": "/api/2024/equipment/studded-leather-armor"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/armor"
+  },
+  {
+    "index": "heavy-armor",
+    "name": "Heavy Armor",
+    "equipment": [
+      {
+        "index": "chain-mail",
+        "name": "Chain Mail",
+        "url": "/api/2024/equipment/chain-mail"
+      },
+      {
+        "index": "plate-armor",
+        "name": "Plate Armor",
+        "url": "/api/2024/equipment/plate-armor"
+      },
+      {
+        "index": "ring-mail",
+        "name": "Ring Mail",
+        "url": "/api/2024/equipment/ring-mail"
+      },
+      {
+        "index": "splint-armor",
+        "name": "Splint Armor",
+        "url": "/api/2024/equipment/splint-armor"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/heavy-armor"
+  },
+  {
+    "index": "light-armor",
+    "name": "Light Armor",
+    "equipment": [
+      {
+        "index": "leather-armor",
+        "name": "Leather Armor",
+        "url": "/api/2024/equipment/leather-armor"
+      },
+      {
+        "index": "padded-armor",
+        "name": "Padded Armor",
+        "url": "/api/2024/equipment/padded-armor"
+      },
+      {
+        "index": "studded-leather-armor",
+        "name": "Studded Leather Armor",
+        "url": "/api/2024/equipment/studded-leather-armor"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/light-armor"
+  },
+  {
     "index": "martial-weapons",
     "name": "Martial Weapons",
     "equipment": [
@@ -310,6 +431,38 @@
     "url": "/api/2024/equipment-categories/martial-ranged-weapons"
   },
   {
+    "index": "medium-armor",
+    "name": "Medium Armor",
+    "equipment": [
+      {
+        "index": "breastplate",
+        "name": "Breastplate",
+        "url": "/api/2024/equipment/breastplate"
+      },
+      {
+        "index": "chain-shirt",
+        "name": "Chain Shirt",
+        "url": "/api/2024/equipment/chain-shirt"
+      },
+      {
+        "index": "half-plate-armor",
+        "name": "Half-Plate Armor",
+        "url": "/api/2024/equipment/half-plate-armor"
+      },
+      {
+        "index": "hide-armor",
+        "name": "Hide Armor",
+        "url": "/api/2024/equipment/hide-armor"
+      },
+      {
+        "index": "scale-mail",
+        "name": "Scale Mail",
+        "url": "/api/2024/equipment/scale-mail"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/medium-armor"
+  },
+  {
     "index": "melee-weapons",
     "name": "Melee Weapons",
     "equipment": [
@@ -512,6 +665,18 @@
       }
     ],
     "url": "/api/2024/equipment-categories/ranged-weapons"
+  },
+  {
+    "index": "shields",
+    "name": "Shields",
+    "equipment": [
+      {
+        "index": "shield",
+        "name": "Shield",
+        "url": "/api/2024/equipment/shield"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/shields"
   },
   {
     "index": "simple-melee-weapons",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -14,6 +14,11 @@
         "url": "/api/2024/equipment/alchemists-fire"
       },
       {
+        "index": "amulet",
+        "name": "Amulet",
+        "url": "/api/2024/equipment/amulet"
+      },
+      {
         "index": "antitoxin",
         "name": "Antitoxin",
         "url": "/api/2024/equipment/antitoxin"
@@ -25,7 +30,7 @@
       },
       {
         "index": "ball-bearings",
-        "name": "Ball Bearings",
+        "name": "Ball bearings",
         "url": "/api/2024/equipment/ball-bearings"
       },
       {
@@ -55,7 +60,7 @@
       },
       {
         "index": "block-and-tackle",
-        "name": "Block and Tackle",
+        "name": "Block and tackle",
         "url": "/api/2024/equipment/block-and-tackle"
       },
       {
@@ -134,6 +139,11 @@
         "url": "/api/2024/equipment/costume"
       },
       {
+        "index": "crowbar",
+        "name": "Crowbar",
+        "url": "/api/2024/equipment/crowbar"
+      },
+      {
         "index": "crystal",
         "name": "Crystal",
         "url": "/api/2024/equipment/crystal"
@@ -149,9 +159,34 @@
         "url": "/api/2024/equipment/dungeoneer-pack"
       },
       {
+        "index": "emblem",
+        "name": "Emblem",
+        "url": "/api/2024/equipment/emblem"
+      },
+      {
         "index": "flask",
         "name": "Flask",
         "url": "/api/2024/equipment/flask"
+      },
+      {
+        "index": "grappling-hook",
+        "name": "Grappling Hook",
+        "url": "/api/2024/equipment/grappling-hook"
+      },
+      {
+        "index": "healers-kit",
+        "name": "Healer's Kit",
+        "url": "/api/2024/equipment/healers-kit"
+      },
+      {
+        "index": "holy-water",
+        "name": "Holy Water",
+        "url": "/api/2024/equipment/holy-water"
+      },
+      {
+        "index": "hunting-trap",
+        "name": "Hunting Trap",
+        "url": "/api/2024/equipment/hunting-trap"
       },
       {
         "index": "ink",
@@ -172,6 +207,11 @@
         "index": "ladder",
         "name": "Ladder",
         "url": "/api/2024/equipment/ladder"
+      },
+      {
+        "index": "lamp",
+        "name": "Lamp",
+        "url": "/api/2024/equipment/lamp"
       },
       {
         "index": "lantern-bullseye",
@@ -282,6 +322,11 @@
         "index": "rations",
         "name": "Rations",
         "url": "/api/2024/equipment/rations"
+      },
+      {
+        "index": "reliquary",
+        "name": "Reliquary",
+        "url": "/api/2024/equipment/reliquary"
       },
       {
         "index": "robe",
@@ -607,9 +652,9 @@
         "url": "/api/2024/equipment/smiths-tools"
       },
       {
-        "index": "tinker-tools",
+        "index": "tinkers-tools",
         "name": "Tinker's Tools",
-        "url": "/api/2024/equipment/tinker-tools"
+        "url": "/api/2024/equipment/tinkers-tools"
       },
       {
         "index": "weavers-tools",
@@ -671,9 +716,9 @@
         "url": "/api/2024/equipment/dungeoneer-pack"
       },
       {
-        "index": "priest-pack",
+        "index": "priests-pack",
         "name": "Priest's Pack",
-        "url": "/api/2024/equipment/priest-pack"
+        "url": "/api/2024/equipment/priests-pack"
       },
       {
         "index": "scholars-pack",
@@ -698,9 +743,9 @@
         "url": "/api/2024/equipment/dragonchess"
       },
       {
-        "index": "playing-card",
+        "index": "playing-cards",
         "name": "Playing Card",
-        "url": "/api/2024/equipment/playing-card"
+        "url": "/api/2024/equipment/playing-cards"
       },
       {
         "index": "three-dragon-ante",
@@ -736,6 +781,28 @@
       }
     ],
     "url": "/api/2024/equipment-categories/heavy-armor"
+  },
+  {
+    "index": "holy-symbols",
+    "name": "Holy Symbols",
+    "equipment": [
+      {
+        "index": "amulet",
+        "name": "Amulet",
+        "url": "/api/2024/equipment/amulet"
+      },
+      {
+        "index": "emblem",
+        "name": "Emblem",
+        "url": "/api/2024/equipment/emblem"
+      },
+      {
+        "index": "reliquary",
+        "name": "Reliquary",
+        "url": "/api/2024/equipment/reliquary"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/holy-symbols"
   },
   {
     "index": "light-armor",
@@ -1683,9 +1750,9 @@
         "url": "/api/2024/equipment/three-dragon-ante"
       },
       {
-        "index": "tinker-tools",
+        "index": "tinkers-tools",
         "name": "Tinker's Tools",
-        "url": "/api/2024/equipment/tinker-tools"
+        "url": "/api/2024/equipment/tinkers-tools"
       },
       {
         "index": "viol",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -528,6 +528,98 @@
     "url": "/api/2024/equipment-categories/armor"
   },
   {
+    "index": "artisans-tools",
+    "name": "Artisan's Tools",
+    "equipment": [
+      {
+        "index": "alchemist-supplies",
+        "name": "Alchemist's Supplies",
+        "url": "/api/2024/equipment/alchemist-supplies"
+      },
+      {
+        "index": "brewers-supplies",
+        "name": "Brewer's Supplies",
+        "url": "/api/2024/equipment/brewers-supplies"
+      },
+      {
+        "index": "calligrapher-supplies",
+        "name": "Calligrapher's Supplies",
+        "url": "/api/2024/equipment/calligrapher-supplies"
+      },
+      {
+        "index": "carpenters-tools",
+        "name": "Carpenter's Tools",
+        "url": "/api/2024/equipment/carpenters-tools"
+      },
+      {
+        "index": "cartographer-tools",
+        "name": "Cartographer's Tools",
+        "url": "/api/2024/equipment/cartographer-tools"
+      },
+      {
+        "index": "cobblers-tools",
+        "name": "Cobbler's Tools",
+        "url": "/api/2024/equipment/cobblers-tools"
+      },
+      {
+        "index": "cooks-utensils",
+        "name": "Cook's Utensils",
+        "url": "/api/2024/equipment/cooks-utensils"
+      },
+      {
+        "index": "glassblowers-tools",
+        "name": "Glassblower's Tools",
+        "url": "/api/2024/equipment/glassblowers-tools"
+      },
+      {
+        "index": "jewelers-tools",
+        "name": "Jeweler's Tools",
+        "url": "/api/2024/equipment/jewelers-tools"
+      },
+      {
+        "index": "leatherworkers-tools",
+        "name": "Leatherworker's Tools",
+        "url": "/api/2024/equipment/leatherworkers-tools"
+      },
+      {
+        "index": "masons-tools",
+        "name": "Mason's Tools",
+        "url": "/api/2024/equipment/masons-tools"
+      },
+      {
+        "index": "painters-supplies",
+        "name": "Painter's Supplies",
+        "url": "/api/2024/equipment/painters-supplies"
+      },
+      {
+        "index": "potters-tools",
+        "name": "Potter's Tools",
+        "url": "/api/2024/equipment/potters-tools"
+      },
+      {
+        "index": "smiths-tools",
+        "name": "Smith's Tools",
+        "url": "/api/2024/equipment/smiths-tools"
+      },
+      {
+        "index": "tinker-tools",
+        "name": "Tinker's Tools",
+        "url": "/api/2024/equipment/tinker-tools"
+      },
+      {
+        "index": "weavers-tools",
+        "name": "Weaver's Tools",
+        "url": "/api/2024/equipment/weavers-tools"
+      },
+      {
+        "index": "woodcarvers-tools",
+        "name": "Woodcarver's Tools",
+        "url": "/api/2024/equipment/woodcarvers-tools"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/artisans-tools"
+  },
+  {
     "index": "druidic-foci",
     "name": "Druidic Foci",
     "equipment": [
@@ -572,9 +664,46 @@
         "index": "dungeoneer-pack",
         "name": "Dungeoneer's Pack",
         "url": "/api/2024/equipment/dungeoneer-pack"
+      },
+      {
+        "index": "priest-pack",
+        "name": "Priest's Pack",
+        "url": "/api/2024/equipment/priest-pack"
+      },
+      {
+        "index": "scholars-pack",
+        "name": "Scholar's Pack",
+        "url": "/api/2024/equipment/scholars-pack"
       }
     ],
     "url": "/api/2024/equipment-categories/equipment-packs"
+  },
+  {
+    "index": "gaming-sets",
+    "name": "Gaming Sets",
+    "equipment": [
+      {
+        "index": "dice",
+        "name": "Dice",
+        "url": "/api/2024/equipment/dice"
+      },
+      {
+        "index": "dragonchess",
+        "name": "Dragonchess",
+        "url": "/api/2024/equipment/dragonchess"
+      },
+      {
+        "index": "playing-card",
+        "name": "Playing Card",
+        "url": "/api/2024/equipment/playing-card"
+      },
+      {
+        "index": "three-dragon-ante",
+        "name": "Three-dragon Ante",
+        "url": "/api/2024/equipment/three-dragon-ante"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/gaming-sets"
   },
   {
     "index": "heavy-armor",
@@ -1061,6 +1190,100 @@
     "url": "/api/2024/equipment-categories/melee-weapons"
   },
   {
+    "index": "musical-instruments",
+    "name": "Musical Instruments",
+    "equipment": [
+      {
+        "index": "bagpipes",
+        "name": "Bagpipes",
+        "url": "/api/2024/equipment/bagpipes"
+      },
+      {
+        "index": "drum",
+        "name": "Drum",
+        "url": "/api/2024/equipment/drum"
+      },
+      {
+        "index": "dulcimer",
+        "name": "Dulcimer",
+        "url": "/api/2024/equipment/dulcimer"
+      },
+      {
+        "index": "flute",
+        "name": "Flute",
+        "url": "/api/2024/equipment/flute"
+      },
+      {
+        "index": "horn",
+        "name": "Horn",
+        "url": "/api/2024/equipment/horn"
+      },
+      {
+        "index": "lute",
+        "name": "Lute",
+        "url": "/api/2024/equipment/lute"
+      },
+      {
+        "index": "lyre",
+        "name": "Lyre",
+        "url": "/api/2024/equipment/lyre"
+      },
+      {
+        "index": "pan-flute",
+        "name": "Pan flute",
+        "url": "/api/2024/equipment/pan-flute"
+      },
+      {
+        "index": "shawm",
+        "name": "Shawm",
+        "url": "/api/2024/equipment/shawm"
+      },
+      {
+        "index": "viol",
+        "name": "Viol",
+        "url": "/api/2024/equipment/viol"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/musical-instruments"
+  },
+  {
+    "index": "other-tools",
+    "name": "Other Tools",
+    "equipment": [
+      {
+        "index": "disguise-kit",
+        "name": "Disguise Kit",
+        "url": "/api/2024/equipment/disguise-kit"
+      },
+      {
+        "index": "forgery-kit",
+        "name": "Forgery Kit",
+        "url": "/api/2024/equipment/forgery-kit"
+      },
+      {
+        "index": "herbalism-kit",
+        "name": "Herbalism Kit",
+        "url": "/api/2024/equipment/herbalism-kit"
+      },
+      {
+        "index": "navigators-tools",
+        "name": "Navigator's Tools",
+        "url": "/api/2024/equipment/navigators-tools"
+      },
+      {
+        "index": "poisoners-kit",
+        "name": "Poisoner's Kit",
+        "url": "/api/2024/equipment/poisoners-kit"
+      },
+      {
+        "index": "thieves-tools",
+        "name": "Thieves' Tools",
+        "url": "/api/2024/equipment/thieves-tools"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/other-tools"
+  },
+  {
     "index": "ranged-weapons",
     "name": "Ranged Weapons",
     "equipment": [
@@ -1289,6 +1512,193 @@
       }
     ],
     "url": "/api/2024/equipment-categories/simple-weapons"
+  },
+  {
+    "index": "tools",
+    "name": "Tools",
+    "equipment": [
+      {
+        "index": "alchemist-supplies",
+        "name": "Alchemist's Supplies",
+        "url": "/api/2024/equipment/alchemist-supplies"
+      },
+      {
+        "index": "bagpipes",
+        "name": "Bagpipes",
+        "url": "/api/2024/equipment/bagpipes"
+      },
+      {
+        "index": "brewers-supplies",
+        "name": "Brewer's Supplies",
+        "url": "/api/2024/equipment/brewers-supplies"
+      },
+      {
+        "index": "calligrapher-supplies",
+        "name": "Calligrapher's Supplies",
+        "url": "/api/2024/equipment/calligrapher-supplies"
+      },
+      {
+        "index": "carpenters-tools",
+        "name": "Carpenter's Tools",
+        "url": "/api/2024/equipment/carpenters-tools"
+      },
+      {
+        "index": "cartographer-tools",
+        "name": "Cartographer's Tools",
+        "url": "/api/2024/equipment/cartographer-tools"
+      },
+      {
+        "index": "cobblers-tools",
+        "name": "Cobbler's Tools",
+        "url": "/api/2024/equipment/cobblers-tools"
+      },
+      {
+        "index": "cooks-utensils",
+        "name": "Cook's Utensils",
+        "url": "/api/2024/equipment/cooks-utensils"
+      },
+      {
+        "index": "dice",
+        "name": "Dice",
+        "url": "/api/2024/equipment/dice"
+      },
+      {
+        "index": "disguise-kit",
+        "name": "Disguise Kit",
+        "url": "/api/2024/equipment/disguise-kit"
+      },
+      {
+        "index": "dragonchess",
+        "name": "Dragonchess",
+        "url": "/api/2024/equipment/dragonchess"
+      },
+      {
+        "index": "drum",
+        "name": "Drum",
+        "url": "/api/2024/equipment/drum"
+      },
+      {
+        "index": "dulcimer",
+        "name": "Dulcimer",
+        "url": "/api/2024/equipment/dulcimer"
+      },
+      {
+        "index": "flute",
+        "name": "Flute",
+        "url": "/api/2024/equipment/flute"
+      },
+      {
+        "index": "glassblowers-tools",
+        "name": "Glassblower's Tools",
+        "url": "/api/2024/equipment/glassblowers-tools"
+      },
+      {
+        "index": "herbalism-kit",
+        "name": "Herbalism Kit",
+        "url": "/api/2024/equipment/herbalism-kit"
+      },
+      {
+        "index": "horn",
+        "name": "Horn",
+        "url": "/api/2024/equipment/horn"
+      },
+      {
+        "index": "jewelers-tools",
+        "name": "Jeweler's Tools",
+        "url": "/api/2024/equipment/jewelers-tools"
+      },
+      {
+        "index": "leatherworkers-tools",
+        "name": "Leatherworker's Tools",
+        "url": "/api/2024/equipment/leatherworkers-tools"
+      },
+      {
+        "index": "lute",
+        "name": "Lute",
+        "url": "/api/2024/equipment/lute"
+      },
+      {
+        "index": "lyre",
+        "name": "Lyre",
+        "url": "/api/2024/equipment/lyre"
+      },
+      {
+        "index": "masons-tools",
+        "name": "Mason's Tools",
+        "url": "/api/2024/equipment/masons-tools"
+      },
+      {
+        "index": "navigators-tools",
+        "name": "Navigator's Tools",
+        "url": "/api/2024/equipment/navigators-tools"
+      },
+      {
+        "index": "painters-supplies",
+        "name": "Painter's Supplies",
+        "url": "/api/2024/equipment/painters-supplies"
+      },
+      {
+        "index": "pan-flute",
+        "name": "Pan flute",
+        "url": "/api/2024/equipment/pan-flute"
+      },
+      {
+        "index": "playing-cards",
+        "name": "Playing Cards",
+        "url": "/api/2024/equipment/playing-cards"
+      },
+      {
+        "index": "poisoners-kit",
+        "name": "Poisoner's Kit",
+        "url": "/api/2024/equipment/poisoners-kit"
+      },
+      {
+        "index": "potters-tools",
+        "name": "Potter's Tools",
+        "url": "/api/2024/equipment/potters-tools"
+      },
+      {
+        "index": "shawm",
+        "name": "Shawm",
+        "url": "/api/2024/equipment/shawm"
+      },
+      {
+        "index": "smiths-tools",
+        "name": "Smith's Tools",
+        "url": "/api/2024/equipment/smiths-tools"
+      },
+      {
+        "index": "thieves-tools",
+        "name": "Thieves' Tools",
+        "url": "/api/2024/equipment/thieves-tools"
+      },
+      {
+        "index": "three-dragon-ante",
+        "name": "Three-dragon Ante",
+        "url": "/api/2024/equipment/three-dragon-ante"
+      },
+      {
+        "index": "tinker-tools",
+        "name": "Tinker's Tools",
+        "url": "/api/2024/equipment/tinker-tools"
+      },
+      {
+        "index": "viol",
+        "name": "Viol",
+        "url": "/api/2024/equipment/viol"
+      },
+      {
+        "index": "weavers-tools",
+        "name": "Weaver's Tools",
+        "url": "/api/2024/equipment/weavers-tools"
+      },
+      {
+        "index": "woodcarvers-tools",
+        "name": "Woodcarver's Tools",
+        "url": "/api/2024/equipment/woodcarvers-tools"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/tools"
   },
   {
     "index": "weapons",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -149,6 +149,11 @@
         "url": "/api/2024/equipment/dungeoneer-pack"
       },
       {
+        "index": "flask",
+        "name": "Flask",
+        "url": "/api/2024/equipment/flask"
+      },
+      {
         "index": "ink",
         "name": "Ink",
         "url": "/api/2024/equipment/ink"

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -54,9 +54,203 @@
     "url": "/api/2024/equipment-categories/ammunition"
   },
   {
+    "index": "martial-weapons",
+    "name": "Martial Weapons",
+    "equipment": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/2024/equipment/battleaxe"
+      },
+      {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/2024/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/2024/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/2024/equipment/greataxe"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/2024/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/2024/equipment/halberd"
+      },
+      {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/2024/equipment/lance"
+      },
+      {
+        "index": "longsword",
+        "name": "Longsword",
+        "url": "/api/2024/equipment/longsword"
+      },
+      {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/2024/equipment/maul"
+      },
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "url": "/api/2024/equipment/morningstar"
+      },
+      {
+        "index": "pike",
+        "name": "Pike",
+        "url": "/api/2024/equipment/pike"
+      },
+      {
+        "index": "rapier",
+        "name": "Rapier",
+        "url": "/api/2024/equipment/rapier"
+      },
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "url": "/api/2024/equipment/scimitar"
+      },
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "url": "/api/2024/equipment/shortsword"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/2024/equipment/trident"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/2024/equipment/warhammer"
+      },
+      {
+        "index": "war-pick",
+        "name": "War Pick",
+        "url": "/api/2024/equipment/war-pick"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/2024/equipment/whip"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/martial-weapons"
+  },
+  {
+    "index": "martial-melee-weapons",
+    "name": "Martial Melee Weapons",
+    "equipment": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/2024/equipment/battleaxe"
+      },
+      {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/2024/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/2024/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/2024/equipment/greataxe"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/2024/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/2024/equipment/halberd"
+      },
+      {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/2024/equipment/lance"
+      },
+      {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/2024/equipment/maul"
+      },
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "url": "/api/2024/equipment/morningstar"
+      },
+      {
+        "index": "pike",
+        "name": "Pike",
+        "url": "/api/2024/equipment/pike"
+      },
+      {
+        "index": "rapier",
+        "name": "Rapier",
+        "url": "/api/2024/equipment/rapier"
+      },
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "url": "/api/2024/equipment/scimitar"
+      },
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "url": "/api/2024/equipment/shortsword"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/2024/equipment/trident"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/2024/equipment/warhammer"
+      },
+      {
+        "index": "war-pick",
+        "name": "War Pick",
+        "url": "/api/2024/equipment/war-pick"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/2024/equipment/whip"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/martial-melee-weapons"
+  },
+  {
     "index": "melee-weapons",
     "name": "Melee Weapons",
     "equipment": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/2024/equipment/battleaxe"
+      },
       {
         "index": "club",
         "name": "Club",
@@ -68,9 +262,34 @@
         "url": "/api/2024/equipment/dagger"
       },
       {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/2024/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/2024/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/2024/equipment/greataxe"
+      },
+      {
         "index": "greatclub",
         "name": "Greatclub",
         "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/2024/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/2024/equipment/halberd"
       },
       {
         "index": "handaxe",
@@ -83,9 +302,19 @@
         "url": "/api/2024/equipment/javelin"
       },
       {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/2024/equipment/lance"
+      },
+      {
         "index": "light-hammer",
         "name": "Light Hammer",
         "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "longsword",
+        "name": "Longsword",
+        "url": "/api/2024/equipment/longsword"
       },
       {
         "index": "mace",
@@ -93,9 +322,39 @@
         "url": "/api/2024/equipment/mace"
       },
       {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/2024/equipment/maul"
+      },
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "url": "/api/2024/equipment/morningstar"
+      },
+      {
+        "index": "pike",
+        "name": "Pike",
+        "url": "/api/2024/equipment/pike"
+      },
+      {
         "index": "quarterstaff",
         "name": "Quarterstaff",
         "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "rapier",
+        "name": "Rapier",
+        "url": "/api/2024/equipment/rapier"
+      },
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "url": "/api/2024/equipment/scimitar"
+      },
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "url": "/api/2024/equipment/shortsword"
       },
       {
         "index": "sickle",
@@ -106,6 +365,26 @@
         "index": "spear",
         "name": "Spear",
         "url": "/api/2024/equipment/spear"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/2024/equipment/trident"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/2024/equipment/warhammer"
+      },
+      {
+        "index": "war-pick",
+        "name": "War Pick",
+        "url": "/api/2024/equipment/war-pick"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/2024/equipment/whip"
       }
     ],
     "url": "/api/2024/equipment-categories/melee-weapons"
@@ -303,6 +582,11 @@
     "name": "Weapons",
     "equipment": [
       {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/2024/equipment/battleaxe"
+      },
+      {
         "index": "club",
         "name": "Club",
         "url": "/api/2024/equipment/club"
@@ -318,9 +602,34 @@
         "url": "/api/2024/equipment/dart"
       },
       {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/2024/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/2024/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/2024/equipment/greataxe"
+      },
+      {
         "index": "greatclub",
         "name": "Greatclub",
         "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/2024/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/2024/equipment/halberd"
       },
       {
         "index": "handaxe",
@@ -333,6 +642,11 @@
         "url": "/api/2024/equipment/javelin"
       },
       {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/2024/equipment/lance"
+      },
+      {
         "index": "light-crossbow",
         "name": "Light Crossbow",
         "url": "/api/2024/equipment/light-crossbow"
@@ -343,9 +657,29 @@
         "url": "/api/2024/equipment/light-hammer"
       },
       {
+        "index": "longsword",
+        "name": "Longsword",
+        "url": "/api/2024/equipment/longsword"
+      },
+      {
         "index": "mace",
         "name": "Mace",
         "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/2024/equipment/maul"
+      },
+      {
+        "index": "morningstar",
+        "name": "Morningstar",
+        "url": "/api/2024/equipment/morningstar"
+      },
+      {
+        "index": "pike",
+        "name": "Pike",
+        "url": "/api/2024/equipment/pike"
       },
       {
         "index": "quarterstaff",
@@ -353,9 +687,24 @@
         "url": "/api/2024/equipment/quarterstaff"
       },
       {
+        "index": "rapier",
+        "name": "Rapier",
+        "url": "/api/2024/equipment/rapier"
+      },
+      {
+        "index": "scimitar",
+        "name": "Scimitar",
+        "url": "/api/2024/equipment/scimitar"
+      },
+      {
         "index": "shortbow",
         "name": "Shortbow",
         "url": "/api/2024/equipment/shortbow"
+      },
+      {
+        "index": "shortsword",
+        "name": "Shortsword",
+        "url": "/api/2024/equipment/shortsword"
       },
       {
         "index": "sickle",
@@ -371,6 +720,26 @@
         "index": "spear",
         "name": "Spear",
         "url": "/api/2024/equipment/spear"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/2024/equipment/trident"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/2024/equipment/warhammer"
+      },
+      {
+        "index": "war-pick",
+        "name": "War Pick",
+        "url": "/api/2024/equipment/war-pick"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/2024/equipment/whip"
       }
     ],
     "url": "/api/2024/equipment-categories/weapons"

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -28,7 +28,8 @@
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
       }
-    ]
+    ],
+    "url": "/api/2024/equipment-categories/melee-weapons"
   },
   {
     "index": "simple-melee-weapons",
@@ -59,7 +60,8 @@
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
       }
-    ]
+    ],
+    "url": "/api/2024/equipment-categories/simple-melee-weapons"
   },
   {
     "index": "simple-weapons",
@@ -90,7 +92,8 @@
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
       }
-    ]
+    ],
+    "url": "/api/2024/equipment-categories/simple-weapons"
   },
   {
     "index": "weapons",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -1,0 +1,127 @@
+[
+  {
+    "index": "melee-weapons",
+    "name": "Melee Weapons",
+    "equipment": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/2024/equipment/javelin"
+      }
+    ]
+  },
+  {
+    "index": "simple-melee-weapons",
+    "name": "Simple Melee Weapons",
+    "equipment": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/2024/equipment/javelin"
+      }
+    ]
+  },
+  {
+    "index": "simple-weapons",
+    "name": "Simple Weapons",
+    "equipment": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/2024/equipment/javelin"
+      }
+    ]
+  },
+  {
+    "index": "weapons",
+    "name": "Weapons",
+    "equipment": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/2024/equipment/javelin"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/weapons"
+  }
+]

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -1,5 +1,59 @@
 [
   {
+    "index": "adventuring-gear",
+    "name": "Adventuring Gear",
+    "equipment": [
+      {
+        "index": "case-crossbow-bolt",
+        "name": "Case, Crossbow Bolt",
+        "url": "/api/2024/equipment/case-crossbow-bolt"
+      },
+      {
+        "index": "pouch",
+        "name": "Pouch",
+        "url": "/api/2024/equipment/pouch"
+      },
+      {
+        "index": "quiver",
+        "name": "Quiver",
+        "url": "/api/2024/equipment/quiver"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/adventuring-gear"
+  },
+  {
+    "index": "ammunition",
+    "name": "Ammunition",
+    "equipment": [
+      {
+        "index": "arrows",
+        "name": "Arrows",
+        "url": "/api/2024/equipment/arrows"
+      },
+      {
+        "index": "bolts",
+        "name": "Bolts",
+        "url": "/api/2024/equipment/bolts"
+      },
+      {
+        "index": "bullets-firearm",
+        "name": "Bullets, Firearm",
+        "url": "/api/2024/equipment/bullets-firearm"
+      },
+      {
+        "index": "bullets-sling",
+        "name": "Bullets, Sling",
+        "url": "/api/2024/equipment/bullets-sling"
+      },
+      {
+        "index": "needles",
+        "name": "Needles",
+        "url": "/api/2024/equipment/needles"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/ammunition"
+  },
+  {
     "index": "melee-weapons",
     "name": "Melee Weapons",
     "equipment": [
@@ -55,6 +109,33 @@
       }
     ],
     "url": "/api/2024/equipment-categories/melee-weapons"
+  },
+  {
+    "index": "ranged-weapons",
+    "name": "Ranged Weapons",
+    "equipment": [
+      {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/2024/equipment/dart"
+      },
+      {
+        "index": "light-crossbow",
+        "name": "Light Crossbow",
+        "url": "/api/2024/equipment/light-crossbow"
+      },
+      {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/2024/equipment/shortbow"
+      },
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/2024/equipment/sling"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/ranged-weapons"
   },
   {
     "index": "simple-melee-weapons",
@@ -114,6 +195,33 @@
     "url": "/api/2024/equipment-categories/simple-melee-weapons"
   },
   {
+    "index": "simple-ranged-weapons",
+    "name": "Simple Ranged Weapons",
+    "equipment": [
+      {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/2024/equipment/dart"
+      },
+      {
+        "index": "light-crossbow",
+        "name": "Light Crossbow",
+        "url": "/api/2024/equipment/light-crossbow"
+      },
+      {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/2024/equipment/shortbow"
+      },
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/2024/equipment/sling"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/simple-ranged-weapons"
+  },
+  {
     "index": "simple-weapons",
     "name": "Simple Weapons",
     "equipment": [
@@ -126,6 +234,11 @@
         "index": "dagger",
         "name": "Dagger",
         "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/2024/equipment/dart"
       },
       {
         "index": "greatclub",
@@ -143,6 +256,11 @@
         "url": "/api/2024/equipment/javelin"
       },
       {
+        "index": "light-crossbow",
+        "name": "Light Crossbow",
+        "url": "/api/2024/equipment/light-crossbow"
+      },
+      {
         "index": "light-hammer",
         "name": "Light Hammer",
         "url": "/api/2024/equipment/light-hammer"
@@ -158,9 +276,19 @@
         "url": "/api/2024/equipment/quarterstaff"
       },
       {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/2024/equipment/shortbow"
+      },
+      {
         "index": "sickle",
         "name": "Sickle",
         "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/2024/equipment/sling"
       },
       {
         "index": "spear",
@@ -185,6 +313,11 @@
         "url": "/api/2024/equipment/dagger"
       },
       {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/2024/equipment/dart"
+      },
+      {
         "index": "greatclub",
         "name": "Greatclub",
         "url": "/api/2024/equipment/greatclub"
@@ -198,6 +331,11 @@
         "index": "javelin",
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "light-crossbow",
+        "name": "Light Crossbow",
+        "url": "/api/2024/equipment/light-crossbow"
       },
       {
         "index": "light-hammer",
@@ -215,9 +353,19 @@
         "url": "/api/2024/equipment/quarterstaff"
       },
       {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/2024/equipment/shortbow"
+      },
+      {
         "index": "sickle",
         "name": "Sickle",
         "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/2024/equipment/sling"
       },
       {
         "index": "spear",

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -744,7 +744,7 @@
       },
       {
         "index": "playing-cards",
-        "name": "Playing Card",
+        "name": "Playing Cards",
         "url": "/api/2024/equipment/playing-cards"
       },
       {

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -27,6 +27,31 @@
         "index": "javelin",
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light Hammer",
+        "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/2024/equipment/spear"
       }
     ],
     "url": "/api/2024/equipment-categories/melee-weapons"
@@ -59,6 +84,31 @@
         "index": "javelin",
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light Hammer",
+        "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/2024/equipment/spear"
       }
     ],
     "url": "/api/2024/equipment-categories/simple-melee-weapons"
@@ -91,6 +141,31 @@
         "index": "javelin",
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light Hammer",
+        "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/2024/equipment/spear"
       }
     ],
     "url": "/api/2024/equipment-categories/simple-weapons"
@@ -123,6 +198,31 @@
         "index": "javelin",
         "name": "Javelin",
         "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light Hammer",
+        "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/2024/equipment/spear"
       }
     ],
     "url": "/api/2024/equipment-categories/weapons"

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -63,6 +63,11 @@
         "url": "/api/2024/equipment/battleaxe"
       },
       {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/2024/equipment/blowgun"
+      },
+      {
         "index": "flail",
         "name": "Flail",
         "url": "/api/2024/equipment/flail"
@@ -83,14 +88,29 @@
         "url": "/api/2024/equipment/greatsword"
       },
       {
+        "index": "hand-crossbow",
+        "name": "Hand Crossbow",
+        "url": "/api/2024/equipment/hand-crossbow"
+      },
+      {
         "index": "halberd",
         "name": "Halberd",
         "url": "/api/2024/equipment/halberd"
       },
       {
+        "index": "heavy-crossbow",
+        "name": "Heavy Crossbow",
+        "url": "/api/2024/equipment/heavy-crossbow"
+      },
+      {
         "index": "lance",
         "name": "Lance",
         "url": "/api/2024/equipment/lance"
+      },
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/2024/equipment/longbow"
       },
       {
         "index": "longsword",
@@ -108,9 +128,19 @@
         "url": "/api/2024/equipment/morningstar"
       },
       {
+        "index": "musket",
+        "name": "Musket",
+        "url": "/api/2024/equipment/musket"
+      },
+      {
         "index": "pike",
         "name": "Pike",
         "url": "/api/2024/equipment/pike"
+      },
+      {
+        "index": "pistol",
+        "name": "Pistol",
+        "url": "/api/2024/equipment/pistol"
       },
       {
         "index": "rapier",
@@ -241,6 +271,43 @@
       }
     ],
     "url": "/api/2024/equipment-categories/martial-melee-weapons"
+  },
+  {
+    "index": "martial-ranged-weapons",
+    "name": "Martial Ranged Weapons",
+    "equipment": [
+      {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/2024/equipment/blowgun"
+      },
+      {
+        "index": "hand-crossbow",
+        "name": "Hand Crossbow",
+        "url": "/api/2024/equipment/hand-crossbow"
+      },
+      {
+        "index": "heavy-crossbow",
+        "name": "Heavy Crossbow",
+        "url": "/api/2024/equipment/heavy-crossbow"
+      },
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/2024/equipment/longbow"
+      },
+      {
+        "index": "musket",
+        "name": "Musket",
+        "url": "/api/2024/equipment/musket"
+      },
+      {
+        "index": "pistol",
+        "name": "Pistol",
+        "url": "/api/2024/equipment/pistol"
+      }
+    ],
+    "url": "/api/2024/equipment-categories/martial-ranged-weapons"
   },
   {
     "index": "melee-weapons",
@@ -394,14 +461,44 @@
     "name": "Ranged Weapons",
     "equipment": [
       {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/2024/equipment/blowgun"
+      },
+      {
         "index": "dart",
         "name": "Dart",
         "url": "/api/2024/equipment/dart"
       },
       {
+        "index": "hand-crossbow",
+        "name": "Hand Crossbow",
+        "url": "/api/2024/equipment/hand-crossbow"
+      },
+      {
+        "index": "heavy-crossbow",
+        "name": "Heavy Crossbow",
+        "url": "/api/2024/equipment/heavy-crossbow"
+      },
+      {
         "index": "light-crossbow",
         "name": "Light Crossbow",
         "url": "/api/2024/equipment/light-crossbow"
+      },
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/2024/equipment/longbow"
+      },
+      {
+        "index": "musket",
+        "name": "Musket",
+        "url": "/api/2024/equipment/musket"
+      },
+      {
+        "index": "pistol",
+        "name": "Pistol",
+        "url": "/api/2024/equipment/pistol"
       },
       {
         "index": "shortbow",
@@ -587,6 +684,11 @@
         "url": "/api/2024/equipment/battleaxe"
       },
       {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/2024/equipment/blowgun"
+      },
+      {
         "index": "club",
         "name": "Club",
         "url": "/api/2024/equipment/club"
@@ -632,9 +734,19 @@
         "url": "/api/2024/equipment/halberd"
       },
       {
+        "index": "hand-crossbow",
+        "name": "Hand Crossbow",
+        "url": "/api/2024/equipment/hand-crossbow"
+      },
+      {
         "index": "handaxe",
         "name": "Handaxe",
         "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "heavy-crossbow",
+        "name": "Heavy Crossbow",
+        "url": "/api/2024/equipment/heavy-crossbow"
       },
       {
         "index": "javelin",
@@ -657,6 +769,11 @@
         "url": "/api/2024/equipment/light-hammer"
       },
       {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/2024/equipment/longbow"
+      },
+      {
         "index": "longsword",
         "name": "Longsword",
         "url": "/api/2024/equipment/longsword"
@@ -677,9 +794,19 @@
         "url": "/api/2024/equipment/morningstar"
       },
       {
+        "index": "musket",
+        "name": "Musket",
+        "url": "/api/2024/equipment/musket"
+      },
+      {
         "index": "pike",
         "name": "Pike",
         "url": "/api/2024/equipment/pike"
+      },
+      {
+        "index": "pistol",
+        "name": "Pistol",
+        "url": "/api/2024/equipment/pistol"
       },
       {
         "index": "quarterstaff",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -152,6 +152,37 @@
     "url": "/api/2024/equipment/blowgun"
   },
   {
+    "index": "breastplate",
+    "name": "Breastplate",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/2024/equipment-categories/medium-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 14,
+      "dex_bonus": true,
+      "max_bonus": 2
+    },
+    "cost": {
+      "quantity": 400,
+      "unit": "gp"
+    },
+    "don_time": "5 minutes",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 20,
+    "url": "/api/2024/equipment/breastplate"
+  },
+  {
     "index": "bolts",
     "name": "Bolts",
     "equipment_categories": [
@@ -237,6 +268,68 @@
     },
     "weight": 1,
     "url": "/api/2024/equipment/case-crossbow-bolt"
+  },
+  {
+    "index": "chain-mail",
+    "name": "Chain Mail",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/2024/equipment-categories/heavy-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 16,
+      "dex_bonus": false,
+      "max_bonus": 0
+    },
+    "cost": {
+      "quantity": 75,
+      "unit": "gp"
+    },
+    "don_time": "10 minutes",
+    "doff_time": "5 minutes",
+    "stealth_disadvantage": true,
+    "str_minimum": 13,
+    "weight": 55,
+    "url": "/api/2024/equipment/chain-mail"
+  },
+  {
+    "index": "chain-shirt",
+    "name": "Chain Shirt",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/2024/equipment-categories/medium-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 13,
+      "dex_bonus": true,
+      "max_bonus": 2
+    },
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "don_time": "5 minutes",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 14,
+    "url": "/api/2024/equipment/chain-shirt"
   },
   {
     "index": "club",
@@ -782,6 +875,37 @@
     "url": "/api/2024/equipment/halberd"
   },
   {
+    "index": "half-plate-armor",
+    "name": "Half-Plate Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/2024/equipment-categories/medium-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 15,
+      "dex_bonus": true,
+      "max_bonus": 2
+    },
+    "cost": {
+      "quantity": 750,
+      "unit": "gp"
+    },
+    "don_time": "5 minutes",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": true,
+    "str_minimum": 0,
+    "weight": 40,
+    "url": "/api/2024/equipment/half-plate-armor"
+  },
+  {
     "index": "hand-crossbow",
     "name": "Hand Crossbow",
     "equipment_categories": [
@@ -994,6 +1118,37 @@
     "url": "/api/2024/equipment/heavy-crossbow"
   },
   {
+    "index": "hide-armor",
+    "name": "Hide Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/2024/equipment-categories/light-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 12,
+      "dex_bonus": true,
+      "max_bonus": 2
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "don_time": "5 minutes",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 12,
+    "url": "/api/2024/equipment/hide-armor"
+  },
+  {
     "index": "javelin",
     "name": "Javelin",
     "equipment_categories": [
@@ -1119,6 +1274,36 @@
       "url": "/api/2024/weapon-mastery-properties/topple"
     },
     "url": "/api/2024/equipment/lance"
+  },
+  {
+    "index": "leather-armor",
+    "name": "Leather Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/2024/equipment-categories/light-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 11,
+      "dex_bonus": true
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "don_time": "1 minute",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 10,
+    "url": "/api/2024/equipment/leather-armor"
   },
   {
     "index": "light-crossbow",
@@ -1639,6 +1824,36 @@
     "url": "/api/2024/equipment/needles"
   },
   {
+    "index": "padded-armor",
+    "name": "Padded Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/2024/equipment-categories/light-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 11,
+      "dex_bonus": true
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "don_time": "1 minute",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": true,
+    "str_minimum": 0,
+    "weight": 8,
+    "url": "/api/2024/equipment/padded-armor"
+  },
+  {
     "index": "pike",
     "name": "Pike",
     "equipment_categories": [
@@ -1768,6 +1983,37 @@
       "url": "/api/2024/weapon-mastery-properties/vex"
     },
     "url": "/api/2024/equipment/pistol"
+  },
+  {
+    "index": "plate-armor",
+    "name": "Plate Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/2024/equipment-categories/heavy-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 18,
+      "dex_bonus": false,
+      "max_bonus": 0
+    },
+    "cost": {
+      "quantity": 1500,
+      "unit": "gp"
+    },
+    "don_time": "10 minutes",
+    "doff_time": "5 minutes",
+    "stealth_disadvantage": true,
+    "str_minimum": 15,
+    "weight": 65,
+    "url": "/api/2024/equipment/plate-armor"
   },
   {
     "index": "pouch",
@@ -1924,6 +2170,68 @@
     "url": "/api/2024/equipment/rapier"
   },
   {
+    "index": "ring-mail",
+    "name": "Ring Mail",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/2024/equipment-categories/heavy-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 14,
+      "dex_bonus": false,
+      "max_bonus": 0
+    },
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "don_time": "10 minutes",
+    "doff_time": "5 minutes",
+    "stealth_disadvantage": true,
+    "str_minimum": 0,
+    "weight": 40,
+    "url": "/api/2024/equipment/ring-mail"
+  },
+  {
+    "index": "scale-mail",
+    "name": "Scale Mail",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "medium-armor",
+        "name": "Medium Armor",
+        "url": "/api/2024/equipment-categories/medium-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 14,
+      "dex_bonus": true,
+      "max_bonus": 2
+    },
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "don_time": "5 minutes",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": true,
+    "str_minimum": 0,
+    "weight": 45,
+    "url": "/api/2024/equipment/scale-mail"
+  },
+  {
     "index": "scimitar",
     "name": "Scimitar",
     "equipment_categories": [
@@ -1982,6 +2290,34 @@
       "url": "/api/2024/weapon-mastery-properties/nick"
     },
     "url": "/api/2024/equipment/scimitar"
+  },
+  {
+    "index": "shield",
+    "name": "Shield",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "shields",
+        "name": "Shields",
+        "url": "/api/2024/equipment-categories/shields"
+      }
+    ],
+    "armor_class": {
+      "base": 2,
+      "dex_bonus": false
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 6,
+    "url": "/api/2024/equipment/shield"
   },
   {
     "index": "shortbow",
@@ -2296,6 +2632,67 @@
       }
     },
     "url": "/api/2024/equipment/spear"
+  },
+  {
+    "index": "splint-armor",
+    "name": "Splint Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "heavy-armor",
+        "name": "Heavy Armor",
+        "url": "/api/2024/equipment-categories/heavy-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 17,
+      "dex_bonus": false,
+      "max_bonus": 0
+    },
+    "cost": {
+      "quantity": 200,
+      "unit": "gp"
+    },
+    "don_time": "10 minutes",
+    "doff_time": "5 minutes",
+    "stealth_disadvantage": true,
+    "str_minimum": 15,
+    "weight": 60,
+    "url": "/api/2024/equipment/splint-armor"
+  },
+  {
+    "index": "studded-leather-armor",
+    "name": "Studded Leather Armor",
+    "equipment_categories": [
+      {
+        "index": "armor",
+        "name": "Armor",
+        "url": "/api/2024/equipment-categories/armor"
+      },
+      {
+        "index": "light-armor",
+        "name": "Light Armor",
+        "url": "/api/2024/equipment-categories/light-armor"
+      }
+    ],
+    "armor_class": {
+      "base": 12,
+      "dex_bonus": true
+    },
+    "cost": {
+      "quantity": 45,
+      "unit": "gp"
+    },
+    "don_time": "1 minute",
+    "doff_time": "1 minute",
+    "stealth_disadvantage": false,
+    "str_minimum": 0,
+    "weight": 13,
+    "url": "/api/2024/equipment/studded-leather-armor"
   },
   {
     "index": "trident",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -36,6 +36,91 @@
     "url": "/api/2024/equipment/alchemists-fire"
   },
   {
+    "index": "alchemist-supplies",
+    "name": "Alchemist's Supplies",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "craft": [
+      {
+        "index": "acid",
+        "name": "Acid",
+        "url": "/api/2024/equipment/acid"
+      },
+      {
+        "index": "alchemist-fire",
+        "name": "Alchemist's Fire",
+        "url": "/api/2024/equipment/alchemist-fire"
+      },
+      {
+        "index": "component-pouch",
+        "name": "Component Pouch",
+        "url": "/api/2024/equipment/component-pouch"
+      },
+      {
+        "index": "oil",
+        "name": "Oil",
+        "url": "/api/2024/equipment/oil"
+      },
+      {
+        "index": "paper",
+        "name": "Paper",
+        "url": "/api/2024/equipment/paper"
+      },
+      {
+        "index": "perfume",
+        "name": "Perfume",
+        "url": "/api/2024/equipment/perfume"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Identify a substance",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Start a fire",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 8,
+    "url": "/api/2024/equipment/alchemist-supplies"
+  },
+  {
     "index": "antitoxin",
     "name": "Antitoxin",
     "equipment_categories": [
@@ -93,6 +178,59 @@
     "description": "A Backpack holds up to 30 pounds within 1 cubic foot. It can also serve as a saddlebag.",
     "weight": 5,
     "url": "/api/2024/equipment/backpack"
+  },
+  {
+    "index": "bagpipes",
+    "name": "Bagpipes",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 6,
+    "url": "/api/2024/equipment/bagpipes"
   },
   {
     "index": "ball-bearings",
@@ -441,6 +579,66 @@
     "url": "/api/2024/equipment/breastplate"
   },
   {
+    "index": "brewers-supplies",
+    "name": "Brewer's Supplies",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "craft": [
+      {
+        "index": "antitoxin",
+        "name": "Antitoxin",
+        "url": "/api/2024/equipment/antitoxin"
+      }
+    ],
+    "cost": {
+      "quantity": 20,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Detect poisoned drink",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Identify alcohol",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 9,
+    "url": "/api/2024/equipment/brewers-supplies"
+  },
+  {
     "index": "bucket",
     "name": "Bucket",
     "equipment_categories": [
@@ -512,6 +710,11 @@
         "index": "adventuring-gear",
         "name": "Adventuring Gear",
         "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/2024/equipment-categories/equipment-packs"
       }
     ],
     "cost": {
@@ -621,6 +824,64 @@
     "url": "/api/2024/equipment/burglars-pack"
   },
   {
+    "index": "calligrapher-supplies",
+    "name": "Calligrapher's Supplies",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "craft": [
+      {
+        "index": "ink",
+        "name": "Ink",
+        "url": "/api/2024/equipment/ink"
+      },
+      {
+        "index": "spell-scroll-cantrip",
+        "name": "Spell Scroll, Cantrip",
+        "url": "/api/2024/equipment/spell-scroll-cantrip"
+      },
+      {
+        "index": "spell-scroll-level-1",
+        "name": "Spell Scroll, Level 1",
+        "url": "/api/2024/equipment/spell-scroll-level-1"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Write text with impressive flourishes that guard against forgery",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/calligrapher-supplies"
+  },
+  {
     "index": "caltrops",
     "name": "Caltrops",
     "equipment_categories": [
@@ -655,6 +916,142 @@
     "weight": 0,
     "description": "For 1 hour, a lit Candle sheds Bright Light in a 5-foot radius and Dim Light for an additional 5 feet.",
     "url": "/api/2024/equipment/candle"
+  },
+  {
+    "index": "carpenters-tools",
+    "name": "Carpenter's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "str",
+      "name": "Str",
+      "url": "/api/2024/ability-scores/str"
+    },
+    "craft": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "barrel",
+        "name": "Barrel",
+        "url": "/api/2024/equipment/barrel"
+      },
+      {
+        "index": "chest",
+        "name": "Chest",
+        "url": "/api/2024/equipment/chest"
+      },
+      {
+        "index": "ladder",
+        "name": "Ladder",
+        "url": "/api/2024/equipment/ladder"
+      },
+      {
+        "index": "pole",
+        "name": "Pole",
+        "url": "/api/2024/equipment/pole"
+      },
+      {
+        "index": "portable-ram",
+        "name": "Portable Ram",
+        "url": "/api/2024/equipment/portable-ram"
+      },
+      {
+        "index": "torch",
+        "name": "Torch",
+        "url": "/api/2024/equipment/torch"
+      }
+    ],
+    "cost": {
+      "quantity": 8,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": ": Seal or pry open a door or container",
+        "dc": {
+          "dc_type": {
+            "index": "str",
+            "name": "Str",
+            "url": "/api/2024/ability-scores/str"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 6,
+    "url": "/api/2024/equipment/carpenters-tools"
+  },
+  {
+    "index": "cartographer-tools",
+    "name": "Cartographer's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "craft": [
+      {
+        "index": "map",
+        "name": "Map",
+        "url": "/api/2024/equipment/map"
+      }
+    ],
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Draft a map of a small area",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 6,
+    "url": "/api/2024/equipment/cartographer-tools"
   },
   {
     "index": "case-crossbow-bolt",
@@ -900,6 +1297,54 @@
     "url": "/api/2024/equipment/club"
   },
   {
+    "index": "cobblers-tools",
+    "name": "Cobbler's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "climbers-kit",
+        "name": "Climber's Kit",
+        "url": "/api/2024/equipment/climbers-kit"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Modify footwear to give Advantage on the wearer’s next Dexterity (Acrobatics) check",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/cobblers-tools"
+  },
+  {
     "index": "component-pouch",
     "name": "Component Pouch",
     "equipment_categories": [
@@ -916,6 +1361,66 @@
     "description": "A Component Pouch is watertight and filled with compartments that hold all the free Material components of your spells.",
     "weight": 1,
     "url": "/api/2024/equipment/component-pouch"
+  },
+  {
+    "index": "cooks-utensils",
+    "name": "Cook's Utensils",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "rations",
+        "name": "Rations",
+        "url": "/api/2024/equipment/rations"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Improve food's flavor",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Detect spoiled or poisoned food",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 8,
+    "url": "/api/2024/equipment/cooks-utensils"
   },
   {
     "index": "costume",
@@ -1092,6 +1597,59 @@
     "url": "/api/2024/equipment/dart"
   },
   {
+    "index": "dice",
+    "name": "Dice",
+    "equipment_categories": [
+      {
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/2024/equipment-categories/gaming-sets"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "utilize": [
+      {
+        "name": "Discern whether someone is cheating",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Win the game",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 0,
+    "url": "/api/2024/equipment/dice"
+  },
+  {
     "index": "diplomat-pack",
     "name": "Diplomat's Pack",
     "equipment_categories": [
@@ -1213,6 +1771,213 @@
     "url": "/api/2024/equipment/diplomat-pack"
   },
   {
+    "index": "disguise-kit",
+    "name": "Disguise Kit",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "costume",
+        "name": "Costume",
+        "url": "/api/2024/equipment/costume"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Apply makeup",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 3,
+    "url": "/api/2024/equipment/disguise-kit"
+  },
+  {
+    "index": "dragonchess",
+    "name": "Dragonchess",
+    "equipment_categories": [
+      {
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/2024/equipment-categories/gaming-sets"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Discern whether someone is cheating",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Win the game",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 0,
+    "url": "/api/2024/equipment/dragonchess"
+  },
+  {
+    "index": "drum",
+    "name": "Drum",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 6,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 3,
+    "url": "/api/2024/equipment/drum"
+  },
+  {
+    "index": "dulcimer",
+    "name": "Dulcimer",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 10,
+    "url": "/api/2024/equipment/dulcimer"
+  },
+  {
     "index": "dungeoneer-pack",
     "name": "Dungeoneer's Pack",
     "equipment_categories": [
@@ -1313,7 +2078,7 @@
         "quantity": 1
       }
     ],
-    "description": "A Dungeoneer’s Pack contains the following items: Backpack, Caltrops, Crowbar, 2 flasks of Oil, 10 days of Rations, Rope, Tinderbox, 10 Torches, and Waterskin.",
+    "description": "A Dungeoneer's Pack contains the following items: Backpack, Caltrops, Crowbar, 2 flasks of Oil, 10 days of Rations, Rope, Tinderbox, 10 Torches, and Waterskin.",
     "weight": 55,
     "url": "/api/2024/equipment/dungeoneer-pack"
   },
@@ -1365,6 +2130,112 @@
       "url": "/api/2024/weapon-mastery-properties/sap"
     },
     "url": "/api/2024/equipment/flail"
+  },
+  {
+    "index": "flute",
+    "name": "Flute",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 1,
+    "url": "/api/2024/equipment/flute"
+  },
+  {
+    "index": "forgery-kit",
+    "name": "Forgery Kit",
+    "equipment_categories": [
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Mimic 10 or fewer words of someone else's handwriting",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Duplicate a wax seal",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/forgery-kit"
   },
   {
     "index": "glaive",
@@ -1430,6 +2301,55 @@
       "url": "/api/2024/weapon-mastery-properties/graze"
     },
     "url": "/api/2024/equipment/glaive"
+  },
+  {
+    "index": "glassblowers-tools",
+    "name": "Glassblower's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "bottle-glass",
+        "name": "Bottle, Glass",
+        "url": "/api/2024/equipment/bottle-glass"
+      },
+      {
+        "index": "magnifying-glass",
+        "name": "Magnifying Glass",
+        "url": "/api/2024/equipment/magnifying-glass"
+      },
+      {
+        "index": "spyglass",
+        "name": "Spyglass",
+        "url": "/api/2024/equipment/spyglass"
+      },
+      {
+        "index": "vial",
+        "name": "Vial",
+        "url": "/api/2024/equipment/vial"
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/glassblowers-tools"
   },
   {
     "index": "greataxe",
@@ -1915,6 +2835,69 @@
     "url": "/api/2024/equipment/heavy-crossbow"
   },
   {
+    "index": "herbalism-kit",
+    "name": "Herbalism Kit",
+    "equipment_categories": [
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "antitoxin",
+        "name": "Antitoxin",
+        "url": "/api/2024/equipment/antitoxin"
+      },
+      {
+        "index": "candle",
+        "name": "Candle",
+        "url": "/api/2024/equipment/candle"
+      },
+      {
+        "index": "healer-s-kit",
+        "name": "Healer's Kit",
+        "url": "/api/2024/equipment/healer-s-kit"
+      },
+      {
+        "index": "potion-of-healing",
+        "name": "Potion of Healing",
+        "url": "/api/2024/equipment/potion-of-healing"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Identify a plant",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 3,
+    "url": "/api/2024/equipment/herbalism-kit"
+  },
+  {
     "index": "hide-armor",
     "name": "Hide Armor",
     "equipment_categories": [
@@ -1944,6 +2927,59 @@
     "str_minimum": 0,
     "weight": 12,
     "url": "/api/2024/equipment/hide-armor"
+  },
+  {
+    "index": "horn",
+    "name": "Horn",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 3,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/horn"
   },
   {
     "index": "ink",
@@ -2039,6 +3075,59 @@
       "long": 120
     },
     "url": "/api/2024/equipment/javelin"
+  },
+  {
+    "index": "jewelers-tools",
+    "name": "Jeweler's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "arcane-focus",
+        "name": "Arcane Focus",
+        "url": "/api/2024/equipment/arcane-focus"
+      },
+      {
+        "index": "holy-symbol",
+        "name": "Holy Symbol",
+        "url": "/api/2024/equipment/holy-symbol"
+      }
+    ],
+    "utilize": [
+      {
+        "name": " Discern a gem’s value",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/jewelers-tools"
   },
   {
     "index": "jug",
@@ -2209,6 +3298,109 @@
     "str_minimum": 0,
     "weight": 10,
     "url": "/api/2024/equipment/leather-armor"
+  },
+  {
+    "index": "leatherworkers-tools",
+    "name": "Leatherworker's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "sling",
+        "name": "Sling",
+        "url": "/api/2024/equipment/sling"
+      },
+      {
+        "index": "whip",
+        "name": "Whip",
+        "url": "/api/2024/equipment/whip"
+      },
+      {
+        "index": "hide-armor",
+        "name": "Hide Armor",
+        "url": "/api/2024/equipment/hide-armor"
+      },
+      {
+        "index": "leather-armor",
+        "name": "Leather Armor",
+        "url": "/api/2024/equipment/leather-armor"
+      },
+      {
+        "index": "studded-leather-armor",
+        "name": "Studded Leather Armor",
+        "url": "/api/2024/equipment/studded-leather-armor"
+      },
+      {
+        "index": "backpack",
+        "name": "Backpack",
+        "url": "/api/2024/equipment/backpack"
+      },
+      {
+        "index": "crossbow-bolt-case",
+        "name": "Crossbow Bolt Case",
+        "url": "/api/2024/equipment/crossbow-bolt-case"
+      },
+      {
+        "index": "case-map-or-scroll",
+        "name": "Case, Map or Scroll",
+        "url": "/api/2024/equipment/case-map-or-scroll"
+      },
+      {
+        "index": "parchment",
+        "name": "Parchment",
+        "url": "/api/2024/equipment/parchment"
+      },
+      {
+        "index": "pouch",
+        "name": "Pouch",
+        "url": "/api/2024/equipment/pouch"
+      },
+      {
+        "index": "quiver",
+        "name": "Quiver",
+        "url": "/api/2024/equipment/quiver"
+      },
+      {
+        "index": "waterskin",
+        "name": "Waterskin",
+        "url": "/api/2024/equipment/waterskin"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Add a design to a leather item",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/leatherworkers-tools"
   },
   {
     "index": "light-crossbow",
@@ -2498,6 +3690,112 @@
     "url": "/api/2024/equipment/longsword"
   },
   {
+    "index": "lute",
+    "name": "Lute",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 35,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/lute"
+  },
+  {
+    "index": "lyre",
+    "name": "Lyre",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/lyre"
+  },
+  {
     "index": "mace",
     "name": "Mace",
     "equipment_categories": [
@@ -2581,6 +3879,54 @@
     "description": "As a Utilize action, you can use Manacles to bind an unwilling Small or Medium creature within 5 feet of yourself that has the Grappled, Incapacitated, or Restrained condition if you succeed on a DC 13 Dexterity (Sleight of Hand) check. While bound, a creature has Disadvantage on attack rolls, and the creature is Restrained if the Manacles are attached to a chain or hook that is fixed in place. Escaping the Manacles requires a successful DC 20 Dexterity (Sleight of Hand) check as an action. Bursting them requires a successful DC 25 Strength (Athletics) check as an action.\nEach set of Manacles comes with a key. Without the key, a creature can use Thieves’ Tools to pick the Manacles’ lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
     "weight": 6,
     "url": "/api/2024/equipment/manacles"
+  },
+  {
+    "index": "masons-tools",
+    "name": "Mason's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "str",
+      "name": "Str",
+      "url": "/api/2024/ability-scores/str"
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "block-and-tackle",
+        "name": "Block and Tackle",
+        "url": "/api/2024/equipment/block-and-tackle"
+      }
+    ],
+    "utilize": [
+      {
+        "name": ": Chisel a symbol or hole in stone",
+        "dc": {
+          "dc_type": {
+            "index": "str",
+            "name": "Str",
+            "url": "/api/2024/ability-scores/str"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 8,
+    "url": "/api/2024/equipment/masons-tools"
   },
   {
     "index": "map",
@@ -2796,6 +4142,59 @@
     "url": "/api/2024/equipment/musket"
   },
   {
+    "index": "navigators-tools",
+    "name": "Navigator's Tools",
+    "equipment_categories": [
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Plot a course",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Determine position by stargazing",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/navigators-tools"
+  },
+  {
     "index": "needles",
     "name": "Needles",
     "equipment_categories": [
@@ -2905,6 +4304,112 @@
     "str_minimum": 0,
     "weight": 8,
     "url": "/api/2024/equipment/padded-armor"
+  },
+  {
+    "index": "painters-supplies",
+    "name": "Painter's Supplies",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Focus",
+        "url": "/api/2024/equipment/druidic-foci"
+      },
+      {
+        "index": "holy-symbol",
+        "name": "Holy Symbol",
+        "url": "/api/2024/equipment/holy-symbol"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Paint a recognizable image of something you've seen",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/painters-supplies"
+  },
+  {
+    "index": "pan-flute",
+    "name": "Pan flute",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 12,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/pan-flute"
   },
   {
     "index": "paper",
@@ -3092,6 +4597,54 @@
     "url": "/api/2024/equipment/pistol"
   },
   {
+    "index": "poisoners-kit",
+    "name": "Poisoner's Kit",
+    "equipment_categories": [
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "poison-basic",
+        "name": "Poison, Basic",
+        "url": "/api/2024/equipment/poison-basic"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Detect a poisoned object",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/poisoners-kit"
+  },
+  {
     "index": "plate-armor",
     "name": "Plate Armor",
     "equipment_categories": [
@@ -3121,6 +4674,59 @@
     "str_minimum": 15,
     "weight": 65,
     "url": "/api/2024/equipment/plate-armor"
+  },
+  {
+    "index": "playing-cards",
+    "name": "Playing Cards",
+    "equipment_categories": [
+      {
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/2024/equipment-categories/gaming-sets"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 5,
+      "unit": "sp"
+    },
+    "utilize": [
+      {
+        "name": "Discern whether someone is cheating",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Win the game",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 0,
+    "url": "/api/2024/equipment/playing-cards"
   },
   {
     "index": "poison-basic",
@@ -3195,6 +4801,59 @@
     "url": "/api/2024/equipment/potion-of-healing"
   },
   {
+    "index": "potters-tools",
+    "name": "Potter's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "int",
+      "name": "Int",
+      "url": "/api/2024/ability-scores/int"
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "jug",
+        "name": "Jug",
+        "url": "/api/2024/equipment/jug"
+      },
+      {
+        "index": "lamp",
+        "name": "Lamp",
+        "url": "/api/2024/equipment/lamp"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Discern what a ceramic object held in the past 24 hours",
+        "dc": {
+          "dc_type": {
+            "index": "int",
+            "name": "Int",
+            "url": "/api/2024/ability-scores/int"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 3,
+    "url": "/api/2024/equipment/potters-tools"
+  },
+  {
     "index": "pouch",
     "name": "Pouch",
     "description": "A Pouch holds up to 6 pounds within one-fifth of a cubic foot.",
@@ -3220,9 +4879,14 @@
         "index": "adventuring-gear",
         "name": "Adventuring Gear",
         "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/2024/equipment-categories/equipment-packs"
       }
     ],
-    "container": [
+    "contents": [
       {
         "index": "backpack",
         "name": "Backpack",
@@ -3264,7 +4928,7 @@
       "quantity": 33,
       "unit": "gp"
     },
-    "description": "A Priest’s Pack contains the following items: Backpack, Blanket, Holy Water, Lamp, 7 days of Rations, Robe, and Tinderbox.",
+    "description": "A Priest's Pack contains the following items: Backpack, Blanket, Holy Water, Lamp, 7 days of Rations, Robe, and Tinderbox.",
     "weight": 29,
     "url": "/api/2024/equipment/priests-pack"
   },
@@ -3596,6 +5260,11 @@
         "index": "adventuring-gear",
         "name": "Adventuring Gear",
         "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/2024/equipment-categories/equipment-packs"
       }
     ],
     "container": [
@@ -3714,6 +5383,59 @@
       "url": "/api/2024/weapon-mastery-properties/nick"
     },
     "url": "/api/2024/equipment/scimitar"
+  },
+  {
+    "index": "shawm",
+    "name": "Shawm",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 1,
+    "url": "/api/2024/equipment/shawm"
   },
   {
     "index": "shield",
@@ -4022,6 +5744,234 @@
     "url": "/api/2024/equipment/sling"
   },
   {
+    "index": "smiths-tools",
+    "name": "Smith's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "str",
+      "name": "Str",
+      "url": "/api/2024/ability-scores/str"
+    },
+    "cost": {
+      "quantity": 20,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "battleaxe",
+        "name": "Battleaxe",
+        "url": "/api/2024/equipment/battleaxe"
+      },
+      {
+        "index": "dagger",
+        "name": "Dagger",
+        "url": "/api/2024/equipment/dagger"
+      },
+      {
+        "index": "flail",
+        "name": "Flail",
+        "url": "/api/2024/equipment/flail"
+      },
+      {
+        "index": "glaive",
+        "name": "Glaive",
+        "url": "/api/2024/equipment/glaive"
+      },
+      {
+        "index": "greataxe",
+        "name": "Greataxe",
+        "url": "/api/2024/equipment/greataxe"
+      },
+      {
+        "index": "greatsword",
+        "name": "Greatsword",
+        "url": "/api/2024/equipment/greatsword"
+      },
+      {
+        "index": "halberd",
+        "name": "Halberd",
+        "url": "/api/2024/equipment/halberd"
+      },
+      {
+        "index": "handaxe",
+        "name": "Handaxe",
+        "url": "/api/2024/equipment/handaxe"
+      },
+      {
+        "index": "javelin",
+        "name": "Javelin",
+        "url": "/api/2024/equipment/javelin"
+      },
+      {
+        "index": "lance",
+        "name": "Lance",
+        "url": "/api/2024/equipment/lance"
+      },
+      {
+        "index": "light-hammer",
+        "name": "Light Hammer",
+        "url": "/api/2024/equipment/light-hammer"
+      },
+      {
+        "index": "longsword",
+        "name": "Longsword",
+        "url": "/api/2024/equipment/longsword"
+      },
+      {
+        "index": "mace",
+        "name": "Mace",
+        "url": "/api/2024/equipment/mace"
+      },
+      {
+        "index": "maul",
+        "name": "Maul",
+        "url": "/api/2024/equipment/maul"
+      },
+      {
+        "index": "sickle",
+        "name": "Sickle",
+        "url": "/api/2024/equipment/sickle"
+      },
+      {
+        "index": "spear",
+        "name": "Spear",
+        "url": "/api/2024/equipment/spear"
+      },
+      {
+        "index": "trident",
+        "name": "Trident",
+        "url": "/api/2024/equipment/trident"
+      },
+      {
+        "index": "warhammer",
+        "name": "Warhammer",
+        "url": "/api/2024/equipment/warhammer"
+      },
+      {
+        "index": "war-pick",
+        "name": "War Pick",
+        "url": "/api/2024/equipment/war-pick"
+      },
+      {
+        "index": "breastplate",
+        "name": "Breastplate",
+        "url": "/api/2024/equipment/breastplate"
+      },
+      {
+        "index": "chain-shirt",
+        "name": "Chain Shirt",
+        "url": "/api/2024/equipment/chain-shirt"
+      },
+      {
+        "index": "half-plate-armor",
+        "name": "Half-Plate Armor",
+        "url": "/api/2024/equipment/half-plate-armor"
+      },
+      {
+        "index": "scale-mail",
+        "name": "Scale Mail",
+        "url": "/api/2024/equipment/scale-mail"
+      },
+      {
+        "index": "chain-mail",
+        "name": "Chain Mail",
+        "url": "/api/2024/equipment/chain-mail"
+      },
+      {
+        "index": "plate-armor",
+        "name": "Plate Armor",
+        "url": "/api/2024/equipment/plate-armor"
+      },
+      {
+        "index": "ring-mail",
+        "name": "Ring Mail",
+        "url": "/api/2024/equipment/ring-mail"
+      },
+      {
+        "index": "splint-armor",
+        "name": "Splint Armor",
+        "url": "/api/2024/equipment/splint-armor"
+      },
+      {
+        "index": "ball-bearings",
+        "name": "Ball Bearings",
+        "url": "/api/2024/equipment/ball-bearings"
+      },
+      {
+        "index": "bucket",
+        "name": "Bucket",
+        "url": "/api/2024/equipment/bucket"
+      },
+      {
+        "index": "caltrops",
+        "name": "Caltrops",
+        "url": "/api/2024/equipment/caltrops"
+      },
+      {
+        "index": "chain",
+        "name": "Chain",
+        "url": "/api/2024/equipment/chain"
+      },
+      {
+        "index": "crowbar",
+        "name": "Crowbar",
+        "url": "/api/2024/equipment/crowbar"
+      },
+      {
+        "index": "bullets-firearm",
+        "name": "Bullets, Firearm",
+        "url": "/api/2024/equipment/bullets-firearm"
+      },
+      {
+        "index": "grappling-hook",
+        "name": "Grappling Hook",
+        "url": "/api/2024/equipment/grappling-hook"
+      },
+      {
+        "index": "iron-pot",
+        "name": "Iron Pot",
+        "url": "/api/2024/equipment/iron-pot"
+      },
+      {
+        "index": "iron-spikes",
+        "name": "Iron Spikes",
+        "url": "/api/2024/equipment/iron-spikes"
+      },
+      {
+        "index": "bullets-sling",
+        "name": "Bullets, Sling",
+        "url": "/api/2024/equipment/bullets-sling"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Pry open a door or container",
+        "dc": {
+          "dc_type": {
+            "index": "str",
+            "name": "Str",
+            "url": "/api/2024/ability-scores/str"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 8,
+    "url": "/api/2024/equipment/smiths-tools"
+  },
+  {
     "index": "spear",
     "name": "Spear",
     "equipment_categories": [
@@ -4312,6 +6262,112 @@
     "url": "/api/2024/equipment/tent"
   },
   {
+    "index": "thieves-tools",
+    "name": "Thieves' Tools",
+    "equipment_categories": [
+      {
+        "index": "other-tools",
+        "name": "Other Tools",
+        "url": "/api/2024/equipment-categories/other-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Pick a lock",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Disarm a trap",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/thieves-tools"
+  },
+  {
+    "index": "three-dragon-ante",
+    "name": "Three-dragon Ante",
+    "equipment_categories": [
+      {
+        "index": "gaming-sets",
+        "name": "Gaming Sets",
+        "url": "/api/2024/equipment-categories/gaming-sets"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "wis",
+      "name": "Wis",
+      "url": "/api/2024/ability-scores/wis"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Discern whether someone is cheating",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Win the game",
+        "dc": {
+          "dc_type": {
+            "index": "wis",
+            "name": "Wis",
+            "url": "/api/2024/ability-scores/wis"
+          },
+          "dc_value": 20,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 0,
+    "url": "/api/2024/equipment/three-dragon-ante"
+  },
+  {
     "index": "tinderbox",
     "name": "Tinderbox",
     "equipment_categories": [
@@ -4328,6 +6384,114 @@
     "description": "A Tinderbox is a small container holding flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a Candle, Lamp, Lantern, or Torch—or anything else with exposed fuel—takes a Bonus Action. Lighting any other fire takes 1 minute.",
     "weight": 1,
     "url": "/api/2024/equipment/tinderbox"
+  },
+  {
+    "index": "tinkers-tools",
+    "name": "Tinker's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "musket",
+        "name": "Musket",
+        "url": "/api/2024/equipment/musket"
+      },
+      {
+        "index": "pistol",
+        "name": "Pistol",
+        "url": "/api/2024/equipment/pistol"
+      },
+      {
+        "index": "bell",
+        "name": "Bell",
+        "url": "/api/2024/equipment/bell"
+      },
+      {
+        "index": "bullseye-lantern",
+        "name": "Bullseye Lantern",
+        "url": "/api/2024/equipment/bullseye-lantern"
+      },
+      {
+        "index": "flask",
+        "name": "Flask",
+        "url": "/api/2024/equipment/flask"
+      },
+      {
+        "index": "hooded-lantern",
+        "name": "Hooded Lantern",
+        "url": "/api/2024/equipment/hooded-lantern"
+      },
+      {
+        "index": "hunting-trap",
+        "name": "Hunting Trap",
+        "url": "/api/2024/equipment/hunting-trap"
+      },
+      {
+        "index": "lock",
+        "name": "Lock",
+        "url": "/api/2024/equipment/lock"
+      },
+      {
+        "index": "manacles",
+        "name": "Manacles",
+        "url": "/api/2024/equipment/manacles"
+      },
+      {
+        "index": "mirror",
+        "name": "Mirror",
+        "url": "/api/2024/equipment/mirror"
+      },
+      {
+        "index": "shovel",
+        "name": "Shovel",
+        "url": "/api/2024/equipment/shovel"
+      },
+      {
+        "index": "signal-whistle",
+        "name": "Signal Whistle",
+        "url": "/api/2024/equipment/signal-whistle"
+      },
+      {
+        "index": "tinderbox",
+        "name": "Tinderbox",
+        "url": "/api/2024/equipment/tinderbox"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Assemble a Tiny item composed of scrap, which falls apart in 1 minute",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          }
+        },
+        "dc_value": 10,
+        "success_type": "none"
+      }
+    ],
+    "weight": 10,
+    "url": "/api/2024/equipment/tinkers-tools"
   },
   {
     "index": "torch",
@@ -4436,6 +6600,59 @@
     "description": "A Vial holds up to 4 ounces.",
     "weight": 0,
     "url": "/api/2024/equipment/vial"
+  },
+  {
+    "index": "viol",
+    "name": "Viol",
+    "equipment_categories": [
+      {
+        "index": "musical-instruments",
+        "name": "Musical Instruments",
+        "url": "/api/2024/equipment-categories/musical-instruments"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "cha",
+      "name": "Charisma",
+      "url": "/api/2024/ability-scores/cha"
+    },
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "utilize": [
+      {
+        "name": "Play a known tune",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "Improvise a song",
+        "dc": {
+          "dc_type": {
+            "index": "cha",
+            "name": "Charisma",
+            "url": "/api/2024/ability-scores/cha"
+          },
+          "dc_value": 15,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 2,
+    "url": "/api/2024/equipment/viol"
   },
   {
     "index": "wand",
@@ -4604,6 +6821,121 @@
     "url": "/api/2024/equipment/water-skin"
   },
   {
+    "index": "weavers-tools",
+    "name": "Weaver's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "padded-armor",
+        "name": "Padded Armor",
+        "url": "/api/2024/equipment/padded-armor"
+      },
+      {
+        "index": "basket",
+        "name": "Basket",
+        "url": "/api/2024/equipment/basket"
+      },
+      {
+        "index": "bedroll",
+        "name": "Bedroll",
+        "url": "/api/2024/equipment/bedroll"
+      },
+      {
+        "index": "blanket",
+        "name": "Blanket",
+        "url": "/api/2024/equipment/blanket"
+      },
+      {
+        "index": "fine-clothes",
+        "name": "Fine Clothes",
+        "url": "/api/2024/equipment/fine-clothes"
+      },
+      {
+        "index": "net",
+        "name": "Net",
+        "url": "/api/2024/equipment/net"
+      },
+      {
+        "index": "robe",
+        "name": "Robe",
+        "url": "/api/2024/equipment/robe"
+      },
+      {
+        "index": "rope",
+        "name": "Rope",
+        "url": "/api/2024/equipment/rope"
+      },
+      {
+        "index": "sack",
+        "name": "Sack",
+        "url": "/api/2024/equipment/sack"
+      },
+      {
+        "index": "string",
+        "name": "String",
+        "url": "/api/2024/equipment/string"
+      },
+      {
+        "index": "tent",
+        "name": "Tent",
+        "url": "/api/2024/equipment/tent"
+      },
+      {
+        "index": "traveler-clothes",
+        "name": "Traveler's Clothes",
+        "url": "/api/2024/equipment/traveler-clothes"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Mend a tear in clothing",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      },
+      {
+        "name": "sew a Tiny design",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/weavers-tools"
+  },
+  {
     "index": "whip",
     "name": "Whip",
     "equipment_categories": [
@@ -4662,6 +6994,129 @@
       "url": "/api/2024/weapon-mastery-properties/slow"
     },
     "url": "/api/2024/equipment/whip"
+  },
+  {
+    "index": "woodcarvers-tools",
+    "name": "Woodcarver's Tools",
+    "equipment_categories": [
+      {
+        "index": "artisans-tools",
+        "name": "Artisan's Tools",
+        "url": "/api/2024/equipment-categories/artisans-tools"
+      },
+      {
+        "index": "tools",
+        "name": "Tools",
+        "url": "/api/2024/equipment-categories/tools"
+      }
+    ],
+    "ability": {
+      "index": "dex",
+      "name": "Dex",
+      "url": "/api/2024/ability-scores/dex"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "craft": [
+      {
+        "index": "club",
+        "name": "Club",
+        "url": "/api/2024/equipment/club"
+      },
+      {
+        "index": "greatclub",
+        "name": "Greatclub",
+        "url": "/api/2024/equipment/greatclub"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "blowgun",
+        "name": "Blowgun",
+        "url": "/api/2024/equipment/blowgun"
+      },
+      {
+        "index": "dart",
+        "name": "Dart",
+        "url": "/api/2024/equipment/dart"
+      },
+      {
+        "index": "hand-crossbow",
+        "name": "Hand Crossbow",
+        "url": "/api/2024/equipment/hand-crossbow"
+      },
+      {
+        "index": "heavy-crossbow",
+        "name": "Heavy Crossbow",
+        "url": "/api/2024/equipment/heavy-crossbow"
+      },
+      {
+        "index": "light-crossbow",
+        "name": "Light Crossbow",
+        "url": "/api/2024/equipment/light-crossbow"
+      },
+      {
+        "index": "longbow",
+        "name": "Longbow",
+        "url": "/api/2024/equipment/longbow"
+      },
+      {
+        "index": "shortbow",
+        "name": "Shortbow",
+        "url": "/api/2024/equipment/shortbow"
+      },
+      {
+        "index": "arcane-focus",
+        "name": "Arcane Focus",
+        "url": "/api/2024/equipment/arcane-focus"
+      },
+      {
+        "index": "arrows",
+        "name": "Arrows",
+        "url": "/api/2024/equipment/arrows"
+      },
+      {
+        "index": "bolts",
+        "name": "Bolts",
+        "url": "/api/2024/equipment/bolts"
+      },
+      {
+        "index": "druidic-focus",
+        "name": "Druidic Focus",
+        "url": "/api/2024/equipment/druidic-focus"
+      },
+      {
+        "index": "ink-pen",
+        "name": "Ink Pen",
+        "url": "/api/2024/equipment/ink-pen"
+      },
+      {
+        "index": "needles",
+        "name": "Needles",
+        "url": "/api/2024/equipment/needles"
+      }
+    ],
+    "utilize": [
+      {
+        "name": "Carve a pattern in wood",
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "Dex",
+            "url": "/api/2024/ability-scores/dex"
+          },
+          "dc_value": 10,
+          "success_type": "none"
+        }
+      }
+    ],
+    "weight": 5,
+    "url": "/api/2024/equipment/woodcarvers-tools"
   },
   {
     "index": "yew-wand",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -1,5 +1,114 @@
 [
   {
+    "index": "arrows",
+    "name": "Arrows",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "quantity": 20,
+    "storage": {
+      "index": "quiver",
+      "name": "Quiver",
+      "url": "/api/2024/equipment/quiver"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/arrows"
+  },
+  {
+    "index": "bolts",
+    "name": "Bolts",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "quantity": 20,
+    "storage": {
+      "index": "case-crossbow-bolt",
+      "name": "Case, Crossbow Bolt",
+      "url": "/api/2024/equipment/case-crossbow-bolt"
+    },
+    "weight": 1.5,
+    "url": "/api/2024/equipment/bolts"
+  },
+  {
+    "index": "bullets-firearm",
+    "name": "Bullets, Firearm",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 3,
+      "unit": "gp"
+    },
+    "quantity": 10,
+    "storage": {
+      "index": "pouch",
+      "name": "Pouch",
+      "url": "/api/2024/equipment/pouch"
+    },
+    "weight": 2,
+    "url": "/api/2024/equipment/bullets-firearm"
+  },
+  {
+    "index": "bullets-sling",
+    "name": "Bullets, Sling",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 4,
+      "unit": "cp"
+    },
+    "quantity": 20,
+    "storage": {
+      "index": "pouch",
+      "name": "Pouch",
+      "url": "/api/2024/equipment/pouch"
+    },
+    "weight": 1.5,
+    "url": "/api/2024/equipment/bullets-sling"
+  },
+  {
+    "index": "case-crossbow-bolt",
+    "name": "Case, Crossbow Bolt",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/case-crossbow-bolt"
+  },
+  {
     "index": "club",
     "name": "Club",
     "equipment_categories": [
@@ -122,6 +231,56 @@
     },
     "weight": 1,
     "url": "/api/2024/equipment/dagger"
+  },
+  {
+    "index": "dart",
+    "name": "Dart",
+    "equipment_categories": [
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 20,
+      "long": 60
+    },
+    "weight": 0.25,
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      },
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "url": "/api/2024/equipment/dart"
   },
   {
     "index": "greatclub",
@@ -302,6 +461,77 @@
     "url": "/api/2024/equipment/javelin"
   },
   {
+    "index": "light-crossbow",
+    "name": "Light Crossbow",
+    "equipment_categories": [
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/2024/equipment-categories/simple-ranged-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 80,
+      "long": 320
+    },
+    "weight": 5,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "ammunition": {
+      "index": "bolts",
+      "name": "Bolts",
+      "url": "/api/2024/equipment/bolts"
+    },
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "url": "/api/2024/equipment/light-crossbow"
+  },
+  {
     "index": "light-hammer",
     "name": "Light Hammer",
     "equipment_categories": [
@@ -415,6 +645,46 @@
     "url": "/api/2024/equipment/mace"
   },
   {
+    "index": "needles",
+    "name": "Needles",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "quantity": 50,
+    "storage": {
+      "index": "pouch",
+      "name": "Pouch",
+      "url": "/api/2024/equipment/pouch"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/needles"
+  },
+  {
+    "index": "pouch",
+    "name": "Pouch",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "sp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/pouch"
+  },
+  {
     "index": "quarterstaff",
     "name": "Quarterstaff",
     "equipment_categories": [
@@ -478,6 +748,89 @@
     "url": "/api/2024/equipment/quarterstaff"
   },
   {
+    "index": "quiver",
+    "name": "Quiver",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/quiver"
+  },
+  {
+    "index": "shortbow",
+    "name": "Shortbow",
+    "equipment_categories": [
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/2024/equipment-categories/simple-ranged-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "ammunition": {
+      "index": "arrows",
+      "name": "Arrows",
+      "url": "/api/2024/equipment/arrows"
+    },
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 80,
+      "long": 320
+    },
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "weight": 2,
+    "url": "/api/2024/equipment/shortbow"
+  },
+  {
     "index": "sickle",
     "name": "Sickle",
     "equipment_categories": [
@@ -531,6 +884,67 @@
       "url": "/api/2024/weapon-mastery-properties/nick"
     },
     "url": "/api/2024/equipment/sickle"
+  },
+  {
+    "index": "sling",
+    "name": "Sling",
+    "equipment_categories": [
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/2024/equipment-categories/simple-ranged-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "ammunition": {
+      "index": "bullets-sling",
+      "name": "Bullets, Sling",
+      "url": "/api/2024/equipment/bullets-sling"
+    },
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 30,
+      "long": 120
+    },
+    "weight": 0,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      }
+    ],
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "url": "/api/2024/equipment/sling"
   },
   {
     "index": "spear",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -157,6 +157,7 @@
   {
     "index": "case-crossbow-bolt",
     "name": "Case, Crossbow Bolt",
+    "description": "A Crossbow Bolt Case holds up to 20 Bolts.",
     "equipment_categories": [
       {
         "index": "adventuring-gear",
@@ -1334,6 +1335,7 @@
   {
     "index": "pouch",
     "name": "Pouch",
+    "description": "A Pouch holds up to 6 pounds within one-fifth of a cubic foot.",
     "equipment_categories": [
       {
         "index": "adventuring-gear",
@@ -1414,6 +1416,7 @@
   {
     "index": "quiver",
     "name": "Quiver",
+    "description": "A Quiver holds up to 20 Arrows.",
     "equipment_categories": [
       {
         "index": "adventuring-gear",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -787,9 +787,9 @@
       },
       {
         "item": {
-          "index": "hooded-lantern",
-          "name": "Hooded Lantern",
-          "url": "/api/2024/equipment/hooded-lantern"
+          "index": "lantern-hooded",
+          "name": "Lantern, Hooded",
+          "url": "/api/2024/equipment/lantern-hooded"
         },
         "quantity": 1
       },

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -300,5 +300,308 @@
       "long": 120
     },
     "url": "/api/2024/equipment/javelin"
+  },
+  {
+    "index": "light-hammer",
+    "name": "Light Hammer",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      },
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      }
+    ],
+    "mastery": {
+      "index": "nick",
+      "name": "Nick",
+      "url": "/api/2024/weapon-mastery-properties/nick"
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "url": "/api/2024/equipment/light-hammer"
+  },
+  {
+    "index": "mace",
+    "name": "Mace",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "url": "/api/2024/equipment/mace"
+  },
+  {
+    "index": "quarterstaff",
+    "name": "Quarterstaff",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "sp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 4,
+    "properties": [
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "topple",
+      "name": "Topple",
+      "url": "/api/2024/weapon-mastery-properties/topple"
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "url": "/api/2024/equipment/quarterstaff"
+  },
+  {
+    "index": "sickle",
+    "name": "Sickle",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons  "
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      }
+    ],
+    "mastery": {
+      "index": "nick",
+      "name": "Nick",
+      "url": "/api/2024/weapon-mastery-properties/nick"
+    },
+    "url": "/api/2024/equipment/sickle"
+  },
+  {
+    "index": "spear",
+    "name": "Spear",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      },
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "url": "/api/2024/equipment/spear"
   }
 ]

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -62,9 +62,9 @@
         "url": "/api/2024/equipment/acid"
       },
       {
-        "index": "alchemist-fire",
+        "index": "alchemists-fire",
         "name": "Alchemist's Fire",
-        "url": "/api/2024/equipment/alchemist-fire"
+        "url": "/api/2024/equipment/alchemists-fire"
       },
       {
         "index": "component-pouch",
@@ -119,6 +119,29 @@
     ],
     "weight": 8,
     "url": "/api/2024/equipment/alchemist-supplies"
+  },
+  {
+    "index": "amulet",
+    "name": "Amulet",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/2024/equipment-categories/holy-symbols"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A Holy Symbol takes one of the forms in the Holy Symbol table and is bejeweled or painted to channel divine magic. A Cleric or Paladin can use a Holy Symbol as a Spellcasting Focus.\nThe table indicates whether a Holy Symbol needs to be held, worn, or borne on fabric (such as a tabard or banner) or a Shield.",
+    "weight": 1,
+    "url": "/api/2024/equipment/amulet"
   },
   {
     "index": "antitoxin",
@@ -974,9 +997,9 @@
         "url": "/api/2024/equipment/pole"
       },
       {
-        "index": "portable-ram",
-        "name": "Portable Ram",
-        "url": "/api/2024/equipment/portable-ram"
+        "index": "ram-portable",
+        "name": "Ram, Portable",
+        "url": "/api/2024/equipment/ram-portable"
       },
       {
         "index": "torch",
@@ -1329,7 +1352,7 @@
     ],
     "utilize": [
       {
-        "name": "Modify footwear to give Advantage on the wearer’s next Dexterity (Acrobatics) check",
+        "name": "Modify footwear to give Advantage on the wearer's next Dexterity (Acrobatics) check",
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -1439,6 +1462,24 @@
     "weight": 4,
     "description": "While wearing a Costume, you have Advantage on any ability check you make to impersonate the person or type of person it represents.",
     "url": "/api/2024/equipment/costume"
+  },
+  {
+    "index": "crowbar",
+    "name": "Crowbar",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 5,
+    "description": "Using a Crowbar gives you Advantage on Strength checks where the Crowbar's leverage can be applied.",
+    "url": "/api/2024/equipment/crowbar"
   },
   {
     "index": "crystal",
@@ -2083,6 +2124,29 @@
     "url": "/api/2024/equipment/dungeoneer-pack"
   },
   {
+    "index": "emblem",
+    "name": "Emblem",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/2024/equipment-categories/holy-symbols"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A Holy Symbol takes one of the forms in the Holy Symbol table and is bejeweled or painted to channel divine magic. A Cleric or Paladin can use a Holy Symbol as a Spellcasting Focus.\nThe table indicates whether a Holy Symbol needs to be held, worn, or borne on fabric (such as a tabard or banner) or a Shield.",
+    "weight": 0,
+    "url": "/api/2024/equipment/emblem"
+  },
+  {
     "index": "flail",
     "name": "Flail",
     "equipment_categories": [
@@ -2368,6 +2432,24 @@
     ],
     "weight": 5,
     "url": "/api/2024/equipment/glassblowers-tools"
+  },
+  {
+    "index": "grappling-hook",
+    "name": "Grappling Hook",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 4,
+    "description": "As a Utilize action, you can throw the Grappling Hook at a railing, a ledge, or another catch within 50 feet of yourself, and the hook catches on if you succeed on a DC 13 Dexterity (Acrobatics) check. If you tied a Rope to the hook, you can then climb it.",
+    "url": "/api/2024/equipment/grappling-hook"
   },
   {
     "index": "greataxe",
@@ -2776,6 +2858,24 @@
     "url": "/api/2024/equipment/handaxe"
   },
   {
+    "index": "healers-kit",
+    "name": "Healer's Kit",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A Healer's Kit has ten uses. As a Utilize action, you can expend one of its uses to stabilize an Unconscious creature that has 0 Hit Points without needing to make a Wisdom (Medicine) check.",
+    "weight": 3,
+    "url": "/api/2024/equipment/healers-kit"
+  },
+  {
     "index": "heavy-crossbow",
     "name": "Heavy Crossbow",
     "equipment_categories": [
@@ -2888,9 +2988,9 @@
         "url": "/api/2024/equipment/candle"
       },
       {
-        "index": "healer-s-kit",
+        "index": "healers-kit",
         "name": "Healer's Kit",
-        "url": "/api/2024/equipment/healer-s-kit"
+        "url": "/api/2024/equipment/healers-kit"
       },
       {
         "index": "potion-of-healing",
@@ -2947,6 +3047,24 @@
     "url": "/api/2024/equipment/hide-armor"
   },
   {
+    "index": "holy-water",
+    "name": "Holy Water",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "description": "When you take the Attack action, you can replace one of your attacks with throwing a flask of Holy Water. Target one creature you can see within 20 feet of yourself. The target must succeed on a Dexterity saving throw (DC 8 plus your Dexterity modifier and Proficiency Bonus) or take 2d8 Radiant damage if it is a Fiend or an Undead.",
+    "weight": 1,
+    "url": "/api/2024/equipment/holy-water"
+  },
+  {
     "index": "horn",
     "name": "Horn",
     "equipment_categories": [
@@ -2998,6 +3116,24 @@
     ],
     "weight": 2,
     "url": "/api/2024/equipment/horn"
+  },
+  {
+    "index": "hunting-trap",
+    "name": "Hunting Trap",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "As a Utilize action, you can set a Hunting Trap, which is a sawtooth steel ring that snaps shut when a creature steps on a pressure plate in the center. The trap is affixed by a heavy chain to an immobile object, such as a tree or a spike driven into the ground. A creature that steps on the plate must succeed on a DC 13 Dexterity saving throw or take 1d4 Piercing damage and have its Speed reduced to 0 until the start of its next turn. Thereafter, until the creature breaks free of the trap, its movement is limited by the length of the chain (typically 3 feet). A creature can use its action to make a DC 13 Strength (Athletics) check, freeing itself or another creature within its reach on a success. Each failed check deals 1 Piercing damage to the trapped creature.",
+    "weight": 25,
+    "url": "/api/2024/equipment/hunting-trap"
   },
   {
     "index": "ink",
@@ -3120,19 +3256,54 @@
     },
     "craft": [
       {
-        "index": "arcane-focus",
-        "name": "Arcane Focus",
-        "url": "/api/2024/equipment/arcane-focus"
+        "index": "crystal",
+        "name": "Crystal",
+        "url": "/api/2024/equipment/crystal"
       },
       {
-        "index": "holy-symbol",
-        "name": "Holy Symbol",
-        "url": "/api/2024/equipment/holy-symbol"
+        "index": "orb",
+        "name": "Orb",
+        "url": "/api/2024/equipment/orb"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "rod",
+        "name": "Rod",
+        "url": "/api/2024/equipment/rod"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "wand",
+        "name": "Wand",
+        "url": "/api/2024/equipment/wand"
+      },
+      {
+        "index": "amulet",
+        "name": "Amulet",
+        "url": "/api/2024/equipment/amulet"
+      },
+      {
+        "index": "emblem",
+        "name": "Emblem",
+        "url": "/api/2024/equipment/emblem"
+      },
+      {
+        "index": "reliquary",
+        "name": "Reliquary",
+        "url": "/api/2024/equipment/reliquary"
       }
     ],
     "utilize": [
       {
-        "name": " Discern a gem’s value",
+        "name": " Discern a gem's value",
         "dc": {
           "dc_type": {
             "index": "int",
@@ -3182,6 +3353,24 @@
     "description": "A Ladder is 10 feet tall. You must climb to move up or down it. Lamp (5 SP)",
     "weight": 25,
     "url": "/api/2024/equipment/ladder"
+  },
+  {
+    "index": "lamp",
+    "name": "Lamp",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "sp"
+    },
+    "description": "A Lamp burns Oil as fuel to cast Bright Light in a 15- foot radius and Dim Light for an additional 30 feet",
+    "weight": 1,
+    "url": "/api/2024/equipment/lamp"
   },
   {
     "index": "lance",
@@ -3373,9 +3562,9 @@
         "url": "/api/2024/equipment/backpack"
       },
       {
-        "index": "crossbow-bolt-case",
-        "name": "Crossbow Bolt Case",
-        "url": "/api/2024/equipment/crossbow-bolt-case"
+        "index": "case-crossbow-bolt",
+        "name": "Case, Crossbow Bolt",
+        "url": "/api/2024/equipment/case-crossbow-bolt"
       },
       {
         "index": "case-map-or-scroll",
@@ -3569,7 +3758,7 @@
       "quantity": 10,
       "unit": "gp"
     },
-    "description": "A Lock comes with a key. Without the key, a creature can use Thieves’ Tools to pick this Lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
+    "description": "A Lock comes with a key. Without the key, a creature can use Thieves' Tools to pick this Lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
     "weight": 1,
     "url": "/api/2024/equipment/lock"
   },
@@ -3894,7 +4083,7 @@
       "quantity": 2,
       "unit": "gp"
     },
-    "description": "As a Utilize action, you can use Manacles to bind an unwilling Small or Medium creature within 5 feet of yourself that has the Grappled, Incapacitated, or Restrained condition if you succeed on a DC 13 Dexterity (Sleight of Hand) check. While bound, a creature has Disadvantage on attack rolls, and the creature is Restrained if the Manacles are attached to a chain or hook that is fixed in place. Escaping the Manacles requires a successful DC 20 Dexterity (Sleight of Hand) check as an action. Bursting them requires a successful DC 25 Strength (Athletics) check as an action.\nEach set of Manacles comes with a key. Without the key, a creature can use Thieves’ Tools to pick the Manacles’ lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
+    "description": "As a Utilize action, you can use Manacles to bind an unwilling Small or Medium creature within 5 feet of yourself that has the Grappled, Incapacitated, or Restrained condition if you succeed on a DC 13 Dexterity (Sleight of Hand) check. While bound, a creature has Disadvantage on attack rolls, and the creature is Restrained if the Manacles are attached to a chain or hook that is fixed in place. Escaping the Manacles requires a successful DC 20 Dexterity (Sleight of Hand) check as an action. Bursting them requires a successful DC 25 Strength (Athletics) check as an action.\nEach set of Manacles comes with a key. Without the key, a creature can use Thieves' Tools to pick the Manacles' lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
     "weight": 6,
     "url": "/api/2024/equipment/manacles"
   },
@@ -4349,14 +4538,39 @@
     },
     "craft": [
       {
-        "index": "druidic-foci",
-        "name": "Druidic Focus",
-        "url": "/api/2024/equipment/druidic-foci"
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
       },
       {
-        "index": "holy-symbol",
-        "name": "Holy Symbol",
-        "url": "/api/2024/equipment/holy-symbol"
+        "index": "sprig-of-mistletoe",
+        "name": "Sprig of Mistletoe",
+        "url": "/api/2024/equipment/sprig-of-mistletoe"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "yew-wand",
+        "name": "Yew Wand",
+        "url": "/api/2024/equipment/yew-wand"
+      },
+      {
+        "index": "amulet",
+        "name": "Amulet",
+        "url": "/api/2024/equipment/amulet"
+      },
+      {
+        "index": "emblem",
+        "name": "Emblem",
+        "url": "/api/2024/equipment/emblem"
+      },
+      {
+        "index": "reliquary",
+        "name": "Reliquary",
+        "url": "/api/2024/equipment/reliquary"
       }
     ],
     "utilize": [
@@ -5133,6 +5347,29 @@
     "url": "/api/2024/equipment/rations"
   },
   {
+    "index": "reliquary",
+    "name": "Reliquary",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "holy-symbols",
+        "name": "Holy Symbols",
+        "url": "/api/2024/equipment-categories/holy-symbols"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A Holy Symbol takes one of the forms in the Holy Symbol table and is bejeweled or painted to channel divine magic. A Cleric or Paladin can use a Holy Symbol as a Spellcasting Focus.\nThe table indicates whether a Holy Symbol needs to be held, worn, or borne on fabric (such as a tabard or banner) or a Shield.",
+    "weight": 2,
+    "url": "/api/2024/equipment/reliquary"
+  },
+  {
     "index": "ring-mail",
     "name": "Ring Mail",
     "equipment_categories": [
@@ -5217,7 +5454,7 @@
       "quantity": 1,
       "unit": "gp"
     },
-    "description": "As a Utilize action, you can tie a knot with Rope if you succeed on a DC 10 Dexterity (Sleight of Hand) check. The Rope can be burst with a successful DC 20 Strength (Athletics) check.\n You can bind an unwilling creature with the Rope only if the creature has the Grappled, Incapacitated, or Restrained condition. If the creature’s legs are bound, the creature has the Restrained condition until it escapes. Escaping the Rope requires the creature to make a successful DC 15 Dexterity (Acrobatics) check as an action.",
+    "description": "As a Utilize action, you can tie a knot with Rope if you succeed on a DC 10 Dexterity (Sleight of Hand) check. The Rope can be burst with a successful DC 20 Strength (Athletics) check.\n You can bind an unwilling creature with the Rope only if the creature has the Grappled, Incapacitated, or Restrained condition. If the creature's legs are bound, the creature has the Restrained condition until it escapes. Escaping the Rope requires the creature to make a successful DC 15 Dexterity (Acrobatics) check as an action.",
     "weight": 5,
     "url": "/api/2024/equipment/rope"
   },
@@ -5957,14 +6194,14 @@
         "url": "/api/2024/equipment/grappling-hook"
       },
       {
-        "index": "iron-pot",
-        "name": "Iron Pot",
-        "url": "/api/2024/equipment/iron-pot"
+        "index": "pot-iron",
+        "name": "Pot, Iron",
+        "url": "/api/2024/equipment/pot-iron"
       },
       {
-        "index": "iron-spikes",
-        "name": "Iron Spikes",
-        "url": "/api/2024/equipment/iron-spikes"
+        "index": "spikes-iron",
+        "name": "Spikes, Iron",
+        "url": "/api/2024/equipment/spikes-iron"
       },
       {
         "index": "bullets-sling",
@@ -6444,9 +6681,9 @@
         "url": "/api/2024/equipment/bell"
       },
       {
-        "index": "bullseye-lantern",
-        "name": "Bullseye Lantern",
-        "url": "/api/2024/equipment/bullseye-lantern"
+        "index": "lantern-bullseye",
+        "name": "Lantern, Bullseye",
+        "url": "/api/2024/equipment/lantern-bullseye"
       },
       {
         "index": "flask",
@@ -6454,9 +6691,9 @@
         "url": "/api/2024/equipment/flask"
       },
       {
-        "index": "hooded-lantern",
-        "name": "Hooded Lantern",
-        "url": "/api/2024/equipment/hooded-lantern"
+        "index": "lantern-hooded",
+        "name": "Lantern, Hooded",
+        "url": "/api/2024/equipment/lantern-hooded"
       },
       {
         "index": "hunting-trap",
@@ -6821,8 +7058,8 @@
     "url": "/api/2024/equipment/war-pick"
   },
   {
-    "index": "water-skin",
-    "name": "Water Skin",
+    "index": "waterskin",
+    "name": "Waterskin",
     "equipment_categories": [
       {
         "index": "adventuring-gear",
@@ -6836,7 +7073,7 @@
     },
     "description": "A Waterskin holds up to 4 pints. If you don't drink sufficient water, you risk dehydration (see “Rules Glossary”).",
     "weight": 5,
-    "url": "/api/2024/equipment/water-skin"
+    "url": "/api/2024/equipment/waterskin"
   },
   {
     "index": "weavers-tools",
@@ -6884,9 +7121,9 @@
         "url": "/api/2024/equipment/blanket"
       },
       {
-        "index": "fine-clothes",
-        "name": "Fine Clothes",
-        "url": "/api/2024/equipment/fine-clothes"
+        "index": "clothes-fine",
+        "name": "Clothes, Fine",
+        "url": "/api/2024/equipment/clothes-fine"
       },
       {
         "index": "net",
@@ -6919,9 +7156,9 @@
         "url": "/api/2024/equipment/tent"
       },
       {
-        "index": "traveler-clothes",
-        "name": "Traveler's Clothes",
-        "url": "/api/2024/equipment/traveler-clothes"
+        "index": "clothes-travelers",
+        "name": "Clothes, Traveler's",
+        "url": "/api/2024/equipment/clothes-travelers"
       }
     ],
     "utilize": [
@@ -7089,9 +7326,34 @@
         "url": "/api/2024/equipment/shortbow"
       },
       {
-        "index": "arcane-focus",
-        "name": "Arcane Focus",
-        "url": "/api/2024/equipment/arcane-focus"
+        "index": "crystal",
+        "name": "Crystal",
+        "url": "/api/2024/equipment/crystal"
+      },
+      {
+        "index": "orb",
+        "name": "Orb",
+        "url": "/api/2024/equipment/orb"
+      },
+      {
+        "index": "quarterstaff",
+        "name": "Quarterstaff",
+        "url": "/api/2024/equipment/quarterstaff"
+      },
+      {
+        "index": "rod",
+        "name": "Rod",
+        "url": "/api/2024/equipment/rod"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "wand",
+        "name": "Wand",
+        "url": "/api/2024/equipment/wand"
       },
       {
         "index": "arrows",
@@ -7104,9 +7366,19 @@
         "url": "/api/2024/equipment/bolts"
       },
       {
-        "index": "druidic-focus",
-        "name": "Druidic Focus",
-        "url": "/api/2024/equipment/druidic-focus"
+        "index": "sprig-of-mistletoe",
+        "name": "Sprig of Mistletoe",
+        "url": "/api/2024/equipment/sprig-of-mistletoe"
+      },
+      {
+        "index": "staff",
+        "name": "Staff",
+        "url": "/api/2024/equipment/staff"
+      },
+      {
+        "index": "yew-wand",
+        "name": "Yew Wand",
+        "url": "/api/2024/equipment/yew-wand"
       },
       {
         "index": "ink-pen",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -23,6 +23,69 @@
     "url": "/api/2024/equipment/arrows"
   },
   {
+    "index": "battleaxe",
+    "name": "Battleaxe",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 4,
+    "properties": [
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "topple",
+      "name": "Topple",
+      "url": "/api/2024/weapon-mastery-properties/topple"
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "url": "/api/2024/equipment/battleaxe"
+  },
+  {
     "index": "bolts",
     "name": "Bolts",
     "equipment_categories": [
@@ -283,6 +346,180 @@
     "url": "/api/2024/equipment/dart"
   },
   {
+    "index": "flail",
+    "name": "Flail",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "url": "/api/2024/equipment/flail"
+  },
+  {
+    "index": "glaive",
+    "name": "Glaive",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 20,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 6,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "reach",
+        "name": "Reach",
+        "url": "/api/2024/weapon-properties/reach"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "graze",
+      "name": "Graze",
+      "url": "/api/2024/weapon-mastery-properties/graze"
+    },
+    "url": "/api/2024/equipment/glaive"
+  },
+  {
+    "index": "greataxe",
+    "name": "Greataxe",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d12",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 7,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "cleave",
+      "name": "Cleave",
+      "url": "/api/2024/weapon-mastery-properties/cleave"
+    },
+    "url": "/api/2024/equipment/greataxe"
+  },
+  {
     "index": "greatclub",
     "name": "Greatclub",
     "equipment_categories": [
@@ -336,6 +573,131 @@
       "url": "/api/2024/weapon-mastery-properties/push"
     },
     "url": "/api/2024/equipment/greatclub"
+  },
+  {
+    "index": "greatsword",
+    "name": "Greatsword",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "2d6",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 6,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "graze",
+      "name": "Graze",
+      "url": "/api/2024/weapon-mastery-properties/graze"
+    },
+    "url": "/api/2024/equipment/greatsword"
+  },
+  {
+    "index": "halberd",
+    "name": "Halberd",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 20,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 6,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "reach",
+        "name": "Reach",
+        "url": "/api/2024/weapon-properties/reach"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "cleave",
+      "name": "Cleave",
+      "url": "/api/2024/weapon-mastery-properties/cleave"
+    },
+    "url": "/api/2024/equipment/halberd"
   },
   {
     "index": "handaxe",
@@ -459,6 +821,74 @@
       "long": 120
     },
     "url": "/api/2024/equipment/javelin"
+  },
+  {
+    "index": "lance",
+    "name": "Lance",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "notes": [
+      "Two-handed unless mounted"
+    ],
+    "range": {
+      "normal": 5
+    },
+    "weight": 6,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "reach",
+        "name": "Reach",
+        "url": "/api/2024/weapon-properties/reach"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "topple",
+      "name": "Topple",
+      "url": "/api/2024/weapon-mastery-properties/topple"
+    },
+    "url": "/api/2024/equipment/lance"
   },
   {
     "index": "light-crossbow",
@@ -596,6 +1026,69 @@
     "url": "/api/2024/equipment/light-hammer"
   },
   {
+    "index": "longsword",
+    "name": "Longsword",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 3,
+    "properties": [
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "url": "/api/2024/equipment/longsword"
+  },
+  {
     "index": "mace",
     "name": "Mace",
     "equipment_categories": [
@@ -645,6 +1138,112 @@
     "url": "/api/2024/equipment/mace"
   },
   {
+    "index": "maul",
+    "name": "Maul",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "2d6",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 10,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "topple",
+      "name": "Topple",
+      "url": "/api/2024/weapon-mastery-properties/topple"
+    },
+    "url": "/api/2024/equipment/maul"
+  },
+  {
+    "index": "morningstar",
+    "name": "Morningstar",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "weight": 4,
+    "properties": [],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "url": "/api/2024/equipment/morningstar"
+  },
+  {
     "index": "needles",
     "name": "Needles",
     "equipment_categories": [
@@ -666,6 +1265,71 @@
     },
     "weight": 1,
     "url": "/api/2024/equipment/needles"
+  },
+  {
+    "index": "pike",
+    "name": "Pike",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 6,
+    "properties": [
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "reach",
+        "name": "Reach",
+        "url": "/api/2024/weapon-properties/reach"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "push",
+      "name": "Push",
+      "url": "/api/2024/weapon-mastery-properties/push"
+    },
+    "url": "/api/2024/equipment/pike"
   },
   {
     "index": "pouch",
@@ -765,6 +1429,121 @@
     "url": "/api/2024/equipment/quiver"
   },
   {
+    "index": "rapier",
+    "name": "Rapier",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "url": "/api/2024/equipment/rapier"
+  },
+  {
+    "index": "scimitar",
+    "name": "Scimitar",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 3,
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      },
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      }
+    ],
+    "mastery": {
+      "index": "nick",
+      "name": "Nick",
+      "url": "/api/2024/weapon-mastery-properties/nick"
+    },
+    "url": "/api/2024/equipment/scimitar"
+  },
+  {
     "index": "shortbow",
     "name": "Shortbow",
     "equipment_categories": [
@@ -829,6 +1608,66 @@
     },
     "weight": 2,
     "url": "/api/2024/equipment/shortbow"
+  },
+  {
+    "index": "shortsword",
+    "name": "Shortsword",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      },
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "url": "/api/2024/equipment/shortsword"
   },
   {
     "index": "sickle",
@@ -1017,5 +1856,263 @@
       }
     },
     "url": "/api/2024/equipment/spear"
+  },
+  {
+    "index": "trident",
+    "name": "Trident",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 4,
+    "properties": [
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      },
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "topple",
+      "name": "Topple",
+      "url": "/api/2024/weapon-mastery-properties/topple"
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "url": "/api/2024/equipment/trident"
+  },
+  {
+    "index": "warhammer",
+    "name": "Warhammer",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 5,
+    "properties": [
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "push",
+      "name": "Push",
+      "url": "/api/2024/weapon-mastery-properties/push"
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "url": "/api/2024/equipment/warhammer"
+  },
+  {
+    "index": "war-pick",
+    "name": "War Pick",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "versatile",
+        "name": "Versatile",
+        "url": "/api/2024/weapon-properties/versatile"
+      }
+    ],
+    "mastery": {
+      "index": "sap",
+      "name": "Sap",
+      "url": "/api/2024/weapon-mastery-properties/sap"
+    },
+    "two_handed_damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "url": "/api/2024/equipment/war-pick"
+  },
+  {
+    "index": "whip",
+    "name": "Whip",
+    "equipment_categories": [
+      {
+        "index": "martial-melee-weapons",
+        "name": "Martial Melee Weapons",
+        "url": "/api/2024/equipment-categories/martial-melee-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 3,
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      },
+      {
+        "index": "reach",
+        "name": "Reach",
+        "url": "/api/2024/weapon-properties/reach"
+      }
+    ],
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "url": "/api/2024/equipment/whip"
   }
 ]

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -1,0 +1,304 @@
+[
+  {
+    "index": "club",
+    "name": "Club",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "properties": [
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      }
+    ],
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "weight": 2,
+    "url": "/api/2024/equipment/club"
+  },
+  {
+    "index": "dagger",
+    "name": "Dagger",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d4",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "mastery": {
+      "index": "nick",
+      "name": "Nick",
+      "url": "/api/2024/weapon-mastery-properties/nick"
+    },
+    "properties": [
+      {
+        "index": "finesse",
+        "name": "Finesse",
+        "url": "/api/2024/weapon-properties/finesse"
+      },
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      },
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      }
+    ],
+    "range": {
+      "normal": 5
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/dagger"
+  },
+  {
+    "index": "greatclub",
+    "name": "Greatclub",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "sp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Bludgeoning",
+        "url": "/api/2024/damage-types/bludgeoning"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 10,
+    "properties": [
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "mastery": {
+      "index": "push",
+      "name": "Push",
+      "url": "/api/2024/weapon-mastery-properties/push"
+    },
+    "url": "/api/2024/equipment/greatclub"
+  },
+  {
+    "index": "handaxe",
+    "name": "Handaxe",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "slashing",
+        "name": "Slashing",
+        "url": "/api/2024/damage-types/slashing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      },
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "throw_range": {
+      "normal": 20,
+      "long": 60
+    },
+    "url": "/api/2024/equipment/handaxe"
+  },
+  {
+    "index": "javelin",
+    "name": "Javelin",
+    "equipment_categories": [
+      {
+        "index": "melee-weapons",
+        "name": "Melee Weapons",
+        "url": "/api/2024/equipment-categories/melee-weapons"
+      },
+      {
+        "index": "simple-melee-weapons",
+        "name": "Simple Melee Weapons",
+        "url": "/api/2024/equipment-categories/simple-melee-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 5
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "thrown",
+        "name": "Thrown",
+        "url": "/api/2024/weapon-properties/thrown"
+      }
+    ],
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "throw_range": {
+      "normal": 30,
+      "long": 120
+    },
+    "url": "/api/2024/equipment/javelin"
+  }
+]

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -1,5 +1,59 @@
 [
   {
+    "index": "acid",
+    "name": "Acid",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "description": "When you take the Attack action, you can replace one of your attacks with throwing a vial of Acid. Target one creature or object you can see within 20 feet of yourself. The target must succeed on a Dexterity saving throw (DC 8 plus your Dexterity modifier and Proficiency Bonus) or take 2d6 Acid damage.",
+    "url": "/api/2024/equipment/acid"
+  },
+  {
+    "index": "alchemists-fire",
+    "name": "Alchemist's Fire",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "description": "When you take the Attack action, you can replace one of your attacks with throwing a flask of Alchemist's Fire. Target one creature or object you can see within 20 feet of yourself. The target must succeed on a Dexterity saving throw (DC 8 plus your Dexterity modifier and Proficiency Bonus) or take 1d4 Fire damage and start burning (see “Rules Glossary”).",
+    "url": "/api/2024/equipment/alchemists-fire"
+  },
+  {
+    "index": "antitoxin",
+    "name": "Antitoxin",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "description": "As a Bonus Action, you can drink a vial of Antitoxin to gain Advantage on saving throws to avoid or end the Poisoned condition for 1 hour.",
+    "url": "/api/2024/equipment/antitoxin"
+  },
+  {
     "index": "arrows",
     "name": "Arrows",
     "equipment_categories": [
@@ -21,6 +75,79 @@
     },
     "weight": 1,
     "url": "/api/2024/equipment/arrows"
+  },
+  {
+    "index": "backpack",
+    "name": "Backpack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "A Backpack holds up to 30 pounds within 1 cubic foot. It can also serve as a saddlebag.",
+    "weight": 5,
+    "url": "/api/2024/equipment/backpack"
+  },
+  {
+    "index": "ball-bearings",
+    "name": "Ball bearings",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 2,
+    "description": "As a Utilize action, you can spill Ball Bearings from their pouch. They spread to cover a level, 10-footsquare area within 10 feet of yourself. A creature that enters this area for the first time on a turn must succeed on a DC 10 Dexterity saving throw or have the Prone condition. It takes 10 minutes to recover the Ball Bearings.",
+    "image": "/api/images/equipment/ball-bearings-bag-of-1000.png",
+    "url": "/api/2024/equipment/ball-bearings"
+  },
+  {
+    "index": "barrel",
+    "name": "Barrel",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 70,
+    "description": "A Barrel holds up to 40 gallons of liquid or up to 4 cubic feet of dry goods.",
+    "url": "/api/2024/equipment/barrel"
+  },
+  {
+    "index": "basket",
+    "name": "Basket",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 2,
+    "description": "A Basket holds up to 40 pounds within 2 cubic feet.",
+    "url": "/api/2024/equipment/basket"
   },
   {
     "index": "battleaxe",
@@ -84,6 +211,78 @@
       }
     },
     "url": "/api/2024/equipment/battleaxe"
+  },
+  {
+    "index": "bedroll",
+    "name": "Bedroll",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 25,
+    "description": "A Bedroll sleeps one Small or Medium creature. While in a Bedroll, you automatically succeed on saving throws against extreme cold (see “Gameplay Toolbox”).",
+    "url": "/api/2024/equipment/bedroll"
+  },
+  {
+    "index": "bell",
+    "name": "Bell",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "description": "When rung as a Utilize action, a Bell produces a sound that can be heard up to 60 feet away.",
+    "url": "/api/2024/equipment/bell"
+  },
+  {
+    "index": "blanket",
+    "name": "Blanket",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "weight": 3,
+    "description": "While wrapped in a blanket, you have Advantage on saving throws against extreme cold (see “Gameplay Toolbox”).",
+    "url": "/api/2024/equipment/blanket"
+  },
+  {
+    "index": "block-and-tackle",
+    "name": "Block and tackle",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 5,
+    "description": "A Block and Tackle allows you to hoist up to four times the weight you can normally lift.",
+    "url": "/api/2024/equipment/block-and-tackle"
   },
   {
     "index": "blowgun",
@@ -152,6 +351,65 @@
     "url": "/api/2024/equipment/blowgun"
   },
   {
+    "index": "book",
+    "name": "Book",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "description": "A Book contains fiction or nonfiction. If you consult an accurate nonfiction Book about its topic, you gain a +5 bonus to Intelligence (Arcana, History, Nature, or Religion) checks you make about that topic.",
+    "weight": 5,
+    "url": "/api/2024/equipment/book"
+  },
+  {
+    "index": "bolts",
+    "name": "Bolts",
+    "equipment_categories": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/equipment-categories/ammunition"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "quantity": 20,
+    "storage": {
+      "index": "case-crossbow-bolt",
+      "name": "Case, Crossbow Bolt",
+      "url": "/api/2024/equipment/case-crossbow-bolt"
+    },
+    "weight": 1.5,
+    "url": "/api/2024/equipment/bolts"
+  },
+  {
+    "index": "bottle-glass",
+    "name": "Bottle, Glass",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 2,
+    "description": "A Glass Bottle holds up to 11/2 pints.",
+    "url": "/api/2024/equipment/bottle-glass"
+  },
+  {
     "index": "breastplate",
     "name": "Breastplate",
     "equipment_categories": [
@@ -183,27 +441,22 @@
     "url": "/api/2024/equipment/breastplate"
   },
   {
-    "index": "bolts",
-    "name": "Bolts",
+    "index": "bucket",
+    "name": "Bucket",
     "equipment_categories": [
       {
-        "index": "ammunition",
-        "name": "Ammunition",
-        "url": "/api/2024/equipment-categories/ammunition"
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
       }
     ],
     "cost": {
-      "quantity": 1,
-      "unit": "gp"
+      "quantity": 5,
+      "unit": "cp"
     },
-    "quantity": 20,
-    "storage": {
-      "index": "case-crossbow-bolt",
-      "name": "Case, Crossbow Bolt",
-      "url": "/api/2024/equipment/case-crossbow-bolt"
-    },
-    "weight": 1.5,
-    "url": "/api/2024/equipment/bolts"
+    "weight": 2,
+    "description": "A Bucket holds up to half a cubic foot of contents.",
+    "url": "/api/2024/equipment/bucket"
   },
   {
     "index": "bullets-firearm",
@@ -252,6 +505,158 @@
     "url": "/api/2024/equipment/bullets-sling"
   },
   {
+    "index": "burglars-pack",
+    "name": "Burglar's Pack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 16,
+      "unit": "gp"
+    },
+    "contents": [
+      {
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/2024/equipment/backpack"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "ball-bearings",
+          "name": "Ball bearings",
+          "url": "/api/2024/equipment/ball-bearings"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "bell",
+          "name": "Bell",
+          "url": "/api/2024/equipment/bell"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "candle",
+          "name": "Candle",
+          "url": "/api/2024/equipment/candle"
+        },
+        "quantity": 10
+      },
+      {
+        "item": {
+          "index": "crowbar",
+          "name": "Crowbar",
+          "url": "/api/2024/equipment/crowbar"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "hooded-lantern",
+          "name": "Hooded Lantern",
+          "url": "/api/2024/equipment/hooded-lantern"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "flask",
+          "name": "Flask",
+          "url": "/api/2024/equipment/flask"
+        },
+        "quantity": 7
+      },
+      {
+        "item": {
+          "index": "oil",
+          "name": "Oil",
+          "url": "/api/2024/equipment/oil"
+        },
+        "quantity": 7
+      },
+      {
+        "item": {
+          "index": "rations",
+          "name": "Rations",
+          "url": "/api/2024/equipment/rations"
+        },
+        "quantity": 5
+      },
+      {
+        "item": {
+          "index": "rope",
+          "name": "Rope",
+          "url": "/api/2024/equipment/rope"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/2024/equipment/tinderbox"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/2024/equipment/waterskin"
+        },
+        "quantity": 1
+      }
+    ],
+    "description": "A Burglar's Pack contains the following items: Backpack, Ball Bearings, Bell, 10 Candles, Crowbar, Hooded Lantern, 7 flasks of Oil, 5 days of Rations, Rope, Tinderbox, and Waterskin.",
+    "weight": 20,
+    "url": "/api/2024/equipment/burglars-pack"
+  },
+  {
+    "index": "caltrops",
+    "name": "Caltrops",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "weight": 2,
+    "description": "As a Utilize action, you can spread Caltrops from their bag to cover a 5-foot-square area within 5 feet of yourself. A creature that enters this area for the first time on a turn must succeed on a DC 15 Dexterity saving throw or take 1 Piercing damage and have its Speed reduced to 0 until the start of its next turn. It takes 10 minutes to recover the Caltrops.",
+    "url": "/api/2024/equipment/caltrops"
+  },
+  {
+    "index": "candle",
+    "name": "Candle",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "cp"
+    },
+    "weight": 0,
+    "description": "For 1 hour, a lit Candle sheds Bright Light in a 5-foot radius and Dim Light for an additional 5 feet.",
+    "url": "/api/2024/equipment/candle"
+  },
+  {
     "index": "case-crossbow-bolt",
     "name": "Case, Crossbow Bolt",
     "description": "A Crossbow Bolt Case holds up to 20 Bolts.",
@@ -268,6 +673,42 @@
     },
     "weight": 1,
     "url": "/api/2024/equipment/case-crossbow-bolt"
+  },
+  {
+    "index": "case-map-or-scroll",
+    "name": "Case, Map or Scroll",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "description": "A Map or Scroll Case holds up to 10 sheets of paper or 5 sheets of parchment.",
+    "url": "/api/2024/equipment/case-map-or-scroll"
+  },
+  {
+    "index": "chain",
+    "name": "Chain",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "weight": 6,
+    "description": "As a Utilize action, you can wrap a Chain around an unwilling creature within 5 feet of yourself that has the Grappled, Incapacitated, or Restrained condition if you succeed on a DC 13 Strength (Athletics) check. If the creature's legs are bound, the creature has the Restrained condition until it escapes. Escaping the Chain requires the creature to make a successful DC 18 Dexterity (Acrobatics) check as an action. Bursting the Chain requires a successful DC 20 Strength (Athletics) check as an action.",
+    "url": "/api/2024/equipment/chain"
   },
   {
     "index": "chain-mail",
@@ -332,6 +773,78 @@
     "url": "/api/2024/equipment/chain-shirt"
   },
   {
+    "index": "chest",
+    "name": "Chest",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "weight": 20,
+    "description": "A Chest holds up to 12 cubic feet of contents.",
+    "url": "/api/2024/equipment/chest"
+  },
+  {
+    "index": "climbers-kit",
+    "name": "Climber's Kit",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "weight": 8,
+    "description": "A Climber's Kit includes boot tips, gloves, pitons, and a harness. As a Utilize action, you can use the Climber's Kit to anchor yourself; when you do, you can't fall more than 25 feet from the anchor point, and you can't move more than 25 feet from there without undoing the anchor as a Bonus Action.",
+    "url": "/api/2024/equipment/climbers-kit"
+  },
+  {
+    "index": "clothes-fine",
+    "name": "Clothes, Fine",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 15,
+      "unit": "gp"
+    },
+    "weight": 3,
+    "description": "Fine Clothes are made of expensive fabrics and adorned with expertly crafted details. Some events and locations admit only people wearing these clothes.",
+    "url": "/api/2024/equipment/clothes-fine"
+  },
+  {
+    "index": "clothes-travelers",
+    "name": "Clothes, Traveler's",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "weight": 4,
+    "description": "Traveler's Clothes are resilient garments designed for travel in various environments.",
+    "url": "/api/2024/equipment/clothes-travelers"
+  },
+  {
     "index": "club",
     "name": "Club",
     "equipment_categories": [
@@ -385,6 +898,64 @@
     },
     "weight": 2,
     "url": "/api/2024/equipment/club"
+  },
+  {
+    "index": "component-pouch",
+    "name": "Component Pouch",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "A Component Pouch is watertight and filled with compartments that hold all the free Material components of your spells.",
+    "weight": 1,
+    "url": "/api/2024/equipment/component-pouch"
+  },
+  {
+    "index": "costume",
+    "name": "Costume",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "weight": 4,
+    "description": "While wearing a Costume, you have Advantage on any ability check you make to impersonate the person or type of person it represents.",
+    "url": "/api/2024/equipment/costume"
+  },
+  {
+    "index": "crystal",
+    "name": "Crystal",
+    "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/crystal"
   },
   {
     "index": "dagger",
@@ -519,6 +1090,232 @@
       "long": 60
     },
     "url": "/api/2024/equipment/dart"
+  },
+  {
+    "index": "diplomat-pack",
+    "name": "Diplomat's Pack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/2024/equipment-categories/equipment-packs"
+      }
+    ],
+    "cost": {
+      "quantity": 39,
+      "unit": "gp"
+    },
+    "contents": [
+      {
+        "item": {
+          "index": "chest",
+          "name": "Chest",
+          "url": "/api/2024/equipment/chest"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "clothes-fine",
+          "name": "Clothes, Fine",
+          "url": "/api/2024/equipment/clothes-fine"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "ink",
+          "name": "Ink",
+          "url": "/api/2024/equipment/ink"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "ink-pen",
+          "name": "Ink Pen",
+          "url": "/api/2024/equipment/ink-pen"
+        },
+        "quantity": 5
+      },
+      {
+        "item": {
+          "index": "lamp",
+          "name": "Lamp",
+          "url": "/api/2024/equipment/lamp"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "case-map-or-scroll",
+          "name": "Case, Map or Scroll",
+          "url": "/api/2024/equipment/case-map-or-scroll"
+        },
+        "quantity": 2
+      },
+      {
+        "item": {
+          "index": "flask",
+          "name": "Flask",
+          "url": "/api/2024/equipment/flask"
+        },
+        "quantity": 4
+      },
+      {
+        "item": {
+          "index": "oil",
+          "name": "Oil",
+          "url": "/api/2024/equipment/oil"
+        },
+        "quantity": 4
+      },
+      {
+        "item": {
+          "index": "paper",
+          "name": "Paper",
+          "url": "/api/2024/equipment/paper"
+        },
+        "quantity": 5
+      },
+      {
+        "item": {
+          "index": "parchment",
+          "name": "Parchment",
+          "url": "/api/2024/equipment/parchment"
+        },
+        "quantity": 5
+      },
+      {
+        "item": {
+          "index": "perfume",
+          "name": "Perfume",
+          "url": "/api/2024/equipment/perfume"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/2024/equipment/tinderbox"
+        },
+        "quantity": 1
+      }
+    ],
+    "description": "A Diplomat's Pack contains the following items: Chest, Fine Clothes, Ink, 5 Ink Pens, Lamp, 2 Map or Scroll Cases, 4 flasks of Oil, 5 sheets of Paper, 5 sheets of Parchment, Perfume, and Tinderbox.",
+    "weight": 20,
+    "url": "/api/2024/equipment/diplomat-pack"
+  },
+  {
+    "index": "dungeoneer-pack",
+    "name": "Dungeoneer's Pack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "equipment-packs",
+        "name": "Equipment Packs",
+        "url": "/api/2024/equipment-categories/equipment-packs"
+      }
+    ],
+    "cost": {
+      "quantity": 12,
+      "unit": "gp"
+    },
+    "contents": [
+      {
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/2024/equipment/backpack"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "caltrops",
+          "name": "Caltrops",
+          "url": "/api/2024/equipment/caltrops"
+        },
+        "quantity": 10
+      },
+      {
+        "item": {
+          "index": "crowbar",
+          "name": "Crowbar",
+          "url": "/api/2024/equipment/crowbar"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "flask",
+          "name": "Flask",
+          "url": "/api/2024/equipment/flask"
+        },
+        "quantity": 2
+      },
+      {
+        "item": {
+          "index": "oil",
+          "name": "Oil",
+          "url": "/api/2024/equipment/oil"
+        },
+        "quantity": 2
+      },
+      {
+        "item": {
+          "index": "rations",
+          "name": "Rations",
+          "url": "/api/2024/equipment/rations"
+        },
+        "quantity": 10
+      },
+      {
+        "item": {
+          "index": "rope",
+          "name": "Rope",
+          "url": "/api/2024/equipment/rope"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/2024/equipment/tinderbox"
+        },
+        "quantity": 1
+      },
+      {
+        "item": {
+          "index": "torch",
+          "name": "Torch",
+          "url": "/api/2024/equipment/torch"
+        },
+        "quantity": 10
+      },
+      {
+        "item": {
+          "index": "waterskin",
+          "name": "Waterskin",
+          "url": "/api/2024/equipment/waterskin"
+        },
+        "quantity": 1
+      }
+    ],
+    "description": "A Dungeoneer’s Pack contains the following items: Backpack, Caltrops, Crowbar, 2 flasks of Oil, 10 days of Rations, Rope, Tinderbox, 10 Torches, and Waterskin.",
+    "weight": 55,
+    "url": "/api/2024/equipment/dungeoneer-pack"
   },
   {
     "index": "flail",
@@ -1149,6 +1946,42 @@
     "url": "/api/2024/equipment/hide-armor"
   },
   {
+    "index": "ink",
+    "name": "Ink",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "description": "Ink comes in a 1-ounce bottle, which provides enough ink to write about 500 pages.",
+    "weight": 0,
+    "url": "/api/2024/equipment/ink"
+  },
+  {
+    "index": "ink-pen",
+    "name": "Ink Pen",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "cp"
+    },
+    "description": "Using Ink, an Ink Pen is used to write or draw.",
+    "weight": 0,
+    "url": "/api/2024/equipment/ink-pen"
+  },
+  {
     "index": "javelin",
     "name": "Javelin",
     "equipment_categories": [
@@ -1206,6 +2039,42 @@
       "long": 120
     },
     "url": "/api/2024/equipment/javelin"
+  },
+  {
+    "index": "jug",
+    "name": "Jug",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "cp"
+    },
+    "description": "A Jug holds up to 1 gallon.",
+    "weight": 4,
+    "url": "/api/2024/equipment/jug"
+  },
+  {
+    "index": "ladder",
+    "name": "Ladder",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "description": "A Ladder is 10 feet tall. You must climb to move up or down it. Lamp (5 SP)",
+    "weight": 25,
+    "url": "/api/2024/equipment/ladder"
   },
   {
     "index": "lance",
@@ -1274,6 +2143,42 @@
       "url": "/api/2024/weapon-mastery-properties/topple"
     },
     "url": "/api/2024/equipment/lance"
+  },
+  {
+    "index": "lantern-bullseye",
+    "name": "Lantern, Bullseye",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "description": "A Bullseye Lantern burns Oil as fuel to cast Bright Light in a 60-foot Cone and Dim Light for an additional 60 feet.",
+    "weight": 2,
+    "url": "/api/2024/equipment/lantern-bullseye"
+  },
+  {
+    "index": "lantern-hooded",
+    "name": "Lantern, Hooded",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A Hooded Lantern burns Oil as fuel to cast Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. As a Bonus Action, you can lower the hood, reducing the light to Dim Light in a 5-foot radius, or raise it again.",
+    "weight": 2,
+    "url": "/api/2024/equipment/lantern-hooded"
   },
   {
     "index": "leather-armor",
@@ -1439,6 +2344,24 @@
       "long": 60
     },
     "url": "/api/2024/equipment/light-hammer"
+  },
+  {
+    "index": "lock",
+    "name": "Lock",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "description": "A Lock comes with a key. Without the key, a creature can use Thieves’ Tools to pick this Lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
+    "weight": 1,
+    "url": "/api/2024/equipment/lock"
   },
   {
     "index": "longbow",
@@ -1622,6 +2545,78 @@
       "url": "/api/2024/weapon-mastery-properties/sap"
     },
     "url": "/api/2024/equipment/mace"
+  },
+  {
+    "index": "magnifying-glass",
+    "name": "Magnifying Glass",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 100,
+      "unit": "gp"
+    },
+    "description": "A Magnifying Glass grants Advantage on any ability check made to appraise or inspect a highly detailed item. Lighting a fire with a Magnifying Glass requires light as bright as sunlight to focus, tinder to ignite, and about 5 minutes for the fire to ignite.",
+    "weight": 0,
+    "url": "/api/2024/equipment/magnifying-glass"
+  },
+  {
+    "index": "manacles",
+    "name": "Manacles",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "As a Utilize action, you can use Manacles to bind an unwilling Small or Medium creature within 5 feet of yourself that has the Grappled, Incapacitated, or Restrained condition if you succeed on a DC 13 Dexterity (Sleight of Hand) check. While bound, a creature has Disadvantage on attack rolls, and the creature is Restrained if the Manacles are attached to a chain or hook that is fixed in place. Escaping the Manacles requires a successful DC 20 Dexterity (Sleight of Hand) check as an action. Bursting them requires a successful DC 25 Strength (Athletics) check as an action.\nEach set of Manacles comes with a key. Without the key, a creature can use Thieves’ Tools to pick the Manacles’ lock with a successful DC 15 Dexterity (Sleight of Hand) check.",
+    "weight": 6,
+    "url": "/api/2024/equipment/manacles"
+  },
+  {
+    "index": "map",
+    "name": "Map",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "If you consult an accurate Map, you gain a +5 bonus to Wisdom (Survival) checks you make to find your way in the place represented on it.",
+    "weight": 0,
+    "url": "/api/2024/equipment/map"
+  },
+  {
+    "index": "mirror",
+    "name": "Mirror",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "A handheld steel Mirror is useful for personal cosmetics but also for peeking around corners and reflecting light as a signal.",
+    "weight": 0.5,
+    "url": "/api/2024/equipment/mirror"
   },
   {
     "index": "maul",
@@ -1824,6 +2819,64 @@
     "url": "/api/2024/equipment/needles"
   },
   {
+    "index": "net",
+    "name": "Net",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "When you take the Attack action, you can replace one of your attacks with throwing a Net. Target a creature you can see within 15 feet of yourself. The target must succeed on a Dexterity saving throw (DC 8 plus your Dexterity modifier and Proficiency Bonus) or have the Restrained condition until it escapes. The target succeeds automatically if it is Huge or larger.\nTo escape, the target or a creature within 5 feet of it must take an action to make a DC 10 Strength (Athletics) check, freeing the Restrained creature on a success. Destroying the Net (AC 10; 5 HP; Immunity to Bludgeoning, Poison, and Psychic damage) also frees the target, ending the effect.",
+    "weight": 3,
+    "url": "/api/2024/equipment/net"
+  },
+  {
+    "index": "oil",
+    "name": "Oil",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "description": "You can douse a creature, object, or space with Oil or use it as fuel, as detailed below.\n**Dousing a Creature or an Object.** When you take the Attack action, you can replace one of your attacks with throwing an Oil flask. Target one creature or object within 20 feet of yourself. The target must succeed on a Dexterity saving throw (DC 8 plus your Dexterity modifier and Proficiency Bonus) or be covered in oil. If the target takes Fire damage before the oil dries (after 1 minute), the target takes an extra 5 Fire damage from burning oil.\n**Dousing a Space.** You can take the Utilize action to pour an Oil flask on level ground to cover a 5-foot-square area within 5 feet of yourself. If lit, the oil burns until the end of the turn 2 rounds from when the oil was lit (or 12 seconds) and deals 5 Fire damage to any creature that enters the area or ends its turn there. A creature can take this damage only once per turn.\n**Fuel.**  Oil serves as fuel for Lamps and Lanterns. Once lit, a flask of Oil burns for 6 hours in a Lamp or Lantern. That duration doesn't need to be consecutive; you can extinguish the burning Oil (as a Utilize action) and rekindle it again until it has burned for a total of 6 hours",
+    "weight": 1,
+    "url": "/api/2024/equipment/oil"
+  },
+  {
+    "index": "orb",
+    "name": "Orb",
+    "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 20,
+      "unit": "gp"
+    },
+    "weight": 3,
+    "url": "/api/2024/equipment/orb"
+  },
+  {
     "index": "padded-armor",
     "name": "Padded Armor",
     "equipment_categories": [
@@ -1852,6 +2905,60 @@
     "str_minimum": 0,
     "weight": 8,
     "url": "/api/2024/equipment/padded-armor"
+  },
+  {
+    "index": "paper",
+    "name": "Paper",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "sp"
+    },
+    "description": "One sheet of Paper can hold about 250 handwritten words.",
+    "weight": 0,
+    "url": "/api/2024/equipment/paper"
+  },
+  {
+    "index": "parchment",
+    "name": "Parchment",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 3,
+      "unit": "gp"
+    },
+    "description": "One sheet of Parchment can hold about 250 handwritten words.",
+    "weight": 0,
+    "url": "/api/2024/equipment/parchment"
+  },
+  {
+    "index": "perfume",
+    "name": "Perfume",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "description": "Perfume comes in a 4-ounce vial. For 1 hour after applying Perfume to yourself, you have Advantage on Charisma (Persuasion) checks made to influence an Indifferent Humanoid within 5 feet of yourself.",
+    "weight": 0,
+    "url": "/api/2024/equipment/perfume"
   },
   {
     "index": "pike",
@@ -2016,6 +3123,78 @@
     "url": "/api/2024/equipment/plate-armor"
   },
   {
+    "index": "poison-basic",
+    "name": "Poison, Basic",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 100,
+      "unit": "gp"
+    },
+    "description": "As a Bonus Action, you can use a vial of Basic Poison to coat one weapon or up to three pieces of ammunition. A creature that takes Piercing or Slashing damage from the poisoned weapon or ammunition takes an extra 1d4 Poison damage. Once applied, the poison retains potency for 1 minute or until its damage is dealt, whichever comes first.",
+    "weight": 0,
+    "url": "/api/2024/equipment/poison-basic"
+  },
+  {
+    "index": "pole",
+    "name": "Pole",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "cp"
+    },
+    "description": "A Pole is 10 feet long. You can use it to touch something up to 10 feet away. If you must make a Strength (Athletics) check as part of a High or Long Jump, you can use the Pole to vault, giving yourself Advantage on the check.",
+    "weight": 7,
+    "url": "/api/2024/equipment/pole"
+  },
+  {
+    "index": "pot-iron",
+    "name": "Pot, Iron",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "An Iron Pot holds up to 1 gallon.",
+    "weight": 10,
+    "url": "/api/2024/equipment/pot-iron"
+  },
+  {
+    "index": "potion-of-healing",
+    "name": "Potion of Healing",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "description": "This potion is a magic item. As a Bonus Action, you can drink it or administer it to another creature within 5 feet of yourself. The creature that drinks the magical red fluid in this vial regains 2d4 + 2 Hit Points.",
+    "weight": 0.5,
+    "url": "/api/2024/equipment/potion-of-healing"
+  },
+  {
     "index": "pouch",
     "name": "Pouch",
     "description": "A Pouch holds up to 6 pounds within one-fifth of a cubic foot.",
@@ -2034,9 +3213,75 @@
     "url": "/api/2024/equipment/pouch"
   },
   {
+    "index": "priests-pack",
+    "name": "Priest's Pack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "container": [
+      {
+        "index": "backpack",
+        "name": "Backpack",
+        "url": "/api/2024/equipment/backpack"
+      },
+      {
+        "index": "blanket",
+        "name": "Blanket",
+        "url": "/api/2024/equipment/blanket"
+      },
+      {
+        "index": "holy-water",
+        "name": "Holy Water",
+        "url": "/api/2024/equipment/holy-water"
+      },
+      {
+        "index": "lamp",
+        "name": "Lamp",
+        "url": "/api/2024/equipment/lamp"
+      },
+      {
+        "index": "rations",
+        "name": "Rations",
+        "url": "/api/2024/equipment/rations",
+        "quantity": 7
+      },
+      {
+        "index": "robe",
+        "name": "Robe",
+        "url": "/api/2024/equipment/robe"
+      },
+      {
+        "index": "tinderbox",
+        "name": "Tinderbox",
+        "url": "/api/2024/equipment/tinderbox"
+      }
+    ],
+    "cost": {
+      "quantity": 33,
+      "unit": "gp"
+    },
+    "description": "A Priest’s Pack contains the following items: Backpack, Blanket, Holy Water, Lamp, 7 days of Rations, Robe, and Tinderbox.",
+    "weight": 29,
+    "url": "/api/2024/equipment/priests-pack"
+  },
+  {
     "index": "quarterstaff",
     "name": "Quarterstaff",
     "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/2024/equipment-categories/druidic-foci"
+      },
       {
         "index": "melee-weapons",
         "name": "Melee Weapons",
@@ -2115,6 +3360,24 @@
     "url": "/api/2024/equipment/quiver"
   },
   {
+    "index": "ram-portable",
+    "name": "Ram, Portable",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 4,
+      "unit": "gp"
+    },
+    "description": "You can use a Portable Ram to break down doors. When doing so, you gain a +4 bonus to the Strength check. One other character can help you use the ram, giving you Advantage on this check.",
+    "weight": 35,
+    "url": "/api/2024/equipment/ram-portable"
+  },
+  {
     "index": "rapier",
     "name": "Rapier",
     "equipment_categories": [
@@ -2170,6 +3433,24 @@
     "url": "/api/2024/equipment/rapier"
   },
   {
+    "index": "rations",
+    "name": "Rations",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "sp"
+    },
+    "description": "Rations consist of travel-ready food, including jerky, dried fruit, hardtack, and nuts. See \"Malnutrition\" in \"Rules Glossary\" for the risks of not eating.",
+    "weight": 2,
+    "url": "/api/2024/equipment/rations"
+  },
+  {
     "index": "ring-mail",
     "name": "Ring Mail",
     "equipment_categories": [
@@ -2201,6 +3482,82 @@
     "url": "/api/2024/equipment/ring-mail"
   },
   {
+    "index": "robe",
+    "name": "Robe",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "A Robe has vocational or ceremonial significance. Some events and locations admit only people wearing a Robe bearing certain colors or symbols.",
+    "weight": 1,
+    "url": "/api/2024/equipment/robe"
+  },
+  {
+    "index": "rod",
+    "name": "Rod",
+    "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "weight": 2,
+    "url": "/api/2024/equipment/rod"
+  },
+  {
+    "index": "rope",
+    "name": "Rope",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "As a Utilize action, you can tie a knot with Rope if you succeed on a DC 10 Dexterity (Sleight of Hand) check. The Rope can be burst with a successful DC 20 Strength (Athletics) check.\n You can bind an unwilling creature with the Rope only if the creature has the Grappled, Incapacitated, or Restrained condition. If the creature’s legs are bound, the creature has the Restrained condition until it escapes. Escaping the Rope requires the creature to make a successful DC 15 Dexterity (Acrobatics) check as an action.",
+    "weight": 5,
+    "url": "/api/2024/equipment/rope"
+  },
+  {
+    "index": "sack",
+    "name": "Sack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "cp"
+    },
+    "description": "A Sack holds up to 30 pounds within 1 cubic foot.",
+    "weight": 1,
+    "url": "/api/2024/equipment/sack"
+  },
+  {
     "index": "scale-mail",
     "name": "Scale Mail",
     "equipment_categories": [
@@ -2230,6 +3587,73 @@
     "str_minimum": 0,
     "weight": 45,
     "url": "/api/2024/equipment/scale-mail"
+  },
+  {
+    "index": "scholars-pack",
+    "name": "Scholar's Pack",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "container": [
+      {
+        "index": "backpack",
+        "name": "Backpack",
+        "url": "/api/2024/equipment/backpack"
+      },
+      {
+        "index": "blanket",
+        "name": "Blanket",
+        "url": "/api/2024/equipment/blanket"
+      },
+      {
+        "index": "book",
+        "name": "Book",
+        "url": "/api/2024/equipment/book"
+      },
+      {
+        "index": "ink",
+        "name": "Ink",
+        "url": "/api/2024/equipment/ink"
+      },
+      {
+        "index": "ink-pen",
+        "name": "Ink Pen",
+        "url": "/api/2024/equipment/ink-pen"
+      },
+      {
+        "index": "lamp",
+        "name": "Lamp",
+        "url": "/api/2024/equipment/lamp"
+      },
+      {
+        "index": "oil",
+        "name": "Oil",
+        "url": "/api/2024/equipment/oil",
+        "quantity": 10
+      },
+      {
+        "index": "parchment",
+        "name": "Parchment",
+        "url": "/api/2024/equipment/parchment",
+        "quantity": 10
+      },
+      {
+        "index": "tinderbox",
+        "name": "Tinderbox",
+        "url": "/api/2024/equipment/tinderbox"
+      }
+    ],
+    "cost": {
+      "quantity": 40,
+      "unit": "gp"
+    },
+    "description": "A Scholar's Pack contains the following items: Backpack, Blanket, Book, Ink, Ink Pen, Lamp, 10 flasks of Oil, 10 sheets of Parchment, and Tinderbox.",
+    "weight": 22,
+    "url": "/api/2024/equipment/scholars-pack"
   },
   {
     "index": "scimitar",
@@ -2446,6 +3870,24 @@
     "url": "/api/2024/equipment/shortsword"
   },
   {
+    "index": "shovel",
+    "name": "Shovel",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "Working for 1 hour, you can use a Shovel to dig a hole that is 5 feet on each side in soil or similar material.",
+    "weight": 5,
+    "url": "/api/2024/equipment/shovel"
+  },
+  {
     "index": "sickle",
     "name": "Sickle",
     "equipment_categories": [
@@ -2499,6 +3941,24 @@
       "url": "/api/2024/weapon-mastery-properties/nick"
     },
     "url": "/api/2024/equipment/sickle"
+  },
+  {
+    "index": "signal-whistle",
+    "name": "Signal Whistle",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "cp"
+    },
+    "description": "When blown as a Utilize action, a Signal Whistle produces a sound that can be heard up to 600 feet away.",
+    "weight": 0,
+    "url": "/api/2024/equipment/signal-whistle"
   },
   {
     "index": "sling",
@@ -2634,6 +4094,60 @@
     "url": "/api/2024/equipment/spear"
   },
   {
+    "index": "spell-scroll-cantrip",
+    "name": "Spell Scroll, Cantrip",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 30,
+      "unit": "gp"
+    },
+    "description": "A *Spell Scroll* (Cantrip) or *Spell Scroll* (Level 1) is a magic item that bears the words of a cantrip or level 1 spell, respectively, determined by the scroll's creator. If the spell is on your class's spell list, you can read the scroll and cast the spell using its normal casting time and without providing any Material components.\nIf the spell requires a saving throw or an attack roll, the spell save DC is 13, and the attack bonus is +5. The scroll disintegrates when the casting is completed.",
+    "weight": 0,
+    "url": "/api/2024/equipment/spell-scroll-cantrip"
+  },
+  {
+    "index": "spell-scroll-level-1",
+    "name": "Spell Scroll, Level 1",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "description": "A *Spell Scroll* (Cantrip) or *Spell Scroll* (Level 1) is a magic item that bears the words of a cantrip or level 1 spell, respectively, determined by the scroll's creator. If the spell is on your class's spell list, you can read the scroll and cast the spell using its normal casting time and without providing any Material components.\nIf the spell requires a saving throw or an attack roll, the spell save DC is 13, and the attack bonus is +5. The scroll disintegrates when the casting is completed.",
+    "weight": 0,
+    "url": "/api/2024/equipment/spell-scroll-level-1"
+  },
+  {
+    "index": "spikes-iron",
+    "name": "Spikes, Iron",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "Iron Spikes come in bundles of ten. As a Utilize action, you can use a blunt object, such as a Light Hammer, to hammer a spike into wood, earth, or a similar material. You can do so to jam a door shut or to then tie a Rope or Chain to the Spike.",
+    "weight": 2,
+    "url": "/api/2024/equipment/spikes-iron"
+  },
+  {
     "index": "splint-armor",
     "name": "Splint Armor",
     "equipment_categories": [
@@ -2665,6 +4179,91 @@
     "url": "/api/2024/equipment/splint-armor"
   },
   {
+    "index": "sprig-of-mistletoe",
+    "name": "Sprig of Mistletoe",
+    "equipment_categories": [
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/2024/equipment-categories/druidic-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "weight": 0,
+    "url": "/api/2024/equipment/sprig-of-mistletoe"
+  },
+  {
+    "index": "spyglass",
+    "name": "Spyglass",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1000,
+      "unit": "gp"
+    },
+    "description": "Objects viewed through a Spyglass are magnified to twice their size.",
+    "weight": 1,
+    "url": "/api/2024/equipment/spyglass"
+  },
+  {
+    "index": "staff",
+    "name": "Staff",
+    "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      },
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/2024/equipment-categories/druidic-foci"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "weight": 4,
+    "url": "/api/2024/equipment/staff"
+  },
+  {
+    "index": "string",
+    "name": "String",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "sp"
+    },
+    "description": "String is 10 feet long. You can tie a knot in it as a Utilize action.",
+    "weight": 0,
+    "url": "/api/2024/equipment/string"
+  },
+  {
     "index": "studded-leather-armor",
     "name": "Studded Leather Armor",
     "equipment_categories": [
@@ -2693,6 +4292,60 @@
     "str_minimum": 0,
     "weight": 13,
     "url": "/api/2024/equipment/studded-leather-armor"
+  },
+  {
+    "index": "tent",
+    "name": "Tent",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "gp"
+    },
+    "description": "A Tent sleeps up to two Small or Medium creatures.",
+    "weight": 20,
+    "url": "/api/2024/equipment/tent"
+  },
+  {
+    "index": "tinderbox",
+    "name": "Tinderbox",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "sp"
+    },
+    "description": "A Tinderbox is a small container holding flint, fire steel, and tinder (usually dry cloth soaked in light oil) used to kindle a fire. Using it to light a Candle, Lamp, Lantern, or Torch—or anything else with exposed fuel—takes a Bonus Action. Lighting any other fire takes 1 minute.",
+    "weight": 1,
+    "url": "/api/2024/equipment/tinderbox"
+  },
+  {
+    "index": "torch",
+    "name": "Torch",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "cp"
+    },
+    "description": "A Torch burns for 1 hour, casting Bright Light in a 20-foot radius and Dim Light for an additional 20 feet. When you take the Attack action, you can attack with the Torch, using it as a Simple Melee weapon. On a hit, the target takes 1 Fire damage.",
+    "weight": 1,
+    "url": "/api/2024/equipment/torch"
   },
   {
     "index": "trident",
@@ -2765,6 +4418,46 @@
       }
     },
     "url": "/api/2024/equipment/trident"
+  },
+  {
+    "index": "vial",
+    "name": "Vial",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 1,
+      "unit": "gp"
+    },
+    "description": "A Vial holds up to 4 ounces.",
+    "weight": 0,
+    "url": "/api/2024/equipment/vial"
+  },
+  {
+    "index": "wand",
+    "name": "Wand",
+    "equipment_categories": [
+      {
+        "index": "arcane-foci",
+        "name": "Arcane Foci",
+        "url": "/api/2024/equipment-categories/arcane-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/wand"
   },
   {
     "index": "warhammer",
@@ -2893,6 +4586,24 @@
     "url": "/api/2024/equipment/war-pick"
   },
   {
+    "index": "water-skin",
+    "name": "Water Skin",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "sp"
+    },
+    "description": "A Waterskin holds up to 4 pints. If you don't drink sufficient water, you risk dehydration (see “Rules Glossary”).",
+    "weight": 5,
+    "url": "/api/2024/equipment/water-skin"
+  },
+  {
     "index": "whip",
     "name": "Whip",
     "equipment_categories": [
@@ -2951,5 +4662,27 @@
       "url": "/api/2024/weapon-mastery-properties/slow"
     },
     "url": "/api/2024/equipment/whip"
+  },
+  {
+    "index": "yew-wand",
+    "name": "Yew Wand",
+    "equipment_categories": [
+      {
+        "index": "druidic-foci",
+        "name": "Druidic Foci",
+        "url": "/api/2024/equipment-categories/druidic-foci"
+      },
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "weight": 1,
+    "url": "/api/2024/equipment/yew-wand"
   }
 ]

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -1676,7 +1676,7 @@
       {
         "index": "melee-weapons",
         "name": "Melee Weapons",
-        "url": "/api/2024/equipment-categories/melee-weapons  "
+        "url": "/api/2024/equipment-categories/melee-weapons"
       },
       {
         "index": "simple-melee-weapons",

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -990,6 +990,7 @@
       "name": "Push",
       "url": "/api/2024/weapon-mastery-properties/push"
     },
+    "image": "/api/images/equipment/crossbow-heavy.png",
     "url": "/api/2024/equipment/heavy-crossbow"
   },
   {

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -52,7 +52,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "craft": [
@@ -97,7 +97,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 15,
@@ -109,7 +109,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 15,
@@ -196,7 +196,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -209,7 +209,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -221,7 +221,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -595,7 +595,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "craft": [
@@ -615,7 +615,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 10,
@@ -627,7 +627,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 10,
@@ -840,7 +840,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "craft": [
@@ -870,7 +870,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 15,
@@ -934,7 +934,7 @@
     ],
     "ability": {
       "index": "str",
-      "name": "Str",
+      "name": "STR",
       "url": "/api/2024/ability-scores/str"
     },
     "craft": [
@@ -994,7 +994,7 @@
         "dc": {
           "dc_type": {
             "index": "str",
-            "name": "Str",
+            "name": "STR",
             "url": "/api/2024/ability-scores/str"
           },
           "dc_value": 20,
@@ -1022,7 +1022,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "craft": [
@@ -1042,7 +1042,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 15,
@@ -1313,7 +1313,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -1333,7 +1333,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 10,
@@ -1379,7 +1379,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -1399,7 +1399,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -1411,7 +1411,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 15,
@@ -1613,7 +1613,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -1626,7 +1626,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -1638,7 +1638,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 20,
@@ -1787,7 +1787,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -1807,7 +1807,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -1835,7 +1835,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -1848,7 +1848,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -1860,7 +1860,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 20,
@@ -1888,7 +1888,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -1901,7 +1901,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -1913,7 +1913,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -1941,7 +1941,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -1954,7 +1954,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -1966,7 +1966,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -2132,6 +2132,24 @@
     "url": "/api/2024/equipment/flail"
   },
   {
+    "index": "flask",
+    "name": "Flask",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "cost": {
+      "quantity": 2,
+      "unit": "cp"
+    },
+    "description": "A Flask holds up to 1 pint.",
+    "weight": 1,
+    "url": "/api/2024/equipment/flask"
+  },
+  {
     "index": "flute",
     "name": "Flute",
     "equipment_categories": [
@@ -2148,7 +2166,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -2161,7 +2179,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -2173,7 +2191,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -2201,7 +2219,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -2214,7 +2232,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 15,
@@ -2226,7 +2244,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 20,
@@ -2319,7 +2337,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "cost": {
@@ -2851,7 +2869,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "cost": {
@@ -2886,7 +2904,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 10,
@@ -2945,7 +2963,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -2958,7 +2976,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -2970,7 +2988,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -3093,7 +3111,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "cost": {
@@ -3118,7 +3136,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 15,
@@ -3316,7 +3334,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -3391,7 +3409,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 10,
@@ -3706,7 +3724,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -3719,7 +3737,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -3731,7 +3749,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -3759,7 +3777,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -3772,7 +3790,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -3784,7 +3802,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -3897,7 +3915,7 @@
     ],
     "ability": {
       "index": "str",
-      "name": "Str",
+      "name": "STR",
       "url": "/api/2024/ability-scores/str"
     },
     "cost": {
@@ -3907,7 +3925,7 @@
     "craft": [
       {
         "index": "block-and-tackle",
-        "name": "Block and Tackle",
+        "name": "Block and tackle",
         "url": "/api/2024/equipment/block-and-tackle"
       }
     ],
@@ -3917,7 +3935,7 @@
         "dc": {
           "dc_type": {
             "index": "str",
-            "name": "Str",
+            "name": "STR",
             "url": "/api/2024/ability-scores/str"
           },
           "dc_value": 10,
@@ -4158,7 +4176,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -4171,7 +4189,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -4183,7 +4201,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 15,
@@ -4322,7 +4340,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -4347,7 +4365,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -4375,7 +4393,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -4388,7 +4406,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -4400,7 +4418,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -4613,7 +4631,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "cost": {
@@ -4633,7 +4651,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 10,
@@ -4692,7 +4710,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -4705,7 +4723,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -4717,7 +4735,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 20,
@@ -4817,7 +4835,7 @@
     ],
     "ability": {
       "index": "int",
-      "name": "Int",
+      "name": "INT",
       "url": "/api/2024/ability-scores/int"
     },
     "cost": {
@@ -4842,7 +4860,7 @@
         "dc": {
           "dc_type": {
             "index": "int",
-            "name": "Int",
+            "name": "INT",
             "url": "/api/2024/ability-scores/int"
           },
           "dc_value": 15,
@@ -5401,7 +5419,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -5414,7 +5432,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -5426,7 +5444,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -5760,7 +5778,7 @@
     ],
     "ability": {
       "index": "str",
-      "name": "Str",
+      "name": "STR",
       "url": "/api/2024/ability-scores/str"
     },
     "cost": {
@@ -5905,7 +5923,7 @@
       },
       {
         "index": "ball-bearings",
-        "name": "Ball Bearings",
+        "name": "Ball bearings",
         "url": "/api/2024/equipment/ball-bearings"
       },
       {
@@ -5960,7 +5978,7 @@
         "dc": {
           "dc_type": {
             "index": "str",
-            "name": "Str",
+            "name": "STR",
             "url": "/api/2024/ability-scores/str"
           },
           "dc_value": 20,
@@ -6278,7 +6296,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -6291,7 +6309,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 15,
@@ -6303,7 +6321,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 15,
@@ -6331,7 +6349,7 @@
     ],
     "ability": {
       "index": "wis",
-      "name": "Wis",
+      "name": "WIS",
       "url": "/api/2024/ability-scores/wis"
     },
     "cost": {
@@ -6344,7 +6362,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 10,
@@ -6356,7 +6374,7 @@
         "dc": {
           "dc_type": {
             "index": "wis",
-            "name": "Wis",
+            "name": "WIS",
             "url": "/api/2024/ability-scores/wis"
           },
           "dc_value": 20,
@@ -6402,7 +6420,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -6482,7 +6500,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           }
         },
@@ -6618,7 +6636,7 @@
     ],
     "ability": {
       "index": "cha",
-      "name": "Charisma",
+      "name": "CHA",
       "url": "/api/2024/ability-scores/cha"
     },
     "cost": {
@@ -6631,7 +6649,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 10,
@@ -6643,7 +6661,7 @@
         "dc": {
           "dc_type": {
             "index": "cha",
-            "name": "Charisma",
+            "name": "CHA",
             "url": "/api/2024/ability-scores/cha"
           },
           "dc_value": 15,
@@ -6837,7 +6855,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -6912,7 +6930,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 10,
@@ -6924,7 +6942,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 10,
@@ -7012,7 +7030,7 @@
     ],
     "ability": {
       "index": "dex",
-      "name": "Dex",
+      "name": "DEX",
       "url": "/api/2024/ability-scores/dex"
     },
     "cost": {
@@ -7107,7 +7125,7 @@
         "dc": {
           "dc_type": {
             "index": "dex",
-            "name": "Dex",
+            "name": "DEX",
             "url": "/api/2024/ability-scores/dex"
           },
           "dc_value": 10,

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -86,6 +86,72 @@
     "url": "/api/2024/equipment/battleaxe"
   },
   {
+    "index": "blowgun",
+    "name": "Blowgun",
+    "equipment_categories": [
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "ammunition": {
+      "index": "needles",
+      "name": "Needles",
+      "url": "/api/2024/equipment/needles"
+    },
+    "cost": {
+      "quantity": 10,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 25,
+      "long": 100
+    },
+    "weight": 1,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      }
+    ],
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "url": "/api/2024/equipment/blowgun"
+  },
+  {
     "index": "bolts",
     "name": "Bolts",
     "equipment_categories": [
@@ -304,6 +370,21 @@
         "index": "ranged-weapons",
         "name": "Ranged Weapons",
         "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "simple-ranged-weapons",
+        "name": "Simple Ranged Weapons",
+        "url": "/api/2024/equipment-categories/simple-ranged-weapons"
+      },
+      {
+        "index": "simple-weapons",
+        "name": "Simple Weapons",
+        "url": "/api/2024/equipment-categories/simple-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
       }
     ],
     "cost": {
@@ -701,6 +782,77 @@
     "url": "/api/2024/equipment/halberd"
   },
   {
+    "index": "hand-crossbow",
+    "name": "Hand Crossbow",
+    "equipment_categories": [
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 25,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d6",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 30,
+      "long": 120
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "light",
+        "name": "Light",
+        "url": "/api/2024/weapon-properties/light"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      }
+    ],
+    "ammunition": {
+      "index": "bolts",
+      "name": "Bolts",
+      "url": "/api/2024/equipment/bolts"
+    },
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "url": "/api/2024/equipment/hand-crossbow"
+  },
+  {
     "index": "handaxe",
     "name": "Handaxe",
     "equipment_categories": [
@@ -763,6 +915,82 @@
       "long": 60
     },
     "url": "/api/2024/equipment/handaxe"
+  },
+  {
+    "index": "heavy-crossbow",
+    "name": "Heavy Crossbow",
+    "equipment_categories": [
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 50,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 100,
+      "long": 400
+    },
+    "weight": 18,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "ammunition": {
+      "index": "bolts",
+      "name": "Bolts",
+      "url": "/api/2024/equipment/bolts"
+    },
+    "mastery": {
+      "index": "push",
+      "name": "Push",
+      "url": "/api/2024/weapon-mastery-properties/push"
+    },
+    "url": "/api/2024/equipment/heavy-crossbow"
   },
   {
     "index": "javelin",
@@ -1027,6 +1255,77 @@
     "url": "/api/2024/equipment/light-hammer"
   },
   {
+    "index": "longbow",
+    "name": "Longbow",
+    "equipment_categories": [
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 5,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d8",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 150,
+      "long": 600
+    },
+    "weight": 2,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "heavy",
+        "name": "Heavy",
+        "url": "/api/2024/weapon-properties/heavy"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "ammunition": {
+      "index": "arrows",
+      "name": "Arrows",
+      "url": "/api/2024/equipment/arrows"
+    },
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "url": "/api/2024/equipment/longbow"
+  },
+  {
     "index": "longsword",
     "name": "Longsword",
     "equipment_categories": [
@@ -1245,6 +1544,77 @@
     "url": "/api/2024/equipment/morningstar"
   },
   {
+    "index": "musket",
+    "name": "Musket",
+    "equipment_categories": [
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 500,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d12",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 40,
+      "long": 120
+    },
+    "weight": 10,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      },
+      {
+        "index": "two-handed",
+        "name": "Two-Handed",
+        "url": "/api/2024/weapon-properties/two-handed"
+      }
+    ],
+    "ammunition": {
+      "index": "bullets-firearm",
+      "name": "Bullets, Firearm",
+      "url": "/api/2024/equipment/bullets-firearm"
+    },
+    "mastery": {
+      "index": "slow",
+      "name": "Slow",
+      "url": "/api/2024/weapon-mastery-properties/slow"
+    },
+    "url": "/api/2024/equipment/musket"
+  },
+  {
     "index": "needles",
     "name": "Needles",
     "equipment_categories": [
@@ -1331,6 +1701,72 @@
       "url": "/api/2024/weapon-mastery-properties/push"
     },
     "url": "/api/2024/equipment/pike"
+  },
+  {
+    "index": "pistol",
+    "name": "Pistol",
+    "equipment_categories": [
+      {
+        "index": "martial-ranged-weapons",
+        "name": "Martial Ranged Weapons",
+        "url": "/api/2024/equipment-categories/martial-ranged-weapons"
+      },
+      {
+        "index": "martial-weapons",
+        "name": "Martial Weapons",
+        "url": "/api/2024/equipment-categories/martial-weapons"
+      },
+      {
+        "index": "ranged-weapons",
+        "name": "Ranged Weapons",
+        "url": "/api/2024/equipment-categories/ranged-weapons"
+      },
+      {
+        "index": "weapons",
+        "name": "Weapons",
+        "url": "/api/2024/equipment-categories/weapons"
+      }
+    ],
+    "cost": {
+      "quantity": 250,
+      "unit": "gp"
+    },
+    "damage": {
+      "damage_dice": "1d10",
+      "damage_type": {
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2024/damage-types/piercing"
+      }
+    },
+    "range": {
+      "normal": 30,
+      "long": 90
+    },
+    "weight": 3,
+    "properties": [
+      {
+        "index": "ammunition",
+        "name": "Ammunition",
+        "url": "/api/2024/weapon-properties/ammunition"
+      },
+      {
+        "index": "loading",
+        "name": "Loading",
+        "url": "/api/2024/weapon-properties/loading"
+      }
+    ],
+    "ammunition": {
+      "index": "bullets-firearm",
+      "name": "Bullets, Firearm",
+      "url": "/api/2024/equipment/bullets-firearm"
+    },
+    "mastery": {
+      "index": "vex",
+      "name": "Vex",
+      "url": "/api/2024/weapon-mastery-properties/vex"
+    },
+    "url": "/api/2024/equipment/pistol"
   },
   {
     "index": "pouch",


### PR DESCRIPTION
## What does this do?

Adds 2024 Equipment and Equipment Categories

**NOTE: This is missing Magic Items, Vehicles, and Barding**

## How was it tested?

CI

## Did you update the docs in the API? Please link an associated PR if applicable.

Not yet

## Here's a fun image for your troubles

<img width="640" height="521" alt="image" src="https://github.com/user-attachments/assets/6040e9c4-b3e6-47e0-b499-33c175b9c86d" />
