### PR TITLE
fix: add remaining 2024 Feats

### DIFF
--- a/src/2024/5e-SRD-Feats.json
+++ b/src/2024/5e-SRD-Feats.json
@@ -28,5 +28,164 @@
     "repeatable": "You can take this feat more than once.",
     "type": "origin",
     "url": "/api/2024/feats/skilled"
+  },
+  {
+    "index": "ability-score-improvement",
+    "name": "Ability Score Improvement",
+    "type": "general",
+    "prerequisites": {
+      "minimum_level": 4
+    },
+    "description": "Increase one ability score of your choice by 2, or increase two ability scores of your choice by 1. This feat can’t increase an ability score above 20.",
+    "repeatable": "You can take this feat more than once.",
+    "url": "/api/2024/feats/ability-score-improvement"
+  },
+  {
+    "index": "grappler",
+    "name": "Grappler",
+    "type": "general",
+    "prerequisites": {
+      "minimum_level": 4
+    },
+    "prerequisite_options": {
+      "type": "ability-scores",
+      "choose": 1,
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "score_prerequisite",
+            "ability_score": {
+              "index": "str",
+              "name": "STR",
+              "url": "/api/2024/ability-scores/str"
+            },
+            "minimum_score": 13
+          },
+          {
+            "option_type": "score_prerequisite",
+            "ability_score": {
+              "index": "dex",
+              "name": "DEX",
+              "url": "/api/2024/ability-scores/dex"
+            },
+            "minimum_score": 13
+          }
+        ]
+      }
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase your Strength or Dexterity score by 1, to a maximum of 20.\n**Punch and Grab.** When you hit a creature with an Unarmed Strike as part of the Attack action on your turn, you can use both the Damage and the Grapple option. You can use this benefit only once per turn.\n**Attack Advantage.** You have Advantage on attack rolls against a creature Grappled by you.\n**Fast Wrestler.** You don’t have to spend extra movement to move a creature Grappled by you if the creature is your size or smaller.",
+    "url": "/api/2024/feats/grappler"
+  },
+  {
+    "index": "archery",
+    "name": "Archery",
+    "type": "fighting-style",
+    "prerequisites": {
+      "feature_named": "Fighting Style"
+    },
+    "description": "You gain a +2 bonus to attack rolls you make with Ranged weapons.",
+    "url": "/api/2024/feats/archery"
+  },
+  {
+    "index": "defense",
+    "name": "Defense",
+    "type": "fighting-style",
+    "prerequisites": {
+      "feature_named": "Fighting Style"
+    },
+    "description": "While you’re wearing Light, Medium, or Heavy armor, you gain a +1 bonus to Armor Class.",
+    "url": "/api/2024/feats/defense"
+  },
+  {
+    "index": "great-weapon-fighting",
+    "name": "Great Weapon Fighting",
+    "type": "fighting-style",
+    "prerequisites": {
+      "feature_named": "Fighting Style"
+    },
+    "description": "When you roll damage for an attack you make with a Melee weapon that you are holding with two hands, you can treat any 1 or 2 on a damage die as a 3. The weapon must have the Two-Handed or Versatile property to gain this benefit.",
+    "url": "/api/2024/feats/great-weapon-fighting"
+  },
+  {
+    "index": "two-weapon-fighting",
+    "name": "Two Weapon Fighting",
+    "type": "fighting-style",
+    "prerequisites": {
+      "feature_named": "Fighting Style"
+    },
+    "description": "When you make an extra attack as a result of using a weapon that has the Light property, you can add your ability modifier to the damage of that attack if you aren’t already adding it to the damage.",
+    "url": "/api/2024/feats/two-weapon-fighting"
+  },
+  {
+    "index": "boon-of-combat-prowess",
+    "name": "Boon of Combat Prowess",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Peerless Aim.** When you miss with an attack roll, you can hit instead. Once you use this benefit, you can’t use it again until the start of your next turn.",
+    "url": "/api/2024/feats/boon-of-combat-prowess"
+  },
+  {
+    "index": "boon-of-dimensional-travel",
+    "name": "Boon of Dimensional Travel",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Blink Steps.** Immediately after you take the Attack action or the Magic action, you can teleport up to 30 feet to an unoccupied space you can see.",
+    "url": "/api/2024/feats/boon-of-dimensional-travel"
+  },
+  {
+    "index": "boon-of-fate",
+    "name": "Boon of Fate",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Improve Fate.** When you or another creature within 60 feet of you succeeds on or fails a D20 Test, you can roll 2d4 and apply the total rolled as a bonus or penalty to the d20 roll. Once you use this benefit, you can’t use it again until you roll Initiative or finish a Short or Long Rest.",
+    "url": "/api/2024/feats/boon-of-fate"
+  },
+  {
+    "index": "boon-of-irresistible-offense",
+    "name": "Boon of Irresistible Offense",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Overcome Defenses.** The Bludgeoning, Piercing, and Slashing damage you deal always ignores Resistance.\n**Overwhelming Strike.** When you roll a 20 on the d20 for an attack roll, you can deal extra damage to the target equal to the ability score increased by this feat. The extra damage’s type is the same as the attack’s type.",
+    "url": "/api/2024/feats/boon-of-irresistible-offense"
+  },
+  {
+    "index": "boon-of-spell-recall",
+    "name": "Boon of Spell Recall",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19,
+      "feature_named": "Spellcasting"
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Free Casting.** Whenever you cast a spell with a level 1–4 spell slot, roll 1d4. If the number you roll is the same as the slot’s level, the slot isn’t expended.",
+    "url": "/api/2024/feats/boon-of-spell-recall"
+  },
+  {
+    "index": "boon-of-the-night-spirit",
+    "name": "Boon of the Night Spirit",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Merge with Shadows.** While within Dim Light or Darkness, you can give yourself the Invisible condition as a Bonus Action. The condition ends on you immediately after you take an action, a Bonus Action, or a Reaction.\n**Shadowy form.** While within Dim Light or Darkness, you have Resistance to all damage except Psychic and Radiant.",
+    "url": "/api/2024/feats/boon-of-the-night-spirit"
+  },
+  {
+    "index": "boon-of-truesight",
+    "name": "Boon of Truesight",
+    "type": "epic-boon",
+    "prerequisites": {
+      "minimum_level": 19
+    },
+    "description": "You gain the following benefits.\n**Ability Score Increase.** Increase one ability score of your choice by 1, to a maximum of 30.\n**Truesight.** You have Truesight with a range of 60 feet.",
+    "url": "/api/2024/feats/boon-of-truesight"
   }
 ]


### PR DESCRIPTION
## What does this do?

This PR adds the remaining feats from the 2024 SRD.

## How was it tested?

Local tests and local DB refresh completed successfully.

## Is there a Github issue this is resolving?

No, but this PR was discussed at some length via Discord.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

For Halloween, I tortured my players with a Daggerheart one-shot, a conversion of *Curse of Strahd*'s introductory adventure module, **Death House**.

<img width="646" height="908" alt="image" src="https://github.com/user-attachments/assets/be5ab688-49fa-4a8a-a863-f5d78d92c456" />



