### PR TITLE
feat(2024): Add backgrounds and feats

### DIFF
--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -1,0 +1,446 @@
+[
+	{
+		"index": "acolyte",
+		"name": "Acolyte",
+		"ability_scores" : [
+			{
+				"index": "cha",
+				"name": "CHA",
+				"full_name": "Charisma",
+				"url": "/api/2024/ability-scores/cha"
+			},
+			{
+				"index": "int",
+				"name": "INT",
+				"full_name": "Intelligence",
+				"url": "/api/2024/ability-scores/int"
+			},
+			{
+				"index": "wis",
+				"name": "WIS",
+				"full_name": "Wisdom",
+				"url": "/api/2024/ability-scores/wis"
+			}
+		],
+		"feat" : {
+			"index": "magic-initiate",
+			"name": "Magic Initiate (Cleric)",
+			"url": "/api/2024/feats/magic-initiate"
+		},
+		"starting_proficiencies": [
+			{
+				"index": "insight",
+				"name": "Insight",
+				"url": "/api/2024/skills/insight"
+			},
+			{
+				"index": "religion",
+				"name": "Religion",
+				"url": "/api/2024/skills/religion"
+			},
+			{
+				"index": "calligrapher-supplies",
+				"name": "Calligrapher's Supplies",
+				"url": "/api/2024/equipment/calligrapher-supplies"
+			}
+		],
+		"starting_equipment_options": [
+			[
+				{
+					"equipment": {
+						"index": "calligrapher-supplies",
+						"name": "Calligrapher's Supplies",
+						"url": "/api/2024/equipment/calligrapher-supplies"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "book",
+						"name": "Book (prayers)",
+						"url": "/api/2024/equipment/book"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "holy-symbols",
+						"name": "Holy Symbols",
+						"url": "/api/2024/equipment-categories/holy-symbols"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "parchment",
+						"name": "Parchment",
+						"url": "/api/2024/equipment/parchment"
+					},
+					"quantity": 10
+				},
+				{
+					"equipment": {
+						"index": "robe",
+						"name": "Robe",
+						"url": "/api/2024/equipment/robe"
+					},
+					"quantity": 1
+				}
+			],
+			[
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 50
+				}
+			]
+		],
+		"url": "/api/2024/backgrounds/acolyte"
+	},
+	{
+		"index": "criminal",
+		"name": "Criminal",
+		"ability_scores" : [
+			{
+				"index": "dex",
+				"name": "DEX",
+				"full_name": "Dexterity",
+				"url": "/api/2024/ability-scores/dex"
+			},
+			{
+				"index": "con",
+				"name": "CON",
+				"full_name": "Constitution",
+				"url": "/api/2024/ability-scores/con"
+			},
+			{
+				"index": "int",
+				"name": "INT",
+				"full_name": "Intelligence",
+				"url": "/api/2024/ability-scores/int"
+			}
+		],
+		"feat" : {
+			"index": "alert",
+			"name": "Alert",
+			"url": "/api/2024/feats/alert"
+		},
+		"starting_proficiencies": [
+			{
+				"index": "sleight-of-hand",
+				"name": "Sleight of Hand",
+				"url": "/api/2024/skills/sleight-of-hand"
+			},
+			{
+				"index": "stealth",
+				"name": "Stealth",
+				"url": "/api/2024/skills/stealth"
+			},
+			{
+				"index": "thieves-tools",
+				"name": "Thieves' Tools",
+				"url": "/api/2024/equipment/thieves-tools"
+			}
+		],
+		"starting_equipment_options": [
+			[
+				{
+					"equipment": {
+						"index": "dagger",
+						"name": "Dagger",
+						"url": "/api/2024/equipment/dagger"
+					},
+					"quantity": 2
+				},
+				{
+					"equipment": {
+						"index": "thieves-tools",
+						"name": "Thieves' Tools",
+						"url": "/api/2024/equipment/thieves-tools"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "crowbar",
+						"name": "Crowbar",
+						"url": "/api/2024/equipment-categories/crowbar"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "pouch",
+						"name": "Pouch",
+						"url": "/api/2024/equipment/pouch"
+					},
+					"quantity": 2
+				},
+				{
+					"equipment": {
+						"index": "clothes-travelers",
+						"name": "Clothes, Travelers",
+						"url": "/api/2024/equipment/clothes-travelers"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 16
+				}
+			],
+			[
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 50
+				}
+			]
+		],
+		"url": "/api/2024/backgrounds/criminal"
+	},
+	{
+		"index": "sage",
+		"name": "Sage",
+		"ability_scores" : [
+			{
+				"index": "con",
+				"name": "CON",
+				"full_name": "Constitution",
+				"url": "/api/2024/ability-scores/con"
+			},
+			{
+				"index": "int",
+				"name": "INT",
+				"full_name": "Intelligence",
+				"url": "/api/2024/ability-scores/int"
+			},
+			{
+				"index": "wis",
+				"name": "WIS",
+				"full_name": "Wisdom",
+				"url": "/api/2024/ability-scores/wis"
+			}
+		],
+		"feat" : {
+			"index": "magic-initiate",
+			"name": "Magic Initiate (Wizard)",
+			"url": "/api/2024/feats/magic-initiate"
+		},
+		"starting_proficiencies": [
+			{
+				"index": "arcana",
+				"name": "Arcana",
+				"url": "/api/2024/skills/arcana"
+			},
+			{
+				"index": "history",
+				"name": "History",
+				"url": "/api/2024/skills/history"
+			},
+			{
+				"index": "calligrapher-supplies",
+				"name": "Calligrapher's Supplies",
+				"url": "/api/2024/equipment/calligrapher-supplies"
+			}
+		],
+		"starting_equipment_options": [
+			[
+				{
+					"equipment": {
+						"index": "quarterstaff",
+						"name": "Quarterstaff",
+						"url": "/api/2024/equipment/quarterstaff"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "calligrapher-supplies",
+						"name": "Calligrapher's Supplies",
+						"url": "/api/2024/equipment/calligrapher-supplies"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "book",
+						"name": "Book (history)",
+						"url": "/api/2024/equipment-categories/book"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "parchment",
+						"name": "Parchment",
+						"url": "/api/2024/equipment/parchment"
+					},
+					"quantity": 8
+				},
+				{
+					"equipment": {
+						"index": "robe",
+						"name": "Robe",
+						"url": "/api/2024/equipment/robe"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 8
+				}
+			],
+			[
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 50
+				}
+			]
+		],
+		"url": "/api/2024/backgrounds/sage"
+	},
+	{
+		"index": "soldier",
+		"name": "Soldier",
+		"ability_scores" : [
+			{
+				"index": "str",
+				"name": "STR",
+				"full_name": "Strength",
+				"url": "/api/2024/ability-scores/str"
+			},
+			{
+				"index": "dex",
+				"name": "DEX",
+				"full_name": "Dexterity",
+				"url": "/api/2024/ability-scores/dex"
+			},
+			{
+				"index": "con",
+				"name": "CON",
+				"full_name": "Constitution",
+				"url": "/api/2024/ability-scores/con"
+			}
+		],
+		"feat" : {
+			"index": "savage-attacker",
+			"name": "Savager Attacker",
+			"url": "/api/2024/feats/savage-attacker"
+		},
+		"starting_proficiencies": [
+			{
+				"index": "athletics",
+				"name": "Athletics",
+				"url": "/api/2024/skills/athletics"
+			},
+			{
+				"index": "intimidation",
+				"name": "Intimidation",
+				"url": "/api/2024/skills/intimidation"
+			},
+			{
+				"index": "gaming-set",
+				"name": "Gaming Set",
+				"url": "/api/2024/equipment-categories/gaming-sets"
+			}
+		],
+		"starting_equipment_options": [
+			[
+				{
+					"equipment": {
+						"index": "spear",
+						"name": "Spear",
+						"url": "/api/2024/equipment/spear"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "shortbow",
+						"name": "Shortbow",
+						"url": "/api/2024/equipment/shortbow"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "arrow",
+						"name": "Arrow",
+						"url": "/api/2024/equipment-categories/arrow"
+					},
+					"quantity": 20
+				},
+				{
+					"equipment": {
+						"index": "gaming-set",
+						"name": "Gaming Set",
+						"url": "/api/2024/equipment-categories/gaming-sets"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "healers-kit",
+						"name": "Healer's Kit",
+						"url": "/api/2024/equipment/healers-kit"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "quiver",
+						"name": "Quiver",
+						"url": "/api/2024/equipment/quiver"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "clothes-travelers",
+						"name": "Clothes, Travelers",
+						"url": "/api/2024/equipment/clothes-travelers"
+					},
+					"quantity": 1
+				},
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 14
+				}
+			],
+			[
+				{
+					"equipment": {
+						"index": "gold",
+						"name": "Gold",
+						"url": "/api/2024/equipment/gold"
+					},
+					"quantity": 50
+				}
+			]
+		],
+		"url": "/api/2024/backgrounds/soldier"
+	}
+]

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -361,7 +361,7 @@
 				"url": "/api/2024/skills/intimidation"
 			},
 			{
-				"index": "gaming-set",
+				"index": "gaming-sets",
 				"name": "Gaming Sets",
 				"url": "/api/2024/equipment-categories/gaming-sets"
 			}
@@ -394,7 +394,7 @@
 				},
 				{
 					"equipment": {
-						"index": "gaming-set",
+						"index": "gaming-sets",
 						"name": "Gaming Sets",
 						"url": "/api/2024/equipment-categories/gaming-sets"
 					},

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -359,7 +359,7 @@
 			},
 			{
 				"index": "gaming-set",
-				"name": "Gaming Set",
+				"name": "Gaming Sets",
 				"url": "/api/2024/equipment-categories/gaming-sets"
 			}
 		],
@@ -392,7 +392,7 @@
 				{
 					"equipment": {
 						"index": "gaming-set",
-						"name": "Gaming Set",
+						"name": "Gaming Sets",
 						"url": "/api/2024/equipment-categories/gaming-sets"
 					},
 					"quantity": 1

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -24,7 +24,8 @@
 		],
 		"feat" : {
 			"index": "magic-initiate",
-			"name": "Magic Initiate (Cleric)",
+			"name": "Magic Initiate",
+			"option": "Cleric",
 			"url": "/api/2024/feats/magic-initiate"
 		},
 		"starting_proficiencies": [
@@ -57,7 +58,8 @@
 				{
 					"equipment": {
 						"index": "book",
-						"name": "Book (prayers)",
+						"name": "Book",
+						"option": "Prayers",
 						"url": "/api/2024/equipment/book"
 					},
 					"quantity": 1
@@ -234,7 +236,8 @@
 		],
 		"feat" : {
 			"index": "magic-initiate",
-			"name": "Magic Initiate (Wizard)",
+			"name": "Magic Initiate",
+			"option": "Wizard",
 			"url": "/api/2024/feats/magic-initiate"
 		},
 		"starting_proficiencies": [

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -167,7 +167,7 @@
 					"equipment": {
 						"index": "crowbar",
 						"name": "Crowbar",
-						"url": "/api/2024/equipment-categories/crowbar"
+						"url": "/api/2024/equipment/crowbar"
 					},
 					"quantity": 1
 				},
@@ -276,7 +276,7 @@
 					"equipment": {
 						"index": "book",
 						"name": "Book (history)",
-						"url": "/api/2024/equipment-categories/book"
+						"url": "/api/2024/equipment/book"
 					},
 					"quantity": 1
 				},
@@ -385,7 +385,7 @@
 					"equipment": {
 						"index": "arrow",
 						"name": "Arrow",
-						"url": "/api/2024/equipment-categories/arrow"
+						"url": "/api/2024/equipment/arrow"
 					},
 					"quantity": 20
 				},

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -387,9 +387,9 @@
 				},
 				{
 					"equipment": {
-						"index": "arrow",
-						"name": "Arrow",
-						"url": "/api/2024/equipment/arrow"
+						"index": "arrows",
+						"name": "Arrows",
+						"url": "/api/2024/equipment/arrows"
 					},
 					"quantity": 20
 				},

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -182,7 +182,7 @@
 				{
 					"equipment": {
 						"index": "clothes-travelers",
-						"name": "Clothes, Travelers",
+						"name": "Clothes, Traveler's",
 						"url": "/api/2024/equipment/clothes-travelers"
 					},
 					"quantity": 1
@@ -416,7 +416,7 @@
 				{
 					"equipment": {
 						"index": "clothes-travelers",
-						"name": "Clothes, Travelers",
+						"name": "Clothes, Traveler's",
 						"url": "/api/2024/equipment/clothes-travelers"
 					},
 					"quantity": 1

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -278,7 +278,8 @@
 				{
 					"equipment": {
 						"index": "book",
-						"name": "Book (history)",
+						"name": "Book",
+						"option": "History",
 						"url": "/api/2024/equipment/book"
 					},
 					"quantity": 1

--- a/src/2024/5e-SRD-Backgrounds.json
+++ b/src/2024/5e-SRD-Backgrounds.json
@@ -343,7 +343,7 @@
 		],
 		"feat" : {
 			"index": "savage-attacker",
-			"name": "Savager Attacker",
+			"name": "Savage Attacker",
 			"url": "/api/2024/feats/savage-attacker"
 		},
 		"starting_proficiencies": [

--- a/src/2024/5e-SRD-Equipment.json
+++ b/src/2024/5e-SRD-Equipment.json
@@ -2434,6 +2434,18 @@
     "url": "/api/2024/equipment/glassblowers-tools"
   },
   {
+    "index": "gold",
+    "name": "Gold",
+    "equipment_categories": [
+      {
+        "index": "adventuring-gear",
+        "name": "Adventuring Gear",
+        "url": "/api/2024/equipment-categories/adventuring-gear"
+      }
+    ],
+    "url": "/api/2024/equipment/gold"
+  },
+  {
     "index": "grappling-hook",
     "name": "Grappling Hook",
     "equipment_categories": [

--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -1,0 +1,69 @@
+[
+	{
+		"index": "alert",
+		"name": "Alert",
+		"category": "origin",
+		"prerequisites": [],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Initiative Proficiency",
+				"description": "When you roll Initiative, you can add your Proficiency Bonus to the roll."
+			},
+			{
+				"name": "Initiative Swap",
+				"description": "Immediately after you roll Initiative, you can swap your Initiative with the Initiative of one willing ally in the same combat. You can’t make this swap if you or the ally has the Incapacitated condition."
+			}
+		],
+		"url": "/api/2024/feats/alert"
+	},
+	{
+		"index": "magic-initiate",
+		"name": "Magic Initiate",
+		"category": "origin",
+		"prerequisites": [],
+		"description":"You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Two Cantrips",
+				"description": "You learn two cantrips of your choice from the Cleric, Druid, or Wizard spell list. Intelligence, Wisdom, or Charisma is your spellcasting ability for this feat’s spells (choose when you select this feat)."
+			},
+			{
+				"name": "Level 1 Spell",
+				"description": "Choose a level 1 spell from the same list you selected for this feat’s cantrips. You always have that spell prepared. You can cast it once without a spell slot, and you regain the ability to cast it in that way when you finish a Long Rest. You can also cast the spell using any spell slots you have."
+			},
+			{
+				"name": "Spell Change",
+				"description": "Whenever you gain a new level, you can replace one of the spells you chose for this feat with a different spell of the same level from the chosen spell list."
+			},
+			{
+				"name": "Repeatable",
+				"description": "You can take this feat more than once, but you must choose a different spell list each time."
+			}
+		],
+		"url": "/api/2024/feats/magic-initiate"
+	},
+	{
+		"index": "savage-attacker",
+		"name": "Savage Attacker",
+		"category": "origin",
+		"prerequisites": [],
+		"description":"You’ve trained to deal particularly damaging strikes. Once per turn when you hit a target with a weapon, you can roll the weapon’s damage dice twice and use either roll against the target.",
+		"benefits": [],
+		"url": "/api/2024/feats/savage-attacker"
+	},
+	{
+		"index": "skilled",
+		"name": "Skilled",
+		"category": "origin",
+		"prerequisites": [],
+		"description":"You gain proficiency in any combination of three skills or tools of your choice.",
+		"benefits": [
+			{
+				"name": "Repeatable",
+				"description": "You can take this feat more than once."
+			}
+		],
+		"url": "/api/2024/feats/skilled"
+	}
+]

--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -65,5 +65,94 @@
 			}
 		],
 		"url": "/api/2024/feats/skilled"
+	},
+	{
+		"index": "ability-score-improvement",
+		"name": "Ability Score Improvement",
+		"category": "general",
+		"prerequisites": [
+			"Level 4+"
+		],
+		"description": "Increase one ability score of your choice by 2, or increase two ability scores of your choice by 1. This feat can’t increase an ability score above 20.",
+		"benefits": [
+			{
+				"name": "Repeatable",
+				"description": "You can take this feat more than once."
+			}
+		],
+		"url": "/api/2024/feats/ability-score-improvement"
+	},
+	{
+		"index": "grappler",
+		"name": "Grappler",
+		"category": "general",
+		"prerequisites": [
+			"Level 4+",
+			"Strength or Dexterity 13+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase your Strength or Dexterity score by 1, to a maximum of 20."
+			},
+			{
+				"name": "Punch and Grab",
+				"description": "When you hit a creature with an Unarmed Strike as part of the Attack action on your turn, you can use both the Damage and the Grapple option. You can use this benefit only once per turn."
+			},
+			{
+				"name": "Attack Advantage",
+				"description": "You have Advantage on attack rolls against a creature Grappled by you."
+			},
+			{
+				"name": "Fast Wrestly",
+				"description": "You don’t have to spend extra movement to move a creature Grappled by you if the creature is your size or smaller."
+			}
+		],
+		"url": "/api/2024/feats/grappler"
+	},
+	{
+		"index": "archery",
+		"name": "Archery",
+		"category": "fighting-style",
+		"prerequisites": [
+			"Fighting Style Feature"
+		],
+		"description": "You gain a +2 bonus to attack rolls you make with Ranged weapons.",
+		"benefits": [],
+		"url": "/api/2024/feats/archery"
+	},
+	{
+		"index": "defense",
+		"name": "Defense",
+		"category": "fighting-style",
+		"prerequisites": [
+			"Fighting Style Feature"
+		],
+		"description": "While you’re wearing Light, Medium, or Heavy armor, you gain a +1 bonus to Armor Class.",
+		"benefits": [],
+		"url": "/api/2024/feats/defense"
+	},
+	{
+		"index": "great-weapon-fighting",
+		"name": "Great Weapon Fighting",
+		"category": "fighting-style",
+		"prerequisites": [
+			"Fighting Style Feature"
+		],
+		"description": "When you roll damage for an attack you make with a Melee weapon that you are holding with two hands, you can treat any 1 or 2 on a damage die as a 3. The weapon must have the Two-Handed or Versatile property to gain this benefit.",
+		"benefits": [],
+		"url": "/api/2024/feats/great-weapon-fighting"
+	},
+	{
+		"index": "two-weapon-fighting",
+		"name": "Two Weapon Fighting",
+		"category": "fighting-style",
+		"prerequisites": [
+			"Fighting Style Feature"
+		],
+		"description": "When you make an extra attack as a result of using a weapon that has the Light property, you can add your ability modifier to the damage of that attack if you aren’t already adding it to the damage.",
+		"benefits": [],
+		"url": "/api/2024/feats/two-weapon-fighting"
 	}
 ]

--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -154,5 +154,154 @@
 		"description": "When you make an extra attack as a result of using a weapon that has the Light property, you can add your ability modifier to the damage of that attack if you aren’t already adding it to the damage.",
 		"benefits": [],
 		"url": "/api/2024/feats/two-weapon-fighting"
+	},
+	{
+		"index": "boon-of-combat-prowess",
+		"name": "Boon of Combat Prowess",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Peerless Aim",
+				"description": "When you miss with an attack roll, you can hit instead. Once you use this benefit, you can’t use it again until the start of your next turn."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-combat-prowess"
+	},
+	{
+		"index": "boon-of-dimensional-travel",
+		"name": "Boon of Dimensional Travel",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Blink Steps",
+				"description": "Immediately after you take the Attack action or the Magic action, you can teleport up to 30 feet to an unoccupied space you can see."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-dimensional-travel"
+	},
+	{
+		"index": "boon-of-fate",
+		"name": "Boon of Fate",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Improve Fate",
+				"description": "When you or another creature within 60 feet of you succeeds on or fails a D20 Test, you can roll 2d4 and apply the total rolled as a bonus or penalty to the d20 roll. Once you use this benefit, you can’t use it again until you roll Initiative or finish a Short or Long Rest."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-fate"
+	},
+	{
+		"index": "boon-of-irresistible-offense",
+		"name": "Boon of Irresistible Offense",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Overcome Defenses",
+				"description": "The Bludgeoning, Piercing, and Slashing damage you deal always ignores Resistance."
+			},
+			{
+				"name": "Overwhelming Strike",
+				"description": "When you roll a 20 on the d20 for an attack roll, you can deal extra damage to the target equal to the ability score increased by this feat. The extra damage’s type is the same as the attack’s type."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-irresistible-offense"
+	},
+	{
+		"index": "boon-of-spell-recall",
+		"name": "Boon of Spell Recall",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+",
+			"Spellcasting Feature"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Free Casting",
+				"description": "Whenever you cast a spell with a level 1–4 spell slot, roll 1d4. If the number you roll is the same as the slot’s level, the slot isn’t expended."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-spell-recall"
+	},
+	{
+		"index": "boon-of-the-night-spirit",
+		"name": "Boon of the Night Spirit",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Merge with Shadows",
+				"description": "While within Dim Light or Darkness, you can give yourself the Invisible condition as a Bonus Action. The condition ends on you immediately after you take an action, a Bonus Action, or a Reaction."
+			},
+			{
+				"name": "Shadowy form",
+				"description": "While within Dim Light or Darkness, you have Resistance to all damage except Psychic and Radiant."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-the-night-spirit"
+	},
+	{
+		"index": "boon-of-truesight",
+		"name": "Boon of Truesight",
+		"category": "epic-boon",
+		"prerequisites": [
+			"Level 19+"
+		],
+		"description": "You gain the following benefits.",
+		"benefits": [
+			{
+				"name": "Ability Score Increase",
+				"description": "Increase one ability score of your choice by 1, to a maximum of 30."
+			},
+			{
+				"name": "Truesight",
+				"description": "You have Truesight with a range of 60 feet."
+			}
+		],
+		"url": "/api/2024/feats/boon-of-truesight"
 	}
 ]

--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -22,7 +22,7 @@
 		"name": "Magic Initiate",
 		"category": "origin",
 		"prerequisites": [],
-		"description":"You gain the following benefits.",
+		"description": "You gain the following benefits.",
 		"benefits": [
 			{
 				"name": "Two Cantrips",
@@ -48,7 +48,7 @@
 		"name": "Savage Attacker",
 		"category": "origin",
 		"prerequisites": [],
-		"description":"You’ve trained to deal particularly damaging strikes. Once per turn when you hit a target with a weapon, you can roll the weapon’s damage dice twice and use either roll against the target.",
+		"description": "You’ve trained to deal particularly damaging strikes. Once per turn when you hit a target with a weapon, you can roll the weapon’s damage dice twice and use either roll against the target.",
 		"benefits": [],
 		"url": "/api/2024/feats/savage-attacker"
 	},
@@ -57,7 +57,7 @@
 		"name": "Skilled",
 		"category": "origin",
 		"prerequisites": [],
-		"description":"You gain proficiency in any combination of three skills or tools of your choice.",
+		"description": "You gain proficiency in any combination of three skills or tools of your choice.",
 		"benefits": [
 			{
 				"name": "Repeatable",


### PR DESCRIPTION
## What does this do?

Adds the SRD v5.2 (aka 5E 2024) Backgrounds (Acolyte, Criminal, Sage, Soldier) and Feats.

## How was it tested?

MongoDB succesfully built locally using DB Refresh script.

## Is there a Github issue this is resolving?

No, but this work will hopefully contribute towards the final implementation of the new 5E 2024 data.

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

My players know that I'm preparing for *Curse of Strahd*. There have been... suggestions.

<img width="898" height="1208" alt="image" src="https://github.com/user-attachments/assets/7ccfe99b-b69c-4ebb-84b6-4a9c7a487c8d" />

