### PR TITLE
Added SRD 2024 Monsters

### DIFF
--- a/src/2024/5e-2024-SRD-Monsters.json
+++ b/src/2024/5e-2024-SRD-Monsters.json
@@ -1,0 +1,31226 @@
+{
+    "Aboleth": {
+        "Id": "Aboleth",
+        "Name": "Aboleth",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Aberration, Lawful Evil",
+        "HP": {
+            "Value": 150,
+            "Notes": "(20d10 + 40)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 9,
+            "Con": 15,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Con",
+                "Modifier": 6
+            },
+            {
+                "Name": "Int",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 12
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 10
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Deep Speech",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "10",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The aboleth can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Eldritch Restoration",
+                "Content": "If destroyed, the aboleth gains a new body in 5d10 days, reviving with all its Hit Points in the Far Realm or another location chosen by the GM.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the aboleth fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            },
+            {
+                "Name": "Mucus Cloud",
+                "Content": "While underwater, the aboleth is sur- rounded by mucus. Constitution Saving Throw: DC 14, each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth’s turn. Failure: The target is cursed. Until the curse ends, the target’s skin becomes slimy, the target can breathe air and water, and it can’t regain Hit Points unless it is underwater. While the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed.",
+                "Usage": ""
+            },
+            {
+                "Name": "Probing Telepathy",
+                "Content": "If a creature the aboleth can see communicates telepathically with the aboleth, the abo- leth learns the creature’s greatest desires.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The aboleth makes two Tentacle attacks and uses either Consume Memories or Dominate Mind if available.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle",
+                "Content": "Melee Attack Roll: +9, reach 15 ft. Hit: 12 (2d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (es- cape DC 14) from one of four tentacles.",
+                "Usage": ""
+            },
+            {
+                "Name": "Consume Memories",
+                "Content": "Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grap- pled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target’s memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
+                "Usage": ""
+            },
+            {
+                "Name": "Dominate Mind",
+                "Content": "Wisdom Saving Throw: DC 16, one creature the aboleth can see within 30 feet. Failure: The target has the Charmed condition until the aboleth dies or is on a different plane of existence from the target. While Charmed, the target acts as an ally to the aboleth and is under its control while within 60 feet of it. In addition, the aboleth and the target can communicate telepathically with each other over any distance. The target repeats the save whenever it takes damage as well as after every 24 hours it spends at least 1 mile away from the aboleth, ending the effect on itself on a success.",
+                "Usage": "2/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Lash",
+                "Content": "The aboleth makes one Tentacle attack. Psychic Drain. If the aboleth has at least one creature Charmed or Grappled, it uses Consume Memories and regains 5 (1d10) Hit Points. Air Elemental Air Elemental",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Tentacle",
+                "ToHit": "+9",
+                "Damage": "2d6 + 5",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Air Elemental": {
+        "Id": "Air Elemental",
+        "Name": "Air Elemental",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral",
+        "HP": {
+            "Value": 90,
+            "Notes": "(12d10 + 24)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 90 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 20,
+            "Con": 14,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Lightning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Poison",
+            "Thunder"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Auran)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Air Form",
+                "Content": "The elemental can enter a creature’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The elemental makes two Thunderous",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Thunderous Slam",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Thunder damage. 259 Whirlwind (Recharge 4–6). Strength Saving Throw: DC 13, one Medium or smaller creature in the elemental’s space. Failure: 24 (4d10 + 2) Thunder damage, and the target is pushed up to 20 feet straight away from the elemental and has the Prone condition. Success: Half damage only. Animated Objects Animated Armor",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Thunderous Slam",
+                "ToHit": "+8",
+                "Damage": "2d8 + 5",
+                "DamageType": "Thunder"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Animated Armor": {
+        "Id": "Animated Armor",
+        "Name": "Animated Armor",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Construct, Unaligned",
+        "HP": {
+            "Value": 33,
+            "Notes": "(6d8 + 6)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "25 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 11,
+            "Con": 13,
+            "Int": 1,
+            "Wis": 3,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The armor makes two Slam attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage. Animated Flying Sword",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Animated Flying Sword": {
+        "Id": "Animated Flying Sword",
+        "Name": "Animated Flying Sword",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Construct, Unaligned",
+        "HP": {
+            "Value": 14,
+            "Notes": "(4d6)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 50 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 1,
+            "Wis": 5,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Slash",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage. Animated Rug of Smothering",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slash",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Animated Rug of Smothering": {
+        "Id": "Animated Rug of Smothering",
+        "Name": "Animated Rug of Smothering",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 27,
+            "Notes": "(5d10)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 14,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 3,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Smother",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the rug can give it the Grappled con- dition (escape DC 13) instead of dealing damage. Until the grapple ends, the target has the Blinded and Re- strained conditions, is suffocating, and takes 10 (2d6 + 3) Bludgeoning damage at the start of each of its turns.",
+                "Usage": ""
+            },
+            {
+                "Name": "The rug can smother only one creature at a time",
+                "Content": "While grappling the target, the rug can’t take this ac- tion, the rug halves the damage it takes (round down), and the target takes the same amount of damage. Ankheg Ankheg",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Smother",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ankheg": {
+        "Id": "Ankheg",
+        "Name": "Ankheg",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 10 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 11,
+            "Con": 14,
+            "Int": 1,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft.",
+            "Tremorsense 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Tunneler",
+                "Content": "The ankheg can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the ankheg), reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 3 (1d6) Acid damage. If the target is a Large or smaller creature, it has the Grappled con- dition (escape DC 13). Acid Spray (Recharge 6). Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-foot-wide Line. Failure: 14 (4d6) Acid damage. Success: Half damage. 260 Assassin Assassin",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Assassin": {
+        "Id": "Assassin",
+        "Name": "Assassin",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 97,
+            "Notes": "(15d8 + 30)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 18,
+            "Con": 14,
+            "Int": 16,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Poison"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Int",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Acrobatics",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 10
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Thieves’ Cant"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Evasion",
+                "Content": "If the assassin is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, the assassin instead takes no damage if it succeeds on the save and only half damage if it fails. It can’t use this trait if it has the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The assassin makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortsword or Light Crossbow in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortsword",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 7 (1d6 + 4) Piercing damage plus 17 (5d6) Poison dam- age, and the target has the Poisoned condition until the start of the assassin’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Light Crossbow",
+                "Content": "Ranged Attack Roll: +7, range 80/320 ft. Hit: 8 (1d8 + 4) Piercing damage plus 21 (6d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Cunning Action",
+                "Content": "The assassin takes the Dash, Disen- gage, or Hide action. Awakened Plants Awakened Shrub",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shortsword",
+                "ToHit": "+7",
+                "Damage": "1d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Awakened Shrub": {
+        "Id": "Awakened Shrub",
+        "Name": "Awakened Shrub",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Plant, Neutral",
+        "HP": {
+            "Value": 10,
+            "Notes": "(3d6)"
+        },
+        "AC": {
+            "Value": 9,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 8,
+            "Con": 11,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [
+            "Piercing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rake",
+                "Content": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Slash- ing damage. Awakened Tree",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Awakened Tree": {
+        "Id": "Awakened Tree",
+        "Name": "Awakened Tree",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Plant, Neutral",
+        "HP": {
+            "Value": 59,
+            "Notes": "(7d12 + 14)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 6,
+            "Con": 15,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (3d6 + 4) Bludgeoning damage. Axe Beak Axe Beak",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+6",
+                "Damage": "3d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Axe Beak": {
+        "Id": "Axe Beak",
+        "Name": "Axe Beak",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d10 + 3)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage. 261 Azer Azer Sentinel",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beak",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Azer Sentinel": {
+        "Id": "Azer Sentinel",
+        "Name": "Azer Sentinel",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Elemental, Lawful Neutral",
+        "HP": {
+            "Value": 39,
+            "Notes": "(6d8 + 12)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 12,
+            "Con": 15,
+            "Int": 12,
+            "Wis": 13,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Primordial (Ignan)"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Fire Aura",
+                "Content": "At the end of each of the azer’s turns, each creature of the azer’s choice in a 5-foot Emanation orig- inating from the azer takes 5 (1d10) Fire damage unless the azer has the Incapacitated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Illumination",
+                "Content": "The azer sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Burning Hammer",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 3 (1d6) Fire damage. Balor Balor",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Burning Hammer",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Balor": {
+        "Id": "Balor",
+        "Name": "Balor",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 287,
+            "Notes": "(23d12 + 138)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 26,
+            "Dex": 15,
+            "Con": 22,
+            "Int": 20,
+            "Wis": 16,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 12
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "19",
+        "Traits": [
+            {
+                "Name": "Death Throes",
+                "Content": "The balor explodes when it dies. Dex- terity Saving Throw: DC 20, each creature in a 30-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the balor",
+                "Content": "Failure: 31 (9d6) Fire damage plus 31 (9d6) Force damage. Success: Half damage. Failure or Success: If the balor dies outside the Abyss, it gains a new body instantly, reviving with all its",
+                "Usage": ""
+            },
+            {
+                "Name": "Fire Aura",
+                "Content": "At the end of each of the balor’s turns, each creature in a 5-foot Emanation originating from the ba- lor takes 13 (3d8) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the balor fails a saving throw, it can choose to succeed instead.",
+                "Usage": "3/Day"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The balor has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The balor makes one Flame Whip attack and one Lightning Blade attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Flame Whip",
+                "Content": "Melee Attack Roll: +14, reach 30 ft. Hit: 18 (3d6 + 8) Force damage plus 17 (5d6) Fire damage. If the target is a Huge or smaller creature, the balor pulls the target up to 25 feet straight toward itself, and the target has the Prone condition. Lightning Blade. Melee Attack Roll: +14, reach 10 ft. Hit: 21 (3d8 + 8) Force damage plus 22 (4d10) Light- ning damage, and the target can’t take Reactions until the start of the balor’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Teleport",
+                "Content": "The balor teleports itself or a willing demon within 10 feet of itself up to 60 feet to an unoccupied space the balor can see. Bandits Bandit",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Flame Whip",
+                "ToHit": "+14",
+                "Damage": "3d6 + 8",
+                "DamageType": "Force"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bandit": {
+        "Id": "Bandit",
+        "Name": "Bandit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Thieves’ Cant"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Scimitar",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Light Crossbow",
+                "Content": "Ranged Attack Roll: +3, range 80/320 ft. Hit: 5 (1d8 + 1) Piercing damage. Bandit Captain",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Scimitar",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bandit Captain": {
+        "Id": "Bandit Captain",
+        "Name": "Bandit Captain",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 52,
+            "Notes": "(8d8 + 16)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 16,
+            "Con": 14,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 4
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 4
+            },
+            {
+                "Name": "Deception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Thieves’ Cant"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bandit makes two attacks, using Scim- itar and Pistol in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scimitar",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pistol",
+                "Content": "Ranged Attack Roll: +5, range 30/90 ft. Hit: 8 (1d10 + 3) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The bandit is hit by a melee attack roll while holding a weapon. Response: The bandit adds 2 to its AC against that attack, possibly causing it to miss. Barbed Devil Barbed Devil",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Scimitar",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Barbed Devil": {
+        "Id": "Barbed Devil",
+        "Name": "Barbed Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 110,
+            "Notes": "(13d8 + 52)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 17,
+            "Con": 18,
+            "Int": 12,
+            "Wis": 14,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 6
+            },
+            {
+                "Name": "Con",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Barbed Hide",
+                "Content": "At the start of each of its turns, the devil deals 5 (1d10) Piercing damage to any creature it is grappling or any creature grappling it.",
+                "Usage": ""
+            },
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes one Claws attack and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail attack, or it makes two Hurl Flame attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Claws",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from both claws.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 14 (2d10 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hurl Flame",
+                "Content": "Ranged Attack Roll: +5, range 150 ft. Hit: 17 (5d6) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning. Basilisk Basilisk",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claws",
+                "ToHit": "+6",
+                "Damage": "2d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Basilisk": {
+        "Id": "Basilisk",
+        "Name": "Basilisk",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Unaligned",
+        "HP": {
+            "Value": 52,
+            "Notes": "(8d8 + 16)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 8,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 8,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Petrified condition instead of the Restrained condition",
+                "Content": "Bearded Devil Bearded Devil",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bearded Devil": {
+        "Id": "Bearded Devil",
+        "Name": "Bearded Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 58,
+            "Notes": "(9d8 + 18)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 15,
+            "Con": 15,
+            "Int": 9,
+            "Wis": 11,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Frightened",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 5
+            },
+            {
+                "Name": "Con",
+                "Modifier": 4
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes one Beard attack and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Infernal Glaive attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Beard",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the target has the Poisoned condition until the start of the devil’s next turn. Until this poison ends, the target can’t regain Hit Points.",
+                "Usage": ""
+            },
+            {
+                "Name": "Infernal Glaive",
+                "Content": "Melee Attack Roll: +5, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage. If the target is a crea- ture and doesn’t already have an infernal wound, it is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target receives an infernal wound. While wounded, the target loses 5 (1d10) Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points at the start of each of its turns",
+                "Content": "The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by suc- ceeding on a DC 12 Wisdom (Medicine) check. Behir Behir",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beard",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Behir": {
+        "Id": "Behir",
+        "Name": "Behir",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Monstrosity, Neutral Evil",
+        "HP": {
+            "Value": 168,
+            "Notes": "(16d12 + 64)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Climb 50 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 16,
+            "Con": 18,
+            "Int": 7,
+            "Wis": 14,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 90 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "11",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The behir makes one Bite attack and uses",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 19 (2d12 + 6) Piercing damage plus 11 (2d10) Lightning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 18, one Large or smaller creature the behir can see within 5 feet. Failure: 28 (5d8 + 6) Bludgeoning damage. The target has the Grappled condition (escape DC 16), and it has the Re- strained condition until the grapple ends. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 16, each creature in a 90-foot-long, 5-foot- wide Line. Failure: 66 (12d10) Lightning damage. Suc- cess: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "Dexterity Saving Throw: DC 18, one Large or smaller creature Grappled by the behir (the behir can have only one creature swallowed at a time). Failure: The behir swallows the target, which is no longer Grap- pled. While swallowed, a creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the behir, and takes 21 (6d6) Acid damage at the start of each of the behir’s turns. If the behir takes 30 damage or more on a single turn from the swallowed creature, the behir must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls in a space within 10 feet of the behir and has the Prone condition. If the behir dies, a swallowed creature is no longer Re- strained and can escape from the corpse by using 15 feet of movement, exiting Prone. Berserker Berserker",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+10",
+                "Damage": "2d12 + 6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Berserker": {
+        "Id": "Berserker",
+        "Name": "Berserker",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 67,
+            "Notes": "(9d8 + 27)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 12,
+            "Con": 17,
+            "Int": 9,
+            "Wis": 11,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Bloodied Frenzy",
+                "Content": "While Bloodied, the berserker has",
+                "Usage": ""
+            },
+            {
+                "Name": "Advantage on attack rolls and saving throws",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Greataxe",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 9 (1d12 + 3) Slashing damage. Black Dragons Black Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Greataxe",
+                "ToHit": "+5",
+                "Damage": "1d12 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Black Dragon Wyrmling": {
+        "Id": "Black Dragon Wyrmling",
+        "Name": "Black Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 33,
+            "Notes": "(6d8 + 6)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 13,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage plus 2 (1d4) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 11, each creature in a 15-foot-long, 5-foot- wide Line. Failure: 22 (5d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "Young Black Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Black Dragon": {
+        "Id": "Young Black Dragon",
+        "Name": "Young Black Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 127,
+            "Notes": "(15d10 + 45)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 14,
+            "Con": 17,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "7",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 3 (1d6) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 30-foot-long, 5-foot- wide Line. Failure: 49 (14d6) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "Adult Black Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d4 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Black Dragon": {
+        "Id": "Adult Black Dragon",
+        "Name": "Adult Black Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 195,
+            "Notes": "(17d12 + 85)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 14,
+            "Con": 21,
+            "Int": 14,
+            "Wis": 13,
+            "Cha": 19
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "14",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 3 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-foot- wide Line. Failure: 54 (12d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17 , +9 to hit with spell attacks): At Will: Acid Arrow (level 3 version), Detect Magic, Fear 1/Day Each: Speak with Dead, Vitriolic Sphere",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Cloud of Insects",
+                "Content": "Dexterity Saving Throw: DC 17 , one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightful Presence",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Fear",
+                "Content": "The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. 265 Ancient Black Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+11",
+                "Damage": "2d6 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Black Dragon": {
+        "Id": "Ancient Black Dragon",
+        "Name": "Ancient Black Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 367,
+            "Notes": "(21d20 + 147)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 14,
+            "Con": 25,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 16
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "21",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Acid Arrow (level 4 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 9 (2d8) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 22, each creature in a 90-foot-long, 10-foot- wide Line. Failure: 67 (15d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): At Will: Acid Arrow (level 4 version), Detect Magic, Fear 1/Day Each: Create Undead, Speak with Dead, Vitriolic Sphere (level 5 version)",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Cloud of Insects",
+                "Content": "Dexterity Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 33 (6d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightful Presence",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Fear",
+                "Content": "The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Black Pudding Black Pudding",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+15",
+                "Damage": "2d8 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Black Pudding": {
+        "Id": "Black Pudding",
+        "Name": "Black Pudding",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Ooze, Unaligned",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d10 + 24)"
+        },
+        "AC": {
+            "Value": 7,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 5,
+            "Con": 16,
+            "Int": 1,
+            "Wis": 6,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid",
+            "Cold",
+            "Lightning",
+            "Slashing"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Prone",
+            "Restrained"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Amorphous",
+                "Content": "The pudding can move through a space as narrow as 1 inch without expending extra move- ment to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Corrosive Form",
+                "Content": "A creature that hits the pudding with a melee attack roll takes 4 (1d8) Acid damage. Nonmag- ical ammunition is destroyed immediately after hitting the pudding and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the pudding and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. In 1 minute, the pudding can eat through 2 feet of nonmagical wood or metal.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spider Climb",
+                "Content": "The pudding can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Dissolving Pseudopod",
+                "Content": "Melee Attack Roll: +5, reach 10 ft. Hit: 17 (4d6 + 3) Acid damage. Nonmagical ar- mor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its",
+                "Usage": ""
+            },
+            {
+                "Name": "Mending spell on the armor",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Split",
+                "Content": "Trigger: While the pudding is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is sub- jected to Lightning or Slashing damage. Response: The pudding splits into two new Black Puddings. Each new pudding is one size smaller than the original pudding and acts on its Initiative. The original pudding’s Hit 266 Points are divided evenly between the new puddings (round down). Blink Dog Blink Dog",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Dissolving Pseudopod",
+                "ToHit": "+5",
+                "Damage": "4d6 + 3",
+                "DamageType": "Acid"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Blink Dog": {
+        "Id": "Blink Dog",
+        "Name": "Blink Dog",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey, Lawful Good",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d8 + 4)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 17,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 13,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Blink Dog",
+            "understands Elvish and Sylvan but can’t speak them"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Blue Dragon Wyrmling": {
+        "Id": "Blue Dragon Wyrmling",
+        "Name": "Blue Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 65,
+            "Notes": "(10d8 + 20)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 15 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 10,
+            "Con": 15,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage plus 3 (1d6) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 12, each creature in a 30-foot-long, 5-foot- wide Line. Failure: 21 (6d6) Lightning damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "Young Blue Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Blue Dragon": {
+        "Id": "Young Blue Dragon",
+        "Name": "Young Blue Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 152,
+            "Notes": "(16d10 + 64)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 20 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 10,
+            "Con": 19,
+            "Int": 14,
+            "Wis": 13,
+            "Cha": 17
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "9",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +9, reach 10 ft. Hit: 12 (2d6 + 5) Slashing damage plus 5 (1d10) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 16, each creature in a 60-foot-long, 5-foot- wide Line. Failure: 55 (10d10) Lightning damage. Suc- cess: Half damage. Adult Blue Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+9",
+                "Damage": "2d6 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Blue Dragon": {
+        "Id": "Adult Blue Dragon",
+        "Name": "Adult Blue Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 212,
+            "Notes": "(17d12 + 102)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 30 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 25,
+            "Dex": 10,
+            "Con": 23,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 12
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "16",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast Shatter.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-foot- 267 wide Line. Failure: 60 (11d10) Lightning damage. Suc- cess: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18): At Will: Detect Magic, Invisibility, Mage Hand, Shatter 1/Day Each: Scrying, Sending",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Cloaked Flight",
+                "Content": "The dragon uses Spellcasting to cast In- visibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sonic Boom",
+                "Content": "The dragon uses Spellcasting to cast Shat- ter. The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail Swipe",
+                "Content": "The dragon makes one Rend attack. Ancient Blue Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+12",
+                "Damage": "2d8 + 7",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Blue Dragon": {
+        "Id": "Ancient Blue Dragon",
+        "Name": "Ancient Blue Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 481,
+            "Notes": "(26d20 + 208)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 29,
+            "Dex": 10,
+            "Con": 27,
+            "Int": 18,
+            "Wis": 17,
+            "Cha": 25
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 17
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "23",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Shatter",
+                "Content": "",
+                "Usage": "level 3 version"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 11 (2d10) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 88 (16d10) Lightning dam- age. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22): At Will: Detect Magic, Invisibility, Mage Hand, Shatter (level 3 version) 1/Day Each: Scrying, Sending",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Cloaked Flight",
+                "Content": "The dragon uses Spellcasting to cast In- visibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sonic Boom",
+                "Content": "The dragon uses Spellcasting to cast Shat- ter (level 3 version). The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail Swipe",
+                "Content": "The dragon makes one Rend attack. Bone Devil Bone Devil",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+16",
+                "Damage": "2d8 + 9",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bone Devil": {
+        "Id": "Bone Devil",
+        "Name": "Bone Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 161,
+            "Notes": "(17d10 + 68)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 16,
+            "Con": 18,
+            "Int": 13,
+            "Wis": 14,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 8
+            },
+            {
+                "Name": "Int",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "9",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes two Claw attacks and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Infernal Sting attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Infernal Sting",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 15 (2d10 + 4) Piercing damage plus 18 (4d8) Poison 268 damage, and the target has the Poisoned condition until the start of the devil’s next turn. While Poisoned, the target can’t regain Hit Points. Brass Dragons Brass Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+8",
+                "Damage": "2d8 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Brass Dragon Wyrmling": {
+        "Id": "Brass Dragon Wyrmling",
+        "Name": "Brass Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d8 + 4)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 15 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 10,
+            "Con": 13,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-foot- wide Line. Failure: 14 (4d6) Fire damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Sleep Breath",
+                "Content": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it. Young Brass Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d10 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Brass Dragon": {
+        "Id": "Young Brass Dragon",
+        "Name": "Young Brass Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 110,
+            "Notes": "(13d10 + 39)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 20 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace two attacks with a use of Sleep Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-foot- wide Line. Failure: 38 (11d6) Fire damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Sleep Breath",
+                "Content": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The target has the Unconscious condition for 1 minute. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it. Adult Brass Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d10 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Brass Dragon": {
+        "Id": "Adult Brass Dragon",
+        "Name": "Adult Brass Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 172,
+            "Notes": "(15d12 + 75)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 30 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 10,
+            "Con": 21,
+            "Int": 14,
+            "Wis": 13,
+            "Cha": 17
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 8
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw: DC 18, each creature in a 60-foot-long, 5-foot- wide Line. Failure: 45 (10d8) Fire damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Sleep Breath",
+                "Content": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The tar- get has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it. 269",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Minor Illusion, Scorching Ray, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals 1/Day Each: Detect Thoughts, Control Weather",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Blazing Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Ray",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Sands",
+                "Content": "Dexterity Saving Throw: DC 16, one creature the dragon can see within 120 feet. Failure: 27 (6d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn. Ancient Brass Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+11",
+                "Damage": "2d10 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Brass Dragon": {
+        "Id": "Ancient Brass Dragon",
+        "Name": "Ancient Brass Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 332,
+            "Notes": "(19d20 + 133)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 10,
+            "Con": 25,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 14
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 12
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "20",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Sleep Breath or (B) Spellcasting to cast Scorching Ray (level 3 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +14, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 7 (2d6) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw: DC 21, each creature in a 90-foot-long, 5-foot- wide Line. Failure: 58 (13d8) Fire damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Sleep Breath",
+                "Content": "Constitution Saving Throw: DC 21, each creature in a 90-foot Cone. Failure: The target has the Incapacitated condition until the end of its next turn, at which point it repeats the save. Second Failure: The tar- get has the Unconscious condition for 10 minutes. This effect ends for the target if it takes damage or a creature within 5 feet of it takes an action to wake it.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20): At Will: Detect Magic, Minor Illusion, Scorching Ray (level 3 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals 1/Day Each: Control Weather, Detect Thoughts",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Blazing Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Ray",
+                "Content": "",
+                "Usage": "level 3 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Sands",
+                "Content": "Dexterity Saving Throw: DC 20, one creature the dragon can see within 120 feet. Failure: 36 (8d8) Fire damage, and the target’s Speed is halved until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn. Bronze Dragons Bronze Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+14",
+                "Damage": "2d10 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bronze Dragon Wyrmling": {
+        "Id": "Bronze Dragon Wyrmling",
+        "Name": "Bronze Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 39,
+            "Notes": "(6d8 + 12)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 10,
+            "Con": 15,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 12, each creature in a 40-foot-long, 5-foot- wide Line. Failure: 16 (3d10) Lightning damage. Suc- cess: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Repulsion Breath",
+                "Content": "Strength Saving Throw: DC 12, each creature in a 30-foot Cone. Failure: The target is pushed up to 30 feet straight away from the dragon and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "Young Bronze Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Bronze Dragon": {
+        "Id": "Young Bronze Dragon",
+        "Name": "Young Bronze Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 142,
+            "Notes": "(15d10 + 60)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 10,
+            "Con": 19,
+            "Int": 14,
+            "Wis": 13,
+            "Cha": 17
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 4
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Repulsion Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 15, each creature in a 60-foot-long, 5-foot- wide Line. Failure: 49 (9d10) Lightning damage. Suc- cess: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Repulsion Breath",
+                "Content": "Strength Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: The target is pushed up to 40 feet straight away from the dragon and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "Adult Bronze Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+8",
+                "Damage": "2d10 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Bronze Dragon": {
+        "Id": "Adult Bronze Dragon",
+        "Name": "Adult Bronze Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 212,
+            "Notes": "(17d12 + 102)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 25,
+            "Dex": 10,
+            "Con": 23,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 12
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "15",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +12, reach 10 ft. Hit: 16 (2d8 + 7) Slashing damage plus 5 (1d10) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 19, each creature in a 90-foot-long, 5-foot- wide Line. Failure: 55 (10d10) Lightning damage. Suc- cess: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Repulsion Breath",
+                "Content": "Strength Saving Throw: DC 19, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17 , +10 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy 1/Day Each: Detect Thoughts, Water Breathing",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Guiding Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Bolt",
+                "Content": "",
+                "Usage": "level 2 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Thunderclap",
+                "Content": "Constitution Saving Throw: DC 17 , each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 10 (3d6) 271 Thunder damage, and the target has the Deafened con- dition until the end of its next turn. Ancient Bronze Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+12",
+                "Damage": "2d8 + 7",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Bronze Dragon": {
+        "Id": "Ancient Bronze Dragon",
+        "Name": "Ancient Bronze Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 444,
+            "Notes": "(24d20 + 192)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 29,
+            "Dex": 10,
+            "Con": 27,
+            "Int": 18,
+            "Wis": 17,
+            "Cha": 25
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 10
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 17
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "22",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Repulsion Breath or (B) Spellcasting to cast Guiding Bolt (level 2 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +16, reach 15 ft. Hit: 18 (2d8 + 9) Slashing damage plus 9 (2d8) Lightning damage. Lightning Breath (Recharge 5–6). Dexterity Saving Throw: DC 23, each creature in a 120-foot-long, 10-foot-wide Line. Failure: 82 (15d10) Lightning dam- age. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Repulsion Breath",
+                "Content": "Strength Saving Throw: DC 23, each creature in a 30-foot Cone. Failure: The target is pushed up to 60 feet straight away from the dragon and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 22, +14 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell), Speak with Animals, Thaumaturgy 1/Day Each: Detect Thoughts, Control Water, Scrying, Water Breathing",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Guiding Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Bolt",
+                "Content": "",
+                "Usage": "level 2 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Thunderclap",
+                "Content": "Constitution Saving Throw: DC 22, each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 13 (3d8) Thunder damage, and the target has the Deafened con- dition until the end of its next turn. Bugbears Bugbear Stalker",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+16",
+                "Damage": "2d8 + 9",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bugbear Stalker": {
+        "Id": "Bugbear Stalker",
+        "Name": "Bugbear Stalker",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey (Goblinoid), Chaotic Evil",
+        "HP": {
+            "Value": 65,
+            "Notes": "(10d8 + 20)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 11,
+            "Wis": 12,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Abduct",
+                "Content": "The bugbear needn’t spend extra movement to move a creature it is grappling.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bugbear makes two Javelin or Morn- ingstar attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Javelin",
+                "Content": "Melee or Ranged Attack Roll: +5, reach 10 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Morningstar",
+                "Content": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Quick Grapple",
+                "Content": "Dexterity Saving Throw: DC 13, one Medium or smaller creature the bugbear can see within 10 feet. Failure: The target has the Grappled condition (escape DC 13). 272 Bugbear Warrior",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Javelin",
+                "ToHit": "+5",
+                "Damage": "3d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bugbear Warrior": {
+        "Id": "Bugbear Warrior",
+        "Name": "Bugbear Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey (Goblinoid), Chaotic Evil",
+        "HP": {
+            "Value": 33,
+            "Notes": "(6d8 + 6)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 13,
+            "Int": 8,
+            "Wis": 11,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Abduct",
+                "Content": "The bugbear needn’t spend extra movement to move a creature it is grappling.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Grab",
+                "Content": "Melee Attack Roll: +4, reach 10 ft. Hit: 9 (2d6 + 2) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (es- cape DC 12).",
+                "Usage": ""
+            },
+            {
+                "Name": "Light Hammer",
+                "Content": "Melee or Ranged Attack Roll: +4 (with Advantage if the target is Grappled by the bugbear), reach 10 ft. or range 20/60 ft. Hit: 9 (3d4 + 2) Blud- geoning damage. Bulette Bulette",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Grab",
+                "ToHit": "+4",
+                "Damage": "2d6 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bulette": {
+        "Id": "Bulette",
+        "Name": "Bulette",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 94,
+            "Notes": "(9d10 + 45)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 11,
+            "Con": 21,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft.",
+            "Tremorsense 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bulette makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Deadly Leap",
+                "Content": "The bulette spends 5 feet of movement to jump to a space within 15 feet that contains one or more Large or smaller creatures. Dexterity Saving Throw: DC 15, each creature in the bulette’s destina- tion space. Failure: 19 (3d12) Bludgeoning damage, and the target has the Prone condition. Success: Half dam- age, and the target is pushed 5 feet straight away from the bulette.",
+                "Usage": ""
+            },
+            {
+                "Name": "Leap",
+                "Content": "The bulette jumps up to 30 feet by spending 10 feet of movement. Centaur Centaur Trooper",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "2d12 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Centaur Trooper": {
+        "Id": "Centaur Trooper",
+        "Name": "Centaur Trooper",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fey, Neutral Good",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 9,
+            "Wis": 13,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 6
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The centaur makes two attacks, using Pike or Longbow in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pike",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pike",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Chain Devil": {
+        "Id": "Chain Devil",
+        "Name": "Chain Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 85,
+            "Notes": "(10d8 + 40)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 18,
+            "Int": 11,
+            "Wis": 12,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Cold",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes two Chain attacks and uses Conjure Infernal Chain.",
+                "Usage": ""
+            },
+            {
+                "Name": "Chain",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 14) from one of two chains, and it has the Restrained con- dition until the grapple ends.",
+                "Usage": ""
+            },
+            {
+                "Name": "Conjure Infernal Chain",
+                "Content": "The devil conjures a fiery chain to bind a creature. Dexterity Saving Throw: DC 15, one creature the devil can see within 60 feet. Failure: 9 (2d4 + 4) Fire damage, and the target has the Restrained condition until the end of the devil’s next turn, at which point the chain disappears. If the target is Large or smaller, the devil moves the target up to 30 feet straight toward itself. Success: The chain disappears.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Unnerving Gaze",
+                "Content": "Trigger: A creature the devil can see starts its turn within 30 feet of the devil and can see the devil. Response—Wisdom Saving Throw: DC 15, the triggering creature. Failure: The target has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightened condition until the end of its turn",
+                "Content": "Success: The target is immune to this devil’s Unnerving Gaze for 24 hours. Chimera Chimera",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Chain",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Chimera": {
+        "Id": "Chimera",
+        "Name": "Chimera",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Chaotic Evil",
+        "HP": {
+            "Value": 114,
+            "Notes": "(12d10 + 48)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 11,
+            "Con": 19,
+            "Int": 3,
+            "Wis": 14,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Draconic but can’t speak"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The chimera makes one Ram attack, one",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite attack, and one Claw attack",
+                "Content": "It can replace the Claw attack with a use of Fire Breath if available.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage, or 18 (4d6 + 4) Piercing damage if the chimera had Advantage on the attack roll.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 7 (1d6 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 10 (1d12 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 15, each creature in a 15-foot Cone",
+                "Content": "Failure: 31 (7d8) Fire damage. Success: Half damage. Chuul Chuul",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Chuul": {
+        "Id": "Chuul",
+        "Name": "Chuul",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Aberration, Chaotic Evil",
+        "HP": {
+            "Value": 76,
+            "Notes": "(9d10 + 27)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 16,
+            "Int": 5,
+            "Wis": 11,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Deep Speech but can’t speak"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The chuul can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sense Magic",
+                "Content": "The chuul senses magic within 120 feet of itself. This trait otherwise works like the Detect Magic spell but isn’t itself magical.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The chuul makes two Pincer attacks and uses Paralyzing Tentacles.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pincer",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 14) from one of two pincers",
+                "Content": "274",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Tentacles",
+                "Content": "Constitution Saving Throw: DC 13, one creature Grappled by the chuul. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. While Poisoned, the target has the Paralyzed condition. Clay Golem Clay Golem",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pincer",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Clay Golem": {
+        "Id": "Clay Golem",
+        "Name": "Clay Golem",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 123,
+            "Notes": "(13d10 + 52)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 9,
+            "Con": 18,
+            "Int": 3,
+            "Wis": 8,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Acid",
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "9",
+        "Traits": [
+            {
+                "Name": "Acid Absorption",
+                "Content": "Whenever the golem is subjected to Acid damage, it takes no damage and instead regains a number of Hit Points equal to the Acid damage dealt.",
+                "Usage": ""
+            },
+            {
+                "Name": "Berserk",
+                "Content": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it continues to be berserk until it is destroyed or it is no longer Bloodied.",
+                "Usage": ""
+            },
+            {
+                "Name": "Immutable Form",
+                "Content": "The golem can’t shape-shift.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The golem has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The golem makes two Slam attacks, or it makes three Slam attacks if it used Hasten this turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +9, reach 5 ft. Hit: 10 (1d10 + 5) Bludgeoning damage plus 6 (1d12) Acid damage, and the target’s Hit Point maximum decreases by an amount equal to the Acid damage taken.",
+                "Usage": ""
+            },
+            {
+                "Name": "Disengage actions",
+                "Content": "Cloaker Cloaker",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+9",
+                "Damage": "1d10 + 5",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cloaker": {
+        "Id": "Cloaker",
+        "Name": "Cloaker",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Aberration, Chaotic Neutral",
+        "HP": {
+            "Value": 91,
+            "Notes": "(14d10 + 14)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 15,
+            "Con": 12,
+            "Int": 13,
+            "Wis": 14,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Frightened"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Deep Speech",
+            "Undercommon"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Light Sensitivity",
+                "Content": "While in Bright Light, the cloaker has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on attack rolls",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The cloaker makes one Attach attack and two Tail attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Attach",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (3d6 + 3) Piercing damage. If the target is a Large or smaller creature, the cloaker attaches to it. While the cloaker is attached, the target has the Blinded condition, and the cloaker can’t make Attach attacks against other tar- gets. In addition, the cloaker halves the damage it takes (round down), and the target takes the same amount of damage. The cloaker can detach itself by spending 5 feet of movement. The target or a creature within 5 feet of it can take an action to try to detach the cloaker, doing so by succeeding on a DC 14 Strength (Athletics) check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Moan",
+                "Content": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Emanation originating from the cloaker. Failure: The target has the Frightened condition until the end of the cloaker’s next turn. Success: The target is immune to this cloaker’s Moan for the next 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Phantasms",
+                "Content": "The cloaker casts the Mirror Image spell, requiring no spell components and using Wisdom as the spellcasting abil- ity. The spell ends early if the cloaker starts or ends its turn in Bright Light. 275 Cloud Giant Cloud Giant",
+                "Usage": "Recharge after a Short or Long Rest"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Attach",
+                "ToHit": "+6",
+                "Damage": "3d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cloud Giant": {
+        "Id": "Cloud Giant",
+        "Name": "Cloud Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Neutral",
+        "HP": {
+            "Value": 200,
+            "Notes": "(16d12 + 96)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 20 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 10,
+            "Con": 22,
+            "Int": 12,
+            "Wis": 16,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 10
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Giant"
+        ],
+        "Challenge": "9",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Thun- derous Mace or Thundercloud in any combination. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Fog Cloud",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Thunderous Mace",
+                "Content": "Melee Attack Roll: +12, reach 10 ft. Hit: 21 (3d8 + 8) Bludgeoning damage plus 7 (2d6) Thunder damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Thundercloud",
+                "Content": "Ranged Attack Roll: +12, range 240 ft. Hit: 18 (3d6 + 8) Thunder damage, and the target has the Incapacitated condition until the end of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The giant casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): At Will: Detect Magic, Fog Cloud, Light 1/Day Each: Control Weather, Gaseous Form, Telekinesis",
+                "Usage": ""
+            },
+            {
+                "Name": "Misty Step",
+                "Content": "The giant casts the Misty Step spell, using the same spellcasting ability as Spellcasting. Cockatrice Cockatrice",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Thunderous Mace",
+                "ToHit": "+12",
+                "Damage": "3d8 + 8",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cockatrice": {
+        "Id": "Cockatrice",
+        "Name": "Cockatrice",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Monstrosity, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d6 + 5)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 13,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Petrified"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Petrifying Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 11. First Failure: The target has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Restrained condition",
+                "Content": "The target repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition, instead of the Restrained condition, for 24 hours. Commoner Commoner",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Petrifying Bite",
+                "ToHit": "+3",
+                "Damage": "1d4 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Commoner": {
+        "Id": "Commoner",
+        "Name": "Commoner",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d8)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 10,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Training",
+                "Content": "The commoner has proficiency in one skill of the GM’s choice and has Advantage whenever it makes an ability check using that skill.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Club",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage. Copper Dragons Copper Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Club",
+                "ToHit": "+2",
+                "Damage": "1d4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Copper Dragon Wyrmling": {
+        "Id": "Copper Dragon Wyrmling",
+        "Name": "Copper Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d8 + 4)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 11, each creature in a 20-foot-long, 5-foot- wide Line. Failure: 18 (4d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Slowing Breath",
+                "Content": "Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both.",
+                "Usage": ""
+            },
+            {
+                "Name": "This effect lasts until the end of its next turn",
+                "Content": "Young Copper Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d10 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Copper Dragon": {
+        "Id": "Young Copper Dragon",
+        "Name": "Young Copper Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 119,
+            "Notes": "(14d10 + 42)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 12,
+            "Con": 17,
+            "Int": 16,
+            "Wis": 13,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "7",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Slowing Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 15 (2d10 + 4) Slashing damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 40-foot-long, 5-foot- wide Line. Failure: 40 (9d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Slowing Breath",
+                "Content": "Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both.",
+                "Usage": ""
+            },
+            {
+                "Name": "This effect lasts until the end of its next turn",
+                "Content": "Adult Copper Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d10 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Copper Dragon": {
+        "Id": "Adult Copper Dragon",
+        "Name": "Adult Copper Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 184,
+            "Notes": "(16d12 + 80)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 12,
+            "Con": 21,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 12
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "14",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 4 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage plus 4 (1d8) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 18, each creature in an 60-foot-long, 5-foot- wide Line. Failure: 54 (12d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Slowing Breath",
+                "Content": "Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both.",
+                "Usage": ""
+            },
+            {
+                "Name": "This effect lasts until the end of its next turn",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Mind Spike (level 4 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Greater Restoration, Major Image",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Giggling Magic",
+                "Content": "Charisma Saving Throw: DC 17 , one creature the dragon can see within 90 feet. Failure: 24 (7d6) Psychic damage. Until the end of its next turn, the target rolls 1d6 whenever it makes an ability check or attack roll and subtracts the number rolled from the",
+                "Usage": ""
+            },
+            {
+                "Name": "D20 Test",
+                "Content": "Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Jolt",
+                "Content": "The dragon uses Spellcasting to cast Mind",
+                "Usage": ""
+            },
+            {
+                "Name": "Spike",
+                "Content": "The dragon can’t take this action again until the start of its next turn. 277",
+                "Usage": "level 4 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Ancient Copper Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+11",
+                "Damage": "2d10 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Copper Dragon": {
+        "Id": "Ancient Copper Dragon",
+        "Name": "Ancient Copper Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Metallic), Chaotic Good",
+        "HP": {
+            "Value": 367,
+            "Notes": "(21d20 + 147)"
+        },
+        "AC": {
+            "Value": 21,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 12,
+            "Con": 25,
+            "Int": 20,
+            "Wis": 17,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 13
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 17
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "21",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Slowing Breath or (B) Spellcasting to cast Mind Spike (level 5 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +15, reach 15 ft. Hit: 19 (2d10 + 8) Slashing damage plus 9 (2d8) Acid damage. Acid Breath (Recharge 5–6). Dexterity Saving Throw: DC 22, each creature in an 90-foot-long, 10-foot- wide Line. Failure: 63 (14d8) Acid damage. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Slowing Breath",
+                "Content": "Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Failure: The target can’t take Reactions; its Speed is halved; and it can take either an action or a Bonus Action on its turn, not both.",
+                "Usage": ""
+            },
+            {
+                "Name": "This effect lasts until the end of its next turn",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): At Will: Detect Magic, Mind Spike (level 5 version), Minor Illusion, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Greater Restoration, Major Image, Project Image",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Giggling Magic",
+                "Content": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 31 (9d6) Psychic damage. Until the end of its next turn, the target rolls 1d8 whenever it makes an ability check or attack roll and subtracts the number rolled from the",
+                "Usage": ""
+            },
+            {
+                "Name": "D20 Test",
+                "Content": "Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Jolt",
+                "Content": "The dragon uses Spellcasting to cast Mind",
+                "Usage": ""
+            },
+            {
+                "Name": "Spike",
+                "Content": "The dragon can’t take this action again until the start of its next turn.",
+                "Usage": "level 5 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Couatl Couatl",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+15",
+                "Damage": "2d10 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Couatl": {
+        "Id": "Couatl",
+        "Name": "Couatl",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Celestial, Lawful Good",
+        "HP": {
+            "Value": 60,
+            "Notes": "(8d8 + 24)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 90 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 20,
+            "Con": 17,
+            "Int": 18,
+            "Wis": 20,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Psychic",
+            "Radiant"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "All",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Shielded Mind",
+                "Content": "The couatl’s thoughts can’t be read by any means, and other creatures can communicate with it telepathically only if it allows them.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 11 (1d12 + 5) Piercing damage, and the target has the Poisoned condition until the end of the couatl’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 15, one Medium or smaller creature the couatl can see within 5 feet. Failure: 8 (1d6 + 5) Bludgeoning damage. The target has the Grappled condition (escape DC 13), and it has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Restrained condition until the grapple ends",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The couatl casts one of the following spells, requiring no spell components and using Wis- dom as the spellcasting ability (spell save DC 15): At Will: Detect Evil and Good, Detect Magic, Detect Thoughts, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, 278 and no Concentration or Temporary Hit Points re- quired to maintain the spell) 1/Day Each: Create Food and Water, Dream, Greater Restoration, Scrying, Sleep",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The couatl casts Bless, Lesser Res- toration, or Sanctuary, requiring no spell components and using the same spellcasting ability as Spellcasting. Crawling Claw Swarm of Crawling Claws",
+                "Usage": "2/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "1d12 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Crawling Claws": {
+        "Id": "Swarm of Crawling Claws",
+        "Name": "Swarm of Crawling Claws",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Undead, Neutral Evil",
+        "HP": {
+            "Value": 49,
+            "Notes": "(11d8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 14,
+            "Con": 11,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Incapacitated",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "Understands Common but can’t speak"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny creature. The swarm can’t regain Hit Points or gain Temporary",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Swarm of Grasping Hands",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 20 (4d8 + 2) Necrotic damage, or 11 (2d8 + 2) Necrotic damage if the swarm is Bloodied. If the target is a Medium or smaller creature, it has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "Cultists Cultist",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Swarm of Grasping Hands",
+                "ToHit": "+4",
+                "Damage": "4d8 + 2",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cultist": {
+        "Id": "Cultist",
+        "Name": "Cultist",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 12,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Ritual Sickle",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 1 Necrotic damage. Cultist Fanatic",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ritual Sickle",
+                "ToHit": "+3",
+                "Damage": "1d4 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cultist Fanatic": {
+        "Id": "Cultist Fanatic",
+        "Name": "Cultist Fanatic",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 44,
+            "Notes": "(8d8 + 8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 14,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 3
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Pact Blade",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 7 (2d6) Ne- crotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The cultist casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): At Will: Light, Thaumaturgy 2/Day: Command 1/Day: Hold Person",
+                "Usage": ""
+            },
+            {
+                "Name": "Spiritual Weapon",
+                "Content": "The cultist casts the Spiritual Weapon spell, using the same spellcasting ability as",
+                "Usage": "2/Day"
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "Darkmantle Darkmantle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pact Blade",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Darkmantle": {
+        "Id": "Darkmantle",
+        "Name": "Darkmantle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Aberration, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d6 + 5)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "",
+            "and it moves with the target."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Crush",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage, and the darkmantle attaches to the target. If the target is a Medium or smaller crea- ture and the darkmantle had Advantage on the attack roll, it covers the target, which has the Blinded condi- tion and is suffocating while the darkmantle is attached in this way. While attached to a target, the darkmantle can attack only the target but has Advantage on its attack rolls. Its Speed becomes 0, it can’t benefit from any bonus to its",
+                "Usage": ""
+            },
+            {
+                "Name": "Darkness Aura",
+                "Content": "Magical Darkness fills a 15-foot",
+                "Usage": "1/Day"
+            },
+            {
+                "Name": "Emanation originating from the darkmantle",
+                "Content": "This effect lasts while the darkmantle maintains Concentration on it, up to 10 minutes. Darkvision can’t penetrate this area, and no light can illuminate it. Death Dog Death Dog",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Crush",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Death Dog": {
+        "Id": "Death Dog",
+        "Name": "Death Dog",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Neutral Evil",
+        "HP": {
+            "Value": 39,
+            "Notes": "(6d8 + 12)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 3,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Frightened",
+            "Stunned",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The death dog makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage. If the target is a creature, it is subjected to the following effect. Constitution Saving Throw: DC 12. First Failure: The target has the Poisoned condition. While Poisoned, the target’s Hit Point max- imum doesn’t return to normal when finishing a Long Rest, and it repeats the save every 24 hours that elapse, ending the effect on itself on a success. Subsequent Failures: The Poisoned target’s Hit Point maximum de- creases by 5 (1d10). Deva Deva",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Deva": {
+        "Id": "Deva",
+        "Name": "Deva",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Celestial (Angel), Lawful Good",
+        "HP": {
+            "Value": 229,
+            "Notes": "(27d8 + 108)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 90 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 18,
+            "Con": 18,
+            "Int": 17,
+            "Wis": 20,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "All",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "10",
+        "Traits": [
+            {
+                "Name": "Exalted Restoration",
+                "Content": "If the deva dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in",
+                "Usage": ""
+            },
+            {
+                "Name": "Mount Celestia",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The deva has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The deva makes two Holy Mace attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Holy Mace",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 18 (4d8) Radi- ant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The deva casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Evil and Good, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Commune, Raise Dead",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The deva casts Cure Wounds, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting. 280 Djinni Djinni",
+                "Usage": "2/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Holy Mace",
+                "ToHit": "+8",
+                "Damage": "1d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Djinni": {
+        "Id": "Djinni",
+        "Name": "Djinni",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental (Genie), Neutral",
+        "HP": {
+            "Value": 218,
+            "Notes": "(19d10 + 114)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 90 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 15,
+            "Con": 22,
+            "Int": 15,
+            "Wis": 16,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning",
+            "Thunder"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Primordial (Auran)"
+        ],
+        "Challenge": "11",
+        "Traits": [
+            {
+                "Name": "Elemental Restoration",
+                "Content": "If the djinni dies outside the Elemental Plane of Air, its body dissolves into mist, and it gains a new body in 1d4 days, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere on the Plane of Air",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The djinni has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Wishes",
+                "Content": "The djinni has a 30 percent chance of knowing the Wish spell. If the djinni knows it, the djinni can cast it only on behalf of a non-genie creature who commu- nicates a wish in a way the djinni can understand. If the djinni casts the spell for the creature, the djinni suffers none of the spell’s stress. Once the djinni has cast it three times, the djinni can’t do so again for 365 days.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The djinni makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Storm Blade or Storm Bolt in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Storm Blade",
+                "Content": "Melee Attack Roll: +9, reach 5 feet. Hit: 12 (2d6 + 5) Slashing damage plus 7 (2d6) Light- ning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Storm Bolt",
+                "Content": "Ranged Attack Roll: +9, range 120 feet. Hit: 13 (3d8) Thunder damage. If the target is a Large or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Create Whirlwind",
+                "Content": "The djinni conjures a whirlwind at a point it can see within 120 feet. The whirlwind fills a 20-foot-radius, 60-foot-high Cylinder centered on that point. The whirlwind lasts until the djinni’s Concentra- tion on it ends. The djinni can move the whirlwind up to 20 feet at the start of each of its turns. Whenever the whirlwind enters a creature’s space or a creature enters the whirlwind, that creature is sub- jected to the following effect. Strength Saving Throw: DC 17 (a creature makes this save only once per turn, and the djinni is unaffected). Failure: While in the whirlwind, the target has the Restrained condition and moves with the whirlwind. At the start of each of its turns, the Restrained target takes 21 (6d6) Thunder damage. At the end of each of its turns, the target re- peats the save, ending the effect on itself on a success.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The djinni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Evil and Good, Detect Magic 2/Day Each: Create Food and Water (can create wine instead of water), Tongues, Wind Walk 1/Day Each: Creation, Gaseous Form, Invisibility, Major Image, Plane Shift Doppelganger Doppelganger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Storm Blade",
+                "ToHit": "+9",
+                "Damage": "2d6 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Doppelganger": {
+        "Id": "Doppelganger",
+        "Name": "Doppelganger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Neutral",
+        "HP": {
+            "Value": 52,
+            "Notes": "(8d8 + 16)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 18,
+            "Con": 14,
+            "Int": 11,
+            "Wis": 12,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus three other languages"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The doppelganger makes two Slam attacks and uses Unsettling Visage if available.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +6 (with Advantage during the first round of each combat), reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Read Thoughts",
+                "Content": "The doppelganger casts Detect Thoughts, requiring no spell components and using Charisma as the spellcasting ability (spell save DC 12).",
+                "Usage": ""
+            },
+            {
+                "Name": "Unsettling Visage",
+                "Content": "Wisdom Saving Throw: DC 12, each creature in a 15-foot Emanation originating from the doppelganger that can see the doppelganger. Failure: The target has the Frightened condition and re- peats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The doppelganger shape-shifts into a Me- dium or Small Humanoid, or it returns to its true form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. 281 Dragon Turtle Dragon Turtle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Dragon Turtle": {
+        "Id": "Dragon Turtle",
+        "Name": "Dragon Turtle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon, Neutral",
+        "HP": {
+            "Value": 356,
+            "Notes": "(23d20 + 115)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 50 ft."
+        ],
+        "Abilities": {
+            "Str": 25,
+            "Dex": 10,
+            "Con": 20,
+            "Int": 10,
+            "Wis": 12,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Fire"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 11
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Draconic",
+            "Primordial (Aquan)"
+        ],
+        "Challenge": "17",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Bite attacks. It can replace one attack with a Tail attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +13, reach 15 ft. Hit: 23 (3d10 + 7) Piercing damage plus 7 (2d6) Fire damage. Being underwater doesn’t grant Resistance to this Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +13, reach 15 ft. Hit: 18 (2d10 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition. Steam Breath (Recharge 5–6). Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 56 (16d6) Fire damage. Success: Half damage. Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage. Dretch Dretch",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+13",
+                "Damage": "3d10 + 7",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Dretch": {
+        "Id": "Dretch",
+        "Name": "Dretch",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 18,
+            "Notes": "(4d6 + 4)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 11,
+            "Con": 12,
+            "Int": 5,
+            "Wis": 8,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 60 ft. (works only with creatures that understand Abyssal)"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fetid Cloud",
+                "Content": "Constitution Saving Throw: DC 11, each creature in a 10-foot Emanation originating from the dretch. Failure: The target has the Poisoned condi- tion until the end of its next turn. While Poisoned, the creature can take either an action or a Bonus Action on its turn, not both, and it can’t take Reactions. Drider Drider",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Drider": {
+        "Id": "Drider",
+        "Name": "Drider",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Chaotic Evil",
+        "HP": {
+            "Value": 123,
+            "Notes": "(13d10 + 52)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 19,
+            "Con": 18,
+            "Int": 13,
+            "Wis": 16,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 10
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Elvish",
+            "Undercommon"
+        ],
+        "Challenge": "6",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The drider can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight Sensitivity",
+                "Content": "While in sunlight, the drider has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Web Walker",
+                "Content": "The drider ignores movement restrictions caused by webs, and the drider knows the location of any other creature in contact with the same web.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The drider makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Foreleg or Poison Burst in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Foreleg",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 13 (2d8 + 4) Piercing damage. Poison Burst. Ranged Attack Roll: +6, range 120 ft. Hit: 13 (3d6 + 3) Poison damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Foreleg",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Druid": {
+        "Id": "Druid",
+        "Name": "Druid",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid (Druid), Neutral",
+        "HP": {
+            "Value": 44,
+            "Notes": "(8d8 + 8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 12,
+            "Wis": 16,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Medicine",
+                "Modifier": 5
+            },
+            {
+                "Name": "Nature",
+                "Modifier": 3
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Druidic",
+            "Sylvan"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The druid makes two attacks, using Vine",
+                "Usage": ""
+            },
+            {
+                "Name": "Staff or Verdant Wisp in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Vine Staff",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 2 (1d4) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Verdant Wisp",
+                "Content": "Ranged Attack Roll: +5, range 90 ft. Hit: 10 (3d6) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The druid casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13): At Will: Druidcraft, Speak with Animals 2/Day Each: Entangle, Thunderwave 1/Day Each: Animal Messenger, Long- strider, Moonbeam Dryad Dryad",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Vine Staff",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Dryad": {
+        "Id": "Dryad",
+        "Name": "Dryad",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey, Neutral",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d8)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 12,
+            "Con": 11,
+            "Int": 14,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The dryad has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Speak with Beasts and Plants",
+                "Content": "The dryad can com- municate with Beasts and Plants as if they shared a language.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dryad makes one Vine Lash or Thorn Burst attack, and it can use Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Charm Monster",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Vine Lash",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 8 (1d8 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Thorn Burst",
+                "Content": "Ranged Attack Roll: +6, range 60 ft. Hit: 7 (1d6 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dryad casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 14): At Will: Animal Friendship, Charm Monster (lasts 24 hours; ends early if the dryad casts the spell again), Druidcraft 1/Day Each: Entangle, Pass without Trace",
+                "Usage": ""
+            },
+            {
+                "Name": "Tree Stride",
+                "Content": "If within 5 feet of a Large or bigger tree, the dryad teleports to an unoccupied space within 5 feet of a second Large or bigger tree that is within 60 feet of the previous tree. Earth Elemental Earth Elemental",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Vine Lash",
+                "ToHit": "+6",
+                "Damage": "1d8 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Earth Elemental": {
+        "Id": "Earth Elemental",
+        "Name": "Earth Elemental",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral",
+        "HP": {
+            "Value": 147,
+            "Notes": "(14d10 + 70)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 30 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 8,
+            "Con": 20,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [
+            "Thunder"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft.",
+            "Tremorsense 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Terran)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Earth Glide",
+                "Content": "The elemental can burrow through nonmagical, unworked earth and stone. While do- ing so, the elemental doesn’t disturb the material it moves through.",
+                "Usage": ""
+            },
+            {
+                "Name": "Siege Monster",
+                "Content": "The elemental deals double damage to objects and structures.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The elemental makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam or Rock Launch in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 14 (2d8 + 5) Bludgeoning damage. 283",
+                "Usage": ""
+            },
+            {
+                "Name": "Rock Launch",
+                "Content": "Ranged Attack Roll: +8, range 60 ft. Hit: 8 (1d6 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Efreeti Efreeti",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+8",
+                "Damage": "2d8 + 5",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Efreeti": {
+        "Id": "Efreeti",
+        "Name": "Efreeti",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental (Genie), Neutral",
+        "HP": {
+            "Value": 212,
+            "Notes": "(17d10 + 119)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 60 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 12,
+            "Con": 24,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 19
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Primordial (Ignan)"
+        ],
+        "Challenge": "11",
+        "Traits": [
+            {
+                "Name": "Elemental Restoration",
+                "Content": "If the efreeti dies outside the Elemental Plane of Fire, its body dissolves into ash, and it gains a new body in 1d4 days, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere on the Plane of Fire",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The efreeti has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Wishes",
+                "Content": "The efreeti has a 30 percent chance of know- ing the Wish spell. If the efreeti knows it, the efreeti can cast it only on behalf of a non-genie creature who communicates a wish in a way the efreeti can under- stand. If the efreeti casts the spell for the creature, the efreeti suffers none of the spell’s stress. Once the efreeti has cast it three times, the efreeti can’t do so again for 365 days.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The efreeti makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Heated Blade or Hurl Flame in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Heated Blade",
+                "Content": "Melee Attack Roll: +10, reach 5 ft. Hit: 13 (2d6 + 6) Slashing damage plus 13 (2d12) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hurl Flame",
+                "Content": "Ranged Attack Roll: +8, range 120 ft. Hit: 24 (7d6) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The efreeti casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Elementalism 1/Day Each: Gaseous Form, Invisibility, Major Image, Plane Shift, Tongues, Wall of Fire (level 7 version) Erinyes Erinyes",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Heated Blade",
+                "ToHit": "+10",
+                "Damage": "2d6 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Erinyes": {
+        "Id": "Erinyes",
+        "Name": "Erinyes",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 178,
+            "Notes": "(21d8 + 84)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 16,
+            "Con": 18,
+            "Int": 14,
+            "Wis": 14,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Con",
+                "Modifier": 8
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "12",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the erinyes dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The erinyes has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Rope",
+                "Content": "The erinyes has a magic rope. While bear- ing it, the erinyes can use the Entangling Rope action. The rope has AC 20, HP 90, and Immunity to Poison and Psychic damage. The rope turns to dust if reduced to 0 Hit Points, if it is 5+ feet away from the erinyes for 1 hour or more, or if the erinyes dies. If the rope is damaged or destroyed, the erinyes can fully restore it when finishing a Short or Long Rest.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The erinyes makes three Withering Sword attacks and can use Entangling Rope.",
+                "Usage": ""
+            },
+            {
+                "Name": "Withering Sword",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage plus 11 (2d10) Ne- crotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Entangling Rope",
+                "Content": "Strength Saving Throw: DC 16, one creature the erinyes can see within 120 feet. Failure: 14 (4d6) Force damage, and the target has the Restrained condition until the rope is de- stroyed, the erinyes uses a Bonus Action to release the target, or the erinyes uses Entangling Rope again.",
+                "Usage": "Requires Magic Rope"
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The erinyes is hit by a melee attack roll while holding a weapon. Response: The erinyes adds 4 to its AC against that attack, possibly causing it to miss. 284 Ettercap Ettercap",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Withering Sword",
+                "ToHit": "+8",
+                "Damage": "2d8 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ettercap": {
+        "Id": "Ettercap",
+        "Name": "Ettercap",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Neutral Evil",
+        "HP": {
+            "Value": 44,
+            "Notes": "(8d8 + 8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 15,
+            "Con": 13,
+            "Int": 7,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The ettercap can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Web Walker",
+                "Content": "The ettercap ignores movement re- strictions caused by webs, and the ettercap knows the location of any other creature in contact with the same web.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ettercap makes one Bite attack and one Claw attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 2 (1d4) Poison damage, and the target has the Poisoned condition until the start of the ettercap’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage. Web Strand (Recharge 5–6). Dexterity Saving Throw: DC 12, one Large or smaller creature the ettercap can see within 30 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage; Immunity to Bludgeoning,",
+                "Usage": ""
+            },
+            {
+                "Name": "Poison, and Psychic damage)",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Reel",
+                "Content": "The ettercap pulls one creature within 30 feet of itself that is Restrained by its Web Strand up to 25 feet straight toward itself. Ettin Ettin",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ettin": {
+        "Id": "Ettin",
+        "Name": "Ettin",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Giant, Chaotic Evil",
+        "HP": {
+            "Value": 85,
+            "Notes": "(10d10 + 30)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 8,
+            "Con": 17,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Frightened",
+            "Stunned",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ettin makes one Battleaxe attack and one Morningstar attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Battleaxe",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Morningstar",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage, and the target has Disad- vantage on the next attack roll it makes before the end of its next turn. Fire Elemental Fire Elemental",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Battleaxe",
+                "ToHit": "+7",
+                "Damage": "2d8 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Fire Elemental": {
+        "Id": "Fire Elemental",
+        "Name": "Fire Elemental",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral",
+        "HP": {
+            "Value": 93,
+            "Notes": "(11d10 + 33)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 17,
+            "Con": 16,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Ignan)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Fire Aura",
+                "Content": "At the end of each of the elemental’s turns, each creature in a 10-foot Emanation originating from the elemental takes 5 (1d10) Fire damage. Creatures and flammable objects in the Emanation start burning. Fire Form. The elemental can move through a space as narrow as 1 inch without expending extra movement to do so, and it can enter a creature’s space and stop there. The first time it enters a creature’s space on a turn, that creature takes 5 (1d10) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Illumination",
+                "Content": "The elemental sheds Bright Light in a 30- foot radius and Dim Light for an additional 30 feet. 285",
+                "Usage": ""
+            },
+            {
+                "Name": "Water Susceptibility",
+                "Content": "The elemental takes 3 (1d6) Cold damage for every 5 feet the elemental moves in water or for every gallon of water splashed on it.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The elemental makes two Burn attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Burn",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Fire damage. If the target is a creature or a flammable object, it starts burning. Fire Giant Fire Giant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Burn",
+                "ToHit": "+6",
+                "Damage": "2d6 + 3",
+                "DamageType": "Fire"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Fire Giant": {
+        "Id": "Fire Giant",
+        "Name": "Fire Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Lawful Evil",
+        "HP": {
+            "Value": 162,
+            "Notes": "(13d12 + 78)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 25,
+            "Dex": 9,
+            "Con": 23,
+            "Int": 10,
+            "Wis": 14,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Con",
+                "Modifier": 10
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 11
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "9",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Flame",
+                "Usage": ""
+            },
+            {
+                "Name": "Sword or Hammer Throw in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Flame Sword",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 21 (4d6 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hammer Throw",
+                "Content": "Ranged Attack Roll: +11, range 60/240 ft. Hit: 23 (3d10 + 7) Bludgeoning damage plus 4 (1d8) Fire damage, and the target is pushed up to 15 feet straight away from the giant and has Disadvantage on the next attack roll it makes before the end of its next turn. Flesh Golem Flesh Golem",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Flame Sword",
+                "ToHit": "+11",
+                "Damage": "4d6 + 7",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Flesh Golem": {
+        "Id": "Flesh Golem",
+        "Name": "Flesh Golem",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Construct, Neutral",
+        "HP": {
+            "Value": 127,
+            "Notes": "(15d8 + 60)"
+        },
+        "AC": {
+            "Value": 9,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 9,
+            "Con": 18,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Lightning",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common plus one other language but can’t speak"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Aversion to Fire",
+                "Content": "If the golem takes Fire damage, it has Disadvantage on attack rolls and ability checks until the end of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Berserk",
+                "Content": "Whenever the golem starts its turn Bloodied, roll 1d6. On a 6, the golem goes berserk. On each of its turns while berserk, the golem attacks the nearest creature it can see. If no creature is near enough to move to and attack, the golem attacks an object. Once the golem goes berserk, it remains so until it is de- stroyed or it is no longer Bloodied. The golem’s creator, if within 60 feet of the berserk golem, can try to calm it by taking an action to make a DC 15 Charisma (Persuasion) check; the golem must be able to hear its creator. If this check succeeds, the go- lem ceases being berserk until the start of its next turn, at which point it resumes rolling for the Berserk trait again if it is still Bloodied.",
+                "Usage": ""
+            },
+            {
+                "Name": "Immutable Form",
+                "Content": "The golem can’t shape-shift. Lightning Absorption. Whenever the golem is sub- jected to Lightning damage, it regains a number of Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points equal to the Lightning damage dealt",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The golem has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The golem makes two Slam attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 4 (1d8) Lightning damage. Frost Giant Frost Giant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Frost Giant": {
+        "Id": "Frost Giant",
+        "Name": "Frost Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Neutral Evil",
+        "HP": {
+            "Value": 149,
+            "Notes": "(13d12 + 65)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 9,
+            "Con": 21,
+            "Int": 9,
+            "Wis": 10,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Frost",
+                "Usage": ""
+            },
+            {
+                "Name": "Axe or Great Bow in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Frost Axe",
+                "Content": "Melee Attack Roll: +9, reach 10 ft. Hit: 19 (2d12 + 6) Slashing damage plus 9 (2d8) Cold damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Great Bow",
+                "Content": "Ranged Attack Roll: +9, range 150/600 ft. Hit: 17 (2d10 + 6) Piercing damage plus 7 (2d6) Cold damage, and the target’s Speed decreases by 10 feet until the end of its next turn.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Frost Axe",
+                "ToHit": "+9",
+                "Damage": "2d12 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Shrieker Fungus": {
+        "Id": "Shrieker Fungus",
+        "Name": "Shrieker Fungus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Plant, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(3d8)"
+        },
+        "AC": {
+            "Value": 5,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft."
+        ],
+        "Abilities": {
+            "Str": 1,
+            "Dex": 1,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 3,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Frightened"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [],
+        "Reactions": [
+            {
+                "Name": "Shriek",
+                "Content": "Trigger: A creature or a source of Bright Light moves within 30 feet of the shrieker. Response: The shrieker emits a shriek audible within 300 feet of itself for 1 minute or until the shrieker dies. Violet Fungus",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Violet Fungus": {
+        "Id": "Violet Fungus",
+        "Name": "Violet Fungus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Plant, Unaligned",
+        "HP": {
+            "Value": 18,
+            "Notes": "(4d8)"
+        },
+        "AC": {
+            "Value": 5,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 1,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 3,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Frightened"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The fungus makes two Rotting",
+                "Usage": ""
+            },
+            {
+                "Name": "Touch attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Rotting Touch",
+                "Content": "Melee Attack Roll: +2, reach 10 ft. Hit: 4 (1d8) Necrotic damage. Gargoyle Gargoyle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rotting Touch",
+                "ToHit": "+2",
+                "Damage": "1d8",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gargoyle": {
+        "Id": "Gargoyle",
+        "Name": "Gargoyle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Elemental, Chaotic Evil",
+        "HP": {
+            "Value": 67,
+            "Notes": "(9d8 + 27)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 11,
+            "Con": 16,
+            "Int": 6,
+            "Wis": 11,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Terran)"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The gargoyle doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The gargoyle makes two Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Slashing damage. Gelatinous Cube Gelatinous Cube",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+4",
+                "Damage": "2d4 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gelatinous Cube": {
+        "Id": "Gelatinous Cube",
+        "Name": "Gelatinous Cube",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Ooze, Unaligned",
+        "HP": {
+            "Value": 63,
+            "Notes": "(6d10 + 30)"
+        },
+        "AC": {
+            "Value": 6,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "15 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 3,
+            "Con": 20,
+            "Int": 1,
+            "Wis": 6,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Prone"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Ooze Cube",
+                "Content": "The cube fills its entire space and is trans- parent. Other creatures can enter that space, but a creature that does so is subjected to the cube’s Engulf and has Disadvantage on the saving throw. Creatures inside the cube have Total Cover, and the cube can hold one Large creature or up to four Medium or Small creatures inside itself at a time. As an action, a creature within 5 feet of the cube can pull a creature or an object out of the cube by suc- ceeding on a DC 12 Strength (Athletics) check, and the puller takes 10 (3d6) Acid damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Transparent",
+                "Content": "Even when the cube is in plain sight, a creature must succeed on a DC 15 Wisdom (Percep- tion) check to notice the cube if the creature hasn’t wit- nessed the cube move or otherwise act.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Pseudopod",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Engulf",
+                "Content": "The cube moves up to its Speed without provoking Opportunity Attacks. The cube can move through the spaces of Large or smaller creatures if it has room inside itself to contain them (see the Ooze Cube trait). Dexterity Saving Throw: DC 12, each creature whose space the cube enters for the first time during this move. Failure: 10 (3d6) Acid damage, and the target is engulfed. An engulfed target is suffocating, can’t cast spells with a Verbal component, has the Restrained condition, and takes 10 (3d6) Acid damage at the start of each of the cube’s turns. When the cube moves, the engulfed target moves with it. An engulfed target can try to escape by taking an action to make a DC 12 Strength (Athletics) check. On a successful check, the target escapes and enters the nearest unoccupied space. Success: Half damage, and the target moves to an unoccupied space within 5 feet of the cube. If there is no unoccupied space, the target fails the save instead. Ghast Ghast",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pseudopod",
+                "ToHit": "+4",
+                "Damage": "3d6 + 2",
+                "DamageType": "Acid"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ghast": {
+        "Id": "Ghast",
+        "Name": "Ghast",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Chaotic Evil",
+        "HP": {
+            "Value": 36,
+            "Notes": "(8d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 17,
+            "Con": 10,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Stench",
+                "Content": "Constitution Saving Throw: DC 10, any creature that starts its turn in a 5-foot Emanation originating from the ghast. Failure: The target has the Poisoned condi- tion until the start of its next turn. Success: The target is immune to this ghast’s Stench for 24 hours.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 9 (2d8) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a non-Undead creature, it is subjected to the following effect. Consti- tution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn. Ghost Ghost",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ghost": {
+        "Id": "Ghost",
+        "Name": "Ghost",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Neutral",
+        "HP": {
+            "Value": 45,
+            "Notes": "(10d8)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 40 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 13,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 12,
+            "Cha": 17
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Bludgeoning",
+            "Cold",
+            "Fire",
+            "Lightning",
+            "Piercing",
+            "Slashing",
+            "Thunder"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Ethereal Sight",
+                "Content": "The ghost can see 60 feet into the Ethe- real Plane when it is on the Material Plane.",
+                "Usage": ""
+            },
+            {
+                "Name": "Incorporeal Movement",
+                "Content": "The ghost can move through other creatures and objects as if they were Difficult",
+                "Usage": ""
+            },
+            {
+                "Name": "Terrain",
+                "Content": "It takes 5 (1d10) Force damage if it ends its turn inside an object. 288",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ghost makes two Withering",
+                "Usage": ""
+            },
+            {
+                "Name": "Touch attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Withering Touch",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 19 (3d10 + 3) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Etherealness",
+                "Content": "The ghost casts the Etherealness spell, requiring no spell components and using Charisma as the spellcasting ability. The ghost is visible on the Mate- rial Plane while on the Border Ethereal and vice versa, but it can’t affect or be affected by anything on the other plane.",
+                "Usage": ""
+            },
+            {
+                "Name": "Horrific Visage",
+                "Content": "Wisdom Saving Throw: DC 13, each creature in a 60-foot Cone that can see the ghost and isn’t an Undead. Failure: 10 (2d6 + 3) Psychic damage, and the target has the Frightened condition until the start of the ghost’s next turn. Success: The target is im- mune to this ghost’s Horrific Visage for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Possession",
+                "Content": "Charisma Saving Throw: DC 13, one Humanoid the ghost can see within 5 feet. Fail- ure: The target is possessed by the ghost; the ghost dis- appears, and the target has the Incapacitated condition and loses control of its body. The ghost now controls the body, but the target retains awareness. The ghost can’t be targeted by any attack, spell, or other effect, except ones that specifically target Undead. The ghost’s game statistics are the same, except it uses the pos- sessed target’s Speed, as well as the target’s Strength,",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "Dexterity, and Constitution modifiers",
+                "Content": "The possession lasts until the body drops to 0 Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points or the ghost leaves as a Bonus Action",
+                "Content": "When the possession ends, the ghost appears in an unoccupied space within 5 feet of the target, and the target is im- mune to this ghost’s Possession for 24 hours. Success: The target is immune to this ghost’s Posses- sion for 24 hours. Ghoul Ghoul",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Withering Touch",
+                "ToHit": "+5",
+                "Damage": "3d10 + 3",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ghoul": {
+        "Id": "Ghoul",
+        "Name": "Ghoul",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Chaotic Evil",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 7,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ghoul makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 3 (1d6) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage. If the target is a creature that isn’t an Undead or elf, it is subjected to the following effect. Constitution Saving Throw: DC 10. Failure: The target has the Paralyzed condition until the end of its next turn. Gibbering Mouther Gibbering Mouther",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gibbering Mouther": {
+        "Id": "Gibbering Mouther",
+        "Name": "Gibbering Mouther",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Aberration, Chaotic Neutral",
+        "HP": {
+            "Value": 52,
+            "Notes": "(7d8 + 21)"
+        },
+        "AC": {
+            "Value": 9,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 20 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 8,
+            "Con": 16,
+            "Int": 3,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Prone"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Aberrant Ground",
+                "Content": "The ground in a 10-foot Emanation originating from the mouther is Difficult Terrain.",
+                "Usage": ""
+            },
+            {
+                "Name": "Gibbering",
+                "Content": "The mouther babbles incoherently while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 10, any creature that starts its turn within 20 feet of the mouther while it is babbling. Failure: The target rolls 1d8 to determine what it does during the current turn: 1–4. The target does nothing. 5–6. The target takes no action or Bonus Action and uses all its movement to move in a random direction. 7–8. The target makes a melee attack against a ran- domly determined creature within its reach or does nothing if it can’t make such an attack.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 7 (2d6) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition. The target dies if it is reduced to 0 Hit Points by this attack. Its body is then absorbed into the mouther, leaving only equip- ment behind. Blinding Spittle (Recharge 5–6). Dexterity Saving Throw: DC 10, each creature in a 10-foot-radius Sphere centered on a point within 30 feet. Failure: 7 (2d6) Ra- diant damage, and the target has the Blinded condition until the end of the mouther’s next turn. 289 Glabrezu Glabrezu",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+2",
+                "Damage": "2d6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Glabrezu": {
+        "Id": "Glabrezu",
+        "Name": "Glabrezu",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 189,
+            "Notes": "(18d10 + 90)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 15,
+            "Con": 21,
+            "Int": 19,
+            "Wis": 17,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 9
+            },
+            {
+                "Name": "Con",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "9",
+        "Traits": [
+            {
+                "Name": "Demonic Restoration",
+                "Content": "If the glabrezu dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Abyss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The glabrezu has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The glabrezu makes two Pincer attacks and uses Pummel or Spellcasting.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pincer",
+                "Content": "Melee Attack Roll: +9, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 15) from one of two pincers",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Pummel",
+                "Content": "Dexterity Saving Throw: DC 17 , one creature",
+                "Usage": ""
+            },
+            {
+                "Name": "Grappled by the glabrezu",
+                "Content": "Failure: 15 (3d6 + 5) Blud- geoning damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The glabrezu casts one of the following spells, requiring no Material components and using In- telligence as the spellcasting ability (spell save DC 16): At Will: Darkness, Detect Magic, Dispel Magic 1/Day Each: Confusion, Fly, Power Word Stun Gladiator Gladiator",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pincer",
+                "ToHit": "+9",
+                "Damage": "2d10 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gladiator": {
+        "Id": "Gladiator",
+        "Name": "Gladiator",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 112,
+            "Notes": "(15d8 + 45)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 12,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 7
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Con",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 10
+            },
+            {
+                "Name": "Performance",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The gladiator makes three Spear attacks. It can replace one attack with a use of Shield Bash.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spear",
+                "Content": "Melee or Ranged Attack Roll: +7 , reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shield Bash",
+                "Content": "Strength Saving Throw: DC 15, one crea- ture within 5 feet that the gladiator can see. Failure: 9 (2d4 + 4) Bludgeoning damage. If the target is a Me- dium or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The gladiator is hit by a melee attack roll while holding a weapon. Response: The gladiator adds 3 to its AC against that attack, possibly causing it to miss. Gnoll Gnoll Warrior",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Spear",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gnoll Warrior": {
+        "Id": "Gnoll Warrior",
+        "Name": "Gnoll Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Chaotic Evil",
+        "HP": {
+            "Value": 27,
+            "Notes": "(6d8)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 12,
+            "Con": 11,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Gnoll"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bone Bow",
+                "Content": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 6 (1d10 + 1) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rampage",
+                "Content": "Immediately after dealing damage to a creature that is already Bloodied, the gnoll moves up to half its Speed, and it makes one Rend attack. 290 Goblins Goblin Minion",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Goblin Minion": {
+        "Id": "Goblin Minion",
+        "Name": "Goblin Minion",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Fey (Goblinoid), Chaotic Neutral",
+        "HP": {
+            "Value": 7,
+            "Notes": "(2d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 8,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Dagger",
+                "Content": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The goblin takes the Disengage or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "Goblin Warrior",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Dagger",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Goblin Warrior": {
+        "Id": "Goblin Warrior",
+        "Name": "Goblin Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Fey (Goblinoid), Chaotic Neutral",
+        "HP": {
+            "Value": 10,
+            "Notes": "(3d6)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 8,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Scimitar",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortbow",
+                "Content": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The goblin takes the Disengage or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "Goblin Boss",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Scimitar",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Goblin Boss": {
+        "Id": "Goblin Boss",
+        "Name": "Goblin Boss",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Fey (Goblinoid), Chaotic Neutral",
+        "HP": {
+            "Value": 21,
+            "Notes": "(6d6)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 10,
+            "Wis": 8,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The goblin makes two attacks, using Scim- itar or Shortbow in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scimitar",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage, plus 2 (1d4) Slashing damage if the attack roll had Advantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortbow",
+                "Content": "Ranged Attack Roll: +4, range 80/320 ft. Hit: 5 (1d6 + 2) Piercing damage, plus 2 (1d4) Piercing damage if the attack roll had Advantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The goblin takes the Disengage or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Redirect Attack",
+                "Content": "Trigger: A creature the goblin can see makes an attack roll against it. Response: The goblin chooses a Small or Medium ally within 5 feet of itself. The goblin and that ally swap places, and the ally be- comes the target of the attack instead. Gold Dragons Gold Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Scimitar",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gold Dragon Wyrmling": {
+        "Id": "Gold Dragon Wyrmling",
+        "Name": "Gold Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 60,
+            "Notes": "(8d8 + 24)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 14,
+            "Con": 17,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 13, each creature in a 15-foot Cone",
+                "Content": "Failure: 22 (4d10) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Weakening Breath",
+                "Content": "Strength Saving Throw: DC 13, each creature that isn’t currently affected by this breath in a 15-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 2 (1d4) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. Af- ter 1 minute, it succeeds automatically. Young Gold Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Gold Dragon": {
+        "Id": "Young Gold Dragon",
+        "Name": "Young Gold Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 178,
+            "Notes": "(17d10 + 85)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 14,
+            "Con": 21,
+            "Int": 16,
+            "Wis": 13,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 9
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "10",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Weakening Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 17 (2d10 + 6) Slashing damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 17 , each creature in a 30-foot Cone",
+                "Content": "Failure: 55 (10d10) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Weakening Breath",
+                "Content": "Strength Saving Throw: DC 17 , each creature that isn’t currently affected by this breath in a 30-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. Af- ter 1 minute, it succeeds automatically. Adult Gold Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+10",
+                "Damage": "2d10 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Gold Dragon": {
+        "Id": "Adult Gold Dragon",
+        "Name": "Adult Gold Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 243,
+            "Notes": "(18d12 + 126)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 14,
+            "Con": 25,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 24
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 8
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 14
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 13
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "17",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 2 version) or (B) Weaken- ing Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 21, each creature in a 60-foot Cone",
+                "Content": "Failure: 66 (12d10) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21, +13 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Flame Strike, Zone of Truth",
+                "Usage": ""
+            },
+            {
+                "Name": "Weakening Breath",
+                "Content": "Strength Saving Throw: DC 21, each creature that isn’t currently affected by this breath in a 60-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 3 (1d6) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a success. Af- ter 1 minute, it succeeds automatically. 292",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Banish",
+                "Content": "Charisma Saving Throw: DC 21, one creature the dragon can see within 120 feet. Failure: 10 (3d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it re appears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Bolt",
+                "Content": "",
+                "Usage": "level 2 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Ancient Gold Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+14",
+                "Damage": "2d8 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Gold Dragon": {
+        "Id": "Ancient Gold Dragon",
+        "Name": "Ancient Gold Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 546,
+            "Notes": "(28d20 + 252)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 30,
+            "Dex": 14,
+            "Con": 29,
+            "Int": 18,
+            "Wis": 17,
+            "Cha": 28
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 10
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 17
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 16
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "24",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Spellcasting to cast Guiding Bolt (level 4 version) or (B) Weaken- ing Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +17 to hit, reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 24, each creature in a 90-foot Cone",
+                "Content": "Failure: 71 (13d10) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 24, +16 to hit with spell attacks): At Will: Detect Magic, Guiding Bolt (level 4 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Flame Strike (level 6 version), Word of Re- call, Zone of Truth",
+                "Usage": ""
+            },
+            {
+                "Name": "Weakening Breath",
+                "Content": "Strength Saving Throw: DC 24, each creature that isn’t currently affected by this breath in a 90-foot Cone. Failure: The target has Disadvantage on Strength-based D20 Tests and subtracts 5 (1d10) from its damage rolls. It repeats the save at the end of each of its turns, ending the effect on itself on a suc- cess. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Banish",
+                "Content": "Charisma Saving Throw: DC 24, one creature the dragon can see within 120 feet. Failure: 24 (7d6) Force damage, and the target has the Incapacitated condition and is transported to a harmless demiplane until the start of the dragon’s next turn, at which point it reappears in an unoccupied space of the dragon’s choice within 120 feet of the dragon. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Light",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Guiding Bolt",
+                "Content": "",
+                "Usage": "level 4 version"
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Gorgon Gorgon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+17",
+                "Damage": "2d8 + 10",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gorgon": {
+        "Id": "Gorgon",
+        "Name": "Gorgon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 114,
+            "Notes": "(12d10 + 48)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 11,
+            "Con": 18,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Petrified"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 18 (2d12 + 5) Piercing damage. If the target is a Large or smaller creature and the gorgon moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition. Petrifying Breath (Recharge 5–6). Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. First Failure: The target has the Restrained condition and repeats the save at the end of its next turn if it is still Restrained, ending the effect on itself on a success. Second Failure: The target has the Petrified condition instead of the Restrained condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Trample",
+                "Content": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 16 (2d10 + 5) Bludgeoning damage. Success: Half damage. Gray Ooze Gray Ooze",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+8",
+                "Damage": "2d12 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Gray Ooze": {
+        "Id": "Gray Ooze",
+        "Name": "Gray Ooze",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Ooze, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(3d8 + 9)"
+        },
+        "AC": {
+            "Value": 9,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Climb 10 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 6,
+            "Con": 16,
+            "Int": 1,
+            "Wis": 6,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Cold",
+            "Fire"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Prone",
+            "Restrained"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Amorphous",
+                "Content": "The ooze can move through a space as narrow as 1 inch without expending extra move- ment to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Corrosive Form",
+                "Content": "Nonmagical ammunition is destroyed immediately after hitting the ooze and dealing any damage. Any nonmagical weapon takes a cumulative −1 penalty to attack rolls immediately after dealing damage to the ooze and coming into contact with it. The weapon is destroyed if the penalty reaches −5. The penalty can be removed by casting the Mending spell on the weapon. The ooze can eat through 2-inch-thick, nonmagical metal or wood in 1 round.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Pseudopod",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 10 (2d8 + 1) Acid damage. Nonmagical armor worn by the target takes a −1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10. The penalty can be removed by casting the Mending spell on the armor. Green Dragons Green Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pseudopod",
+                "ToHit": "+3",
+                "Damage": "2d8 + 1",
+                "DamageType": "Acid"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Green Dragon Wyrmling": {
+        "Id": "Green Dragon Wyrmling",
+        "Name": "Green Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 38,
+            "Notes": "(7d8 + 7)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage plus 3 (1d6) Poison damage. Poison Breath (Recharge 5–6). Constitution Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 21 (6d6) Poison damage. Success: Half damage. Young Green Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d10 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Green Dragon": {
+        "Id": "Young Green Dragon",
+        "Name": "Young Green Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 136,
+            "Notes": "(16d10 + 48)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 12,
+            "Con": 17,
+            "Int": 16,
+            "Wis": 13,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water. 294",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage plus 7 (2d6) Poison damage. Poison Breath (Recharge 5–6). Constitution Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 42 (12d6) Poison damage. Success: Half damage. Adult Green Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Green Dragon": {
+        "Id": "Adult Green Dragon",
+        "Name": "Adult Green Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 207,
+            "Notes": "(18d12 + 90)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 12,
+            "Con": 21,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 12
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 9
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "15",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Spike",
+                "Content": "",
+                "Usage": "level 3 version"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage plus 7 (2d6) Poison damage. Poison Breath (Recharge 5–6). Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Fail- ure: 56 (16d6) Poison damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Mind Spike (level 3 version) 1/Day: Geas",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Mind Invasion",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Spike",
+                "Content": "",
+                "Usage": "level 3 version"
+            },
+            {
+                "Name": "Noxious Miasma",
+                "Content": "Constitution Saving Throw: DC 17 , each creature in a 20-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 7 (2d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Ancient Green Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+11",
+                "Damage": "2d8 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Green Dragon": {
+        "Id": "Ancient Green Dragon",
+        "Name": "Ancient Green Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Chromatic), Lawful Evil",
+        "HP": {
+            "Value": 402,
+            "Notes": "(23d20 + 161)"
+        },
+        "AC": {
+            "Value": 21,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 12,
+            "Con": 25,
+            "Int": 20,
+            "Wis": 17,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 13
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 17
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 13
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "22",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The dragon can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Spike",
+                "Content": "",
+                "Usage": "level 5 version"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +15, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 10 (3d6) Poison damage. Poison Breath (Recharge 5–6). Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Fail- ure: 77 (22d6) Poison damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 21): At Will: Detect Magic, Mind Spike (level 5 version) 1/Day Each: Geas, Modify Memory 295",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Mind Invasion",
+                "Content": "The dragon uses Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Mind Spike",
+                "Content": "",
+                "Usage": "level 5 version"
+            },
+            {
+                "Name": "Noxious Miasma",
+                "Content": "Constitution Saving Throw: DC 21, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 90 feet. Failure: 17 (5d6) Poison damage, and the target takes a −2 penalty to AC until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Green Hag Green Hag",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+15",
+                "Damage": "2d8 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Green Hag": {
+        "Id": "Green Hag",
+        "Name": "Green Hag",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey, Neutral Evil",
+        "HP": {
+            "Value": 82,
+            "Notes": "(11d8 + 33)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 12,
+            "Con": 16,
+            "Int": 13,
+            "Wis": 14,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 5
+            },
+            {
+                "Name": "Deception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The hag can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Coven Magic",
+                "Content": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spell- casting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again.",
+                "Usage": ""
+            },
+            {
+                "Name": "Mimicry",
+                "Content": "The hag can mimic animal sounds and hu- manoid voices. A creature that hears the sounds can tell they are imitations only with a successful DC 14",
+                "Usage": ""
+            },
+            {
+                "Name": "Wisdom",
+                "Content": "",
+                "Usage": "Insight check"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hag makes two Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage plus 3 (1d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The hag casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 12, +4 to hit with spell attacks): At Will: Dancing Lights, Disguise Self (24-hour du- ration), Invisibility (self only, and the hag leaves no tracks while Invisible), Minor Illusion, Ray of Sickness (level 3 version) Grick Grick",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+6",
+                "Damage": "1d8 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Grick": {
+        "Id": "Grick",
+        "Name": "Grick",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Aberration, Unaligned",
+        "HP": {
+            "Value": 54,
+            "Notes": "(12d8)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 14,
+            "Con": 11,
+            "Int": 3,
+            "Wis": 14,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The grick makes one Beak attack and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacles attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacles",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 12) from all four tentacles",
+                "Content": "Griffon Griffon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beak",
+                "ToHit": "+4",
+                "Damage": "2d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Griffon": {
+        "Id": "Griffon",
+        "Name": "Griffon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 59,
+            "Notes": "(7d10 + 21)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 2,
+            "Wis": 13,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The griffon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 14) from both of the griffon’s front claws. 296 Grimlock Grimlock",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "1d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Grimlock": {
+        "Id": "Grimlock",
+        "Name": "Grimlock",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Aberration, Neutral Evil",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 9,
+            "Wis": 8,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bone Cudgel",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 2 (1d4) Psy- chic damage. Guardian Naga Guardian Naga",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bone Cudgel",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Guardian Naga": {
+        "Id": "Guardian Naga",
+        "Name": "Guardian Naga",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Lawful Good",
+        "HP": {
+            "Value": 136,
+            "Notes": "(16d10 + 48)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 18,
+            "Con": 16,
+            "Int": 16,
+            "Wis": 19,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Paralyzed",
+            "Poisoned",
+            "Restrained"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 8
+            },
+            {
+                "Name": "Con",
+                "Modifier": 7
+            },
+            {
+                "Name": "Int",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 8
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 11
+            },
+            {
+                "Name": "History",
+                "Modifier": 11
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 11
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "Common"
+        ],
+        "Challenge": "10",
+        "Traits": [
+            {
+                "Name": "Celestial Restoration",
+                "Content": "If the naga dies, it returns to life in 1d6 days and regains all its Hit Points unless Dispel",
+                "Usage": ""
+            },
+            {
+                "Name": "Evil and Good is cast on its remains",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The naga makes two Bite attacks. It can replace any attack with a use of Poisonous Spittle.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 17 (2d12 + 4) Piercing damage plus 22 (4d10) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Poisonous Spittle",
+                "Content": "Constitution Saving Throw: DC 16, one creature the naga can see within 60 feet. Failure: 31 (7d8) Poison damage, and the target has the Blinded condition until the start of the naga’s next turn. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage only",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The naga casts one of the following spells, requiring no Somatic or Material components and using Wisdom as the spellcasting ability (spell save DC 16): At Will: Thaumaturgy 1/Day Each: Clairvoyance, Cure Wounds (level 6 ver- sion), Flame Strike (level 6 version), Geas, True Seeing Guards Guard",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+8",
+                "Damage": "2d12 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Guard": {
+        "Id": "Guard",
+        "Name": "Guard",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Spear",
+                "Content": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage. Guard Captain",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Spear",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Guard Captain": {
+        "Id": "Guard Captain",
+        "Name": "Guard Captain",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 75,
+            "Notes": "(10d8 + 30)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 16,
+            "Int": 12,
+            "Wis": 14,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 6
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The guard makes two attacks, using Javelin or Longsword in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Javelin",
+                "Content": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 14 (3d6 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longsword",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Slashing damage. 297 Half-Dragon Half-Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Javelin",
+                "ToHit": "+6",
+                "Damage": "3d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Half-Dragon": {
+        "Id": "Half-Dragon",
+        "Name": "Half-Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon, Neutral",
+        "HP": {
+            "Value": 105,
+            "Notes": "(14d8 + 42)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 14,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 15,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Damage type chosen for the Draconic Origin trait below"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Draconic Origin",
+                "Content": "The half-dragon is related to a type of dragon associated with one of the following damage types (GM’s choice): Acid, Cold, Fire, Lightning, or Poi- son. This choice affects other aspects of the stat block.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The half-dragon makes two Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 6 (1d4 + 4) Slashing damage plus 7 (2d6) damage of the type chosen for the Draconic Origin trait. Dragon’s Breath (Recharge 5–6). Dexterity Saving Throw: DC 14, each creature in a 30-foot Cone. Failure: 28 (8d6) damage of the type chosen for the Draconic",
+                "Usage": ""
+            },
+            {
+                "Name": "Origin trait",
+                "Content": "Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Leap",
+                "Content": "The half-dragon jumps up to 30 feet by spending 10 feet of movement. Harpy Harpy",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+7",
+                "Damage": "1d4 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Harpy": {
+        "Id": "Harpy",
+        "Name": "Harpy",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Chaotic Evil",
+        "HP": {
+            "Value": 38,
+            "Notes": "(7d8 + 7)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 13,
+            "Con": 12,
+            "Int": 7,
+            "Wis": 10,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Luring Song",
+                "Content": "The harpy sings a magical melody, which lasts until the harpy’s Concentration ends on it. Wisdom Saving Throw: DC 11, each Humanoid and Giant in a 300-foot Emanation originating from the harpy when the song starts. Failure: The target has the Charmed condition until the song ends and repeats the save at the end of each of its turns. While Charmed, the target has the Incapacitated condition and ignores the Luring",
+                "Usage": ""
+            },
+            {
+                "Name": "Song of other harpies",
+                "Content": "If the target is more than 5 feet from the harpy, the target moves on its turn toward the harpy by the most direct route, trying to get within 5 feet of the harpy. It doesn’t avoid Opportunity Attacks; however, before moving into damaging terrain (such as lava or a pit) and whenever it takes damage from a source other than the harpy, the target repeats the save. Success: The target is immune to this harpy’s Luring",
+                "Usage": ""
+            },
+            {
+                "Name": "Song for 24 hours",
+                "Content": "Hell Hound Hell Hound",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+3",
+                "Damage": "2d4 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hell Hound": {
+        "Id": "Hell Hound",
+        "Name": "Hell Hound",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Lawful Evil",
+        "HP": {
+            "Value": 58,
+            "Notes": "(9d8 + 18)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 12,
+            "Con": 14,
+            "Int": 6,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Infernal but can’t speak"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The hound has Advantage on an attack roll against a creature if at least one of the hound’s al- lies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hound makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 3 (1d6) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 12, each creature in a 15-foot Cone",
+                "Content": "Failure: 17 (5d6) Fire damage. Success: Half damage. 298 Hezrou Hezrou",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hezrou": {
+        "Id": "Hezrou",
+        "Name": "Hezrou",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 157,
+            "Notes": "(15d10 + 75)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 17,
+            "Con": 20,
+            "Int": 5,
+            "Wis": 12,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 7
+            },
+            {
+                "Name": "Con",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Demonic Restoration",
+                "Content": "If the hezrou dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Abyss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The hezrou has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Stench",
+                "Content": "Constitution Saving Throw: DC 16, any creature that starts its turn in a 10-foot Emanation originating from the hezrou. Failure: The target has the Poisoned condition until the start of its next turn.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hezrou makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 6 (1d4 + 4) Slashing damage plus 9 (2d8) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Leap",
+                "Content": "The hezrou jumps up to 30 feet by spending 10 feet of movement. Hill Giant Hill Giant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "1d4 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hill Giant": {
+        "Id": "Hill Giant",
+        "Name": "Hill Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Chaotic Evil",
+        "HP": {
+            "Value": 105,
+            "Notes": "(10d12 + 40)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 8,
+            "Con": 19,
+            "Int": 5,
+            "Wis": 9,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Tree",
+                "Usage": ""
+            },
+            {
+                "Name": "Club or Trash Lob in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Tree Club",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Trash Lob",
+                "Content": "Ranged Attack Roll: +8, range 60/240 ft. Hit: 16 (2d10 + 5) Bludgeoning damage, and the target has the Poisoned condition until the end of its next turn. Hippogriff Hippogriff",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Tree Club",
+                "ToHit": "+8",
+                "Damage": "3d8 + 5",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hippogriff": {
+        "Id": "Hippogriff",
+        "Name": "Hippogriff",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 26,
+            "Notes": "(4d10 + 4)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 13,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The hippogriff doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hippogriff makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage. Hobgoblins Hobgoblin Warrior",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hobgoblin Warrior": {
+        "Id": "Hobgoblin Warrior",
+        "Name": "Hobgoblin Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey (Goblinoid), Lawful Evil",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The hobgoblin has Advantage on an at- tack roll against a creature if at least one of the hobgob- lin’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Longsword",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 12 (2d10 + 1) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +3, range 150/600 ft. Hit: 5 (1d8 + 1) Piercing damage plus 7 (3d4) Poi- son damage. Hobgoblin Captain",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Longsword",
+                "ToHit": "+3",
+                "Damage": "2d10 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hobgoblin Captain": {
+        "Id": "Hobgoblin Captain",
+        "Name": "Hobgoblin Captain",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey (Goblinoid), Lawful Evil",
+        "HP": {
+            "Value": 58,
+            "Notes": "(9d8 + 18)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 12,
+            "Wis": 10,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Goblin"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Aura of Authority",
+                "Content": "While in a 10-foot Emanation origi- nating from the hobgoblin, the hobgoblin and its allies have Advantage on attack rolls and saving throws, provided the hobgoblin doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hobgoblin makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Greatsword or Longbow in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Greatsword",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Slashing damage plus 3 (1d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 5 (2d4) Poi- son damage. Homunculus Homunculus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Greatsword",
+                "ToHit": "+4",
+                "Damage": "2d6 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Homunculus": {
+        "Id": "Homunculus",
+        "Name": "Homunculus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Construct, Neutral",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d4 + 2)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 4,
+            "Dex": 15,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 0
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common plus one other language but can’t speak"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Telepathic Bond",
+                "Content": "While the homunculus is on the same plane of existence as its master, the two of them can communicate telepathically with each other.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage, and the target is subjected to the following effect. Constitution Saving Throw: DC 12. Failure: The target has the Poisoned condition until the end of the homunculus’s next turn. Failure by 5 or More: The tar- get has the Poisoned condition for 1 minute. While Poi- soned, the target has the Unconscious condition, which ends early if the target takes any damage. Horned Devil Horned Devil",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Horned Devil": {
+        "Id": "Horned Devil",
+        "Name": "Horned Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 199,
+            "Notes": "(19d10 + 95)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 17,
+            "Con": 21,
+            "Int": 12,
+            "Wis": 16,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 10
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 150 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "11",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes three attacks, using Sear- ing Fork or Hurl Flame in any combination. It can re- place one attack with a use of Infernal Tail. 300",
+                "Usage": ""
+            },
+            {
+                "Name": "Searing Fork",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Piercing damage plus 9 (2d8) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hurl Flame",
+                "Content": "Ranged Attack Roll: +8, range 150 ft. Hit: 26 (5d8 + 4) Fire damage. If the target is a flammable object that isn’t being worn or carried, it starts burning.",
+                "Usage": ""
+            },
+            {
+                "Name": "Infernal Tail",
+                "Content": "Dexterity Saving Throw: DC 17 , one crea- ture the devil can see within 10 feet. Failure: 10 (1d8 + 6) Necrotic damage, and the target receives an infer- nal wound if it doesn’t have one. While wounded, the target loses 10 (3d6) Hit Points at the start of each of its turns. The wound closes after 1 minute, after a spell restores Hit Points to the target, or after the target or a creature within 5 feet of it takes an action to stanch the wound, doing so by succeeding on a DC 17 Wisdom (Medicine) check. Hydra Hydra",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Searing Fork",
+                "ToHit": "+10",
+                "Damage": "2d8 + 6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hydra": {
+        "Id": "Hydra",
+        "Name": "Hydra",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Monstrosity, Unaligned",
+        "HP": {
+            "Value": 184,
+            "Notes": "(16d12 + 80)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 12,
+            "Con": 20,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Blinded",
+            "Charmed",
+            "Deafened",
+            "Frightened",
+            "Stunned",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The hydra can hold its breath for 1 hour.",
+                "Usage": ""
+            },
+            {
+                "Name": "Multiple Heads",
+                "Content": "The hydra has five heads. Whenever the hydra takes 25 damage or more on a single turn, one of its heads dies. The hydra dies if all its heads are dead. At the end of each of its turns when it has at least one living head, the hydra grows two heads for each of its heads that died since its last turn, unless it has taken Fire damage since its last turn. The hydra regains 20 Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points when it grows new heads",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Reactive Heads",
+                "Content": "For each head the hydra has beyond one, it gets an extra Reaction that can be used only for",
+                "Usage": ""
+            },
+            {
+                "Name": "Opportunity Attacks",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hydra makes as many Bite attacks as it has heads.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 10 (1d10 + 5) Piercing damage. Ice Devil Ice Devil",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+8",
+                "Damage": "1d10 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ice Devil": {
+        "Id": "Ice Devil",
+        "Name": "Ice Devil",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 228,
+            "Notes": "(24d10 + 96)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 14,
+            "Con": 18,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold",
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Con",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Insight",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Blindsight 120 ft."
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "14",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the devil dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The devil has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The devil makes three Ice Spear attacks. It can replace one attack with a Tail attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Ice Spear",
+                "Content": "Melee or Ranged Attack Roll: +10, reach 5 ft. or range 30/120 ft. Hit: 14 (2d8 + 5) Piercing damage plus 10 (3d6) Cold damage. Until the end of its next turn, the target can’t take a Bonus Action or Reaction, its Speed decreases by 10 feet, and it can move or take one action on its turn, not both. Hit or Miss: The spear magically returns to the devil’s hand immediately after a ranged attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (3d6 + 5) Bludgeoning damage plus 18 (4d8) Cold damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Ice Wall",
+                "Content": "The devil casts Wall of Ice (level 8 version), requiring no spell components and using In- telligence as the spellcasting ability (spell save DC 17). Imp Imp",
+                "Usage": "Recharge 6"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ice Spear",
+                "ToHit": "+10",
+                "Damage": "2d8 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Imp": {
+        "Id": "Imp",
+        "Name": "Imp",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 21,
+            "Notes": "(6d4 + 6)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 17,
+            "Con": 13,
+            "Int": 11,
+            "Wis": 12,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Common",
+            "Infernal"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The imp has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Sting",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage plus 7 (2d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Invisibility",
+                "Content": "The imp casts Invisibility on itself, requiring no spell components and using Charisma as the spell- casting ability.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The imp shape-shifts to resemble a rat (Speed 20 ft.), a raven (20 ft., Fly 60 ft.), or a spider (20 ft., Climb 20 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed. Incubus Incubus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Sting",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Incubus": {
+        "Id": "Incubus",
+        "Name": "Incubus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Neutral Evil",
+        "HP": {
+            "Value": 66,
+            "Notes": "(12d8 + 12)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 17,
+            "Con": 13,
+            "Int": 15,
+            "Wis": 12,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Poison",
+            "Psychic"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 9
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common",
+            "Infernal",
+            "telepathy 60 ft."
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Succubus Form",
+                "Content": "When the incubus finishes a Long Rest, it can shape-shift into a Succubus, using that stat block instead of this one. Any equipment it is wearing or carrying isn’t transformed.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The incubus makes two Restless",
+                "Usage": ""
+            },
+            {
+                "Name": "Touch attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Restless Touch",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 15 (3d6 + 5) Psychic damage, and the target is cursed for 24 hours or until the incubus dies. Until the curse ends, the target gains no benefit from finishing",
+                "Usage": ""
+            },
+            {
+                "Name": "Short Rests",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The incubus casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 15): At Will: Disguise Self, Etherealness 1/Day Each: Dream, Hypnotic Pattern",
+                "Usage": ""
+            },
+            {
+                "Name": "Nightmare",
+                "Content": "Wisdom Saving Throw: DC 15, one creature the incubus can see within 60 feet. Failure: If the target has 20 Hit Points or fewer, it has the Unconscious condition for 1 hour, until it takes damage, or until a creature within 5 feet of it takes an action to wake it. Otherwise, the target takes 18 (4d8) Psychic damage. Invisible Stalker Invisible Stalker",
+                "Usage": "Recharge 6"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Restless Touch",
+                "ToHit": "+7",
+                "Damage": "3d6 + 5",
+                "DamageType": "Psychic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Invisible Stalker": {
+        "Id": "Invisible Stalker",
+        "Name": "Invisible Stalker",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral",
+        "HP": {
+            "Value": 97,
+            "Notes": "(13d10 + 26)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Fly 50 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 19,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 15,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 10
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Primordial (Auran)"
+        ],
+        "Challenge": "6",
+        "Traits": [
+            {
+                "Name": "Air Form",
+                "Content": "The stalker can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Invisibility",
+                "Content": "The stalker has the Invisible condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The stalker makes three Wind Swipe at- tacks. It can replace one attack with a use of Vortex.",
+                "Usage": ""
+            },
+            {
+                "Name": "Wind Swipe",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 11 (2d6 + 4) Force damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Vortex",
+                "Content": "Constitution Saving Throw: DC 14, one Large or smaller creature in the stalker’s space. Failure: 7 (1d8 + 3) Thunder damage, and the target has the Grappled condition (escape DC 13). Until the grapple ends, the target can’t cast spells with a Verbal component and 302 takes 7 (2d6) Thunder damage at the start of each of the stalker’s turns. Iron Golem Iron Golem",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Wind Swipe",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Force"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Iron Golem": {
+        "Id": "Iron Golem",
+        "Name": "Iron Golem",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 252,
+            "Notes": "(24d10 + 120)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 24,
+            "Dex": 9,
+            "Con": 20,
+            "Int": 3,
+            "Wis": 11,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire",
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Understands Common plus two other",
+            "but can’t speak"
+        ],
+        "Challenge": "16",
+        "Traits": [
+            {
+                "Name": "Fire Absorption",
+                "Content": "Whenever the golem is subjected to Fire damage, it regains a number of Hit Points equal to the Fire damage dealt.",
+                "Usage": ""
+            },
+            {
+                "Name": "Immutable Form",
+                "Content": "The golem can’t shape-shift.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The golem has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The golem makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Bladed Arm or Fiery Bolt in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bladed Arm",
+                "Content": "Melee Attack Roll: +12, reach 10 ft. Hit: 20 (3d8 + 7) Slashing damage plus 10 (3d6) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiery Bolt",
+                "Content": "Ranged Attack Roll: +10, range 120 ft. Hit: 36 (8d8) Fire damage. Poison Breath (Recharge 6). Constitution Saving Throw: DC 18, each creature in a 60-foot Cone. Fail- ure: 55 (10d10) Poison damage. Success: Half damage. Knight Knight",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bladed Arm",
+                "ToHit": "+12",
+                "Damage": "3d8 + 7",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Knight": {
+        "Id": "Knight",
+        "Name": "Knight",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 52,
+            "Notes": "(8d8 + 16)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 11,
+            "Con": 14,
+            "Int": 11,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Frightened"
+        ],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The knight makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Greatsword or Heavy Crossbow in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Greatsword",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage plus 4 (1d8) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Heavy Crossbow",
+                "Content": "Ranged Attack Roll: +2, range 100/400 ft. Hit: 11 (2d10) Piercing damage plus 4 (1d8) Radiant damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The knight is hit by a melee attack roll while holding a weapon. Response: The knight adds 2 to its AC against that attack, possibly causing it to miss. Kobold Kobold Warrior",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Greatsword",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Kobold Warrior": {
+        "Id": "Kobold Warrior",
+        "Name": "Kobold Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Dragon, Neutral",
+        "HP": {
+            "Value": 7,
+            "Notes": "(3d6 − 3)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 15,
+            "Con": 9,
+            "Int": 8,
+            "Wis": 7,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The kobold has Advantage on an attack roll against a creature if at least one of the kobold’s al- lies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight Sensitivity",
+                "Content": "While in sunlight, the kobold has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Dagger",
+                "Content": "Melee or Ranged Attack Roll: +4, reach 5 ft. or range 20/60 ft. Hit: 4 (1d4 + 2) Piercing damage. 303 Kraken Kraken",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Dagger",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Kraken": {
+        "Id": "Kraken",
+        "Name": "Kraken",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Monstrosity (Titan), Chaotic Evil",
+        "HP": {
+            "Value": 481,
+            "Notes": "(26d20 + 208)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 120 ft."
+        ],
+        "Abilities": {
+            "Str": 30,
+            "Dex": 11,
+            "Con": 26,
+            "Int": 22,
+            "Wis": 18,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold",
+            "Lightning"
+        ],
+        "ConditionImmunities": [
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Restrained"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 17
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Con",
+                "Modifier": 15
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 11
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 13
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Understands Abyssal",
+            "Celestial",
+            "Infernal",
+            "and Primordial but can’t speak",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "23",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The kraken can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the kraken fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            },
+            {
+                "Name": "Siege Monster",
+                "Content": "The kraken deals double damage to ob- jects and structures.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The kraken makes two Tentacle attacks and uses Fling, Lightning Strike, or Swallow.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle",
+                "Content": "Melee Attack Roll: +17 , reach 30 ft. Hit: 24 (4d6 + 10) Bludgeoning damage. The target has the Grappled condition (escape DC 20) from one of ten tentacles, and it has the Restrained condition until the grapple ends.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fling",
+                "Content": "The kraken throws a Large or smaller creature Grappled by it to a space it can see within 60 feet of itself that isn’t in the air. Dexterity Saving Throw: DC 25, the creature thrown and each creature in the des- tination space. Failure: 18 (4d8) Bludgeoning damage, and the target has the Prone condition. Success: Half damage only. Lightning Strike. Dexterity Saving Throw: DC 23, one creature the kraken can see within 120 feet. Failure: 33 (6d10) Lightning damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "Dexterity Saving Throw: DC 25, one creature Grappled by the kraken (it can have up to four crea- tures swallowed at a time). Failure: 23 (3d8 + 10) Pierc- ing damage. If the target is Large or smaller, it is swal- lowed and no longer Grappled. A swallowed creature has the Restrained condition, has Total Cover against attacks and other effects outside the kraken, and takes 24 (7d6) Acid damage at the start of each of its turns. If the kraken takes 50 damage or more on a single turn from a creature inside it, the kraken must succeed on a DC 25 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the kraken with the Prone condition. If the kraken dies, any swallowed creature no longer has the Restrained condition and can escape from the corpse using 15 feet of movement, exiting Prone.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Storm Bolt",
+                "Content": "The kraken uses Lightning Strike.",
+                "Usage": ""
+            },
+            {
+                "Name": "Toxic Ink",
+                "Content": "Constitution Saving Throw: DC 23, each creature in a 15-foot Emanation originating from the kraken while it is underwater. Failure: The target has the Blinded and Poisoned conditions until the end of the kraken’s next turn. The kraken then moves up to its Speed. Failure or Success: The kraken can’t take this action again until the start of its next turn. Lamia Lamia",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Tentacle",
+                "ToHit": "+17",
+                "Damage": "4d6 + 10",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Lamia": {
+        "Id": "Lamia",
+        "Name": "Lamia",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend, Chaotic Evil",
+        "HP": {
+            "Value": 97,
+            "Notes": "(13d10 + 26)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 15,
+            "Int": 14,
+            "Wis": 15,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The lamia makes two Claw attacks. It can replace one attack with a use of Corrupting Touch.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 7 (2d6) Psychic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Corrupting Touch",
+                "Content": "Wisdom Saving Throw: DC 13, one creature the lamia can see within 5 feet. Failure: 13 (3d8) Psychic damage, and the target is cursed for 1 hour. Until the curse ends, the target has the Charmed and Poisoned conditions.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The lamia casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): At Will: Disguise Self (can appear as a Large or Medium biped), Minor Illusion 1/Day Each: Geas, Major Image, Scrying 304",
+                "Usage": ""
+            },
+            {
+                "Name": "Leap",
+                "Content": "The lamia jumps up to 30 feet by spending 10 feet of movement. Lemure Lemure",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Lemure": {
+        "Id": "Lemure",
+        "Name": "Lemure",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d8)"
+        },
+        "AC": {
+            "Value": 9,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 5,
+            "Con": 11,
+            "Int": 1,
+            "Wis": 11,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft. (unimpeded by magical Darkness)"
+        ],
+        "Languages": [
+            "Understands Infernal but can’t speak"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Hellish Restoration",
+                "Content": "If the lemure dies in the Nine Hells, it revives with all its Hit Points in 1d10 days un- less it is killed by a creature under the effects of a Bless spell or its remains are sprinkled with Holy Water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Vile Slime",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Poison damage. Lich Lich",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Vile Slime",
+                "ToHit": "+2",
+                "Damage": "1d4",
+                "DamageType": "Poison"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Lich": {
+        "Id": "Lich",
+        "Name": "Lich",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead (Wizard), Neutral Evil",
+        "HP": {
+            "Value": 315,
+            "Notes": "(42d8 + 126)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 16,
+            "Con": 16,
+            "Int": 21,
+            "Wis": 14,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 10
+            },
+            {
+                "Name": "Con",
+                "Modifier": 10
+            },
+            {
+                "Name": "Int",
+                "Modifier": 12
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 19
+            },
+            {
+                "Name": "History",
+                "Modifier": 12
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "All"
+        ],
+        "Challenge": "21",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the lich fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            },
+            {
+                "Name": "Spirit Jar",
+                "Content": "If destroyed, the lich reforms in 1d10 days if it has a spirit jar, reviving with all its Hit Points. The new body appears in an unoccupied space within the lich’s lair.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The lich makes three attacks, using El- dritch Burst or Paralyzing Touch in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Eldritch Burst",
+                "Content": "Melee or Ranged Attack Roll: +12, reach 5 ft. or range 120 ft. Hit: 31 (4d12 + 5) Force damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Touch",
+                "Content": "Melee Attack Roll: +12, reach 5 ft. Hit: 15 (3d6 + 5) Cold damage, and the target has the Paralyzed condition until the start of the lich’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The lich casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 20): At Will: Detect Magic, Detect Thoughts, Dispel Magic, Fireball (level 5 version), Invisibility, Lightning Bolt (level 5 version), Mage Hand, Prestidigitation 2/Day Each: Animate Dead, Dimension Door, Plane Shift 1/Day Each: Chain Lightning, Finger of Death, Power Word Kill, Scrying",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Protective Magic",
+                "Content": "The lich casts Counterspell or Shield in response to the spell’s trigger, using the same spell- casting ability as Spellcasting.",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [
+            {
+                "Name": "Deathly Teleport",
+                "Content": "The lich teleports up to 60 feet to an unoccupied space it can see, and each creature within 10 feet of the space it left takes 11 (2d10) Ne- crotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Disrupt Life",
+                "Content": "Constitution Saving Throw: DC 20, each creature that isn’t an Undead in a 20-foot Emanation originating from the lich. Failure: 31 (9d6) Necrotic damage. Success: Half damage. Failure or Success: The lich can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightening Gaze",
+                "Content": "The lich casts Fear, using the same spellcasting ability as Spellcasting. The lich can’t take this action again until the start of its next turn. 305 Mages Mage",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Eldritch Burst",
+                "ToHit": "+12",
+                "Damage": "4d12 + 5",
+                "DamageType": "Force"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mage": {
+        "Id": "Mage",
+        "Name": "Mage",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid (Wizard), Neutral",
+        "HP": {
+            "Value": 81,
+            "Notes": "(18d8)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 9,
+            "Dex": 14,
+            "Con": 11,
+            "Int": 17,
+            "Wis": 12,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Int",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 6
+            },
+            {
+                "Name": "History",
+                "Modifier": 6
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus three other languages"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The mage makes three Arcane",
+                "Usage": ""
+            },
+            {
+                "Name": "Burst attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Arcane Burst",
+                "Content": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 120 ft. Hit: 16 (3d8 + 3) Force damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The mage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation 2/Day Each: Fireball (level 4 version), Invisibility 1/Day Each: Cone of Cold, Fly",
+                "Usage": ""
+            },
+            {
+                "Name": "Misty Step",
+                "Content": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting.",
+                "Usage": "3/Day"
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Protective Magic",
+                "Content": "The mage casts Counterspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting. Archmage",
+                "Usage": "3/Day"
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Arcane Burst",
+                "ToHit": "+6",
+                "Damage": "3d8 + 3",
+                "DamageType": "Force"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Archmage": {
+        "Id": "Archmage",
+        "Name": "Archmage",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid (Wizard), Neutral",
+        "HP": {
+            "Value": 170,
+            "Notes": "(31d8 + 31)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 20,
+            "Wis": 15,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed (with Mind Blank)"
+        ],
+        "Saves": [
+            {
+                "Name": "Int",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 13
+            },
+            {
+                "Name": "History",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus five other languages"
+        ],
+        "Challenge": "12",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The archmage has Advantage on",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The archmage makes four Arcane",
+                "Usage": ""
+            },
+            {
+                "Name": "Burst attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Arcane Burst",
+                "Content": "Melee or Ranged Attack Roll: +9, reach 5 ft. or range 150 ft. Hit: 27 (4d10 + 5) Force damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The archmage casts one of the following spells, using Intelligence as the spellcasting ability (spell save DC 17): At Will: Detect Magic, Detect Thoughts, Disguise Self, Invisibility, Light, Mage Armor (included in AC), Mage Hand, Prestidigitation 2/Day Each: Fly, Lightning Bolt (level 7 version) 1/Day Each: Cone of Cold (level 9 version), Mind Blank (cast before combat), Scrying, Teleport",
+                "Usage": ""
+            },
+            {
+                "Name": "Misty Step",
+                "Content": "The mage casts Misty Step, using the same spellcasting ability as Spellcasting.",
+                "Usage": "3/Day"
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Protective Magic",
+                "Content": "The archmage casts Coun- terspell or Shield in response to the spell’s trigger, using the same spellcasting ability as Spellcasting. Magmin Magmin",
+                "Usage": "3/Day"
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Arcane Burst",
+                "ToHit": "+9",
+                "Damage": "4d10 + 5",
+                "DamageType": "Force"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Magmin": {
+        "Id": "Magmin",
+        "Name": "Magmin",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Elemental, Chaotic Neutral",
+        "HP": {
+            "Value": 13,
+            "Notes": "(3d6 + 3)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 15,
+            "Con": 12,
+            "Int": 8,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Ignan)"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Death Burst",
+                "Content": "The magmin explodes when it dies. Dex- terity Saving Throw: DC 11, each creature in a 10-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the magmin",
+                "Content": "Failure: 7 (2d6) Fire damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Touch",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Fire damage. If the target is a creature or a flammable object that isn’t being worn or carried, it starts burning. 306",
+                "Usage": ""
+            },
+            {
+                "Name": "Ignited Illumination",
+                "Content": "The magmin sets itself ablaze or extinguishes its flames. While ablaze, the magmin sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. Manticore Manticore",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Touch",
+                "ToHit": "+4",
+                "Damage": "2d4 + 2",
+                "DamageType": "Fire"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Manticore": {
+        "Id": "Manticore",
+        "Name": "Manticore",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Lawful Evil",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d10 + 24)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 50 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 16,
+            "Con": 17,
+            "Int": 7,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The manticore makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend or Tail Spike in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail Spike",
+                "Content": "Ranged Attack Roll: +5, range 100/200 ft. Hit: 7 (1d8 + 3) Piercing damage. Marilith Marilith",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Marilith": {
+        "Id": "Marilith",
+        "Name": "Marilith",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 220,
+            "Notes": "(21d10 + 105)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 20,
+            "Con": 20,
+            "Int": 18,
+            "Wis": 16,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 9
+            },
+            {
+                "Name": "Con",
+                "Modifier": 10
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 8
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "16",
+        "Traits": [
+            {
+                "Name": "Demonic Restoration",
+                "Content": "If the marilith dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Abyss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The marilith has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Reactive",
+                "Content": "The marilith can take one Reaction on every turn of combat.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The marilith makes six Pact Blade attacks and uses Constrict.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pact Blade",
+                "Content": "Melee Attack Roll: +10, reach 5 ft. Hit: 10 (1d10 + 5) Slashing damage plus 7 (2d6) Ne- crotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 17 , one Medium or smaller creature the marilith can see within 5 feet. Failure: 15 (2d10 + 4) Bludgeoning damage. The target has the Grappled condition (escape DC 14), and it has the Restrained condition until the grapple ends.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The marilith is hit by a melee attack roll while holding a weapon. Response: The marilith adds 5 to its AC against that attack, possibly causing it to miss. Medusa Medusa",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pact Blade",
+                "ToHit": "+10",
+                "Damage": "1d10 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Medusa": {
+        "Id": "Medusa",
+        "Name": "Medusa",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Lawful Evil",
+        "HP": {
+            "Value": 127,
+            "Notes": "(17d8 + 51)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 17,
+            "Con": 16,
+            "Int": 12,
+            "Wis": 13,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 150 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The medusa makes two Claw attacks and one Snake Hair attack, or it makes three Poison",
+                "Usage": ""
+            },
+            {
+                "Name": "Ray attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Snake Hair",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 14 (4d6) Poi- son damage. Poison Ray. Ranged Attack Roll: +5, range 150 ft. Hit: 11 (2d8 + 2) Poison damage. 307",
+                "Usage": ""
+            },
+            {
+                "Name": "Petrified condition instead of the Restrained condition",
+                "Content": "Mephits Dust Mephit",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+6",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Dust Mephit": {
+        "Id": "Dust Mephit",
+        "Name": "Dust Mephit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Elemental, Neutral Evil",
+        "HP": {
+            "Value": 17,
+            "Notes": "(5d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 14,
+            "Con": 10,
+            "Int": 9,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Auran",
+            "Terran)"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Death Burst",
+                "Content": "The mephit explodes when it dies. Dex- terity Saving Throw: DC 10, each creature in a 5-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the mephit",
+                "Content": "Failure: 5 (2d4) Bludgeoning damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Blinding Breath",
+                "Content": "Dexterity Saving Throw:",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "DC 10, each creature in a 15-foot Cone",
+                "Content": "Failure: The target has the Blinded condition until the end of the mephit’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sleep",
+                "Content": "The mephit casts the Sleep spell, requir- ing no spell components and using Charisma as the spellcasting ability (spell save DC 10). Ice Mephit",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ice Mephit": {
+        "Id": "Ice Mephit",
+        "Name": "Ice Mephit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Elemental, Neutral Evil",
+        "HP": {
+            "Value": 21,
+            "Notes": "(6d6)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 13,
+            "Con": 10,
+            "Int": 9,
+            "Wis": 11,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Aquan",
+            "Auran)"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Death Burst",
+                "Content": "The mephit explodes when it dies. Consti- tution Saving Throw: DC 10, each creature in a 5-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the mephit",
+                "Content": "Failure: 5 (2d4) Cold damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 2 (1d4) Cold damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fog Cloud",
+                "Content": "The mephit casts Fog Cloud, re- quiring no spell components and using Charisma as the spellcasting ability.",
+                "Usage": "1/Day"
+            },
+            {
+                "Name": "Frost Breath",
+                "Content": "Constitution Saving Throw:",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "DC 10, each creature in a 15-foot Cone",
+                "Content": "Failure: 7 (3d4) Cold damage. Success: Half damage. Magma Mephit",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+3",
+                "Damage": "1d4 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Magma Mephit": {
+        "Id": "Magma Mephit",
+        "Name": "Magma Mephit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Elemental, Neutral Evil",
+        "HP": {
+            "Value": 18,
+            "Notes": "(4d6 + 4)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 12,
+            "Con": 12,
+            "Int": 7,
+            "Wis": 10,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [
+            "Cold"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Ignan",
+            "Terran)"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Death Burst",
+                "Content": "The mephit explodes when it dies. Dex- terity Saving Throw: DC 11, each creature in a 5-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the mephit",
+                "Content": "Failure: 7 (2d6) Fire damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 3 (1d4 + 1) Slashing damage plus 3 (1d6) Fire damage. Fire Breath (Recharge 6). Dexterity Saving Throw: DC 11, each creature in a 15-foot Cone. Failure: 7 (2d6) Fire damage. Success: Half damage. 308 Steam Mephit",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+3",
+                "Damage": "1d4 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Steam Mephit": {
+        "Id": "Steam Mephit",
+        "Name": "Steam Mephit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Elemental, Neutral Evil",
+        "HP": {
+            "Value": 17,
+            "Notes": "(5d6)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 11,
+            "Con": 10,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Aquan",
+            "Ignan)"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Blurred Form",
+                "Content": "Attack rolls against the mephit are made with Disadvantage unless the mephit has the Incapaci- tated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Death Burst",
+                "Content": "The mephit explodes when it dies. Dex- terity Saving Throw: DC 10, each creature in a 5-foot",
+                "Usage": ""
+            },
+            {
+                "Name": "Emanation originating from the mephit",
+                "Content": "Failure: 5 (2d4) Fire damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Slashing damage plus 2 (1d4) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Steam Breath",
+                "Content": "Constitution Saving Throw:",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "DC 10, each creature in a 15-foot Cone",
+                "Content": "Failure: 5 (2d4) Fire damage, and the target’s Speed decreases by 10 feet until the end of the mephit’s next turn. Success:",
+                "Usage": ""
+            },
+            {
+                "Name": "Half damage only",
+                "Content": "Failure or Success: Being underwater doesn’t grant Resistance to this Fire damage. Merfolk Merfolk Skirmisher",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+2",
+                "Damage": "1d4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Merfolk Skirmisher": {
+        "Id": "Merfolk Skirmisher",
+        "Name": "Merfolk Skirmisher",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Elemental, Neutral",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 13,
+            "Con": 12,
+            "Int": 11,
+            "Wis": 14,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Primordial (Aquan)"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The merfolk can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Ocean Spear",
+                "Content": "Melee or Ranged Attack Roll: +2, reach 5 ft. or range 20/60 ft. Hit: 3 (1d6) Piercing damage plus 2 (1d4) Cold damage. If the target is a creature, its Speed decreases by 10 feet until the end of its next turn. Hit or Miss: The spear magically returns to the merfolk’s hand immediately after a ranged attack. Merrow Merrow",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ocean Spear",
+                "ToHit": "+2",
+                "Damage": "1d6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Merrow": {
+        "Id": "Merrow",
+        "Name": "Merrow",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Chaotic Evil",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 15,
+            "Int": 8,
+            "Wis": 10,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Primordial (Aquan)"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The merrow can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The merrow makes two attacks, using Bite,",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw, or Harpoon in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage, and the target has the Poisoned con- dition until the end of the merrow’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Harpoon",
+                "Content": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 20/60 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature, the merrow pulls the target up to 15 feet straight toward itself. Mimic Mimic",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "1d4 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mimic": {
+        "Id": "Mimic",
+        "Name": "Mimic",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Neutral",
+        "HP": {
+            "Value": 58,
+            "Notes": "(9d8 + 18)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 12,
+            "Con": 15,
+            "Int": 5,
+            "Wis": 13,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Acid"
+        ],
+        "ConditionImmunities": [
+            "Prone"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Adhesive",
+                "Content": "The mimic adheres to anything that touches it. A Huge or smaller creature ad- hered to the mimic has the Grappled condition (escape",
+                "Usage": "Object Form Only"
+            },
+            {
+                "Name": "DC 13)",
+                "Content": "Ability checks made to escape this grapple have Disadvantage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5 (with Advantage if the target is Grappled by the mimic), reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage—or 12 (2d8 + 3) Piercing damage if the target is Grappled by the mimic—plus 4 (1d8) Acid damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pseudopod",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage plus 4 (1d8) Acid dam- age. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13). Ability checks made to escape this grapple have Disadvantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The mimic shape-shifts to resemble a Me- dium or Small object while retaining its game statistics, or it returns to its true blob form. Any equipment it is wearing or carrying isn’t transformed. Minotaur of Baphomet Minotaur of Baphomet",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Minotaur of Baphomet": {
+        "Id": "Minotaur of Baphomet",
+        "Name": "Minotaur of Baphomet",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Chaotic Evil",
+        "HP": {
+            "Value": 85,
+            "Notes": "(10d10 + 30)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 11,
+            "Con": 16,
+            "Int": 6,
+            "Wis": 16,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Abyssal Glaive",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 10 (3d6) Ne- crotic damage. Gore (Recharge 5–6). Melee Attack Roll: +6, reach 5 ft. Hit: 18 (4d6 + 4) Piercing damage. If the target is a Large or smaller creature and the minotaur moved 10+ feet straight toward it immediately before the hit, the target takes an extra 10 (3d6) Piercing damage and has the Prone condition. Mummies Mummy",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Abyssal Glaive",
+                "ToHit": "+6",
+                "Damage": "1d12 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mummy": {
+        "Id": "Mummy",
+        "Name": "Mummy",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Undead, Lawful Evil",
+        "HP": {
+            "Value": 58,
+            "Notes": "(9d8 + 18)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 8,
+            "Con": 15,
+            "Int": 6,
+            "Wis": 12,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus two other languages"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The mummy makes two Rotting Fist at- tacks and uses Dreadful Glare.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rotting Fist",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, its Hit Point maximum doesn’t return to normal when finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0 Hit Points by this attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Dreadful Glare",
+                "Content": "Wisdom Saving Throw: DC 11, one creature the mummy can see within 60 feet. Failure: The target has the Frightened condition until the end of the mummy’s next turn. Success: The target is immune to this mummy’s Dreadful Glare for 24 hours. Mummy Lord",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rotting Fist",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mummy Lord": {
+        "Id": "Mummy Lord",
+        "Name": "Mummy Lord",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Undead (Cleric), Lawful Evil",
+        "HP": {
+            "Value": 187,
+            "Notes": "(25d8 + 75)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 11,
+            "Wis": 19,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Int",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Truesight 60 ft."
+        ],
+        "Languages": [
+            "Common plus three other languages"
+        ],
+        "Challenge": "15",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the mummy fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The mummy has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Undead Restoration",
+                "Content": "If destroyed, the mummy gains a new body in 24 hours if its heart is intact, reviving with all its Hit Points. The new body appears in an unoccu- pied space within the mummy’s lair. The heart is a Tiny object that has AC 17 , HP 10, and Immunity to all dam- age except Fire.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The mummy makes one Rotting Fist or Channel Negative Energy attack, and it uses",
+                "Usage": ""
+            },
+            {
+                "Name": "Dreadful Glare",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Rotting Fist",
+                "Content": "Melee Attack Roll: +9, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage plus 10 (3d6) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target can’t regain Hit Points, it gains no benefit from finishing a Long Rest, and its Hit Point maximum decreases by 10 (3d6) every 24 hours that elapse. A creature dies and turns to dust if reduced to 0",
+                "Usage": ""
+            },
+            {
+                "Name": "Channel Negative Energy",
+                "Content": "Ranged Attack Roll: +9, range 60 ft. Hit: 25 (6d6 + 4) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Dreadful Glare",
+                "Content": "Wisdom Saving Throw: DC 17 , one creature the mummy can see within 60 feet. Failure: 25 (6d6 + 4) Psychic damage, and the target has the Para- lyzed condition until the end of the mummy’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The mummy casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 17 , +9 to hit with spell attacks): At Will: Dispel Magic, Thaumaturgy 1/Day Each: Animate Dead, Harm, Insect Plague (level 7 version)",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Whirlwind of Sand",
+                "Content": "Trigger: The mummy is hit by an attack roll. Response: The mummy adds 2 to its AC against the attack, possibly causing the attack to miss, and the mummy teleports up to 60 feet to an unoccu- pied space it can see. Each creature of its choice that it can see within 5 feet of its destination space has the Blinded condition until the end of the mummy’s next turn.",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [
+            {
+                "Name": "Dread Command",
+                "Content": "The mummy casts Command (level 2 version), using the same spellcasting ability as Spell- casting. The mummy can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Glare",
+                "Content": "The mummy uses Dreadful Glare. The mummy can’t take this action again until the start of its next turn. Necrotic Strike. The mummy makes one Rotting Fist or",
+                "Usage": ""
+            },
+            {
+                "Name": "Channel Negative Energy attack",
+                "Content": "Nalfeshnee Nalfeshnee",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rotting Fist",
+                "ToHit": "+9",
+                "Damage": "2d10 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Nalfeshnee": {
+        "Id": "Nalfeshnee",
+        "Name": "Nalfeshnee",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 184,
+            "Notes": "(16d10 + 96)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 10,
+            "Con": 22,
+            "Int": 19,
+            "Wis": 12,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Frightened",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 11
+            },
+            {
+                "Name": "Int",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Demonic Restoration",
+                "Content": "If the nalfeshnee dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Abyss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The nalfeshnee has Advantage on",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The nalfeshnee makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 16 (2d10 + 5) Slashing damage plus 11 (2d10) Force damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Teleport",
+                "Content": "The nalfeshnee teleports up to 120 feet to an unoccupied space it can see.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Pursuit",
+                "Content": "Trigger: Another creature the nalfeshnee can see ends its move within 120 feet of the nalfeshnee. Response: The nalfeshnee uses Teleport, but its des- tination space must be within 10 feet of the trigger- ing creature. Night Hag Night Hag",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+10",
+                "Damage": "2d10 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Night Hag": {
+        "Id": "Night Hag",
+        "Name": "Night Hag",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Neutral Evil",
+        "HP": {
+            "Value": 112,
+            "Notes": "(15d8 + 45)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 16,
+            "Wis": 14,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common",
+            "Infernal",
+            "Primordial"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Coven Magic",
+                "Content": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spell- casting ability (spell save DC 14): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The hag has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Soul Bag",
+                "Content": "The hag has a soul bag. While holding or carrying the bag, the hag can use its Nightmare Haunt- ing action. The bag has AC 15, HP 20, and Resistance to all dam- age. The bag turns to dust if reduced to 0 Hit Points. If the bag is destroyed, any souls the bag is holding are released. The hag can create a new bag after 7 days.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hag makes two Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage. Nightmare Haunting (1/Day; Requires Soul Bag). While on the Ethereal Plane, the hag casts Dream, us- ing the same spellcasting ability as Spellcasting. Only the hag can serve as the spell’s messenger, and the tar- get must be a creature the hag can see on the Material",
+                "Usage": ""
+            },
+            {
+                "Name": "Plane",
+                "Content": "The spell fails and is wasted if the target is under the effect of the Protection from Evil and Good spell or within a Magic Circle spell. If the target takes damage from the Dream spell, the target’s Hit Point maximum decreases by an amount equal to that damage. If the spell kills the target, its soul is trapped in the hag’s soul bag, and the target can’t be raised from the dead until its soul is released.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The hag casts one of the following spells, requiring no Material components and using Intelli- gence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Etherealness, Magic Missile (level 4 version) 2/Day Each: Phantasmal Killer, Plane Shift (self only)",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The hag shape-shifts into a Small or Me- dium Humanoid, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or carrying isn’t transformed. Nightmare Nightmare",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Nightmare": {
+        "Id": "Nightmare",
+        "Name": "Nightmare",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend, Neutral Evil",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d10 + 24)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft.",
+            "Fly 90 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 13,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Understands Abyssal",
+            "Common",
+            "and Infernal but can’t speak"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Confer Fire Resistance",
+                "Content": "The nightmare can grant Re- sistance to Fire damage to a rider while it is on the nightmare.",
+                "Usage": ""
+            },
+            {
+                "Name": "Illumination",
+                "Content": "The nightmare sheds Bright Light in a 10- foot radius and Dim Light for an additional 10 feet.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage plus 10 (3d6) Fire damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Ethereal Stride",
+                "Content": "The nightmare and up to three willing creatures within 5 feet of it teleport to the Ethereal",
+                "Usage": ""
+            },
+            {
+                "Name": "Plane from the Material Plane or vice versa",
+                "Content": "312 Noble Noble",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+6",
+                "Damage": "2d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Noble": {
+        "Id": "Noble",
+        "Name": "Noble",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d8)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 12,
+            "Con": 11,
+            "Int": 12,
+            "Wis": 14,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 4
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus two other languages"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rapier",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The noble is hit by a melee attack roll while holding a weapon. Response: The noble adds 2 to its AC against that attack, possibly causing it to miss. Ochre Jelly Ochre Jelly",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rapier",
+                "ToHit": "+3",
+                "Damage": "1d8 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ochre Jelly": {
+        "Id": "Ochre Jelly",
+        "Name": "Ochre Jelly",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Ooze, Unaligned",
+        "HP": {
+            "Value": 52,
+            "Notes": "(7d10 + 14)"
+        },
+        "AC": {
+            "Value": 8,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 6,
+            "Con": 14,
+            "Int": 2,
+            "Wis": 6,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid"
+        ],
+        "DamageImmunities": [
+            "Lightning",
+            "Slashing"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Prone",
+            "Restrained"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amorphous",
+                "Content": "The jelly can move through a space as narrow as 1 inch without expending extra move- ment to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spider Climb",
+                "Content": "The jelly can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Pseudopod",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 12 (3d6 + 2) Acid damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Split",
+                "Content": "Trigger: While the jelly is Large or Medium and has 10+ Hit Points, it becomes Bloodied or is subjected to Lightning or Slashing damage. Response: The jelly splits into two new Ochre Jellies. Each new jelly is one size smaller than the original jelly and acts on its Initia- tive. The original jelly’s Hit Points are divided evenly between the new jellies (round down). Ogre Ogre",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Pseudopod",
+                "ToHit": "+4",
+                "Damage": "3d6 + 2",
+                "DamageType": "Acid"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ogre": {
+        "Id": "Ogre",
+        "Name": "Ogre",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Giant, Chaotic Evil",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d10 + 24)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 8,
+            "Con": 16,
+            "Int": 5,
+            "Wis": 7,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Giant"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Greatclub",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Javelin",
+                "Content": "Melee or Ranged Attack Roll: +6, reach 5 ft. or range 30/120 ft. Hit: 11 (2d6 + 4) Piercing damage. Oni Oni",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Greatclub",
+                "ToHit": "+6",
+                "Damage": "2d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Oni": {
+        "Id": "Oni",
+        "Name": "Oni",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend, Lawful Evil",
+        "HP": {
+            "Value": 119,
+            "Notes": "(14d10 + 42)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 30 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 11,
+            "Con": 16,
+            "Int": 14,
+            "Wis": 12,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            },
+            {
+                "Name": "Con",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 5
+            },
+            {
+                "Name": "Deception",
+                "Modifier": 8
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Giant"
+        ],
+        "Challenge": "7",
+        "Traits": [
+            {
+                "Name": "Regeneration",
+                "Content": "The oni regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The oni makes two Claw or Nightmare",
+                "Usage": ""
+            },
+            {
+                "Name": "Ray attacks",
+                "Content": "It can replace one attack with a use of",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "313",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 10 (1d12 + 4) Slashing damage plus 9 (2d8) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nightmare Ray",
+                "Content": "Ranged Attack Roll: +5, range 60 ft. Hit: 9 (2d6 + 2) Psychic damage, and the target has the Frightened condition until the start of the oni’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The oni shape-shifts into a Small or Me- dium Humanoid or a Large Giant, or it returns to its true form. Other than its size, its game statistics are the same in each form. Any equipment it is wearing or car- rying isn’t transformed.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The oni casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 13): 1/Day Each: Charm Person (level 2 version), Darkness, Gaseous Form, Sleep",
+                "Usage": ""
+            },
+            {
+                "Name": "Invisibility",
+                "Content": "The oni casts Invisibility on itself, requiring no spell components and using the same spellcasting ability as Spellcasting. Otyugh Otyugh",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+7",
+                "Damage": "1d12 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Otyugh": {
+        "Id": "Otyugh",
+        "Name": "Otyugh",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Aberration, Neutral",
+        "HP": {
+            "Value": 104,
+            "Notes": "(11d10 + 44)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 11,
+            "Con": 19,
+            "Int": 6,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Otyugh",
+            "telepathy 120 ft. (doesn’t allow the receiving creature to respond telepathically)"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The otyugh makes one Bite attack and two",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage, and the target has the Poisoned con- dition. Whenever the Poisoned target finishes a Long",
+                "Usage": ""
+            },
+            {
+                "Name": "Rest, it is subjected to the following effect",
+                "Content": "Constitution Saving Throw: DC 15. Failure: The target’s Hit Point maximum decreases by 5 (1d10) and doesn’t return to normal until the Poisoned condition ends on the target. Success: The Poisoned condition ends.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 13) from one of two tentacles",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle Slam",
+                "Content": "Constitution Saving Throw: DC 14, each creature Grappled by the otyugh. Failure: 16 (3d8 + 3) Bludgeoning damage, and the target has the Stunned condition until the start of the otyugh’s next turn. Suc- cess: Half damage only. Owlbear Owlbear",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "2d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Owlbear": {
+        "Id": "Owlbear",
+        "Name": "Owlbear",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 59,
+            "Notes": "(7d10 + 21)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 12,
+            "Con": 17,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The owlbear makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 14 (2d8 + 5) Slashing damage. Pegasus Pegasus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d8 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pegasus": {
+        "Id": "Pegasus",
+        "Name": "Pegasus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Chaotic Good",
+        "HP": {
+            "Value": 59,
+            "Notes": "(7d10 + 21)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft.",
+            "Fly 90 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 15,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Con",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Understands Celestial",
+            "Common",
+            "Elvish",
+            "and Sylvan but can’t speak"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage. Phase Spider Phase Spider",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+6",
+                "Damage": "1d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Phase Spider": {
+        "Id": "Phase Spider",
+        "Name": "Phase Spider",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(7d10 + 7)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 16,
+            "Con": 12,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Ethereal Sight",
+                "Content": "The spider can see 60 feet into the Ethe- real Plane while on the Material Plane and vice versa.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spider Climb",
+                "Content": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Web Walker",
+                "Content": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The spider makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage plus 9 (2d8) Poison damage. If this damage reduces the target to 0 Hit Points, the target becomes Stable, and it has the Poisoned condition for 1 hour. While Poisoned, the target also has the Paralyzed condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Ethereal Jaunt",
+                "Content": "The spider teleports from the Material",
+                "Usage": ""
+            },
+            {
+                "Name": "Plane to the Ethereal Plane or vice versa",
+                "Content": "Pirates Pirate",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pirate": {
+        "Id": "Pirate",
+        "Name": "Pirate",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 33,
+            "Notes": "(6d8 + 6)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 16,
+            "Con": 12,
+            "Int": 8,
+            "Wis": 12,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The pirate makes two Dagger attacks. It can replace one attack with a use of Enthrall- ing Panache.",
+                "Usage": ""
+            },
+            {
+                "Name": "Dagger",
+                "Content": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Enthralling Panache",
+                "Content": "Wisdom Saving Throw: DC 12, one creature the pirate can see within 30 feet. Failure: The target has the Charmed condition until the start of the pirate’s next turn. Pirate Captain",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Dagger",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pirate Captain": {
+        "Id": "Pirate Captain",
+        "Name": "Pirate Captain",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 84,
+            "Notes": "(13d8 + 26)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 18,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 14,
+            "Cha": 17
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 3
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Acrobatics",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The pirate makes three attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Rapier or Pistol in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Rapier",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage, and the pirate has Advantage on the next attack roll it makes before the end of this turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pistol",
+                "Content": "Ranged Attack Roll: +7 , range 30/90 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Riposte",
+                "Content": "Trigger: The pirate is hit by a melee attack roll while holding a weapon. Response: The pirate adds 3 to its AC against that attack, possibly causing it to miss. On a miss, the pirate makes one Rapier attack against the triggering creature if within range. Pit Fiend Pit Fiend",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rapier",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pit Fiend": {
+        "Id": "Pit Fiend",
+        "Name": "Pit Fiend",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Devil), Lawful Evil",
+        "HP": {
+            "Value": 337,
+            "Notes": "(27d10 + 189)"
+        },
+        "AC": {
+            "Value": 21,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 26,
+            "Dex": 14,
+            "Con": 24,
+            "Int": 22,
+            "Wis": 18,
+            "Cha": 24
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 10
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 19
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Infernal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "20",
+        "Traits": [
+            {
+                "Name": "Diabolical Restoration",
+                "Content": "If the pit fiend dies outside the Nine Hells, its body disappears in sulfurous smoke, and it gains a new body instantly, reviving with all its Hit",
+                "Usage": ""
+            },
+            {
+                "Name": "Points somewhere in the Nine Hells",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Fear Aura",
+                "Content": "The pit fiend emanates an aura in a 20- foot Emanation while it doesn’t have the Incapacitated condition. Wisdom Saving Throw: DC 21, any enemy that starts its turn in the aura. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this pit fiend’s aura for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the pit fiend fails a saving throw, it can choose to succeed instead.",
+                "Usage": "4/Day"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The pit fiend has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The pit fiend makes one Bite attack, two",
+                "Usage": ""
+            },
+            {
+                "Name": "Devilish Claw attacks, and one Fiery Mace attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 18 (3d6 + 8) Piercing damage. If the target is a creature, it must make the following saving throw. Constitution Saving Throw: DC 21. Failure: The target has the Poisoned condition. While Poisoned, the target can’t regain Hit Points and takes 21 (6d6) Poison damage at the start of each of its turns, and it repeats the save at the end of each of its turns, ending the effect on itself on a suc- cess. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            },
+            {
+                "Name": "Devilish Claw",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 26 (4d8 + 8) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiery Mace",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (4d6 + 8) Force damage plus 21 (6d6) Fire damage. Hellfire Spellcasting (Recharge 4–6). The pit fiend casts Fireball (level 5 version) twice, requiring no Mate- rial components and using Charisma as the spellcasting ability (spell save DC 21). It can replace one Fireball with Hold Monster (level 7 version) or Wall of Fire. Planetar Planetar",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+14",
+                "Damage": "3d6 + 8",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Planetar": {
+        "Id": "Planetar",
+        "Name": "Planetar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial (Angel), Lawful Good",
+        "HP": {
+            "Value": 262,
+            "Notes": "(21d10 + 147)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 120 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 24,
+            "Dex": 20,
+            "Con": 24,
+            "Int": 19,
+            "Wis": 22,
+            "Cha": 25
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened"
+        ],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 12
+            },
+            {
+                "Name": "Con",
+                "Modifier": 12
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 11
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 12
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "All",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "16",
+        "Traits": [
+            {
+                "Name": "Divine Awareness",
+                "Content": "The planetar knows if it hears a lie.",
+                "Usage": ""
+            },
+            {
+                "Name": "Exalted Restoration",
+                "Content": "If the planetar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in",
+                "Usage": ""
+            },
+            {
+                "Name": "Mount Celestia",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The planetar has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The planetar makes three Radiant Sword attacks or uses Holy Burst twice. Radiant Sword. Melee Attack Roll: +12, reach 10 ft. Hit: 14 (2d6 + 7) Slashing damage plus 18 (4d8) Radi- ant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Holy Burst",
+                "Content": "Dexterity Saving Throw: DC 20, each en- emy in a 20-foot-radius Sphere centered on a point the planetar can see within 120 feet. Failure: 24 (7d6) Radi- ant damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The planetar casts one of the following spells, requiring no Material components and using Charisma as spellcasting ability (spell save DC 20): At Will: Detect Evil and Good 1/Day Each: Commune, Control Weather, Dispel Evil and Good, Raise Dead",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The planetar casts Cure Wounds, Invisibility, Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting. 316 Priests Priest Acolyte",
+                "Usage": "2/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Radiant Sword",
+                "ToHit": "+12",
+                "Damage": "2d6 + 7",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Priest Acolyte": {
+        "Id": "Priest Acolyte",
+        "Name": "Priest Acolyte",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid (Cleric), Neutral",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 10,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 14,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Medicine",
+                "Modifier": 4
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Mace",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage plus 2 (1d4) Radiant damage. Radiant Flame. Ranged Attack Roll: +4, range 60 ft. Hit: 7 (2d6) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The priest casts one of the following spells, using Wisdom as the spellcasting ability: At Will: Light, Thaumaturgy",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The priest casts Bless, Healing Word, or Sanctuary, using the same spellcasting ability as Spellcasting. Priest",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Mace",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Priest": {
+        "Id": "Priest",
+        "Name": "Priest",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid (Cleric), Neutral",
+        "HP": {
+            "Value": 38,
+            "Notes": "(7d8 + 7)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 10,
+            "Con": 12,
+            "Int": 13,
+            "Wis": 16,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Medicine",
+                "Modifier": 7
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The priest makes two attacks, using Mace or Radiant Flame in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Mace",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage plus 5 (2d4) Radiant damage. Radiant Flame. Ranged Attack Roll: +5, range 60 ft. Hit: 11 (2d10) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The priest casts one of the following spells, using Wisdom as the spellcasting ability (spell save DC 13): At Will: Light, Thaumaturgy 1/Day: Spirit Guardians",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The priest casts Bless, Dispel Magic, Healing Word, or Lesser Restoration, using the same spellcasting ability as Spellcasting. Pseudodragon Pseudodragon",
+                "Usage": "3/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Mace",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pseudodragon": {
+        "Id": "Pseudodragon",
+        "Name": "Pseudodragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Dragon, Neutral Good",
+        "HP": {
+            "Value": 10,
+            "Notes": "(3d4 + 3)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "15 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 15,
+            "Con": 13,
+            "Int": 10,
+            "Wis": 12,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common and Draconic but can’t speak"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The pseudodragon has Advan- tage on saving throws against spells and other magi- cal effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The pseudodragon makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sting",
+                "Content": "Constitution Saving Throw: DC 12, one creature the pseudodragon can see within 5 feet. Failure: 5 (2d4) Poison damage, and the target has the Poisoned condi- tion for 1 hour. Failure by 5 or More: While Poisoned, the target also has the Unconscious condition, which ends early if the target takes damage or a creature within 5 feet of it takes an action to wake it. Purple Worm Purple Worm",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Purple Worm": {
+        "Id": "Purple Worm",
+        "Name": "Purple Worm",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Monstrosity, Unaligned",
+        "HP": {
+            "Value": 247,
+            "Notes": "(15d20 + 90)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Burrow 50 ft."
+        ],
+        "Abilities": {
+            "Str": 28,
+            "Dex": 7,
+            "Con": 22,
+            "Int": 1,
+            "Wis": 8,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 11
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Tremorsense 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "15",
+        "Traits": [
+            {
+                "Name": "Tunneler",
+                "Content": "The worm can burrow through solid rock at half its Burrow Speed and leaves a 10-foot-diameter tunnel in its wake.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The worm makes one Bite attack and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail Stinger attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 22 (3d8 + 9) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 19), and it has the Restrained condition until the grapple ends.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail Stinger",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 16 (2d6 + 9) Piercing damage plus 35 (10d6) Poi- son damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the worm (it can have up to three creatures swallowed at a time). Failure: The tar- get is swallowed by the worm, and the Grappled con- dition ends. A swallowed creature has the Blinded and Restrained conditions, has Total Cover against attacks and other effects outside the worm, and takes 17 (5d6) Acid damage at the start of each of the worm’s turns. If the worm takes 30 damage or more on a single turn from a creature inside it, the worm must succeed on a DC 21 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the worm and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "If the worm dies, any swallowed crea- ture no longer has the Restrained condition and can escape from the corpse using 20 feet of movement, exiting Prone. Quasit Quasit",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+14",
+                "Damage": "3d8 + 9",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Quasit": {
+        "Id": "Quasit",
+        "Name": "Quasit",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 25,
+            "Notes": "(10d4)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 17,
+            "Con": 10,
+            "Int": 7,
+            "Wis": 10,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The quasit has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage, and the target has the Poisoned con- dition until the start of the quasit’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Invisibility",
+                "Content": "The quasit casts Invisibility on itself, requir- ing no spell components and using Charisma as the spellcasting ability.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scare",
+                "Content": "Wisdom Saving Throw: DC 10, one creature within 20 feet. Failure: The target has the",
+                "Usage": "1/Day"
+            },
+            {
+                "Name": "Frightened condition",
+                "Content": "At the end of each of its turns, the target repeats the save, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The quasit shape-shifts to resemble a bat (Speed 10 ft., Fly 40 ft.), a centipede (40 ft., Climb 40 ft.), or a toad (40 ft., Swim 40 ft.), or it returns to its true form. Its game statistics are the same in each form, except for its Speed. Any equipment it is wearing or carrying isn’t transformed. Rakshasa Rakshasa",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Rakshasa": {
+        "Id": "Rakshasa",
+        "Name": "Rakshasa",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Lawful Evil",
+        "HP": {
+            "Value": 221,
+            "Notes": "(26d8 + 104)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 17,
+            "Con": 18,
+            "Int": 13,
+            "Wis": 16,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [
+            "Piercing damage from weapons wielded by creatures under the effect of a Bless spell"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 10
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 8
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [
+            "Truesight 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Infernal"
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Greater Magic Resistance",
+                "Content": "The rakshasa automatically succeeds on saving throws against spells and other magical effects, and the attack rolls of spells automat- ically miss it. Without the rakshasa’s permission, no spell can observe the rakshasa remotely or detect its thoughts, creature type, or alignment.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiendish Restoration",
+                "Content": "If the rakshasa dies outside the Nine Hells, its body turns to ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Nine Hells.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The rakshasa makes three Cursed",
+                "Usage": ""
+            },
+            {
+                "Name": "Touch attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Cursed Touch",
+                "Content": "Melee Attack Roll: +10, reach 5 ft. Hit: 12 (2d6 + 5) Slashing damage plus 19 (3d12) Necrotic damage. If the target is a creature, it is cursed. While cursed, the target gains no benefit from finishing a",
+                "Usage": ""
+            },
+            {
+                "Name": "Short or Long Rest",
+                "Content": "Baleful Command (Recharge 5–6). Wisdom Saving Throw: DC 18, each enemy in a 30-foot Emanation orig- inating from the rakshasa. Failure: 28 (8d6) Psychic dam- age, and the target has the Frightened and Incapacitated conditions until the start of the rakshasa’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The rakshasa casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 18): At Will: Detect Magic, Detect Thoughts, Disguise Self, Mage Hand, Minor Illusion 1/Day Each: Fly, Invisibility, Major Image, Plane Shift Red Dragons Red Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Cursed Touch",
+                "ToHit": "+10",
+                "Damage": "2d6 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Red Dragon Wyrmling": {
+        "Id": "Red Dragon Wyrmling",
+        "Name": "Red Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 75,
+            "Notes": "(10d8 + 30)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Slashing damage plus 3 (1d6) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 13, each creature in a 15-foot Cone",
+                "Content": "Failure: 24 (7d6) Fire damage. Success: Half damage. Young Red Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Red Dragon": {
+        "Id": "Young Red Dragon",
+        "Name": "Young Red Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 178,
+            "Notes": "(17d10 + 85)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 10,
+            "Con": 21,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 19
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "10",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 3 (1d6) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 17 , each creature in a 30-foot Cone",
+                "Content": "Failure: 56 (16d6) Fire damage. Success: Half damage. Adult Red Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+10",
+                "Damage": "2d6 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Red Dragon": {
+        "Id": "Adult Red Dragon",
+        "Name": "Adult Red Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 256,
+            "Notes": "(19d12 + 133)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 10,
+            "Con": 25,
+            "Int": 16,
+            "Wis": 13,
+            "Cha": 23
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 13
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "17",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Ray",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 13 (1d10 + 8) Slashing damage plus 5 (2d4) Fire damage. 319 Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 21, each creature in a 60-foot Cone",
+                "Content": "Failure: 59 (17d6) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 20, +12 to hit with spell attacks): At Will: Command (level 2 version), Detect Magic, Scorching Ray 1/Day: Fireball",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Commanding Presence",
+                "Content": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiery Rays",
+                "Content": "The dragon uses Spellcasting to cast Scorch- ing Ray. The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Ancient Red Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+14",
+                "Damage": "1d10 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Red Dragon": {
+        "Id": "Ancient Red Dragon",
+        "Name": "Ancient Red Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 507,
+            "Notes": "(26d20 + 234)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 30,
+            "Dex": 10,
+            "Con": 29,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 27
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 16
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "24",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Spellcasting to cast",
+                "Usage": ""
+            },
+            {
+                "Name": "Scorching Ray",
+                "Content": "",
+                "Usage": "level 3 version"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +17 , reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 10 (3d6) Fire damage. Fire Breath (Recharge 5–6). Dexterity Saving Throw:",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 24, each creature in a 90-foot Cone",
+                "Content": "Failure: 91 (26d6) Fire damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): At Will: Command (level 2 version), Detect Magic, Scorching Ray (level 3 version) 1/Day Each: Fireball (level 6 version), Scrying",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Commanding Presence",
+                "Content": "The dragon uses Spellcasting to cast Command (level 2 version). The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiery Rays",
+                "Content": "The dragon uses Spellcasting to cast Scorch- ing Ray (level 3 version). The dragon can’t take this ac- tion again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Remorhaz Remorhaz",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+17",
+                "Damage": "2d8 + 10",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Remorhaz": {
+        "Id": "Remorhaz",
+        "Name": "Remorhaz",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Monstrosity, Unaligned",
+        "HP": {
+            "Value": 195,
+            "Notes": "(17d12 + 85)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 30 ft."
+        ],
+        "Abilities": {
+            "Str": 24,
+            "Dex": 13,
+            "Con": 21,
+            "Int": 4,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold",
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft.",
+            "Tremorsense 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "11",
+        "Traits": [
+            {
+                "Name": "Heat Aura",
+                "Content": "At the end of each of the remorhaz’s turns, each creature in a 5-foot Emanation originating from the remorhaz takes 16 (3d10) Fire damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage plus 14 (4d6) Fire damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17), and it has the Restrained condition until the grapple ends.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "Strength Saving Throw: DC 19, one Large or smaller creature Grappled by the remorhaz (it can have up to two creatures swallowed at a time). Failure: The target is swallowed by the remorhaz, and the Grappled condition ends. A swallowed creature has the Blinded 320 and Restrained conditions, it has Total Cover against attacks and other effects outside the remorhaz, and it takes 10 (3d6) Acid damage plus 10 (3d6) Fire damage at the start of each of the remorhaz’s turns. If the remorhaz takes 30 damage or more on a single turn from a creature inside it, the remorhaz must suc- ceed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 5 feet of the remorhaz and has the Prone condition. If the remorhaz dies, any swallowed creature no longer has the Restrained condi- tion and can escape from the corpse by using 15 feet of movement, exiting Prone. Roc Roc",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+11",
+                "Damage": "2d10 + 7",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Roc": {
+        "Id": "Roc",
+        "Name": "Roc",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Monstrosity, Unaligned",
+        "HP": {
+            "Value": 248,
+            "Notes": "(16d20 + 80)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 120 ft."
+        ],
+        "Abilities": {
+            "Str": 28,
+            "Dex": 10,
+            "Con": 20,
+            "Int": 3,
+            "Wis": 10,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "11",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The roc makes two Beak attacks. It can replace one attack with a Talons attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +13, reach 10 ft. Hit: 28 (3d12 + 9) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Talons",
+                "Content": "Melee Attack Roll: +13, reach 5 ft. Hit: 23 (4d6 + 9) Slashing damage. If the target is a Huge or smaller creature, it has the Grappled condition (escape DC 19) from both talons, and it has the Restrained condition until the grapple ends.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beak",
+                "ToHit": "+13",
+                "Damage": "3d12 + 9",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Roper": {
+        "Id": "Roper",
+        "Name": "Roper",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Aberration, Neutral Evil",
+        "HP": {
+            "Value": 93,
+            "Notes": "(11d10 + 33)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 8,
+            "Con": 17,
+            "Int": 7,
+            "Wis": 16,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The roper can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The roper makes two Tentacle attacks, uses Reel, and makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 17 (3d8 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tentacle",
+                "Content": "Melee Attack Roll: +7 , reach 60 ft. Hit: The target has the Grappled condition (escape DC 14) from one of six tentacles, and the target has the Poisoned condition until the grapple ends. The tentacle can be damaged, freeing a creature it has Grappled when destroyed (AC 20, HP 10, Immunity to Poison and Psychic damage). Damaging the tentacle deals no damage to the roper, and a destroyed tentacle regrows at the start of the roper’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Reel",
+                "Content": "The roper pulls each creature Grappled by it up to 30 feet straight toward it. Rust Monster Rust Monster",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "3d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Rust Monster": {
+        "Id": "Rust Monster",
+        "Name": "Rust Monster",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Monstrosity, Unaligned",
+        "HP": {
+            "Value": 33,
+            "Notes": "(6d8 + 6)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Iron Scent",
+                "Content": "The rust monster can pinpoint the location of ferrous metal within 30 feet of itself.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The rust monster makes one Bite attack and uses Antennae twice.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Piercing damage. 321",
+                "Usage": ""
+            },
+            {
+                "Name": "Antennae",
+                "Content": "The rust monster targets one nonmagical metal object—armor or a weapon—worn or carried by a creature within 5 feet of itself. Dexterity Saving Throw: DC 11, the creature with the object. Failure: The object takes a −1 penalty to the AC it offers (ar- mor) or to its attack rolls (weapon). Armor is destroyed if the penalty reduces its AC to 10, and a weapon is destroyed if its penalty reaches −5. The penalty can be removed by casting the Mending spell on the armor or weapon.",
+                "Usage": ""
+            },
+            {
+                "Name": "Destroy Metal",
+                "Content": "The rust monster touches a nonmagi- cal metal object within 5 feet of itself that isn’t being worn or carried. The touch destroys a 1-foot Cube of the object.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Reflexive Antennae",
+                "Content": "Trigger: An attack roll hits the rust monster. Response: The rust monster uses Antennae. Sahuagin Sahuagin Warrior",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+3",
+                "Damage": "1d8 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sahuagin Warrior": {
+        "Id": "Sahuagin Warrior",
+        "Name": "Sahuagin Warrior",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Lawful Evil",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d8 + 4)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "straight toward an enemy it can see."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 11,
+            "Con": 12,
+            "Int": 12,
+            "Wis": 13,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Cold"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Sahuagin"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Blood Frenzy",
+                "Content": "The sahuagin has Advantage on at- tack rolls against any creature that doesn’t have all its",
+                "Usage": ""
+            },
+            {
+                "Name": "Limited Amphibiousness",
+                "Content": "The sahuagin can breathe air and water, but it must be submerged at least once every 4 hours to avoid suffocating outside water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shark Telepathy",
+                "Content": "The sahuagin can magically control sharks within 120 feet of itself, using a special telepathy.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The sahuagin makes two Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Aquatic Charge",
+                "Content": "The sahuagin swims up to its Swim",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Salamander": {
+        "Id": "Salamander",
+        "Name": "Salamander",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral Evil",
+        "HP": {
+            "Value": 90,
+            "Notes": "(12d10 + 24)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 15,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [
+            "Cold"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Fire"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Ignan)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Fire Aura",
+                "Content": "At the end of each of the salamander’s turns, each creature of the salamander’s choice in a 5-foot Emanation originating from the salamander takes 7 (2d6) Fire damage.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The salamander makes two Flame",
+                "Usage": ""
+            },
+            {
+                "Name": "Spear attacks",
+                "Content": "It can replace one attack with a use of",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Flame Spear",
+                "Content": "Melee or Ranged Attack Roll: +7 , reach 5 ft. or range 20/60 ft. Hit: 13 (2d8 + 4) Piercing damage plus 7 (2d6) Fire damage. Hit or Miss: The spear magi- cally returns to the salamander’s hand immediately after a ranged attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 15, one Large or smaller creature the salamander can see within 10 feet. Failure: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Fire damage. The target has the Grappled condition (es- cape DC 14), and it has the Restrained condition until the grapple ends. Satyr Satyr",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Flame Spear",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Satyr": {
+        "Id": "Satyr",
+        "Name": "Satyr",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey, Chaotic Neutral",
+        "HP": {
+            "Value": 31,
+            "Notes": "(7d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 16,
+            "Con": 11,
+            "Int": 12,
+            "Wis": 10,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Performance",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The satyr has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage. If the target is a Medium or smaller creature, the satyr pushes the target up to 10 feet straight away from itself.",
+                "Usage": ""
+            },
+            {
+                "Name": "Mockery",
+                "Content": "Wisdom Saving Throw: DC 12, one creature the satyr can see within 90 feet. Failure: 5 (1d6 + 2) Psychic damage. Scout Scout",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Scout": {
+        "Id": "Scout",
+        "Name": "Scout",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 16,
+            "Notes": "(3d8 + 3)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 11,
+            "Wis": 13,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Nature",
+                "Modifier": 4
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The scout makes two attacks, using Shorts- word and Longbow in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortsword",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage. Sea Hag Sea Hag",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shortsword",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sea Hag": {
+        "Id": "Sea Hag",
+        "Name": "Sea Hag",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fey, Chaotic Evil",
+        "HP": {
+            "Value": 52,
+            "Notes": "(7d8 + 21)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 16,
+            "Int": 12,
+            "Wis": 12,
+            "Cha": 13
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Giant",
+            "Primordial (Aquan)"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The hag can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Coven Magic",
+                "Content": "While within 30 feet of at least two hag allies, the hag can cast one of the following spells, requiring no Material components, using the spell’s normal casting time, and using Intelligence as the spell- casting ability (spell save DC 11): Augury, Find Familiar, Identify, Locate Object, Scrying, or Unseen Servant. The hag must finish a Long Rest before using this trait to cast that spell again.",
+                "Usage": ""
+            },
+            {
+                "Name": "Vile Appearance",
+                "Content": "Wisdom Saving Throw: DC 11, any Beast or Humanoid that starts its turn within 30 feet of the hag and can see the hag’s true form. Failure: The target has the Frightened condition until the start of its next turn. Success: The target is immune to this hag’s",
+                "Usage": ""
+            },
+            {
+                "Name": "Vile Appearance for 24 hours",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. Death Glare (Recharge 5–6). Wisdom Saving Throw: DC 11, one Frightened creature the hag can see within 30 feet. Failure: If the target has 20 Hit Points or fewer, it drops to 0 Hit Points. Otherwise, the target takes 13 (3d8) Psychic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Illusory Appearance",
+                "Content": "The hag casts Disguise Self, using Constitution as the spellcasting ability (spell save DC 13). The spell’s duration is 24 hours. Shadow Shadow",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Shadow": {
+        "Id": "Shadow",
+        "Name": "Shadow",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Chaotic Evil",
+        "HP": {
+            "Value": 27,
+            "Notes": "(5d8 + 5)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 14,
+            "Con": 13,
+            "Int": 6,
+            "Wis": 10,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [
+            "Radiant"
+        ],
+        "DamageResistances": [
+            "Acid",
+            "Cold",
+            "Fire",
+            "Lightning",
+            "Thunder"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Amorphous",
+                "Content": "The shadow can move through a space as narrow as 1 inch without expending extra move- ment to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight Weakness",
+                "Content": "While in sunlight, the shadow has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on D20 Tests",
+                "Content": "323",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Draining Swipe",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Necrotic damage, and the target’s Strength score decreases by 1d4. The target dies if this reduces that score to 0. If a Humanoid is slain by this attack, a",
+                "Usage": ""
+            },
+            {
+                "Name": "Shadow rises from the corpse 1d4 hours later",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Shadow Stealth",
+                "Content": "While in Dim Light or Darkness, the shadow takes the Hide action. Shambling Mound Shambling Mound",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Draining Swipe",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Shambling Mound": {
+        "Id": "Shambling Mound",
+        "Name": "Shambling Mound",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Plant, Unaligned",
+        "HP": {
+            "Value": 110,
+            "Notes": "(13d10 + 39)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 20 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 8,
+            "Con": 16,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire"
+        ],
+        "DamageImmunities": [
+            "Lightning"
+        ],
+        "ConditionImmunities": [
+            "Deafened",
+            "Exhaustion"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Lightning Absorption",
+                "Content": "Whenever the shambling mound is subjected to Lightning damage, it regains a number of",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The shambling mound makes three",
+                "Usage": ""
+            },
+            {
+                "Name": "Charged Tendril attacks",
+                "Content": "It can replace one attack with a use of Engulf.",
+                "Usage": ""
+            },
+            {
+                "Name": "Charged Tendril",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 7 (1d6 + 4) Bludgeoning damage plus 5 (2d4) Lightning damage. If the target is a Medium or smaller creature, the shambling mound pulls the target 5 feet straight toward itself.",
+                "Usage": ""
+            },
+            {
+                "Name": "Engulf",
+                "Content": "Strength Saving Throw: DC 15, one Medium or smaller creature within 5 feet. Failure: The target is pulled into the shambling mound’s space and has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Grappled condition",
+                "Content": "Until the grapple ends, the target has the Blinded and Restrained con- ditions, and it takes 10 (3d6) Lightning damage at the start of each of its turns. When the shambling mound moves, the Grappled target moves with it, costing it no extra movement. The shambling mound can have only one creature Grappled by this action at a time. Shield Guardian Shield Guardian",
+                "Usage": "escape DC 14"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Charged Tendril",
+                "ToHit": "+7",
+                "Damage": "1d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Shield Guardian": {
+        "Id": "Shield Guardian",
+        "Name": "Shield Guardian",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 142,
+            "Notes": "(15d10 + 60)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 8,
+            "Con": 18,
+            "Int": 7,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands commands given in any language but can’t speak"
+        ],
+        "Challenge": "7",
+        "Traits": [
+            {
+                "Name": "Bound",
+                "Content": "The guardian is magically bound to an amulet. While the guardian and its amulet are on the same plane of existence, the amulet’s wearer can telepathi- cally call the guardian to travel to it, and the guardian knows the distance and direction to the amulet. If the guardian is within 60 feet of the amulet’s wearer, half of any damage the wearer takes (round up) is transferred to the guardian.",
+                "Usage": ""
+            },
+            {
+                "Name": "Regeneration",
+                "Content": "The guardian regains 10 Hit Points at the start of each of its turns if it has at least 1 Hit Point.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spell Storing",
+                "Content": "A spellcaster who wears the guardian’s amulet can cause the guardian to store one spell of level 4 or lower. To do so, the wearer must cast the spell on the guardian while within 5 feet of it. The spell has no effect but is stored within the guardian. Any previously stored spell is lost when a new spell is stored. The guardian can cast the spell stored with any parameters set by the original caster, requiring no spell components and using the caster’s spellcasting ability.",
+                "Usage": ""
+            },
+            {
+                "Name": "The stored spell is then lost",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The guardian makes two Fist attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fist",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 7 (2d6) Force damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Protection",
+                "Content": "Trigger: An attack roll hits the wearer of the guardian’s amulet while the wearer is within 5 feet of the guardian. Response: The wearer gains a +5 bonus to AC, including against the triggering attack and pos- sibly causing it to miss, until the start of the guardian’s next turn. 324 Silver Dragons Silver Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Fist",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Silver Dragon Wyrmling": {
+        "Id": "Silver Dragon Wyrmling",
+        "Name": "Silver Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d8 + 18)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 12,
+            "Wis": 11,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (1d10 + 4) Piercing damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Breath",
+                "Content": "Constitution Saving Throw: DC 13, each creature in a 15-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The tar- get has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. Young Silver Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young Silver Dragon": {
+        "Id": "Young Silver Dragon",
+        "Name": "Young Silver Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 168,
+            "Notes": "(16d10 + 80)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 10,
+            "Con": 21,
+            "Int": 14,
+            "Wis": 11,
+            "Cha": 19
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 6
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "9",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of Paralyzing Breath.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 15 (2d8 + 6) Slashing damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 17 , each creature in a 30-foot Cone. Failure: 49 (11d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Breath",
+                "Content": "Constitution Saving Throw: DC 17 , each creature in a 30-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The tar- get has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically. Adult Silver Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+10",
+                "Damage": "2d8 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult Silver Dragon": {
+        "Id": "Adult Silver Dragon",
+        "Name": "Adult Silver Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 216,
+            "Notes": "(16d12 + 112)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 27,
+            "Dex": 10,
+            "Con": 25,
+            "Int": 16,
+            "Wis": 13,
+            "Cha": 22
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 8
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "16",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyzing",
+                "Usage": ""
+            },
+            {
+                "Name": "Breath or",
+                "Content": "",
+                "Usage": "B Spellcasting to cast Ice Knife"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +13, reach 10 ft. Hit: 17 (2d8 + 8) Slashing damage plus 4 (1d8) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. Fail- ure: 54 (12d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Breath",
+                "Content": "Constitution Saving Throw: DC 20, each creature in a 60-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The tar- get has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 19, +11 to hit with spell attacks): 325 At Will: Detect Magic, Hold Monster, Ice Knife, Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Ice Storm (level 5 version), Zone of Truth",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Chill",
+                "Content": "The dragon uses Spellcasting to cast Hold Mon- ster. The dragon can’t take this action again until the start of its next turn. Cold Gale. Dexterity Saving Throw: DC 19, each crea- ture in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half dam- age only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Ancient Silver Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+13",
+                "Damage": "2d8 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient Silver Dragon": {
+        "Id": "Ancient Silver Dragon",
+        "Name": "Ancient Silver Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Metallic), Lawful Good",
+        "HP": {
+            "Value": 468,
+            "Notes": "(24d20 + 216)"
+        },
+        "AC": {
+            "Value": 22,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 30,
+            "Dex": 10,
+            "Con": 29,
+            "Int": 18,
+            "Wis": 15,
+            "Cha": 26
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 7
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "History",
+                "Modifier": 11
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 16
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "23",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks. It can replace one attack with a use of (A) Paralyz- ing Breath or (B) Spellcasting to cast Ice Knife (level 2 version).",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +17 , reach 15 ft. Hit: 19 (2d8 + 10) Slashing damage plus 9 (2d8) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. Fail- ure: 67 (15d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Paralyzing Breath",
+                "Content": "Constitution Saving Throw: DC 24, each creature in a 90-foot Cone. First Failure: The target has the Incapacitated condition until the end of its next turn, when it repeats the save. Second Failure: The tar- get has the Paralyzed condition, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The dragon casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 23, +15 to hit with spell attacks): At Will: Detect Magic, Hold Monster, Ice Knife (level 2 version), Shapechange (Beast or Humanoid form only, no Temporary Hit Points gained from the spell, and no Concentration or Temporary Hit Points required to maintain the spell) 1/Day Each: Control Weather, Ice Storm (level 7 ver- sion), Teleport, Zone of Truth",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Chill",
+                "Content": "The dragon uses Spellcasting to cast Hold Mon- ster. The dragon can’t take this action again until the start of its next turn. Cold Gale. Dexterity Saving Throw: DC 23, each crea- ture in a 60-foot-long, 10-foot-wide Line. Failure: 14 (4d6) Cold damage, and the target is pushed up to 30 feet straight away from the dragon. Success: Half dam- age only. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Skeletons Skeleton",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+17",
+                "Damage": "2d8 + 10",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Skeleton": {
+        "Id": "Skeleton",
+        "Name": "Skeleton",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Lawful Evil",
+        "HP": {
+            "Value": 13,
+            "Notes": "(2d8 + 4)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 16,
+            "Con": 15,
+            "Int": 6,
+            "Wis": 8,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [
+            "Bludgeoning"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common plus one other language but can’t speak"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Shortsword",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shortbow",
+                "Content": "Ranged Attack Roll: +5, range 80/320 ft. Hit: 6 (1d6 + 3) Piercing damage. Warhorse Skeleton",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shortsword",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Warhorse Skeleton": {
+        "Id": "Warhorse Skeleton",
+        "Name": "Warhorse Skeleton",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Undead, Lawful Evil",
+        "HP": {
+            "Value": 22,
+            "Notes": "(3d10 + 6)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 12,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 8,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [
+            "Bludgeoning"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 7 (1d6 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target has the Prone condition. Minotaur Skeleton",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+6",
+                "Damage": "1d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Minotaur Skeleton": {
+        "Id": "Minotaur Skeleton",
+        "Name": "Minotaur Skeleton",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Undead, Lawful Evil",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 11,
+            "Con": 15,
+            "Int": 6,
+            "Wis": 8,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [
+            "Bludgeoning"
+        ],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Abyssal but can’t speak"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller creature and the skeleton moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Bludgeoning damage. Solar Solar",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Solar": {
+        "Id": "Solar",
+        "Name": "Solar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial (Angel), Lawful Good",
+        "HP": {
+            "Value": 297,
+            "Notes": "(22d10 + 176)"
+        },
+        "AC": {
+            "Value": 21,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Fly 150 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 26,
+            "Dex": 22,
+            "Con": 26,
+            "Int": 25,
+            "Wis": 25,
+            "Cha": 30
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison",
+            "Radiant"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 14
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "All",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "21",
+        "Traits": [
+            {
+                "Name": "Divine Awareness",
+                "Content": "The solar knows if it hears a lie.",
+                "Usage": ""
+            },
+            {
+                "Name": "Exalted Restoration",
+                "Content": "If the solar dies outside Mount Celestia, its body disappears, and it gains a new body instantly, reviving with all its Hit Points somewhere in",
+                "Usage": ""
+            },
+            {
+                "Name": "Mount Celestia",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the solar fails a saving throw, it can choose to succeed instead.",
+                "Usage": "4/Day"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The solar has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The solar makes two Flying Sword attacks. It can replace one attack with a use of Slaying Bow.",
+                "Usage": ""
+            },
+            {
+                "Name": "Flying Sword",
+                "Content": "Melee or Ranged Attack Roll: +15, reach 10 ft. or range 120 ft. Hit: 22 (4d6 + 8) Slashing damage plus 36 (8d8) Radiant damage. Hit or Miss: The sword magically returns to the solar’s hand or hovers within 5 feet of the solar immediately after a ranged attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slaying Bow",
+                "Content": "Dexterity Saving Throw: DC 21, one crea- ture the solar can see within 600 feet. Failure: If the creature has 100 Hit Points or fewer, it dies. It other- wise takes 24 (4d8 + 6) Piercing damage plus 36 (8d8) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The solar casts one of the following spells, requiring no Material components and using Charisma as the spellcasting ability (spell save DC 25): At Will: Detect Evil and Good 1/Day Each: Commune, Control Weather, Dispel Evil and Good, Resurrection",
+                "Usage": ""
+            },
+            {
+                "Name": "Divine Aid",
+                "Content": "The solar casts Cure Wounds (level 2 version), Lesser Restoration, or Remove Curse, using the same spellcasting ability as Spellcasting. 327",
+                "Usage": "3/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Blinding Gaze",
+                "Content": "Constitution Saving Throw: DC 25, one creature the solar can see within 120 feet. Failure: The target has the Blinded condition for 1 minute. Failure or Success: The solar can’t take this action again until the start of its next turn. Radiant Teleport. The solar teleports up to 60 feet to an unoccupied space it can see. Dexterity Saving Throw: DC 25, each creature in a 10-foot Emanation originat- ing from the solar at its destination space. Failure: 11 (2d10) Radiant damage. Success: Half damage. Specter Specter",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Flying Sword",
+                "ToHit": "+15",
+                "Damage": "4d6 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Specter": {
+        "Id": "Specter",
+        "Name": "Specter",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Chaotic Evil",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 50 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 1,
+            "Dex": 14,
+            "Con": 11,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Bludgeoning",
+            "Cold",
+            "Fire",
+            "Lightning",
+            "Piercing",
+            "Slashing",
+            "Thunder"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common plus one other language but can’t speak"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Incorporeal Movement",
+                "Content": "The specter can move through other creatures and objects as if they were Difficult",
+                "Usage": ""
+            },
+            {
+                "Name": "Terrain",
+                "Content": "It takes 5 (1d10) Force damage if it ends its turn inside an object.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight Sensitivity",
+                "Content": "While in sunlight, the specter has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Life Drain",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d6) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken. Sphinxes Sphinx of Wonder",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Life Drain",
+                "ToHit": "+4",
+                "Damage": "2d6",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sphinx of Wonder": {
+        "Id": "Sphinx of Wonder",
+        "Name": "Sphinx of Wonder",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Celestial, Lawful Good",
+        "HP": {
+            "Value": 24,
+            "Notes": "(7d4 + 7)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 17,
+            "Con": 13,
+            "Int": 15,
+            "Wis": 12,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Psychic",
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 4
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "Common"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Magic Resistance",
+                "Content": "The sphinx has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 7 (2d6) Radiant damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Burst of Ingenuity",
+                "Content": "Trigger: The sphinx or an- other creature within 30 feet makes an ability check or a saving throw. Response: The sphinx adds 2 to the roll. Sphinx of Lore",
+                "Usage": "2/Day"
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sphinx of Lore": {
+        "Id": "Sphinx of Lore",
+        "Name": "Sphinx of Lore",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Lawful Neutral",
+        "HP": {
+            "Value": 170,
+            "Notes": "(20d10 + 60)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 18,
+            "Wis": 18,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Radiant"
+        ],
+        "DamageImmunities": [
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 12
+            },
+            {
+                "Name": "History",
+                "Modifier": 12
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 8
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 12
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "Common"
+        ],
+        "Challenge": "11",
+        "Traits": [
+            {
+                "Name": "Inscrutable",
+                "Content": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sin- cerity are made with Disadvantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the sphinx fails a saving throw, it can choose to suc- ceed instead. 328",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The sphinx makes three Claw attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 14 (3d6 + 4) Slashing damage. Mind-Rending Roar (Recharge 5–6). Wisdom Saving Throw: DC 16, each enemy in a 300-foot Emanation originating from the sphinx. Failure: 35 (10d6) Psychic damage, and the target has the Incapacitated condition until the start of the sphinx’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The sphinx casts one of the following spells, requiring no Material components and using In- telligence as the spellcasting ability (spell save DC 16): At Will: Detect Magic, Identify, Mage Hand, Minor Illu- sion, Prestidigitation 1/Day Each: Dispel Magic, Legend Lore, Locate Object, Plane Shift, Remove Curse, Tongues",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Arcane Prowl",
+                "Content": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Weight of Years",
+                "Content": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure:",
+                "Usage": ""
+            },
+            {
+                "Name": "The target gains 1 Exhaustion level",
+                "Content": "While the target has any Exhaustion levels, it appears 3d10 years older. Fail- ure or Success: The sphinx can’t take this action again until the start of its next turn. Sphinx of Valor",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+8",
+                "Damage": "3d6 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sphinx of Valor": {
+        "Id": "Sphinx of Valor",
+        "Name": "Sphinx of Valor",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Lawful Neutral",
+        "HP": {
+            "Value": 199,
+            "Notes": "(19d10 + 95)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 10,
+            "Con": 20,
+            "Int": 16,
+            "Wis": 23,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Radiant"
+        ],
+        "DamageImmunities": [
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Con",
+                "Modifier": 11
+            },
+            {
+                "Name": "Int",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 12
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 12
+            },
+            {
+                "Name": "Religion",
+                "Modifier": 15
+            }
+        ],
+        "Senses": [
+            "Truesight 120 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "Common"
+        ],
+        "Challenge": "17",
+        "Traits": [
+            {
+                "Name": "Inscrutable",
+                "Content": "No magic can observe the sphinx remotely or detect its thoughts without its permission. Wisdom (Insight) checks made to ascertain its intentions or sin- cerity are made with Disadvantage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the sphinx fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The sphinx makes two Claw attacks and uses Roar.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +12, reach 5 ft. Hit: 20 (4d6 + 6) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Roar",
+                "Content": "The sphinx emits a magical roar. When- ever it roars, the roar has a different effect, as detailed below (the sequence resets when it takes a Long Rest):",
+                "Usage": "3/Day"
+            },
+            {
+                "Name": "First Roar",
+                "Content": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Frightened condition for 1 minute.",
+                "Usage": ""
+            },
+            {
+                "Name": "Second Roar",
+                "Content": "Wisdom Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: The target has the Paralyzed condi- tion, and it repeats the save at the end of each of its turns, ending the effect on itself on a success. After 1 minute, it succeeds automatically.",
+                "Usage": ""
+            },
+            {
+                "Name": "Third Roar",
+                "Content": "Constitution Saving Throw: DC 20, each enemy in a 500-foot Emanation originating from the sphinx. Failure: 44 (8d10) Thunder damage, and the target has the Prone condition. Success: Half damage only.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The sphinx casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 20): At Will: Detect Evil and Good, Thaumaturgy 1/Day Each: Detect Magic, Dispel Magic, Greater Res- toration, Heroes’ Feast, Zone of Truth",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Arcane Prowl",
+                "Content": "The sphinx can teleport up to 30 feet to an unoccupied space it can see, and it makes one",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Weight of Years",
+                "Content": "Constitution Saving Throw: DC 16, one creature the sphinx can see within 120 feet. Failure:",
+                "Usage": ""
+            },
+            {
+                "Name": "The target gains 1 Exhaustion level",
+                "Content": "While the target has any Exhaustion levels, it appears 3d10 years older. Fail- ure or Success: The sphinx can’t take this action again until the start of its next turn. 329 Spirit Naga Spirit Naga",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+12",
+                "Damage": "4d6 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Spirit Naga": {
+        "Id": "Spirit Naga",
+        "Name": "Spirit Naga",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend, Chaotic Evil",
+        "HP": {
+            "Value": 135,
+            "Notes": "(18d10 + 36)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 17,
+            "Con": 14,
+            "Int": 16,
+            "Wis": 15,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Con",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 5
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common"
+        ],
+        "Challenge": "8",
+        "Traits": [
+            {
+                "Name": "Fiendish Restoration",
+                "Content": "If it dies, the naga returns to life in 1d6 days and regains all its Hit Points. Only a Wish spell can prevent this trait from functioning.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The naga makes three attacks, using Bite or Necrotic Ray in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 7 (1d6 + 4) Piercing damage plus 14 (4d6) Poison damage. Necrotic Ray. Ranged Attack Roll: +6, range 60 ft. Hit: 21 (6d6) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The naga casts one of the following spells, requiring no Somatic or Material components and using Intelligence as the spellcasting ability (spell save DC 14): At Will: Detect Magic, Mage Hand, Minor Illusion, Wa- ter Breathing 2/Day Each: Detect Thoughts, Dimension Door, Hold Person (level 3 version), Lightning Bolt (level 4 version) Sprite Sprite",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "1d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Sprite": {
+        "Id": "Sprite",
+        "Name": "Sprite",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Fey, Neutral Good",
+        "HP": {
+            "Value": 10,
+            "Notes": "(4d4)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 18,
+            "Con": 10,
+            "Int": 14,
+            "Wis": 13,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 8
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Needle Sword",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Enchanting Bow",
+                "Content": "Ranged Attack Roll: +6, range 40/160 ft. Hit: 1 Piercing damage, and the target has the Charmed condition until the start of the sprite’s next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Heart Sight",
+                "Content": "Charisma Saving Throw: DC 10, one crea- ture within 5 feet the sprite can see (Celestials, Fiends, and Undead automatically fail the save). Failure: The sprite knows the target’s emotions and alignment.",
+                "Usage": ""
+            },
+            {
+                "Name": "Invisibility",
+                "Content": "The sprite casts Invisibility on itself, requir- ing no spell components and using Charisma as the spellcasting ability. Spy Spy",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Needle Sword",
+                "ToHit": "+6",
+                "Damage": "1d4 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Spy": {
+        "Id": "Spy",
+        "Name": "Spy",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 27,
+            "Notes": "(6d8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 12,
+            "Wis": 14,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 4
+            },
+            {
+                "Name": "Investigation",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Sleight of Hand",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Shortsword",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hand Crossbow",
+                "Content": "Ranged Attack Roll: +4, range 30/120 ft. Hit: 5 (1d6 + 2) Piercing damage plus 7 (2d6) Poi- son damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Cunning Action",
+                "Content": "The spy takes the Dash, Disengage, or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "Stirge Stirge",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shortsword",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Stirge": {
+        "Id": "Stirge",
+        "Name": "Stirge",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Monstrosity, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(2d4)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 40 ft."
+        ],
+        "Abilities": {
+            "Str": 4,
+            "Dex": 16,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 8,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Proboscis",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage, and the stirge attaches to the target. While attached, the stirge can’t make Proboscis attacks, and the target takes 5 (2d4) Necrotic damage at the start of each of the stirge’s turns. The stirge can detach itself by spending 5 feet of its movement. The target or a creature within 5 feet of it can detach the stirge as an action. Stone Giant Stone Giant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Proboscis",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Stone Giant": {
+        "Id": "Stone Giant",
+        "Name": "Stone Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Neutral",
+        "HP": {
+            "Value": 126,
+            "Notes": "(11d12 + 55)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 15,
+            "Con": 20,
+            "Int": 10,
+            "Wis": 12,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Con",
+                "Modifier": 8
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 12
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "7",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Stone",
+                "Usage": ""
+            },
+            {
+                "Name": "Club or Boulder in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Stone Club",
+                "Content": "Melee Attack Roll: +9, reach 15 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Boulder",
+                "Content": "Ranged Attack Roll: +9, range 60/240 ft. Hit: 15 (2d8 + 6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Stone Club",
+                "ToHit": "+9",
+                "Damage": "3d10 + 6",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Stone Golem": {
+        "Id": "Stone Golem",
+        "Name": "Stone Golem",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Construct, Unaligned",
+        "HP": {
+            "Value": 220,
+            "Notes": "(21d10 + 105)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 9,
+            "Con": 20,
+            "Int": 3,
+            "Wis": 11,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison",
+            "Psychic"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Frightened",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Understands Common plus two other",
+            "but can’t speak"
+        ],
+        "Challenge": "10",
+        "Traits": [
+            {
+                "Name": "Immutable Form",
+                "Content": "The golem can’t shape-shift.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The golem has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The golem makes two attacks, using Slam or Force Bolt in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +10, reach 5 ft. Hit: 15 (2d8 + 6) Bludgeoning damage plus 9 (2d8) Force damage. Force Bolt. Ranged Attack Roll: +9, range 120 ft. Hit: 22 (4d10) Force damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+10",
+                "Damage": "2d8 + 6",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Storm Giant": {
+        "Id": "Storm Giant",
+        "Name": "Storm Giant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Giant, Chaotic Good",
+        "HP": {
+            "Value": 230,
+            "Notes": "(20d12 + 100)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Fly 25 ft. (hover)",
+            "Swim 50 ft."
+        ],
+        "Abilities": {
+            "Str": 29,
+            "Dex": 14,
+            "Con": 20,
+            "Int": 16,
+            "Wis": 20,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [
+            "Lightning",
+            "Thunder"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 14
+            },
+            {
+                "Name": "Con",
+                "Modifier": 10
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 10
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Arcana",
+                "Modifier": 8
+            },
+            {
+                "Name": "Athletics",
+                "Modifier": 14
+            },
+            {
+                "Name": "History",
+                "Modifier": 8
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 10
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft.",
+            "Truesight 30 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Giant"
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The giant can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The giant makes two attacks, using Storm",
+                "Usage": ""
+            },
+            {
+                "Name": "Sword or Thunderbolt in any combination",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Storm Sword",
+                "Content": "Melee Attack Roll: +14, reach 10 ft. Hit: 23 (4d6 + 9) Slashing damage plus 13 (3d8) Light- ning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Thunderbolt",
+                "Content": "Ranged Attack Roll: +14, range 500 ft. Hit: 22 (2d12 + 9) Lightning damage, and the target has the Blinded and Deafened conditions until the start of the giant’s next turn. Lightning Storm (Recharge 5–6). Dexterity Saving Throw: DC 18, each creature in a 10-foot-radius, 40-foot-high Cylinder originating from a point the giant can see within 500 feet. Failure: 55 (10d10) Lightning damage. Success: Half damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The giant casts one of the following spells, requiring no Material components and using Wisdom as the spellcasting ability (spell save DC 18): At Will: Detect Magic, Light 1/Day: Control Weather Succubus Succubus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Storm Sword",
+                "ToHit": "+14",
+                "Damage": "4d6 + 9",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Succubus": {
+        "Id": "Succubus",
+        "Name": "Succubus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Fiend, Neutral Evil",
+        "HP": {
+            "Value": 71,
+            "Notes": "(13d8 + 13)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "is available only in its true form. Any equipment"
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 17,
+            "Con": 13,
+            "Int": 15,
+            "Wis": 12,
+            "Cha": 20
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Poison",
+            "Psychic"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Deception",
+                "Modifier": 9
+            },
+            {
+                "Name": "Insight",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 9
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "Common",
+            "Infernal",
+            "telepathy 60 ft."
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Incubus Form",
+                "Content": "When the succubus finishes a Long Rest, it can shape-shift into an Incubus, using that stat block instead of this one.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The succubus makes one Fiendish Touch attack and uses Charm or Draining Kiss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fiendish Touch",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 16 (2d10 + 5) Psychic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Charm",
+                "Content": "The succubus casts Dominate Person (level 8 version), requiring no spell components and using Cha- risma as the spellcasting ability (spell save DC 15).",
+                "Usage": ""
+            },
+            {
+                "Name": "Draining Kiss",
+                "Content": "Constitution Saving Throw: DC 15, one creature Charmed by the succubus within 5 feet. Fail- ure: 13 (3d8) Psychic damage. Success: Half damage. Failure or Success: The target’s Hit Point maximum de- creases by an amount equal to the damage taken.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The succubus shape-shifts into a Medium or Small Humanoid, or it returns to its true form. Its game statistics are the same in each form, except its Fly",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Fiendish Touch",
+                "ToHit": "+7",
+                "Damage": "2d10 + 5",
+                "DamageType": "Psychic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Tarrasque": {
+        "Id": "Tarrasque",
+        "Name": "Tarrasque",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Monstrosity (Titan), Unaligned",
+        "HP": {
+            "Value": 697,
+            "Notes": "(34d20 + 340)"
+        },
+        "AC": {
+            "Value": 25,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft.",
+            "Burrow 40 ft.",
+            "Climb 60 ft."
+        ],
+        "Abilities": {
+            "Str": 30,
+            "Dex": 11,
+            "Con": 30,
+            "Int": 3,
+            "Wis": 11,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Fire",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Deafened",
+            "Frightened",
+            "Paralyzed",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 9
+            },
+            {
+                "Name": "Int",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 9
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Blindsight 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "30",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the tarrasque fails a saving throw, it can choose to succeed instead.",
+                "Usage": "6/Day"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The tarrasque has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            },
+            {
+                "Name": "Reflective Carapace",
+                "Content": "If the tarrasque is targeted by a Magic Missile spell or a spell that requires a ranged attack roll, roll 1d6. On a 1–5, the tarrasque is unaf- fected. On a 6, the tarrasque is unaffected and reflects the spell, turning the caster into the target.",
+                "Usage": ""
+            },
+            {
+                "Name": "Siege Monster",
+                "Content": "The tarrasque deals double damage to objects and structures.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The tarrasque makes one Bite attack and three other attacks, using Claw or Tail in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +19, reach 15 ft. Hit: 36 (4d12 + 10) Piercing damage, and the target has the Grappled 332 condition (escape DC 20). Until the grapple ends, the target has the Restrained condition and can’t teleport.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +19, reach 15 ft. Hit: 28 (4d8 + 10) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +19, reach 30 ft. Hit: 23 (3d8 + 10) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition. Thunderous Bellow (Recharge 5–6). Constitution Sav- ing Throw: DC 27 , each creature and each object that isn’t being worn or carried in a 150-foot Cone. Failure: 78 (12d12) Thunder damage, and the target has the Deafened and Frightened conditions until the end of its next turn. Success: Half damage only.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "Strength Saving Throw: DC 27 , one Large or smaller creature Grappled by the tarrasque (it can have up to six creatures swallowed at a time). Failure: The target is swallowed, and the Grappled condition ends. A swallowed creature has the Blinded and Restrained conditions and can’t teleport, it has Total Cover against attacks and other effects outside the tarrasque, and it takes 56 (16d6) Acid damage at the start of each of the tarrasque’s turns. If the tarrasque takes 60 damage or more on a single turn from a creature inside it, the tarrasque must suc- ceed on a DC 20 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, each of which falls in a space within 10 feet of the tarrasque and has the Prone condition. If the tarrasque dies, any swallowed creature no longer has the Restrained con- dition and can escape from the corpse using 20 feet of movement, exiting Prone.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Onslaught",
+                "Content": "The tarrasque moves up to half its Speed, and it makes one Claw or Tail attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "World-Shaking Movement",
+                "Content": "The tarrasque moves up to its Speed. At the end of this movement, the tarrasque creates an instantaneous shock wave in a 60-foot Em- anation originating from itself. Creatures in that area lose Concentration and, if Medium or smaller, have the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "The tarrasque can’t take this action again until the start of its next turn. Toughs Tough",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+19",
+                "Damage": "4d12 + 10",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Tough": {
+        "Id": "Tough",
+        "Name": "Tough",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 32,
+            "Notes": "(5d8 + 10)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Mace",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Heavy Crossbow",
+                "Content": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 6 (1d10 + 1) Piercing damage. Tough Boss",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Mace",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Tough Boss": {
+        "Id": "Tough Boss",
+        "Name": "Tough Boss",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 82,
+            "Notes": "(11d8 + 33)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 14,
+            "Con": 16,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 5
+            },
+            {
+                "Name": "Con",
+                "Modifier": 5
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The tough has Advantage on an attack roll against a creature if at least one of the tough’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The tough makes two attacks, using War- hammer or Heavy Crossbow in any combination.",
+                "Usage": ""
+            },
+            {
+                "Name": "Warhammer",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Bludgeoning damage. If the target is a Large or smaller creature, the tough pushes the target up to 10 feet straight away from itself.",
+                "Usage": ""
+            },
+            {
+                "Name": "Heavy Crossbow",
+                "Content": "Ranged Attack Roll: +4, range 100/400 ft. Hit: 13 (2d10 + 2) Piercing damage. 333 Treant Treant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Warhammer",
+                "ToHit": "+5",
+                "Damage": "2d8 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Treant": {
+        "Id": "Treant",
+        "Name": "Treant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Plant, Chaotic Good",
+        "HP": {
+            "Value": 138,
+            "Notes": "(12d12 + 60)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 8,
+            "Con": 21,
+            "Int": 12,
+            "Wis": 16,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [
+            "Fire"
+        ],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Druidic",
+            "Elvish",
+            "Sylvan"
+        ],
+        "Challenge": "9",
+        "Traits": [
+            {
+                "Name": "Siege Monster",
+                "Content": "The treant deals double damage to ob- jects and structures.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The treant makes two Slam attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +10, reach 5 ft. Hit: 16 (3d6 + 6) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hail of Bark",
+                "Content": "Ranged Attack Roll: +10, range 180 ft. Hit: 28 (4d10 + 6) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Animate Trees",
+                "Content": "The treant magically animates up to two trees it can see within 60 feet of itself. Each tree uses the Treant stat block, except it has Intelligence and Charisma scores of 1, it can’t speak, and it lacks this action. The tree takes its turn immediately after the treant on the same Initiative count, and it obeys the tre- ant. A tree remains animate for 1 day or until it dies, the treant dies, or it is more than 120 feet from the treant.",
+                "Usage": "1/Day"
+            },
+            {
+                "Name": "The tree then takes root if possible",
+                "Content": "Troll Troll",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+10",
+                "Damage": "3d6 + 6",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Troll": {
+        "Id": "Troll",
+        "Name": "Troll",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Giant, Chaotic Evil",
+        "HP": {
+            "Value": 94,
+            "Notes": "(9d10 + 45)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 13,
+            "Con": 20,
+            "Int": 7,
+            "Wis": 9,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Giant"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Loathsome Limbs",
+                "Content": "If the troll ends any turn Bloodied and took 15+ Slashing damage during that turn, one of the troll’s limbs is severed, falls into the troll’s space, and becomes a Troll Limb. The limb acts immediately after the troll’s turn. The troll has 1 Exhaus- tion level for each missing limb, and it grows replace- ment limbs the next time it regains Hit Points.",
+                "Usage": "4/Day"
+            },
+            {
+                "Name": "Regeneration",
+                "Content": "The troll regains 15 Hit Points at the start of each of its turns. If the troll takes Acid or Fire dam- age, this trait doesn’t function on the troll’s next turn. The troll dies only if it starts its turn with 0 Hit Points and doesn’t regenerate.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The troll makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Charge",
+                "Content": "The troll moves up to half its Speed straight toward an enemy it can see. Troll Limb",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Troll Limb": {
+        "Id": "Troll Limb",
+        "Name": "Troll Limb",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Giant, Chaotic Evil",
+        "HP": {
+            "Value": 14,
+            "Notes": "(4d6)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 12,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 9,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Regeneration",
+                "Content": "The limb regains 5 Hit Points at the start of each of its turns. If the limb takes Acid or Fire dam- age, this trait doesn’t function on the limb’s next turn. The limb dies only if it starts its turn with 0 Hit Points and doesn’t regenerate.",
+                "Usage": ""
+            },
+            {
+                "Name": "Troll Spawn",
+                "Content": "The limb uncannily has the same senses as a whole troll. If the limb isn’t destroyed within 24 hours, roll 1d12. On a 12, the limb turns into a Troll.",
+                "Usage": ""
+            },
+            {
+                "Name": "Otherwise, the limb withers away",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Slashing damage. 334 Unicorn Unicorn",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "2d4 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Unicorn": {
+        "Id": "Unicorn",
+        "Name": "Unicorn",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Lawful Good",
+        "HP": {
+            "Value": 97,
+            "Notes": "(13d10 + 26)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 15,
+            "Int": 11,
+            "Wis": 17,
+            "Cha": 16
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Paralyzed",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "Elvish",
+            "Sylvan",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the unicorn fails a sav- ing throw, it can choose to succeed instead.",
+                "Usage": "3/Day"
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The unicorn has Advantage on sav- ing throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The unicorn makes one Hooves attack and one Radiant Horn attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 11 (2d6 + 4) Bludgeoning damage. Radiant Horn. Melee Attack Roll: +7 , reach 5 ft. Hit: 9 (1d10 + 4) Radiant damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The unicorn casts one of the following spells, requiring no spell components and using Cha- risma as the spellcasting ability (spell save DC 14): At Will: Detect Evil and Good, Druidcraft 1/Day Each: Calm Emotions, Dispel Evil and Good, En- tangle, Pass without Trace, Word of Recall",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Charging Horn",
+                "Content": "The unicorn moves up to half its Speed without provoking Opportunity Attacks, and it makes one Radiant Horn attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shimmering Shield",
+                "Content": "The unicorn targets itself or one creature it can see within 60 feet of itself. The target gains 10 (3d6) Temporary Hit Points, and its AC in- creases by 2 until the end of the unicorn’s next turn. The unicorn can’t take this action again until the start of its next turn. Vampires Vampire Familiar",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+7",
+                "Damage": "2d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Vampire Familiar": {
+        "Id": "Vampire Familiar",
+        "Name": "Vampire Familiar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral Evil",
+        "HP": {
+            "Value": 65,
+            "Notes": "(10d8 + 20)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 16,
+            "Con": 15,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 14
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [
+            "Charmed (except from its vampire master)"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Persuasion",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Vampiric Connection",
+                "Content": "While the familiar and its vam- pire master are on the same plane of existence, the vampire can communicate with the familiar telepathi- cally, and the vampire can perceive through the famil- iar’s senses.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The familiar makes two Umbral Dag- ger attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Umbral Dagger",
+                "Content": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 20/60 ft. Hit: 5 (1d4 + 3) Piercing damage plus 7 (3d4) Necrotic damage. If the target is reduced to 0 Hit Points by this attack, the target becomes Stable but has the Poisoned condition for 1 hour. While it has the Poisoned condition, the target has the Paralyzed condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Deathless Agility",
+                "Content": "The familiar takes the Dash or Disen- gage action. Vampire Spawn",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Umbral Dagger",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Vampire Spawn": {
+        "Id": "Vampire Spawn",
+        "Name": "Vampire Spawn",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Undead, Neutral Evil",
+        "HP": {
+            "Value": 90,
+            "Notes": "(12d8 + 36)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 16,
+            "Con": 16,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Vampire Weakness",
+                "Content": "The vampire has these weaknesses:",
+                "Usage": ""
+            },
+            {
+                "Name": "Forbiddance",
+                "Content": "The vampire can’t enter a residence with- out an invitation from an occupant.",
+                "Usage": ""
+            },
+            {
+                "Name": "Running Water",
+                "Content": "The vampire takes 20 Acid damage if it ends its turn in running water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Stake to the Heart",
+                "Content": "The vampire is destroyed if a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapaci- tated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight",
+                "Content": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Dis- advantage on attack rolls and ability checks.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The vampire makes two Claw attacks and uses Bite.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (2d4 + 3) Slashing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Constitution Saving Throw: DC 14, one creature within 5 feet that is willing or that has the Grappled,",
+                "Usage": ""
+            },
+            {
+                "Name": "Incapacitated, or Restrained condition",
+                "Content": "Failure: 5 (1d4 + 3) Piercing damage plus 10 (3d6) Necrotic dam- age. The target’s Hit Point maximum decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount.",
+                "Usage": ""
+            },
+            {
+                "Name": "Deathless Agility",
+                "Content": "The vampire takes the Dash or Dis- engage action. Vampire",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+6",
+                "Damage": "2d4 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Vampire": {
+        "Id": "Vampire",
+        "Name": "Vampire",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Undead, Lawful Evil",
+        "HP": {
+            "Value": 195,
+            "Notes": "(23d8 + 92)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "",
+            "and it makes one Grave Strike attack."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 18,
+            "Con": 18,
+            "Int": 17,
+            "Wis": 15,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 9
+            },
+            {
+                "Name": "Con",
+                "Modifier": 9
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 9
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 9
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common plus two other languages"
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the vampire fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            },
+            {
+                "Name": "Misty Escape",
+                "Content": "If the vampire drops to 0 Hit Points out- side its resting place, the vampire uses Shape-Shift to become mist (no action required). If it can’t use Shape-",
+                "Usage": ""
+            },
+            {
+                "Name": "Shift, it is destroyed",
+                "Content": "While it has 0 Hit Points in mist form, it can’t return to its vampire form, and it must reach its resting place within 2 hours or be destroyed. Once in its resting place, it returns to its vampire form and has the Para- lyzed condition until it regains any Hit Points, and it regains 1 Hit Point after spending 1 hour there.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spider Climb",
+                "Content": "The vampire can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Vampire Weakness",
+                "Content": "The vampire has these weaknesses:",
+                "Usage": ""
+            },
+            {
+                "Name": "Forbiddance",
+                "Content": "The vampire can’t enter a residence with- out an invitation from an occupant.",
+                "Usage": ""
+            },
+            {
+                "Name": "Running Water",
+                "Content": "The vampire takes 20 Acid damage if it ends its turn in running water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Stake to the Heart",
+                "Content": "If a weapon that deals Piercing damage is driven into the vampire’s heart while the vampire has the Incapacitated condition in its resting place, the vampire has the Paralyzed condition until the weapon is removed.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight",
+                "Content": "The vampire takes 20 Radiant damage if it starts its turn in sunlight. While in sunlight, it has Dis- advantage on attack rolls and ability checks.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The vampire makes two Grave Strike attacks and uses Bite.",
+                "Usage": "Vampire Form Only"
+            },
+            {
+                "Name": "Grave Strike",
+                "Content": "Melee Attack Roll: +9, reach 5 ft. Hit: 8 (1d8 + 4) Bludgeoning damage plus 7 (2d6) Necrotic damage. If the target is a Large or smaller creature, it has the Grappled condition (escape",
+                "Usage": "Vampire Form Only"
+            },
+            {
+                "Name": "DC 14) from one of two hands",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Constitution Saving Throw: DC 17 , one creature within 5 feet that is willing or that has the Grappled, Incapacitated, or Restrained condition. Failure: 6 (1d4 + 4) Piercing damage plus 13 (3d8) Necrotic damage. The target’s Hit Point maximum 336 decreases by an amount equal to the Necrotic damage taken, and the vampire regains Hit Points equal to that amount. A Humanoid reduced to 0 Hit Points by this damage and then buried rises the following sunset as a Vampire Spawn under the vampire’s control.",
+                "Usage": "Bat or Vampire Form Only"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "If the vampire isn’t in sunlight or running water, it shape-shifts into a Tiny bat (Speed 5 ft., Fly",
+                "Usage": ""
+            },
+            {
+                "Name": "Fly Speed 20 ft",
+                "Content": "[hover]), or it returns to its vampire form. Anything it is wearing transforms with it. While in bat form, the vampire can’t speak. Its game statistics, other than its size and Speed, are unchanged. While in mist form, the vampire can’t take any ac- tions, speak, or manipulate objects. It is weightless and can enter an enemy’s space and stop there. If air can pass through a space, the mist can do so, but it can’t pass through liquid. It has Resistance to all damage, ex- cept the damage it takes from sunlight.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Beguile",
+                "Content": "The vampire casts Command, requiring no spell components and using Charisma as the spellcast- ing ability (spell save DC 17). The vampire can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Deathless Strike",
+                "Content": "The vampire moves up to half its",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Grave Strike",
+                "ToHit": "+9",
+                "Damage": "1d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Vrock": {
+        "Id": "Vrock",
+        "Name": "Vrock",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fiend (Demon), Chaotic Evil",
+        "HP": {
+            "Value": 152,
+            "Notes": "(16d10 + 64)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 15,
+            "Con": 18,
+            "Int": 8,
+            "Wis": 13,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold",
+            "Fire",
+            "Lightning"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            },
+            {
+                "Name": "Cha",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Abyssal",
+            "telepathy 120 ft."
+        ],
+        "Challenge": "6",
+        "Traits": [
+            {
+                "Name": "Demonic Restoration",
+                "Content": "If the vrock dies outside the Abyss, its body dissolves into ichor, and it gains a new body instantly, reviving with all its Hit Points some- where in the Abyss.",
+                "Usage": ""
+            },
+            {
+                "Name": "Magic Resistance",
+                "Content": "The vrock has Advantage on saving throws against spells and other magical effects.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The vrock makes two Shred attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shred",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage plus 10 (3d6) Poison damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spores",
+                "Content": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock. Failure: The target has the Poisoned condition and repeats the save at the end of each of its turns, ending the effect on itself on a success. While Poisoned, the target takes 5 (1d10) Poison damage at the start of each of its turns. Emptying a flask of Holy",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "Water on the target ends the effect early",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Stunning Screech",
+                "Content": "Constitution Saving Throw: DC 15, each creature in a 20-foot Emanation originating from the vrock (demons succeed automatically). Fail- ure: 10 (3d6) Thunder damage, and the target has the Stunned condition until the end of the vrock’s next turn. Warriors Warrior Infantry",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shred",
+                "ToHit": "+6",
+                "Damage": "2d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Warrior Infantry": {
+        "Id": "Warrior Infantry",
+        "Name": "Warrior Infantry",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 11,
+            "Con": 11,
+            "Int": 8,
+            "Wis": 11,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "Common"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The warrior has Advantage on an attack roll against a creature if at least one of the warrior’s al- lies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Spear",
+                "Content": "Melee or Ranged Attack Roll: +3, reach 5 ft. or range 20/60 ft. Hit: 4 (1d6 + 1) Piercing damage. Warrior Veteran",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Spear",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Warrior Veteran": {
+        "Id": "Warrior Veteran",
+        "Name": "Warrior Veteran",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Humanoid, Neutral",
+        "HP": {
+            "Value": 65,
+            "Notes": "(10d8 + 20)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The warrior makes two Greatsword or",
+                "Usage": ""
+            },
+            {
+                "Name": "Heavy Crossbow attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Greatsword",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Heavy Crossbow",
+                "Content": "Ranged Attack Roll: +3, range 100/400 ft. Hit: 12 (2d10 + 1) Piercing damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Parry",
+                "Content": "Trigger: The warrior is hit by a melee attack roll while holding a weapon. Response: The warrior adds 2 to its AC against that attack, possibly causing it to miss. Water Elemental Water Elemental",
+                "Usage": ""
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Greatsword",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Water Elemental": {
+        "Id": "Water Elemental",
+        "Name": "Water Elemental",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Elemental, Neutral",
+        "HP": {
+            "Value": 114,
+            "Notes": "(12d10 + 48)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 90 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 18,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Fire"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Aquan)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Freeze",
+                "Content": "If the elemental takes Cold damage, its Speed decreases by 20 feet until the end of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Water Form",
+                "Content": "The elemental can enter an enemy’s space and stop there. It can move through a space as narrow as 1 inch without expending extra movement to do so.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The elemental makes two Slam attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Prone condition. Whelm (Recharge 4–6). Strength Saving Throw: DC 15, each creature in the elemental’s space. Failure: 22 (4d8 + 4) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 14)",
+                "Content": "Until the grapple ends, the target has the Re- strained condition, is suffocating unless it can breathe water, and takes 9 (2d8) Bludgeoning damage at the start of each of the elemental’s turns. The elemental can grapple one Large creature or up to two Medium or smaller creatures at a time with Whelm. As an ac- tion, a creature within 5 feet of the elemental can pull a creature out of it by succeeding on a DC 14 Strength (Athletics) check. Success: Half damage only. Werebear Werebear",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Werebear": {
+        "Id": "Werebear",
+        "Name": "Werebear",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Monstrosity (Lycanthrope), Neutral Good",
+        "HP": {
+            "Value": 135,
+            "Notes": "(18d8 + 54)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "40 ft. (bear form only)",
+            "Climb 30 ft. (bear"
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 11,
+            "Wis": 12,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common (can’t speak in bear form)"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The werebear makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Handaxe or Rend in any combination",
+                "Content": "It can replace one attack with a Bite attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 17 (2d12 + 4) Piercing damage. If the target is a Humanoid, it is subjected to the follow- ing effect. Constitution Saving Throw: DC 14. Failure:",
+                "Usage": "Bear or Hybrid Form Only"
+            },
+            {
+                "Name": "The target is cursed",
+                "Content": "If the cursed target drops to 0 Hit Points, it instead becomes a Werebear under the GM’s 338 control and has 10 Hit Points. Success: The target is im- mune to this werebear’s curse for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Handaxe",
+                "Content": "Melee or Ranged Attack Roll: +7 , reach 5 ft or range 20/60 ft. Hit: 14 (3d6 + 4) Slashing damage.",
+                "Usage": "Humanoid or Hybrid Form Only"
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Slashing damage.",
+                "Usage": "Bear or Hybrid Form Only"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The werebear shape-shifts into a Large bear-humanoid hybrid form or a Large bear, or it re- turns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. Wereboar Wereboar",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "2d12 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wereboar": {
+        "Id": "Wereboar",
+        "Name": "Wereboar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Monstrosity (Lycanthrope), Neutral Evil",
+        "HP": {
+            "Value": 97,
+            "Notes": "(15d8 + 30)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "40 ft. (boar form only)"
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 10,
+            "Con": 15,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common (can’t speak in boar form)"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The wereboar makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Javelin or Tusk in any combination",
+                "Content": "It can replace one attack with a Gore attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the follow- ing effect. Constitution Saving Throw: DC 12. Failure:",
+                "Usage": "Boar or Hybrid Form Only"
+            },
+            {
+                "Name": "The target is cursed",
+                "Content": "If the cursed target drops to 0 Hit Points, it instead becomes a Wereboar under the GM’s control and has 10 Hit Points. Success: The target is im- mune to this wereboar’s curse for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Javelin",
+                "Content": "Melee or Ranged Attack Roll: +5, reach 5 ft. or range 30/120 ft. Hit: 13 (3d6 + 3) Piercing damage.",
+                "Usage": "Humanoid or Hybrid Form Only"
+            },
+            {
+                "Name": "Tusk",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Medium or smaller creature and the were- boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition.",
+                "Usage": "Boar or Hybrid Form Only"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The wereboar shape-shifts into a Medium boar-humanoid hybrid or a Small boar, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. Wererat Wererat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+5",
+                "Damage": "2d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wererat": {
+        "Id": "Wererat",
+        "Name": "Wererat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Monstrosity (Lycanthrope), Lawful Evil",
+        "HP": {
+            "Value": 60,
+            "Notes": "(11d8 + 11)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 16,
+            "Con": 12,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common (can’t speak in rat form)"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The wererat makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Scratch or Hand Crossbow in any combination",
+                "Content": "It can replace one attack with a Bite attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the following effect. Constitution Saving Throw: DC 11. Failure: The target is cursed. If the cursed target drops to 0 Hit Points, it instead becomes a Wererat under the GM’s control and has 10 Hit Points. Success: The target is im- mune to this wererat’s curse for 24 hours.",
+                "Usage": "Rat or Hybrid Form Only"
+            },
+            {
+                "Name": "Scratch",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Hand Crossbow",
+                "Content": "Ranged Attack Roll: +5, range 30/120 ft. Hit: 6 (1d6 + 3) Piercing damage.",
+                "Usage": "Humanoid or Hybrid Form Only"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The wererat shape-shifts into a Medium rat-humanoid hybrid or a Small rat, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. 339 Weretiger Weretiger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Weretiger": {
+        "Id": "Weretiger",
+        "Name": "Weretiger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Monstrosity (Lycanthrope), Neutral",
+        "HP": {
+            "Value": 120,
+            "Notes": "(16d8 + 48)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "40 ft. (tiger form only)"
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 13,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common (can’t speak in tiger form)"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The weretiger makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Scratch or Longbow in any combination",
+                "Content": "It can replace one attack with a Bite attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the follow- ing effect. Constitution Saving Throw: DC 13. Failure:",
+                "Usage": "Tiger or Hybrid Form Only"
+            },
+            {
+                "Name": "The target is cursed",
+                "Content": "If the cursed target drops to 0 Hit Points, it instead becomes a Weretiger under the GM’s control and has 10 Hit Points. Success: The target is im- mune to this weretiger’s curse for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scratch",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+                "Usage": "Humanoid or Hybrid Form Only"
+            },
+            {
+                "Name": "Prowl",
+                "Content": "The weretiger moves up to its Speed without provoking Opportunity",
+                "Usage": "Tiger or Hybrid Form Only"
+            },
+            {
+                "Name": "Attacks",
+                "Content": "At the end of this movement, the weretiger can take the Hide action.",
+                "Usage": ""
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The weretiger shape-shifts into a Large tiger-humanoid hybrid or a Large tiger, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. Werewolf Werewolf",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Werewolf": {
+        "Id": "Werewolf",
+        "Name": "Werewolf",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Monstrosity (Lycanthrope), Chaotic Evil",
+        "HP": {
+            "Value": 71,
+            "Notes": "(11d8 + 22)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "40 ft. (wolf form only)"
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 10,
+            "Wis": 11,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common (can’t speak in wolf form)"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The werewolf has Advantage on an attack roll against a creature if at least one of the werewolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The werewolf makes two attacks, using",
+                "Usage": ""
+            },
+            {
+                "Name": "Scratch or Longbow in any combination",
+                "Content": "It can replace one attack with a Bite attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 12 (2d8 + 3) Piercing damage. If the target is a Humanoid, it is subjected to the follow- ing effect. Constitution Saving Throw: DC 12. Failure:",
+                "Usage": "Wolf or Hybrid Form Only"
+            },
+            {
+                "Name": "The target is cursed",
+                "Content": "If the cursed target drops to 0 Hit Points, it instead becomes a Werewolf under the GM’s control and has 10 Hit Points. Success: The target is im- mune to this werewolf’s curse for 24 hours.",
+                "Usage": ""
+            },
+            {
+                "Name": "Scratch",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Longbow",
+                "Content": "Ranged Attack Roll: +4, range 150/600 ft. Hit: 11 (2d8 + 2) Piercing damage.",
+                "Usage": "Humanoid or Hybrid Form Only"
+            },
+            {
+                "Name": "Shape-Shift",
+                "Content": "The werewolf shape-shifts into a Large wolf-humanoid hybrid or a Medium wolf, or it returns to its true humanoid form. Its game statistics, other than its size, are the same in each form. Any equipment it is wearing or carrying isn’t transformed. White Dragons White Dragon Wyrmling",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "White Dragon Wyrmling": {
+        "Id": "White Dragon Wyrmling",
+        "Name": "White Dragon Wyrmling",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 32,
+            "Notes": "(5d8 + 10)"
+        },
+        "AC": {
+            "Value": 16,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 15 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 10,
+            "Con": 14,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Draconic"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Ice Walk",
+                "Content": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 2 (1d4) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 22 (5d8) Cold damage. Success: Half damage. Young White Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Young White Dragon": {
+        "Id": "Young White Dragon",
+        "Name": "Young White Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 123,
+            "Notes": "(13d10 + 52)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 20 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 10,
+            "Con": 18,
+            "Int": 10,
+            "Wis": 10,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "6",
+        "Traits": [
+            {
+                "Name": "Ice Walk",
+                "Content": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 9 (2d4 + 4) Slashing damage plus 2 (1d4) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 15, each creature in a 30-foot Cone. Failure: 40 (9d8) Cold damage. Success: Half damage. Adult White Dragon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "2d4 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Adult White Dragon": {
+        "Id": "Adult White Dragon",
+        "Name": "Adult White Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 200,
+            "Notes": "(16d12 + 96)"
+        },
+        "AC": {
+            "Value": 18,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 30 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 10,
+            "Con": 22,
+            "Int": 8,
+            "Wis": 12,
+            "Cha": 12
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 11
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "13",
+        "Traits": [
+            {
+                "Name": "Ice Walk",
+                "Content": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "3/Day, or 4/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +11, reach 10 ft. Hit: 13 (2d6 + 6) Slashing damage plus 4 (1d8) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 19, each creature in a 60-foot Cone. Failure: 54 (12d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Freezing Burst",
+                "Content": "Constitution Saving Throw: DC 14, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 7 (2d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightful Presence",
+                "Content": "The dragon casts Fear, requiring no Material components and using Charisma as the spell- casting ability (spell save DC 14). The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. 341 Ancient White Dragon",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+11",
+                "Damage": "2d6 + 6",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ancient White Dragon": {
+        "Id": "Ancient White Dragon",
+        "Name": "Ancient White Dragon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Gargantuan Dragon (Chromatic), Chaotic Evil",
+        "HP": {
+            "Value": 333,
+            "Notes": "(18d20 + 144)"
+        },
+        "AC": {
+            "Value": 20,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Burrow 40 ft.",
+            "Fly 80 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 26,
+            "Dex": 10,
+            "Con": 26,
+            "Int": 10,
+            "Wis": 13,
+            "Cha": 18
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 13
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft.",
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common",
+            "Draconic"
+        ],
+        "Challenge": "20",
+        "Traits": [
+            {
+                "Name": "Ice Walk",
+                "Content": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, Difficult Terrain composed of ice or snow doesn’t cost it extra movement.",
+                "Usage": ""
+            },
+            {
+                "Name": "Legendary Resistance",
+                "Content": "If the dragon fails a saving throw, it can choose to suc- ceed instead.",
+                "Usage": "4/Day, or 5/Day in Lair"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The dragon makes three Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +14, reach 15 ft. Hit: 17 (2d8 + 8) Slashing damage plus 7 (2d6) Cold damage. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 22, each creature in a 90-foot Cone. Fail- ure: 63 (14d8) Cold damage. Success: Half damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [
+            {
+                "Name": "Freezing Burst",
+                "Content": "Constitution Saving Throw: DC 20, each creature in a 30-foot-radius Sphere centered on a point the dragon can see within 120 feet. Failure: 14 (4d6) Cold damage, and the target’s Speed is 0 until the end of the target’s next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Frightful Presence",
+                "Content": "The dragon casts Fear, requiring no Material components and using Charisma as the spell- casting ability (spell save DC 18). The dragon can’t take this action again until the start of its next turn.",
+                "Usage": ""
+            },
+            {
+                "Name": "Pounce",
+                "Content": "The dragon moves up to half its Speed, and it makes one Rend attack. Wight Wight",
+                "Usage": ""
+            }
+        ],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+14",
+                "Damage": "2d8 + 8",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wight": {
+        "Id": "Wight",
+        "Name": "Wight",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Neutral Evil",
+        "HP": {
+            "Value": 82,
+            "Notes": "(11d8 + 33)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 16,
+            "Int": 10,
+            "Wis": 13,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Sunlight Sensitivity",
+                "Content": "While in sunlight, the wight has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The wight makes two attacks, using Ne- crotic Sword or Necrotic Bow in any combination. It can replace one attack with a use of Life Drain. Necrotic Sword. Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Slashing damage plus 4 (1d8) Ne- crotic damage. Necrotic Bow. Ranged Attack Roll: +4, range 150/600 ft. Hit: 6 (1d8 + 2) Piercing damage plus 4 (1d8) Necrotic damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Life Drain",
+                "Content": "Constitution Saving Throw: DC 13, one creature within 5 feet. Failure: 6 (1d8 + 2) Necrotic damage, and the target’s Hit Point maximum decreases by an amount equal to the damage taken. A Humanoid slain by this attack rises 24 hours later as a Zombie under the wight’s control, unless the Hu- manoid is restored to life or its body is destroyed. The wight can have no more than twelve zombies under its control at a time. Will-o’-Wisp Will-o’-Wisp",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Necrotic Sword",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Will-o’-Wisp": {
+        "Id": "Will-o’-Wisp",
+        "Name": "Will-o’-Wisp",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Undead, Chaotic Evil",
+        "HP": {
+            "Value": 27,
+            "Notes": "(11d4)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 50 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 1,
+            "Dex": 28,
+            "Con": 10,
+            "Int": 13,
+            "Wis": 14,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Bludgeoning",
+            "Cold",
+            "Fire",
+            "Necrotic",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Lightning",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Common plus one other language"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Ephemeral",
+                "Content": "The wisp can’t wear or carry anything.",
+                "Usage": ""
+            },
+            {
+                "Name": "Illumination",
+                "Content": "The wisp sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet.",
+                "Usage": ""
+            },
+            {
+                "Name": "Incorporeal Movement",
+                "Content": "The wisp can move through other creatures and objects as if they were Difficult",
+                "Usage": ""
+            },
+            {
+                "Name": "Terrain",
+                "Content": "It takes 5 (1d10) Force damage if it ends its turn inside an object.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Shock",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 11 (2d8 + 2) Lightning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Consume Life",
+                "Content": "Constitution Saving Throw: DC 10, one living creature the wisp can see within 5 feet that has 0",
+                "Usage": ""
+            },
+            {
+                "Name": "Vanish",
+                "Content": "The wisp and its light have the Invisible condi- tion until the wisp’s Concentration ends on this effect, which ends early immediately after the wisp makes an attack roll or uses Consume Life. Winter Wolf Winter Wolf",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Shock",
+                "ToHit": "+4",
+                "Damage": "2d8 + 2",
+                "DamageType": "Lightning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Winter Wolf": {
+        "Id": "Winter Wolf",
+        "Name": "Winter Wolf",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Neutral Evil",
+        "HP": {
+            "Value": 75,
+            "Notes": "(10d10 + 20)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 13,
+            "Con": 14,
+            "Int": 7,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Cold"
+        ],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Common",
+            "Giant"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Piercing damage. If the target is a Large or smaller crea- ture, it has the Prone condition. Cold Breath (Recharge 5–6). Constitution Saving Throw: DC 12, each creature in a 15-foot Cone. Failure: 18 (4d8) Cold damage. Success: Half damage. Worg Worg",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Worg": {
+        "Id": "Worg",
+        "Name": "Worg",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Fey, Neutral Evil",
+        "HP": {
+            "Value": 26,
+            "Notes": "(4d10 + 4)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 13,
+            "Int": 7,
+            "Wis": 11,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Goblin",
+            "Worg"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage, and the next attack roll made against the target before the start of the worg’s next turn has",
+                "Usage": ""
+            },
+            {
+                "Name": "Advantage",
+                "Content": "Wraith Wraith",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wraith": {
+        "Id": "Wraith",
+        "Name": "Wraith",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium or Small Undead, Neutral Evil",
+        "HP": {
+            "Value": 67,
+            "Notes": "(9d8 + 27)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 60 ft. (hover)"
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 16,
+            "Con": 16,
+            "Int": 12,
+            "Wis": 14,
+            "Cha": 15
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Acid",
+            "Bludgeoning",
+            "Cold",
+            "Fire",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [
+            "Necrotic",
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Charmed",
+            "Exhaustion",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Poisoned",
+            "Prone",
+            "Restrained",
+            "Unconscious"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Common plus two other languages"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Incorporeal Movement",
+                "Content": "The wraith can move through other creatures and objects as if they were Difficult",
+                "Usage": ""
+            },
+            {
+                "Name": "Terrain",
+                "Content": "It takes 5 (1d10) Force damage if it ends its turn inside an object.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sunlight Sensitivity",
+                "Content": "While in sunlight, the wraith has",
+                "Usage": ""
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Life Drain",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (4d8 + 3) Necrotic damage. If the target is a creature, its Hit Point maximum decreases by an amount equal to the damage taken.",
+                "Usage": ""
+            },
+            {
+                "Name": "Create Specter",
+                "Content": "The wraith targets a Humanoid corpse within 10 feet of itself that has been dead for no longer than 1 minute. The target’s spirit rises as a Specter in the space of its corpse or in the nearest unoccupied space. The specter is under the wraith’s control. The wraith can have no more than seven specters under its control at a time. Wyvern Wyvern",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Life Drain",
+                "ToHit": "+6",
+                "Damage": "4d8 + 3",
+                "DamageType": "Necrotic"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wyvern": {
+        "Id": "Wyvern",
+        "Name": "Wyvern",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Dragon, Unaligned",
+        "HP": {
+            "Value": 127,
+            "Notes": "(15d10 + 45)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 10,
+            "Con": 16,
+            "Int": 5,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The wyvern makes one Bite attack and one Sting attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 13 (2d8 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sting",
+                "Content": "Melee Attack Roll: +7 , reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage plus 24 (7d6) Poison damage, and the target has the Poisoned condition until the start of the wyvern’s next turn. Xorn Xorn",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "2d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Xorn": {
+        "Id": "Xorn",
+        "Name": "Xorn",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Elemental, Neutral",
+        "HP": {
+            "Value": 84,
+            "Notes": "(8d8 + 48)"
+        },
+        "AC": {
+            "Value": 19,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "straight toward an enemy it can sense."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 10,
+            "Con": 22,
+            "Int": 11,
+            "Wis": 10,
+            "Cha": 11
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Paralyzed",
+            "Petrified",
+            "Poisoned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft.",
+            "Tremorsense 60 ft."
+        ],
+        "Languages": [
+            "Primordial (Terran)"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Earth Glide",
+                "Content": "The xorn can burrow through nonmagical, unworked earth and stone. While doing so, the xorn doesn’t disturb the material it moves through.",
+                "Usage": ""
+            },
+            {
+                "Name": "Treasure Sense",
+                "Content": "The xorn can pinpoint the location of precious metals and stones within 60 feet of itself.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The xorn makes one Bite attack and three",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw attacks",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 17 (4d6 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d10 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Charge",
+                "Content": "The xorn moves up to its Speed or Burrow",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "4d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Zombie": {
+        "Id": "Zombie",
+        "Name": "Zombie",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Undead, Neutral Evil",
+        "HP": {
+            "Value": 15,
+            "Notes": "(2d8 + 6)"
+        },
+        "AC": {
+            "Value": 8,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 6,
+            "Con": 16,
+            "Int": 3,
+            "Wis": 6,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 0
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common plus one other language but can’t speak"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Undead Fortitude",
+                "Content": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead. 344",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d8 + 1) Bludgeoning damage. Ogre Zombie",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+3",
+                "Damage": "1d8 + 1",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ogre Zombie": {
+        "Id": "Ogre Zombie",
+        "Name": "Ogre Zombie",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Undead, Neutral Evil",
+        "HP": {
+            "Value": 85,
+            "Notes": "(9d10 + 36)"
+        },
+        "AC": {
+            "Value": 8,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 6,
+            "Con": 18,
+            "Int": 3,
+            "Wis": 6,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [
+            "Poison"
+        ],
+        "ConditionImmunities": [
+            "Exhaustion",
+            "Poisoned"
+        ],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 0
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common and Giant but can’t speak"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Undead Fortitude",
+                "Content": "If damage reduces the zombie to 0 Hit Points, it makes a Constitution saving throw (DC 5 plus the damage taken) unless the damage is Radiant or from a Critical Hit. On a successful save, the zombie drops to 1 Hit Point instead.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Slam",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 13 (2d8 + 4) Bludgeoning damage. Animals Allosaurus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Slam",
+                "ToHit": "+6",
+                "Damage": "2d8 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Allosaurus": {
+        "Id": "Allosaurus",
+        "Name": "Allosaurus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 51,
+            "Notes": "(6d10 + 18)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 13,
+            "Con": 17,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 15 (2d10 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claws",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Slashing damage. If the target is a Large or smaller creature and the allosaurus moved 30+ feet straight toward it immediately before the hit, the target has the Prone condition, and the allosaurus can make one Bite attack against it. Ankylosaurus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "2d10 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ankylosaurus": {
+        "Id": "Ankylosaurus",
+        "Name": "Ankylosaurus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d12 + 16)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 11,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ankylosaurus makes two Tail attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 9 (1d10 + 4) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition. Ape",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Tail",
+                "ToHit": "+6",
+                "Damage": "1d10 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Ape": {
+        "Id": "Ape",
+        "Name": "Ape",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d8 + 6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 6,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ape makes two Fist attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fist",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rock",
+                "Content": "Ranged Attack Roll: +5, range 25/50 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. Archelon",
+                "Usage": "Recharge 6"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Fist",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Archelon": {
+        "Id": "Archelon",
+        "Name": "Archelon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 90,
+            "Notes": "(12d12 + 12)"
+        },
+        "AC": {
+            "Value": 17,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 80 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 16,
+            "Con": 13,
+            "Int": 4,
+            "Wis": 14,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The archelon can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The archelon makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage. Baboon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "3d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Baboon": {
+        "Id": "Baboon",
+        "Name": "Baboon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 3,
+            "Notes": "(1d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 14,
+            "Con": 11,
+            "Int": 4,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The baboon has Advantage on an attack roll against a creature if at least one of the baboon’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 − 1) Piercing damage. Badger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+1",
+                "Damage": "1d4 − 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Badger": {
+        "Id": "Badger",
+        "Name": "Badger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(1d4 + 3)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Burrow 5 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 11,
+            "Con": 16,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Poison"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage. Bat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Bat": {
+        "Id": "Bat",
+        "Name": "Bat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 15,
+            "Con": 8,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage. Black Bear",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Black Bear": {
+        "Id": "Black Bear",
+        "Name": "Black Bear",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d8 + 6)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 14,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bear makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Slashing damage. Blood Hawk",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Blood Hawk": {
+        "Id": "Blood Hawk",
+        "Name": "Blood Hawk",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 7,
+            "Notes": "(2d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 14,
+            "Con": 10,
+            "Int": 3,
+            "Wis": 14,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The hawk has Advantage on an attack roll against a creature if at least one of the hawk’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, or 6 (1d8 + 2) Piercing damage if the target is Bloodied. Boar",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beak",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Boar": {
+        "Id": "Boar",
+        "Name": "Boar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(2d8 + 4)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 11,
+            "Con": 14,
+            "Int": 2,
+            "Wis": 9,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Bloodied Fury",
+                "Content": "While Bloodied, the boar has Advan- tage on attack rolls.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Piercing damage and has the Prone condition. Brown Bear",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Brown Bear": {
+        "Id": "Brown Bear",
+        "Name": "Brown Bear",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(3d10 + 6)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 12,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 13,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bear makes one Bite attack and one",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw attack",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage. If the target is a Large or smaller crea- ture, it has the Prone condition. Camel",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Camel": {
+        "Id": "Camel",
+        "Name": "Camel",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 17,
+            "Notes": "(2d10 + 6)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 8,
+            "Con": 17,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage. Cat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Cat": {
+        "Id": "Cat",
+        "Name": "Cat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 2,
+            "Notes": "(1d4)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Jumper",
+                "Content": "The cat’s jump distance is determined using its",
+                "Usage": ""
+            },
+            {
+                "Name": "Dexterity rather than its Strength",
+                "Content": "",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Scratch",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Slash- ing damage. Constrictor Snake",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Constrictor Snake": {
+        "Id": "Constrictor Snake",
+        "Name": "Constrictor Snake",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(2d10 + 2)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 12, one Medium or smaller creature the snake can see within 5 feet. Failure: 7 (3d4) Bludgeoning damage, and the target has the Grappled condition (escape DC 12). Crab",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Crab": {
+        "Id": "Crab",
+        "Name": "Crab",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 3,
+            "Notes": "(1d4 + 1)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 20 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 11,
+            "Con": 12,
+            "Int": 1,
+            "Wis": 8,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The crab can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Blud- geoning damage. Crocodile",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Crocodile": {
+        "Id": "Crocodile",
+        "Name": "Crocodile",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(2d10 + 2)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 10,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Con",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The crocodile can hold its breath for 1 hour.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 12)",
+                "Content": "While Grappled, the target has the Restrained condition. Deer",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Deer": {
+        "Id": "Deer",
+        "Name": "Deer",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 16,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 14,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Agile",
+                "Content": "The deer doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Bludgeoning damage. Dire Wolf",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ram",
+                "ToHit": "+2",
+                "Damage": "1d4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Dire Wolf": {
+        "Id": "Dire Wolf",
+        "Name": "Dire Wolf",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(3d10 + 6)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 15,
+            "Con": 15,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The wolf has Advantage on an attack roll against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 8 (1d10 + 3) Piercing damage. If the target is a Large or smaller crea- ture, it has the Prone condition. Draft Horse",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d10 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Draft Horse": {
+        "Id": "Draft Horse",
+        "Name": "Draft Horse",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 15,
+            "Notes": "(2d10 + 4)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 10,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 6 (1d4 + 4) Bludgeoning damage. Eagle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+6",
+                "Damage": "1d4 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Eagle": {
+        "Id": "Eagle",
+        "Name": "Eagle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d6 + 1)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 15,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 14,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Talons",
+                "Content": "Melee Attack Roll: +4, reach 5 feet. Hit: 4 (1d4 + 2) Slashing damage. Elephant",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Talons",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Elephant": {
+        "Id": "Elephant",
+        "Name": "Elephant",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 76,
+            "Notes": "(8d12 + 24)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 9,
+            "Con": 17,
+            "Int": 3,
+            "Wis": 11,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The elephant makes two Gore attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 15 (2d8 + 6) Piercing damage. If the target is a Huge or smaller creature and the elephant moved 20+ feet straight to- ward it immediately before the hit, the target has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Trample",
+                "Content": "Dexterity Saving Throw: DC 16, one creature within 5 feet that has the Prone condition. Failure: 17 (2d10 + 6) Bludgeoning damage. Success: Half damage. Elk",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+8",
+                "Damage": "2d8 + 6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Elk": {
+        "Id": "Elk",
+        "Name": "Elk",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d10)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 10,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 3 (1d6) Bludgeoning damage and has the Prone condition. Flying Snake",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ram",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Flying Snake": {
+        "Id": "Flying Snake",
+        "Name": "Flying Snake",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Monstrosity, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(2d4)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Fly 60 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 4,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The snake doesn’t provoke an Opportunity At- tack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 5 (2d4) Poison damage. Frog",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Frog": {
+        "Id": "Frog",
+        "Name": "Frog",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 20 ft."
+        ],
+        "Abilities": {
+            "Str": 1,
+            "Dex": 13,
+            "Con": 8,
+            "Int": 1,
+            "Wis": 8,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 1
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The frog can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Standing Leap",
+                "Content": "The frog’s Long Jump is up to 10 feet and its High Jump is up to 5 feet with or without a run- ning start.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Piercing damage. Giant Ape",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Ape": {
+        "Id": "Giant Ape",
+        "Name": "Giant Ape",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 168,
+            "Notes": "(16d12 + 64)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 14,
+            "Con": 18,
+            "Int": 5,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Athletics",
+                "Modifier": 9
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Survival",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "7",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The ape makes two Fist attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Fist",
+                "Content": "Melee Attack Roll: +9, reach 10 ft. Hit: 22 (3d10 + 6) Bludgeoning damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Boulder Toss",
+                "Content": "The ape hurls a boulder at a point it can see within 90 feet. Dexterity Saving Throw: DC 17 , each creature in a 5-foot-radius Sphere centered on that point. Failure: 24 (7d6) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Success: Half damage only.",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "Leap",
+                "Content": "The ape jumps up to 30 feet by spending 10 feet of movement. Giant Badger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Fist",
+                "ToHit": "+9",
+                "Damage": "3d10 + 6",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Badger": {
+        "Id": "Giant Badger",
+        "Name": "Giant Badger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 15,
+            "Notes": "(2d8 + 6)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Burrow 10 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 10,
+            "Con": 17,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Poison"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Piercing damage. Giant Bat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+3",
+                "Damage": "2d4 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Bat": {
+        "Id": "Giant Bat",
+        "Name": "Giant Bat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d10)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 16,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Piercing damage. Giant Boar",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Boar": {
+        "Id": "Giant Boar",
+        "Name": "Giant Boar",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 42,
+            "Notes": "(5d10 + 15)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 10,
+            "Con": 16,
+            "Int": 2,
+            "Wis": 7,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Bloodied Fury",
+                "Content": "The boar has Advantage on melee at- tack rolls while it is Bloodied.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage. If the target is a Large or smaller creature and the boar moved 20+ feet straight toward it immediately before the hit, the target takes an extra 7 (2d6) Piercing damage and has the Prone condition. Giant Centipede",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Centipede": {
+        "Id": "Giant Centipede",
+        "Name": "Giant Centipede",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d6 + 2)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 1,
+            "Wis": 7,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage, and the target has the Poisoned con- dition until the start of the centipede’s next turn. Giant Constrictor Snake",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Constrictor Snake": {
+        "Id": "Giant Constrictor Snake",
+        "Name": "Giant Constrictor Snake",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 60,
+            "Notes": "(8d12 + 8)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The snake makes one Bite attack and uses",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Constrict",
+                "Content": "Strength Saving Throw: DC 14, one Large or smaller creature the snake can see within 10 feet. Fail- ure: 13 (2d8 + 4) Bludgeoning damage, and the target has the Grappled condition (escape DC 14). Giant Crab",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Crab": {
+        "Id": "Giant Crab",
+        "Name": "Giant Crab",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(3d8)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 13,
+            "Con": 11,
+            "Int": 1,
+            "Wis": 9,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The crab can breathe air and water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Bludgeoning damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape",
+                "Usage": ""
+            },
+            {
+                "Name": "DC 11) from one of two claws",
+                "Content": "Giant Crocodile",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Crocodile": {
+        "Id": "Giant Crocodile",
+        "Name": "Giant Crocodile",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 85,
+            "Notes": "(9d12 + 27)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 50 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 9,
+            "Con": 17,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The crocodile can hold its breath for 1 hour.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The crocodile makes one Bite attack and one Tail attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +8, reach 5 ft. Hit: 21 (3d10 + 5) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 15). While Grappled, the target has the Restrained condition and can’t be targeted by the crocodile’s Tail.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +8, reach 10 ft. Hit: 18 (3d8 + 5) Bludgeoning damage. If the target is a Large or smaller creature, it has the Prone condition. Giant Eagle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+8",
+                "Damage": "3d10 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Eagle": {
+        "Id": "Giant Eagle",
+        "Name": "Giant Eagle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Neutral Good",
+        "HP": {
+            "Value": 26,
+            "Notes": "(4d10 + 4)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 80 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 17,
+            "Con": 13,
+            "Int": 8,
+            "Wis": 14,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "Celestial",
+            "understands Common and Primordial (Auran) but can’t speak them"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The eagle makes two Rend attacks. 351",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Slashing damage plus 3 (1d6) Radiant damage. Giant Elk",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Elk": {
+        "Id": "Giant Elk",
+        "Name": "Giant Elk",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Celestial, Neutral Good",
+        "HP": {
+            "Value": 42,
+            "Notes": "(5d12 + 10)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 18,
+            "Con": 14,
+            "Int": 7,
+            "Wis": 14,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 6
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 6
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 90 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "understands Common",
+            "Elvish",
+            "and Sylvan but can’t speak them"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Bludgeoning damage plus 5 (2d4) Radiant damage. If the target is a Huge or smaller creature and the elk moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition. Giant Fire Beetle",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ram",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Fire Beetle": {
+        "Id": "Giant Fire Beetle",
+        "Name": "Giant Fire Beetle",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d6 + 1)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 10,
+            "Con": 12,
+            "Int": 1,
+            "Wis": 7,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Fire"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Illumination",
+                "Content": "The beetle sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 Fire damage. Giant Frog",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Frog": {
+        "Id": "Giant Frog",
+        "Name": "Giant Frog",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 18,
+            "Notes": "(4d8)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 13,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The frog can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Standing Leap",
+                "Content": "The frog’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Grappled condition (escape DC 11).",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "The frog swallows a Small or smaller target it is grappling. While swallowed, the target isn’t Grappled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the frog. While swallowing the target, the frog can’t use Bite, and if the frog dies, the swallowed target is no lon- ger Restrained and can escape from the corpse using 5 feet of movement, exiting with the Prone condition. At the end of the frog’s next turn, the swallowed target takes 5 (2d4) Acid damage. If that damage doesn’t kill it, the frog disgorges it, causing it to exit Prone. Giant Goat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+3",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Goat": {
+        "Id": "Giant Goat",
+        "Name": "Giant Goat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d10 + 3)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 13,
+            "Con": 12,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature and the goat moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition. 352 Giant Hyena",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ram",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Hyena": {
+        "Id": "Giant Hyena",
+        "Name": "Giant Hyena",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 14,
+            "Con": 14,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Piercing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rampage",
+                "Content": "Immediately after dealing damage to a creature that was already Bloodied, the hyena can move up to half its Speed, and it makes one Bite attack. Giant Lizard",
+                "Usage": "1/Day"
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Lizard": {
+        "Id": "Giant Lizard",
+        "Name": "Giant Lizard",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d10 + 3)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. Giant Octopus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Octopus": {
+        "Id": "Giant Octopus",
+        "Name": "Giant Octopus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(7d10 + 7)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Swim 60 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 13,
+            "Con": 13,
+            "Int": 5,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The octopus can breathe only under- water. It can hold its breath for 1 hour outside water.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Tentacles",
+                "Content": "Melee Attack Roll: +5, reach 10 ft. Hit: 10 (2d6 + 3) Bludgeoning damage. If the target is a Me- dium or smaller creature, it has the Grappled condition (escape DC 13) from all eight tentacles. While Grap- pled, the target has the Restrained condition.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Ink Cloud",
+                "Content": "Trigger: The octopus takes damage while underwater. Response: The octopus releases ink that fills a 10-foot Cube centered on itself, and the oc- topus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or simi- lar effect disperses the ink. Giant Owl",
+                "Usage": "1/Day"
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Tentacles",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Owl": {
+        "Id": "Giant Owl",
+        "Name": "Giant Owl",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Celestial, Neutral",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d10 + 3)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 15,
+            "Con": 12,
+            "Int": 10,
+            "Wis": 14,
+            "Cha": 10
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic",
+            "Radiant"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "Celestial",
+            "understands Common",
+            "Elvish",
+            "and Sylvan but can’t speak them"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Talons",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (1d10 + 2) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Spellcasting",
+                "Content": "The owl casts one of the following spells, requiring no spell components and using Wisdom as the spellcasting ability: At Will: Detect Evil and Good, Detect Magic 1/Day: Clairvoyance 353 Giant Rat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Talons",
+                "ToHit": "+4",
+                "Damage": "1d10 + 2",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Rat": {
+        "Id": "Giant Rat",
+        "Name": "Giant Rat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 7,
+            "Notes": "(2d6)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 16,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The rat has Advantage on an attack roll against a creature if at least one of the rat’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 feet. Hit: 5 (1d4 + 3) Piercing damage. Giant Scorpion",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Scorpion": {
+        "Id": "Giant Scorpion",
+        "Name": "Giant Scorpion",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 52,
+            "Notes": "(7d10 + 14)"
+        },
+        "AC": {
+            "Value": 15,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 15,
+            "Int": 1,
+            "Wis": 9,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The scorpion makes two Claw attacks and one Sting attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Claw",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Bludgeoning damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 13) from one of two claws.",
+                "Usage": ""
+            },
+            {
+                "Name": "Sting",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 11 (2d10) Poison damage. Giant Seahorse",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Claw",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Seahorse": {
+        "Id": "Giant Seahorse",
+        "Name": "Giant Seahorse",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 16,
+            "Notes": "(3d10)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 12,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The seahorse can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Bludgeoning damage, or 11 (2d8 + 2) Bludgeoning damage if the seahorse moved 20+ feet straight toward the target immediately before the hit.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bubble Dash",
+                "Content": "While underwater, the seahorse moves up to half its Swim Speed without provoking Opportu- nity Attacks. Giant Shark",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Ram",
+                "ToHit": "+4",
+                "Damage": "2d6 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Shark": {
+        "Id": "Giant Shark",
+        "Name": "Giant Shark",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 92,
+            "Notes": "(8d12 + 40)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 60 ft."
+        ],
+        "Abilities": {
+            "Str": 23,
+            "Dex": 11,
+            "Con": 21,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The shark can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The shark makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +9 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 22 (3d10 + 6) Piercing damage. Giant Spider",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+9",
+                "Damage": "3d10 + 6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Spider": {
+        "Id": "Giant Spider",
+        "Name": "Giant Spider",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 26,
+            "Notes": "(4d10 + 4)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 16,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Web Walker",
+                "Content": "The spider ignores movement restrictions caused by webs, and it knows the location of any other creature in contact with the same web.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Piercing damage plus 7 (2d6) Poison damage. Web (Recharge 5–6). Dexterity Saving Throw: DC 13, one creature the spider can see within 60 feet. Failure: The target has the Restrained condition until the web is destroyed (AC 10; HP 5; Vulnerability to Fire damage;",
+                "Usage": ""
+            },
+            {
+                "Name": "Immunity to Poison and Psychic damage)",
+                "Content": "Giant Toad",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Toad": {
+        "Id": "Giant Toad",
+        "Name": "Giant Toad",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 39,
+            "Notes": "(6d10 + 6)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 13,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Amphibious",
+                "Content": "The toad can breathe air and water.",
+                "Usage": ""
+            },
+            {
+                "Name": "Standing Leap",
+                "Content": "The toad’s Long Jump is up to 20 feet and its High Jump is up to 10 feet with or without a running start.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage. If the tar- get is a Medium or smaller creature, it has the Grappled condition (escape DC 12).",
+                "Usage": ""
+            },
+            {
+                "Name": "Swallow",
+                "Content": "The toad swallows a Medium or smaller target it is grappling. While swallowed, the target isn’t Grap- pled but has the Blinded and Restrained conditions, and it has Total Cover against attacks and other effects outside the toad. In addition, the target takes 10 (3d6) Acid damage at the end of each of the toad’s turns. The toad can have only one target swallowed at a time, and it can’t use Bite while it has a swallowed target. If the toad dies, a swallowed creature is no longer Restrained and can escape from the corpse using 5 feet of move- ment, exiting with the Prone condition. Giant Venomous Snake",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Venomous Snake": {
+        "Id": "Giant Venomous Snake",
+        "Name": "Giant Venomous Snake",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 18,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 6 (1d4 + 4) Piercing damage plus 4 (1d8) Poison damage. Giant Vulture",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "1d4 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Vulture": {
+        "Id": "Giant Vulture",
+        "Name": "Giant Vulture",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Monstrosity, Neutral Evil",
+        "HP": {
+            "Value": 25,
+            "Notes": "(3d10 + 9)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 10,
+            "Con": 16,
+            "Int": 6,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Necrotic"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "Understands Common but can’t speak"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s al- lies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Gouge",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 9 (2d6 + 2) Piercing damage, and the target has the Poisoned condition until the end of its next turn. Giant Wasp",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gouge",
+                "ToHit": "+4",
+                "Damage": "2d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Wasp": {
+        "Id": "Giant Wasp",
+        "Name": "Giant Wasp",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(5d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 50 ft."
+        ],
+        "Abilities": {
+            "Str": 10,
+            "Dex": 14,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The wasp doesn’t provoke an Opportunity At- tack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Sting",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage plus 5 (2d4) Poison damage. Giant Weasel",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Sting",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Weasel": {
+        "Id": "Giant Weasel",
+        "Name": "Giant Weasel",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 9,
+            "Notes": "(2d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 17,
+            "Con": 10,
+            "Int": 4,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Acrobatics",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage. Giant Wolf Spider",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Giant Wolf Spider": {
+        "Id": "Giant Wolf Spider",
+        "Name": "Giant Wolf Spider",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 16,
+            "Con": 13,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Blindsight 10 ft.",
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 5 (1d4 + 3) Piercing damage plus 5 (2d4) Poison damage. Goat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+5",
+                "Damage": "1d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Goat": {
+        "Id": "Goat",
+        "Name": "Goat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 4,
+            "Notes": "(1d8)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 10,
+            "Con": 11,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Ram",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Blud- geoning damage, or 2 (1d4) Bludgeoning damage if the goat moved 20+ feet straight toward the target immedi- ately before the hit. Hawk",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hawk": {
+        "Id": "Hawk",
+        "Name": "Hawk",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 16,
+            "Con": 8,
+            "Int": 2,
+            "Wis": 14,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Talons",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Slash- ing damage. Hippopotamus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hippopotamus": {
+        "Id": "Hippopotamus",
+        "Name": "Hippopotamus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 82,
+            "Notes": "(11d10 + 22)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 7,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 7
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "4",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The hippopotamus can hold its breath for 10 minutes. 356",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The hippopotamus makes two Bite attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 16 (2d10 + 5) Piercing damage. Hunter Shark",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+7",
+                "Damage": "2d10 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hunter Shark": {
+        "Id": "Hunter Shark",
+        "Name": "Hunter Shark",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 14,
+            "Con": 15,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The shark can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6 (with Advantage if the tar- get doesn’t have all its Hit Points), reach 5 ft. Hit: 14 (3d6 + 4) Piercing damage. Hyena",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "3d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Hyena": {
+        "Id": "Hyena",
+        "Name": "Hyena",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(1d8 + 1)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 11,
+            "Dex": 13,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The hyena has Advantage on an attack roll against a creature if at least one of the hyena’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 3 (1d6) Piercing damage. Jackal",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+2",
+                "Damage": "1d6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Jackal": {
+        "Id": "Jackal",
+        "Name": "Jackal",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 3,
+            "Notes": "(1d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 90 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +1, reach 5 ft. Hit: 1 (1d4 – 1) Piercing damage. Killer Whale",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+1",
+                "Damage": "1d4 – 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Killer Whale": {
+        "Id": "Killer Whale",
+        "Name": "Killer Whale",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 90,
+            "Notes": "(12d12 + 12)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 60 ft."
+        ],
+        "Abilities": {
+            "Str": 19,
+            "Dex": 14,
+            "Con": 13,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Blindsight 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "3",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The whale can hold its breath for 30 minutes.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 21 (5d6 + 4) Piercing damage. Lion",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "5d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Lion": {
+        "Id": "Lion",
+        "Name": "Lion",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d10)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The lion has Advantage on an attack roll against a creature if at least one of the lion’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Running Leap",
+                "Content": "With a 10-foot running start, the lion can Long Jump up to 25 feet.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The lion makes two Rend attacks. It can replace one attack with a use of Roar.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Roar",
+                "Content": "Wisdom Saving Throw: DC 11, one creature within 15 feet. Failure: The target has the Frightened condition until the start of the lion’s next turn. Lizard",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Lizard": {
+        "Id": "Lizard",
+        "Name": "Lizard",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 2,
+            "Notes": "(1d4)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 11,
+            "Con": 10,
+            "Int": 1,
+            "Wis": 8,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The lizard can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage. Mammoth",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mammoth": {
+        "Id": "Mammoth",
+        "Name": "Mammoth",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast, Unaligned",
+        "HP": {
+            "Value": 126,
+            "Notes": "(11d12 + 55)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 24,
+            "Dex": 9,
+            "Con": 21,
+            "Int": 3,
+            "Wis": 11,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 10
+            },
+            {
+                "Name": "Con",
+                "Modifier": 8
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "6",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The mammoth makes two Gore attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 18 (2d10 + 7) Piercing damage. If the target is a Huge or smaller creature and the mammoth moved 20+ feet straight toward it immediately before the hit, the target has the",
+                "Usage": ""
+            },
+            {
+                "Name": "Prone condition",
+                "Content": "",
+                "Usage": ""
+            },
+            {
+                "Name": "Trample",
+                "Content": "Dexterity Saving Throw: DC 18, one creature within 5 feet that has the Prone condition. Failure: 29 (4d10 + 7) Bludgeoning damage. Success: Half damage. Mastiff",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+10",
+                "Damage": "2d10 + 7",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mastiff": {
+        "Id": "Mastiff",
+        "Name": "Mastiff",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(1d8 + 1)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 4 (1d6 + 1) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition. Mule",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+3",
+                "Damage": "1d6 + 1",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Mule": {
+        "Id": "Mule",
+        "Name": "Mule",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 10,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [
+            {
+                "Name": "Beast of Burden",
+                "Content": "The mule counts as one size larger for the purpose of determining its carrying capacity.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage. Octopus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Octopus": {
+        "Id": "Octopus",
+        "Name": "Octopus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Small Beast, Unaligned",
+        "HP": {
+            "Value": 3,
+            "Notes": "(1d6)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 4,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 3,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 6
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Compression",
+                "Content": "The octopus can move through a space as narrow as 1 inch without expending extra move- ment to do so.",
+                "Usage": ""
+            },
+            {
+                "Name": "Water Breathing",
+                "Content": "The octopus can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Tentacles",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Bludgeoning damage.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [
+            {
+                "Name": "Ink Cloud",
+                "Content": "Trigger: A creature ends its turn within 5 feet of the octopus while underwater. Re- sponse: The octopus releases ink that fills a 5-foot Cube centered on itself, and the octopus moves up to its Swim Speed. The Cube is Heavily Obscured for 1 minute or until a strong current or similar effect dis- perses the ink. Owl",
+                "Usage": "1/Day"
+            }
+        ],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Owl": {
+        "Id": "Owl",
+        "Name": "Owl",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 13,
+            "Con": 8,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 120 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The owl doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Talons",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 1 Slash- ing damage. Panther",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Panther": {
+        "Id": "Panther",
+        "Name": "Panther",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(3d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft.",
+            "Climb 40 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 16,
+            "Con": 10,
+            "Int": 3,
+            "Wis": 14,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 6 (1d6 + 3) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The panther takes the Disengage or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "Piranha",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "1d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Piranha": {
+        "Id": "Piranha",
+        "Name": "Piranha",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 16,
+            "Con": 9,
+            "Int": 1,
+            "Wis": 7,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The piranha can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 1 Pierc- ing damage. Plesiosaurus",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Plesiosaurus": {
+        "Id": "Plesiosaurus",
+        "Name": "Plesiosaurus",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 68,
+            "Notes": "(8d10 + 24)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 15,
+            "Con": 16,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Hold Breath",
+                "Content": "The plesiosaurus can hold its breath for 1 hour. 359",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +6, reach 10 ft. Hit: 11 (2d6 + 4) Piercing damage. Polar Bear",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Polar Bear": {
+        "Id": "Polar Bear",
+        "Name": "Polar Bear",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 42,
+            "Notes": "(5d10 + 15)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 20,
+            "Dex": 14,
+            "Con": 16,
+            "Int": 2,
+            "Wis": 13,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Cold"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The bear makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 9 (1d8 + 5) Slashing damage. Pony",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+7",
+                "Damage": "1d8 + 5",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pony": {
+        "Id": "Pony",
+        "Name": "Pony",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 15,
+            "Dex": 10,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Bludgeoning damage. Pteranodon",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Pteranodon": {
+        "Id": "Pteranodon",
+        "Name": "Pteranodon",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(3d8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 60 ft."
+        ],
+        "Abilities": {
+            "Str": 12,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 2,
+            "Wis": 9,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 1
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Flyby",
+                "Content": "The pteranodon doesn’t provoke an Opportunity Attack when it flies out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 6 (1d8 + 2) Piercing damage. Rat",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d8 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Rat": {
+        "Id": "Rat",
+        "Name": "Rat",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 11,
+            "Con": 9,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Agile",
+                "Content": "The rat doesn’t provoke an Opportunity Attack when it moves out of an enemy’s reach.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage. Raven",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Raven": {
+        "Id": "Raven",
+        "Name": "Raven",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 2,
+            "Notes": "(1d4)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 50 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 14,
+            "Con": 10,
+            "Int": 5,
+            "Wis": 13,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Mimicry",
+                "Content": "The raven can mimic simple sounds it has heard, such as a whisper or chitter. A hearer can dis- cern the sounds are imitations with a successful DC 10",
+                "Usage": ""
+            },
+            {
+                "Name": "Wisdom",
+                "Content": "",
+                "Usage": "Insight check"
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage. 360 Reef Shark",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Reef Shark": {
+        "Id": "Reef Shark",
+        "Name": "Reef Shark",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 22,
+            "Notes": "(4d8 + 4)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 15,
+            "Con": 13,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            }
+        ],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The shark has Advantage on an attack roll against a creature if at least one of the shark’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Water Breathing",
+                "Content": "The shark can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 7 (2d4 + 2) Piercing damage. Rhinoceros",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "2d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Rhinoceros": {
+        "Id": "Rhinoceros",
+        "Name": "Rhinoceros",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 45,
+            "Notes": "(6d10 + 12)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 21,
+            "Dex": 8,
+            "Con": 15,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +7 , reach 5 ft. Hit: 14 (2d8 + 5) Piercing damage. If target is a Large or smaller crea- ture and the rhinoceros moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition. Riding Horse",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+7",
+                "Damage": "2d8 + 5",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Riding Horse": {
+        "Id": "Riding Horse",
+        "Name": "Riding Horse",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 13,
+            "Notes": "(2d10 + 2)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft."
+        ],
+        "Abilities": {
+            "Str": 16,
+            "Dex": 13,
+            "Con": 12,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 7 (1d8 + 3) Bludgeoning damage. Saber-Toothed Tiger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+5",
+                "Damage": "1d8 + 3",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Saber-Toothed Tiger": {
+        "Id": "Saber-Toothed Tiger",
+        "Name": "Saber-Toothed Tiger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 52,
+            "Notes": "(7d10 + 14)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 17,
+            "Con": 15,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 6
+            },
+            {
+                "Name": "Dex",
+                "Modifier": 5
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Running Leap",
+                "Content": "With a 10-foot running start, the tiger can Long Jump up to 25 feet.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The tiger makes two Rend attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 11 (2d6 + 4) Slashing damage.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The tiger takes the Disengage or Hide action. Scorpion",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+6",
+                "Damage": "2d6 + 4",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Scorpion": {
+        "Id": "Scorpion",
+        "Name": "Scorpion",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 11,
+            "Con": 8,
+            "Int": 1,
+            "Wis": 8,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Sting",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 1 Piercing damage plus 3 (1d6) Poison damage. 361 Seahorse",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Seahorse": {
+        "Id": "Seahorse",
+        "Name": "Seahorse",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 20 ft."
+        ],
+        "Abilities": {
+            "Str": 1,
+            "Dex": 12,
+            "Con": 8,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 2
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Water Breathing",
+                "Content": "The seahorse can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bubble Dash",
+                "Content": "While underwater, the seahorse moves up to its Swim Speed without provoking Opportu- nity Attacks. Spider",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Spider": {
+        "Id": "Spider",
+        "Name": "Spider",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb 20 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 14,
+            "Con": 8,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "The spider can climb difficult surfaces, including along ceilings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Web Walker",
+                "Content": "The spider ignores movement restrictions caused by webs, and the spider knows the location of any other creature in contact with the same web.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 1 Piercing damage plus 2 (1d4) Poison damage. Swarm of Bats",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Bats": {
+        "Id": "Swarm of Bats",
+        "Name": "Swarm of Bats",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d10)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Fly 30 ft."
+        ],
+        "Abilities": {
+            "Str": 5,
+            "Dex": 15,
+            "Con": 10,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny bat. The swarm can’t regain Hit Points or gain Temporary Hit Points.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bites",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied. Swarm of Insects",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bites",
+                "ToHit": "+4",
+                "Damage": "2d4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Insects": {
+        "Id": "Swarm of Insects",
+        "Name": "Swarm of Insects",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d8 + 6)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "20 ft.",
+            "Climb or Fly 20 ft. (GM’s choice)"
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 13,
+            "Con": 14,
+            "Int": 1,
+            "Wis": 7,
+            "Cha": 1
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [
+            {
+                "Name": "Spider Climb",
+                "Content": "If the swarm has a Climb Speed, the swarm can climb difficult surfaces, including along ceil- ings, without needing to make an ability check.",
+                "Usage": ""
+            },
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny insect. The swarm can’t regain Hit Points or gain Temporary Hit Points.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bites",
+                "Content": "Melee Attack Roll: +3, reach 5 ft. Hit: 6 (2d4 + 1) Poison damage, or 3 (1d4 + 1) Poison damage if the swarm is Bloodied. 362 Swarm of Piranhas",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bites",
+                "ToHit": "+3",
+                "Damage": "2d4 + 1",
+                "DamageType": "Poison"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Piranhas": {
+        "Id": "Swarm of Piranhas",
+        "Name": "Swarm of Piranhas",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 28,
+            "Notes": "(8d8 − 8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "5 ft.",
+            "Swim 40 ft."
+        ],
+        "Abilities": {
+            "Str": 13,
+            "Dex": 16,
+            "Con": 9,
+            "Int": 1,
+            "Wis": 7,
+            "Cha": 2
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny piranha. The swarm can’t regain Hit Points or gain Temporary",
+                "Usage": ""
+            },
+            {
+                "Name": "Water Breathing",
+                "Content": "The swarm can breathe only underwater.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bites",
+                "Content": "Melee Attack Roll: +5 (with Advantage if the target doesn’t have all its Hit Points), reach 5 ft. Hit: 8 (2d4 + 3) Piercing damage, or 5 (1d4 + 3) Piercing dam- age if the swarm is Bloodied. Swarm of Rats",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bites",
+                "ToHit": "+5",
+                "Damage": "2d4 + 3",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Rats": {
+        "Id": "Swarm of Rats",
+        "Name": "Swarm of Rats",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 14,
+            "Notes": "(4d8 − 4)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 9,
+            "Dex": 11,
+            "Con": 9,
+            "Int": 2,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [
+            {
+                "Name": "Dex",
+                "Modifier": 2
+            }
+        ],
+        "Skills": [],
+        "Senses": [
+            "Darkvision 30 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny rat. The swarm can’t regain Hit Points or gain Temporary Hit Points.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bites",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 5 (2d4) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied. Swarm of Ravens",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bites",
+                "ToHit": "+2",
+                "Damage": "2d4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Ravens": {
+        "Id": "Swarm of Ravens",
+        "Name": "Swarm of Ravens",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 50 ft."
+        ],
+        "Abilities": {
+            "Str": 6,
+            "Dex": 14,
+            "Con": 12,
+            "Int": 5,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny raven. The swarm can’t regain Hit Points or gain Temporary Hit Points.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Beaks",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage, or 2 (1d4) Piercing damage if the swarm is Bloodied.",
+                "Usage": ""
+            },
+            {
+                "Name": "Cacophony",
+                "Content": "Wisdom Saving Throw: DC 10, one creature in the swarm’s space. Failure: The target has the Deafened condition until the start of the swarm’s next turn. While Deafened, the target also has",
+                "Usage": "Recharge 6"
+            },
+            {
+                "Name": "Disadvantage on ability checks and attack rolls",
+                "Content": "Swarm of Venomous Snakes",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beaks",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Swarm of Venomous Snakes": {
+        "Id": "Swarm of Venomous Snakes",
+        "Name": "Swarm of Venomous Snakes",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Swarm of Tiny Beasts, Unaligned",
+        "HP": {
+            "Value": 36,
+            "Notes": "(8d8)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 8,
+            "Dex": 18,
+            "Con": 11,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [
+            "Bludgeoning",
+            "Piercing",
+            "Slashing"
+        ],
+        "DamageImmunities": [],
+        "ConditionImmunities": [
+            "Charmed",
+            "Frightened",
+            "Grappled",
+            "Paralyzed",
+            "Petrified",
+            "Prone",
+            "Restrained",
+            "Stunned"
+        ],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "2",
+        "Traits": [
+            {
+                "Name": "Swarm",
+                "Content": "The swarm can occupy another creature’s space and vice versa, and the swarm can move through any opening large enough for a Tiny snake. The swarm can’t regain Hit Points or gain Temporary Hit Points.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bites",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 8 (1d8 + 4) Piercing damage—or 6 (1d4 + 4) Piercing damage if the swarm is Bloodied—plus 10 (3d6) Poison damage. Tiger",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bites",
+                "ToHit": "+6",
+                "Damage": "1d8 + 4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Tiger": {
+        "Id": "Tiger",
+        "Name": "Tiger",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 30,
+            "Notes": "(4d10 + 8)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 17,
+            "Dex": 16,
+            "Con": 14,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 8
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 7
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Rend",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 10 (2d6 + 3) Slashing damage. If the target is a Large or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            },
+            {
+                "Name": "Nimble Escape",
+                "Content": "The tiger takes the Disengage or",
+                "Usage": ""
+            },
+            {
+                "Name": "Hide action",
+                "Content": "Triceratops",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Rend",
+                "ToHit": "+5",
+                "Damage": "2d6 + 3",
+                "DamageType": "Slashing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Triceratops": {
+        "Id": "Triceratops",
+        "Name": "Triceratops",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 114,
+            "Notes": "(12d12 + 36)"
+        },
+        "AC": {
+            "Value": 14,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 22,
+            "Dex": 9,
+            "Con": 17,
+            "Int": 2,
+            "Wis": 11,
+            "Cha": 5
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "5",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The triceratops makes two Gore attacks.",
+                "Usage": ""
+            },
+            {
+                "Name": "Gore",
+                "Content": "Melee Attack Roll: +9, reach 5 ft. Hit: 19 (2d12 + 6) Piercing damage. If the target is Huge or smaller and the triceratops moved 20+ feet straight toward it immediately before the hit, the target takes an extra 9 (2d8) Piercing damage and has the Prone condition. Tyrannosaurus Rex",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Gore",
+                "ToHit": "+9",
+                "Damage": "2d12 + 6",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Tyrannosaurus Rex": {
+        "Id": "Tyrannosaurus Rex",
+        "Name": "Tyrannosaurus Rex",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Huge Beast (Dinosaur), Unaligned",
+        "HP": {
+            "Value": 136,
+            "Notes": "(13d12 + 52)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "50 ft."
+        ],
+        "Abilities": {
+            "Str": 25,
+            "Dex": 10,
+            "Con": 19,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 9
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Str",
+                "Modifier": 10
+            },
+            {
+                "Name": "Wis",
+                "Modifier": 4
+            }
+        ],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Multiattack",
+                "Content": "The tyrannosaurus makes one Bite attack and one Tail attack.",
+                "Usage": ""
+            },
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +10, reach 10 ft. Hit: 33 (4d12 + 7) Piercing damage. If the target is a Large or smaller creature, it has the Grappled condition (escape DC 17). While Grappled, the target has the Restrained condition and can’t be targeted by the tyrannosaurus’s Tail.",
+                "Usage": ""
+            },
+            {
+                "Name": "Tail",
+                "Content": "Melee Attack Roll: +10, reach 15 ft. Hit: 25 (4d8 + 7) Bludgeoning damage. If the target is a Huge or smaller creature, it has the Prone condition. Venomous Snake",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+10",
+                "Damage": "4d12 + 7",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Venomous Snake": {
+        "Id": "Venomous Snake",
+        "Name": "Venomous Snake",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(2d4)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Swim 30 ft."
+        ],
+        "Abilities": {
+            "Str": 2,
+            "Dex": 15,
+            "Con": 11,
+            "Int": 1,
+            "Wis": 10,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [],
+        "Senses": [
+            "Blindsight 10 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/8",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 4 (1d4 + 2) Piercing damage plus 3 (1d6) Poison damage. Vulture",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d4 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Vulture": {
+        "Id": "Vulture",
+        "Name": "Vulture",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 5,
+            "Notes": "(1d8 + 1)"
+        },
+        "AC": {
+            "Value": 10,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "10 ft.",
+            "Fly 50 ft."
+        ],
+        "Abilities": {
+            "Str": 7,
+            "Dex": 10,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 4
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            }
+        ],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The vulture has Advantage on an attack roll against a creature if at least one of the vulture’s al- lies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Beak",
+                "Content": "Melee Attack Roll: +2, reach 5 ft. Hit: 2 (1d4) Piercing damage. Warhorse",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Beak",
+                "ToHit": "+2",
+                "Damage": "1d4",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Warhorse": {
+        "Id": "Warhorse",
+        "Name": "Warhorse",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Large Beast, Unaligned",
+        "HP": {
+            "Value": 19,
+            "Notes": "(3d10 + 3)"
+        },
+        "AC": {
+            "Value": 11,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "60 ft."
+        ],
+        "Abilities": {
+            "Str": 18,
+            "Dex": 12,
+            "Con": 13,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 7
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [
+            {
+                "Name": "Wis",
+                "Modifier": 3
+            }
+        ],
+        "Skills": [],
+        "Senses": [],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/2",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Hooves",
+                "Content": "Melee Attack Roll: +6, reach 5 ft. Hit: 9 (2d4 + 4) Bludgeoning damage. If the target is a Large or smaller creature and the horse moved 20+ feet straight toward it immediately before the hit, the target takes an extra 5 (2d4) Bludgeoning damage and has the Prone condition. Weasel",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Hooves",
+                "ToHit": "+6",
+                "Damage": "2d4 + 4",
+                "DamageType": "Bludgeoning"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Weasel": {
+        "Id": "Weasel",
+        "Name": "Weasel",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Tiny Beast, Unaligned",
+        "HP": {
+            "Value": 1,
+            "Notes": "(1d4 − 1)"
+        },
+        "AC": {
+            "Value": 13,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "30 ft.",
+            "Climb 30 ft."
+        ],
+        "Abilities": {
+            "Str": 3,
+            "Dex": 16,
+            "Con": 8,
+            "Int": 2,
+            "Wis": 12,
+            "Cha": 3
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Acrobatics",
+                "Modifier": 5
+            },
+            {
+                "Name": "Perception",
+                "Modifier": 3
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 5
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "0",
+        "Traits": [],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +5, reach 5 ft. Hit: 1 Piercing damage. Wolf",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    },
+    "Wolf": {
+        "Id": "Wolf",
+        "Name": "Wolf",
+        "Path": "",
+        "Source": "SRD 5.2.1",
+        "Year": "2024",
+        "Type": "Medium Beast, Unaligned",
+        "HP": {
+            "Value": 11,
+            "Notes": "(2d8 + 2)"
+        },
+        "AC": {
+            "Value": 12,
+            "Notes": ""
+        },
+        "InitiativeModifier": 0,
+        "InitiativeAdvantage": false,
+        "Speed": [
+            "40 ft."
+        ],
+        "Abilities": {
+            "Str": 14,
+            "Dex": 15,
+            "Con": 12,
+            "Int": 3,
+            "Wis": 12,
+            "Cha": 6
+        },
+        "DamageVulnerabilities": [],
+        "DamageResistances": [],
+        "DamageImmunities": [],
+        "ConditionImmunities": [],
+        "Saves": [],
+        "Skills": [
+            {
+                "Name": "Perception",
+                "Modifier": 5
+            },
+            {
+                "Name": "Stealth",
+                "Modifier": 4
+            }
+        ],
+        "Senses": [
+            "Darkvision 60 ft."
+        ],
+        "Languages": [
+            "None"
+        ],
+        "Challenge": "1/4",
+        "Traits": [
+            {
+                "Name": "Pack Tactics",
+                "Content": "The wolf has Advantage on attack rolls against a creature if at least one of the wolf’s allies is within 5 feet of the creature and the ally doesn’t have the Incapacitated condition.",
+                "Usage": ""
+            }
+        ],
+        "Actions": [
+            {
+                "Name": "Bite",
+                "Content": "Melee Attack Roll: +4, reach 5 ft. Hit: 5 (1d6 + 2) Piercing damage. If the target is a Medium or smaller creature, it has the Prone condition.",
+                "Usage": ""
+            }
+        ],
+        "Reactions": [],
+        "LegendaryActions": [],
+        "QuickAction": [
+            {
+                "Name": "Bite",
+                "ToHit": "+4",
+                "Damage": "1d6 + 2",
+                "DamageType": "Piercing"
+            }
+        ],
+        "Description": "",
+        "Player": "",
+        "Version": "1.0.0",
+        "ImageURL": ""
+    }
+}


### PR DESCRIPTION
Has some differences in your file format that I needed for my project but is fairly similar.

## What does this do?

Adds a similar version of the 2024 srd monsters. 

## How was it tested?

I did not do any testing it was created for my project and was just close. 

## Is there a Github issue this is resolving?
none 

## Did you update the docs in the API? Please link an associated PR if applicable.

I did not

