### PR TITLE
fix: Correct Ankheg XP

### DIFF
--- a/src/2014/5e-SRD-Monsters.json
+++ b/src/2014/5e-SRD-Monsters.json
@@ -6493,7 +6493,7 @@
     "languages": "",
     "challenge_rating": 2,
     "proficiency_bonus": 2,
-    "xp": 250,
+    "xp": 450,
     "actions": [
       {
         "name": "Bite",


### PR DESCRIPTION
## What does this do?

Corrects Ankheg XP to 450 from 250

## How was it tested?

N/A

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

N/A

## Here's a fun image for your troubles

:)