### PR TITLE
fix(trident): change damage type to piercing

### DIFF
--- a/src/2014/5e-SRD-Equipment.json
+++ b/src/2014/5e-SRD-Equipment.json
@@ -1226,9 +1226,9 @@
     "damage": {
       "damage_dice": "1d6",
       "damage_type": {
-        "index": "slashing",
-        "name": "Slashing",
-        "url": "/api/2014/damage-types/slashing"
+        "index": "piercing",
+        "name": "Piercing",
+        "url": "/api/2014/damage-types/piercing"
       }
     },
     "range": {


### PR DESCRIPTION
## What does this do?

Changes the damage type of `trident` to `piercing` (was `slashing`) as specified in the [SRD](https://www.5esrd.com/equipment/WEAPONS/#Martial_Weapons).

## How was it tested?

Locally by running the [5e-srd-api](https://github.com/5e-bits/5e-srd-api) with `docker compose` using the local fork of [5e-database](https://github.com/5e-bits/5e-database) as database and calling the `2014/equipment/trident` endpoint.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

I don't believe this is necessary in this instance. 

## Here's a fun image for your troubles

A little guy named Twilly that appears in my campaign 😄
Stolen from [DragonFable](https://www.dragonfable.com/)

![Twilly](https://github.com/user-attachments/assets/e62771b0-f473-4f16-b77d-d7c5237fdfcf)

