### PR TITLE
feat(2024): Finish Traits, Species, and Subspecies

### DIFF
--- a/src/2024/5e-SRD-Species.json
+++ b/src/2024/5e-SRD-Species.json
@@ -372,17 +372,17 @@
 			{
 				"index": "fiendish-legacy-abyssal",
 				"url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
-				"name": "Fiendish Lineage: Abyssal"
+				"name": "Fiendish Legacy: Abyssal"
 			},
 			{
 				"index": "fiendish-legacy-chthonic",
 				"url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
-				"name": "Fiendish Lineage: Chthonic"
+				"name": "Fiendish Legacy: Chthonic"
 			},
 			{
 				"index": "fiendish-legacy-infernal",
 				"url" : "/api/2024/subspecies/fiendish-legacy-infernal",
-				"name": "Fiendish Lineage: Infernal"
+				"name": "Fiendish Legacy: Infernal"
 			}
 		]
 	}

--- a/src/2024/5e-SRD-Subspecies.json
+++ b/src/2024/5e-SRD-Subspecies.json
@@ -241,20 +241,20 @@
 				"level": 1
 			},
 			{
-				"index": "lineage-dancing-lights",
-				"url": "/api/2024/traits/lineage-dancing-lights",
+				"index": "lineage-spell-dancing-lights",
+				"url": "/api/2024/traits/lineage-spell-dancing-lights",
 				"name": "Dancing Lights",
 				"level": 1
 			},
 			{
-				"index": "lineage-faerie-fire",
-				"url": "/api/2024/traits/lineage-faerie-fire",
+				"index": "lineage-spell-faerie-fire",
+				"url": "/api/2024/traits/lineage-spell-faerie-fire",
 				"name": "Faerie Fire",
 				"level": 3
 			},
 			{
-				"index": "lineage-darkness",
-				"url": "/api/2024/traits/lineage-darkness",
+				"index": "lineage-spell-darkness",
+				"url": "/api/2024/traits/lineage-spell-darkness",
 				"name": "Darkness",
 				"level": 5
 			}
@@ -277,14 +277,14 @@
 				"level": 1
 			},
 			{
-				"index": "lineage-detect-magic",
-				"url": "/api/2024/traits/lineage-detect-magic",
+				"index": "lineage-spell-detect-magic",
+				"url": "/api/2024/traits/lineage-spell-detect-magic",
 				"name": "Detect Magic",
 				"level": 3
 			},
 			{
-				"index": "lineage-misty-step",
-				"url": "/api/2024/traits/lineage-misty-step",
+				"index": "lineage-spell-misty-step",
+				"url": "/api/2024/traits/lineage-spell-misty-step",
 				"name": "Misty Step",
 				"level": 5
 			}
@@ -307,14 +307,14 @@
 				"level": 1
 			},
 			{
-				"index": "lineage-longstrider",
-				"url": "/api/2024/traits/lineage-longstrider",
+				"index": "lineage-spell-longstrider",
+				"url": "/api/2024/traits/lineage-spell-longstrider",
 				"name": "Longstrider",
 				"level": 3
 			},
 			{
-				"index": "lineage-pass-without-trace",
-				"url": "/api/2024/traits/lineage-pass-without-trace",
+				"index": "lineage-spell-pass-without-trace",
+				"url": "/api/2024/traits/lineage-spell-pass-without-trace",
 				"name": "Pass without Trace",
 				"level": 5
 			}
@@ -335,6 +335,12 @@
 				"url" : "/api/2024/traits/gnomish-lineage-forest-gnome",
 				"name": "Gnomish Lineage: Forest Gnome",
 				"level": 1
+			},
+			{
+				"index": "lineage-spell-minor-illusion",
+				"url" : "/api/2024/traits/lineage-spell-minor-illusion",
+				"name": "Minor Illusion",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -352,6 +358,12 @@
 				"index": "gnomish-lineage-rock-gnome",
 				"url" : "/api/2024/traits/gnomish-lineage-rock-gnome",
 				"name": "Gnomish Lineage: Rock Gnome",
+				"level": 1
+			},
+			{
+				"index": "lineage-spell-mending",
+				"url" : "/api/2024/traits/lineage-spell-mending",
+				"name": "Mending",
 				"level": 1
 			}
 		],
@@ -475,26 +487,26 @@
 		"name": "Fiendish Legacy: Abyssal",
 		"traits": [
 			{
-				"index": "fiendish-damage-resistance-poison",
-				"url": "/api/2024/traits/fiendish-damage-resistance-poison",
+				"index": "lineage-resistance-poison",
+				"url": "/api/2024/traits/lineage-resistance-poison",
 				"name": "Damage Resistance: Poison",
 				"level": 1
 			},
 			{
-				"index": "lineage-poison-spray",
-				"url": "/api/2024/traits/lineage-poison-spray",
+				"index": "lineage-spell-poison-spray",
+				"url": "/api/2024/traits/lineage-spell-poison-spray",
 				"name": "Poison Spray",
 				"level": 1
 			},
 			{
-				"index": "lineage-ray-of-sickness",
-				"url": "/api/2024/traits/lineage-ray-of-sickness",
+				"index": "lineage-spell-ray-of-sickness",
+				"url": "/api/2024/traits/lineage-spell-ray-of-sickness",
 				"name": "Ray of Sickness",
 				"level": 3
 			},
 			{
-				"index": "lineage-hold-person",
-				"url": "/api/2024/traits/lineage-hold-person",
+				"index": "lineage-spell-hold-person",
+				"url": "/api/2024/traits/lineage-spell-hold-person",
 				"name": "Hold Person",
 				"level": 5
 			}
@@ -511,25 +523,25 @@
 		"name": "Fiendish Legacy: Chthonic",
 		"traits": [
 			{
-				"index": "fiendish-damage-resistance-necrotic",
-				"url": "/api/2024/traits/fiendish-damage-resistance-necrotic",
+				"index": "lineage-resistance-necrotic",
+				"url": "/api/2024/traits/lineage-resistance-necrotic",
 				"name": "Damage Resistance: Necrotic",
 				"level": 1
 			},{
-				"index": "lineage-chill-touch",
-				"url": "/api/2024/traits/lineage-chill-touch",
+				"index": "lineage-spell-chill-touch",
+				"url": "/api/2024/traits/lineage-spell-chill-touch",
 				"name": "Chill Touch",
 				"level": 1
 			},
 			{
-				"index": "lineage-false-life",
-				"url": "/api/2024/traits/lineage-false-life",
+				"index": "lineage-spell-false-life",
+				"url": "/api/2024/traits/lineage-spell-false-life",
 				"name": "False Life",
 				"level": 3
 			},
 			{
-				"index": "lineage-ray-of-enfeeblement",
-				"url": "/api/2024/traits/lineage-ray-of-enfeeblement",
+				"index": "lineage-spell-ray-of-enfeeblement",
+				"url": "/api/2024/traits/lineage-spell-ray-of-enfeeblement",
 				"name": "Ray of Enfeeblement",
 				"level": 5
 			}
@@ -546,26 +558,26 @@
 		"name": "Fiendish Legacy: Infernal",
 		"traits": [
 			{
-				"index": "fiendish-damage-resistance-fire",
-				"url": "/api/2024/traits/fiendish-damage-resistance-fire",
+				"index": "lineage-resistance-fire",
+				"url": "/api/2024/traits/lineage-resistance-fire",
 				"name": "Damage Resistance: Fire",
 				"level": 1
 			},
 			{
-				"index": "lineage-fire-bolt",
-				"url": "/api/2024/traits/lineage-fire-bolt",
+				"index": "lineage-spell-fire-bolt",
+				"url": "/api/2024/traits/lineage-spell-fire-bolt",
 				"name": "Fire Bolt",
 				"level": 1
 			},
 			{
-				"index": "lineage-hellish-rebuke",
-				"url": "/api/2024/traits/lineage-hellish-rebuke",
+				"index": "lineage-spell-hellish-rebuke",
+				"url": "/api/2024/traits/lineage-spell-hellish-rebuke",
 				"name": "Hellish Rebuke",
 				"level": 3
 			},
 			{
-				"index": "lineage-darkness",
-				"url": "/api/2024/traits/lineage-darkness",
+				"index": "lineage-spell-darkness",
+				"url": "/api/2024/traits/lineage-spell-darkness",
 				"name": "Darkness",
 				"level": 5
 			}

--- a/src/2024/5e-SRD-Subspecies.json
+++ b/src/2024/5e-SRD-Subspecies.json
@@ -329,20 +329,12 @@
 		"index": "gnomish-lineage-forest-gnome",
 		"url" : "/api/2024/subspecies/gnomish-lineage-forest-gnome",
 		"name": "Gnomish Lineage: Forest Gnome",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "You know the Minor Illusion cantrip. You also always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
-				"spells": [
-					{
-						"nyi": "Minor Illusion"
-					},
-					{
-						"nyi": "Speak with Animals",
-						"uses": "Proficiency Bonus",
-						"recovery": "Long Rest"
-					}
-				]
+				"index": "gnomish-lineage-forest-gnome",
+				"url" : "/api/2024/traits/gnomish-lineage-forest-gnome",
+				"name": "Gnomish Lineage: Forest Gnome",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -355,18 +347,12 @@
 		"index": "gnomish-lineage-rock-gnome",
 		"url" : "/api/2024/subspecies/gnomish-lineage-rock-gnome",
 		"name": "Gnomish Lineage: Rock Gnome",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "You know the Mending and Prestidigitation cantrips. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell’s ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn’t do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.",
-				"spells": [
-					{
-						"nyi": "Mending"
-					},
-					{
-						"nyi": "Prestidigitation"
-					}
-				]
+				"index": "gnomish-lineage-rock-gnome",
+				"url" : "/api/2024/traits/gnomish-lineage-rock-gnome",
+				"name": "Gnomish Lineage: Rock Gnome",
+				"level": 1
 			}
 		],
 		"species" : {

--- a/src/2024/5e-SRD-Subspecies.json
+++ b/src/2024/5e-SRD-Subspecies.json
@@ -365,10 +365,12 @@
 		"index": "giant-ancestry-clouds-jaunt",
 		"url" : "/api/2024/subspecies/giant-ancestry-clouds-jaunt",
 		"name": "Giant Ancestry: Cloud's Jaunt",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "As a Bonus Action, you magically teleport up to 30 feet to an unoccupied space you can see."
+				"index": "giant-ancestry-clouds-jaunt",
+				"url" : "/api/2024/subspecies/giant-ancestry-clouds-jaunt",
+				"name": "Giant Ancestry: Cloud's Jaunt",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -381,10 +383,12 @@
 		"index": "giant-ancestry-fires-burn",
 		"url" : "/api/2024/subspecies/giant-ancestry-fires-burn",
 		"name": "Giant Ancestry: Fire's Burn",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "When you hit a target with an attack roll and deal damage to it, you can also deal 1d10 Fire damage to that target."
+				"index": "giant-ancestry-fires-burn",
+				"url" : "/api/2024/subspecies/giant-ancestry-fires-burn",
+				"name": "Giant Ancestry: Fire's Burn",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -397,10 +401,12 @@
 		"index": "giant-ancestry-frosts-chill",
 		"url" : "/api/2024/subspecies/giant-ancestry-frosts-chill",
 		"name": "Giant Ancestry: Frost's Chill",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "When you hit a target with an attack roll and deal damage to it, you can also deal 1d6 Cold damage to that target and reduce its Speed by 10 feet until the start of your next turn."
+				"index": "giant-ancestry-frosts-chill",
+				"url" : "/api/2024/subspecies/giant-ancestry-frosts-chill",
+				"name": "Giant Ancestry: Frost's Chill",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -413,10 +419,12 @@
 		"index": "giant-ancestry-hills-tumble",
 		"url" : "/api/2024/subspecies/giant-ancestry-hills-tumble",
 		"name": "Giant Ancestry: Hill's Tumble",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "When you hit a Large or smaller creature with an attack roll and deal damage to it, you can give that target the Prone condition."
+				"index": "giant-ancestry-hills-tumble",
+				"url" : "/api/2024/subspecies/giant-ancestry-hills-tumble",
+				"name": "Giant Ancestry: Hill's Tumble",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -429,10 +437,12 @@
 		"index": "giant-ancestry-stones-endurance",
 		"url" : "/api/2024/subspecies/giant-ancestry-stones-endurance",
 		"name": "Giant Ancestry: Stone's Endurance",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "When you take damage, you can take a Reaction to roll 1d12. Add your Constitution modifier to the number rolled and reduce the damage by that total."
+				"index": "giant-ancestry-stones-endurance",
+				"url" : "/api/2024/subspecies/giant-ancestry-stones-endurance",
+				"name": "Giant Ancestry: Stone's Endurance",
+				"level": 1
 			}
 		],
 		"species" : {
@@ -445,10 +455,12 @@
 		"index": "giant-ancestry-storms-thunder",
 		"url" : "/api/2024/subspecies/giant-ancestry-storms-thunder",
 		"name": "Giant Ancestry: Storm's Thunder",
-		"level_effects": [
+		"traits": [
 			{
-				"level": 1,
-				"description": "When you take damage from a creature within 60 feet of you, you can take a Reaction to deal 1d8 Thunder damage to that creature."
+				"index": "giant-ancestry-storms-thunder",
+				"url" : "/api/2024/subspecies/giant-ancestry-storms-thunder",
+				"name": "Giant Ancestry: Storm's Thunder",
+				"level": 1
 			}
 		],
 		"species" : {

--- a/src/2024/5e-SRD-Subspecies.json
+++ b/src/2024/5e-SRD-Subspecies.json
@@ -509,7 +509,7 @@
 		"index": "fiendish-legacy-chthonic",
 		"url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
 		"name": "Fiendish Legacy: Chthonic",
-		"level_effects": [
+		"traits": [
 			{
 				"index": "fiendish-damage-resistance-necrotic",
 				"url": "/api/2024/traits/fiendish-damage-resistance-necrotic",

--- a/src/2024/5e-SRD-Subspecies.json
+++ b/src/2024/5e-SRD-Subspecies.json
@@ -241,21 +241,21 @@
 				"level": 1
 			},
 			{
-				"index": "drow-dancing-lights",
-				"url": "/api/2024/traits/drow-dancing-lights",
-				"name": "Drow: Dancing Lights",
+				"index": "lineage-dancing-lights",
+				"url": "/api/2024/traits/lineage-dancing-lights",
+				"name": "Dancing Lights",
 				"level": 1
 			},
 			{
-				"index": "drow-faerie-fire",
-				"url": "/api/2024/traits/drow-faerie-fire",
-				"name": "Drow: Faerie Fire",
+				"index": "lineage-faerie-fire",
+				"url": "/api/2024/traits/lineage-faerie-fire",
+				"name": "Faerie Fire",
 				"level": 3
 			},
 			{
-				"index": "drow-darkness",
-				"url": "/api/2024/traits/drow-darkness",
-				"name": "Drow: Darkness",
+				"index": "lineage-darkness",
+				"url": "/api/2024/traits/lineage-darkness",
+				"name": "Darkness",
 				"level": 5
 			}
 		],
@@ -277,15 +277,15 @@
 				"level": 1
 			},
 			{
-				"index": "high-elf-detect-magic",
-				"url": "/api/2024/traits/high-elf-detect-magic",
-				"name": "High Elf: Detect Magic",
+				"index": "lineage-detect-magic",
+				"url": "/api/2024/traits/lineage-detect-magic",
+				"name": "Detect Magic",
 				"level": 3
 			},
 			{
-				"index": "high-elf-misty-step",
-				"url": "/api/2024/traits/high-elf-misty-step",
-				"name": "High Elf: Misty Step",
+				"index": "lineage-misty-step",
+				"url": "/api/2024/traits/lineage-misty-step",
+				"name": "Misty Step",
 				"level": 5
 			}
 		],
@@ -307,15 +307,15 @@
 				"level": 1
 			},
 			{
-				"index": "wood-elf-longstrider",
-				"url": "/api/2024/traits/wood-elf-longstrider",
-				"name": "Wood Elf: Longstrider",
+				"index": "lineage-longstrider",
+				"url": "/api/2024/traits/lineage-longstrider",
+				"name": "Longstrider",
 				"level": 3
 			},
 			{
-				"index": "wood-elf-pass-without-trace",
-				"url": "/api/2024/traits/wood-elf-pass-without-trace",
-				"name": "Wood Elf: Pass without Trace",
+				"index": "lineage-pass-without-trace",
+				"url": "/api/2024/traits/lineage-pass-without-trace",
+				"name": "Pass without Trace",
 				"level": 5
 			}
 		],
@@ -472,35 +472,31 @@
 	{
 		"index": "fiendish-legacy-abyssal",
 		"url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
-		"name": "Fiendish Lineage: Abyssal",
-		"level_effects": [
+		"name": "Fiendish Legacy: Abyssal",
+		"traits": [
 			{
-				"level": 1,
-				"description": "You have Resistance to Poison damage.\nYou also know the Poison Spray cantrip.",
-				"traits" : [
-					{
-						"index": "fiendish-damage-resistance-poison",
-						"url": "/api/2024/traits/fiendish-damage-resistance-poison",
-						"name": "Damage Resistance: Poison"
-					}
-				],
-				"spells": [
-					{ "nyi": "Poison Spray" }
-				]
+				"index": "fiendish-damage-resistance-poison",
+				"url": "/api/2024/traits/fiendish-damage-resistance-poison",
+				"name": "Damage Resistance: Poison",
+				"level": 1
 			},
 			{
-				"level": 3,
-				"description": "Ray of Sickness",
-				"spells": [
-					{ "nyi": "Ray of Sickness" }
-				]
+				"index": "lineage-poison-spray",
+				"url": "/api/2024/traits/lineage-poison-spray",
+				"name": "Poison Spray",
+				"level": 1
 			},
 			{
-				"level": 5,
-				"description": "Hold Person",
-				"spells": [
-					{ "nyi": "Hold Person" }
-				]
+				"index": "lineage-ray-of-sickness",
+				"url": "/api/2024/traits/lineage-ray-of-sickness",
+				"name": "Ray of Sickness",
+				"level": 3
+			},
+			{
+				"index": "lineage-hold-person",
+				"url": "/api/2024/traits/lineage-hold-person",
+				"name": "Hold Person",
+				"level": 5
 			}
 		],
 		"species" : {
@@ -512,35 +508,30 @@
 	{
 		"index": "fiendish-legacy-chthonic",
 		"url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
-		"name": "Fiendish Lineage: Chthonic",
+		"name": "Fiendish Legacy: Chthonic",
 		"level_effects": [
 			{
-				"level": 1,
-				"description": "You have Resistance to Necrotic damage.\nYou also know the Chill Touch cantrip.",
-				"traits" : [
-					{
-						"index": "fiendish-damage-resistance-necrotic",
-						"url": "/api/2024/traits/fiendish-damage-resistance-necrotic",
-						"name": "Damage Resistance: Necrotic"
-					}
-				],
-				"spells": [
-					{ "nyi": "Chill Touch" }
-				]
+				"index": "fiendish-damage-resistance-necrotic",
+				"url": "/api/2024/traits/fiendish-damage-resistance-necrotic",
+				"name": "Damage Resistance: Necrotic",
+				"level": 1
+			},{
+				"index": "lineage-chill-touch",
+				"url": "/api/2024/traits/lineage-chill-touch",
+				"name": "Chill Touch",
+				"level": 1
 			},
 			{
-				"level": 3,
-				"description": "False Life",
-				"spells": [
-					{ "nyi": "False Life" }
-				]
+				"index": "lineage-false-life",
+				"url": "/api/2024/traits/lineage-false-life",
+				"name": "False Life",
+				"level": 3
 			},
 			{
-				"level": 5,
-				"description": "Ray of Enfeeblement",
-				"spells": [
-					{ "nyi": "Ray of Enfeeblement" }
-				]
+				"index": "lineage-ray-of-enfeeblement",
+				"url": "/api/2024/traits/lineage-ray-of-enfeeblement",
+				"name": "Ray of Enfeeblement",
+				"level": 5
 			}
 		],
 		"species" : {
@@ -552,35 +543,31 @@
 	{
 		"index": "fiendish-legacy-infernal",
 		"url" : "/api/2024/subspecies/fiendish-legacy-infernal",
-		"name": "Fiendish Lineage: Infernal",
-		"level_effects": [
+		"name": "Fiendish Legacy: Infernal",
+		"traits": [
 			{
-				"level": 1,
-				"description": "You have Resistance to Fire damage.\nYou also know the Fire Bolt cantrip.",
-				"traits" : [
-					{
-						"index": "fiendish-damage-resistance-fire",
-						"url": "/api/2024/traits/fiendish-damage-resistance-fire",
-						"name": "Damage Resistance: Fire"
-					}
-				],
-				"spells": [
-					{ "nyi": "Fire Bolt" }
-				]
+				"index": "fiendish-damage-resistance-fire",
+				"url": "/api/2024/traits/fiendish-damage-resistance-fire",
+				"name": "Damage Resistance: Fire",
+				"level": 1
 			},
 			{
-				"level": 3,
-				"description": "Hellish Rebuke",
-				"spells": [
-					{ "nyi": "Hellish Rebuke" }
-				]
+				"index": "lineage-fire-bolt",
+				"url": "/api/2024/traits/lineage-fire-bolt",
+				"name": "Fire Bolt",
+				"level": 1
 			},
 			{
-				"level": 5,
-				"description": "Darkness",
-				"spells": [
-					{ "nyi": "Darkness" }
-				]
+				"index": "lineage-hellish-rebuke",
+				"url": "/api/2024/traits/lineage-hellish-rebuke",
+				"name": "Hellish Rebuke",
+				"level": 3
+			},
+			{
+				"index": "lineage-darkness",
+				"url": "/api/2024/traits/lineage-darkness",
+				"name": "Darkness",
+				"level": 5
 			}
 		],
 		"species" : {

--- a/src/2024/5e-SRD-Traits.json
+++ b/src/2024/5e-SRD-Traits.json
@@ -388,66 +388,6 @@
     ]
   },
   {
-    "index": "fiendish-damage-resistance-fire",
-    "url": "/api/2024/traits/fiendish-damage-resistance-fire",
-    "name": "Damage Resistance: Fire",
-    "description": "You have Resistance to Fire damage.",
-    "species": [
-      {
-        "index": "tiefling",
-        "url": "/api/2024/species/tiefling",
-        "name": "Tiefling"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "fiendish-legacy-infernal",
-        "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
-        "name": "Fiendish Legacy: Infernal"
-      }
-    ]
-  },
-  {
-    "index": "fiendish-damage-resistance-necrotic",
-    "url": "/api/2024/traits/fiendish-damage-resistance-necrotic",
-    "name": "Damage Resistance: Necrotic",
-    "description": "You have Resistance to Necrotic damage.",
-    "species": [
-      {
-        "index": "tiefling",
-        "url": "/api/2024/species/tiefling",
-        "name": "Tiefling"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "fiendish-legacy-chthonic",
-        "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
-        "name": "Fiendish Legacy: Chthonic"
-      }
-    ]
-  },
-  {
-    "index": "fiendish-damage-resistance-poison",
-    "url": "/api/2024/traits/fiendish-damage-resistance-poison",
-    "name": "Damage Resistance: Poison",
-    "description": "You have Resistance to Poison damage.",
-    "species": [
-      {
-        "index": "tiefling",
-        "url": "/api/2024/species/tiefling",
-        "name": "Tiefling"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "fiendish-legacy-abyssal",
-        "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
-        "name": "Fiendish Legacy: Abyssal"
-      }
-    ]
-  },
-  {
     "index": "fiendish-legacy",
     "url": "/api/2024/traits/fiendish-legacy",
     "name": "Fiendish Legacy",
@@ -611,11 +551,8 @@
     "index": "gnomish-lineage-forest-gnome",
     "url" : "/api/2024/traits/gnomish-lineage-forest-gnome",
     "name": "Gnomish Lineage: Forest Gnome",
-    "description": "You know the Minor Illusion cantrip. You also always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
+    "description": "You always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
     "spells": [
-      {
-        "nyi": "Minor Illusion"
-      },
       {
         "nyi": "Speak with Animals",
         "uses": "Proficiency Bonus",
@@ -639,11 +576,8 @@
     "index": "gnomish-lineage-rock-gnome",
     "url" : "/api/2024/traits/gnomish-lineage-rock-gnome",
     "name": "Gnomish Lineage: Rock Gnome",
-    "description": "You know the Mending and Prestidigitation cantrips. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell’s ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn’t do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.",
+    "description": "You know the Prestidigitation cantrip. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell’s ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn’t do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.",
     "spells": [
-      {
-        "nyi": "Mending"
-      },
       {
         "nyi": "Prestidigitation"
       }
@@ -743,8 +677,68 @@
     ]
   },
   {
-    "index": "lineage-chill-touch",
-    "url": "/api/2024/traits/lineage-chill-touch",
+    "index": "lineage-resistance-fire",
+    "url": "/api/2024/traits/lineage-resistance-fire",
+    "name": "Damage Resistance: Fire",
+    "description": "You have Resistance to Fire damage.",
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-infernal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
+        "name": "Fiendish Legacy: Infernal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-resistance-necrotic",
+    "url": "/api/2024/traits/lineage-resistance-necrotic",
+    "name": "Damage Resistance: Necrotic",
+    "description": "You have Resistance to Necrotic damage.",
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-chthonic",
+        "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
+        "name": "Fiendish Legacy: Chthonic"
+      }
+    ]
+  },
+  {
+    "index": "lineage-resistance-poison",
+    "url": "/api/2024/traits/lineage-resistance-poison",
+    "name": "Damage Resistance: Poison",
+    "description": "You have Resistance to Poison damage.",
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-abyssal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
+        "name": "Fiendish Legacy: Abyssal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-spell-chill-touch",
+    "url": "/api/2024/traits/lineage-spell-chill-touch",
     "name": "Chill Touch",
     "description": "You know the spell Chill Touch.",
     "spells": [
@@ -768,8 +762,8 @@
     ]
   },
   {
-    "index": "lineage-dancing-lights",
-    "url": "/api/2024/traits/lineage-dancing-lights",
+    "index": "lineage-spell-dancing-lights",
+    "url": "/api/2024/traits/lineage-spell-dancing-lights",
     "name": "Dancing Lights",
     "description": "You know the spell Dancing Lights.",
     "spells": [
@@ -793,8 +787,8 @@
     ]
   },
   {
-    "index": "lineage-darkness",
-    "url": "/api/2024/traits/lineage-darkness",
+    "index": "lineage-spell-darkness",
+    "url": "/api/2024/traits/lineage-spell-darkness",
     "name": "Darkness",
     "description": "You know the spell Darkness.",
     "spells": [
@@ -818,8 +812,8 @@
     ]
   },
   {
-    "index": "lineage-detect-magic",
-    "url": "/api/2024/traits/lineage-detect-magic",
+    "index": "lineage-spell-detect-magic",
+    "url": "/api/2024/traits/lineage-spell-detect-magic",
     "name": "Detect Magic",
     "description": "You know the spell Detect Magic.",
     "spells": [
@@ -843,8 +837,8 @@
     ]
   },
   {
-    "index": "lineage-faerie-fire",
-    "url": "/api/2024/traits/lineage-faerie-fire",
+    "index": "lineage-spell-faerie-fire",
+    "url": "/api/2024/traits/lineage-spell-faerie-fire",
     "name": "Faerie Fire",
     "description": "You know the spell Faerie Fire.",
     "spells": [
@@ -868,8 +862,8 @@
     ]
   },
   {
-    "index": "lineage-false-life",
-    "url": "/api/2024/traits/lineage-false-life",
+    "index": "lineage-spell-false-life",
+    "url": "/api/2024/traits/lineage-spell-false-life",
     "name": "False Life",
     "description": "You know the spell False Life.",
     "spells": [
@@ -893,8 +887,8 @@
     ]
   },
   {
-    "index": "lineage-fire-bolt",
-    "url": "/api/2024/traits/lineage-fire-bolt",
+    "index": "lineage-spell-fire-bolt",
+    "url": "/api/2024/traits/lineage-spell-fire-bolt",
     "name": "Fire Bolt",
     "description": "You know the spell Fire Bolt.",
     "spells": [
@@ -918,8 +912,8 @@
     ]
   },
   {
-    "index": "lineage-hellish-rebuke",
-    "url": "/api/2024/traits/lineage-hellish-rebuke",
+    "index": "lineage-spell-hellish-rebuke",
+    "url": "/api/2024/traits/lineage-spell-hellish-rebuke",
     "name": "Hellish Rebuke",
     "description": "You know the spell Hellish Rebuke.",
     "spells": [
@@ -943,8 +937,8 @@
     ]
   },
   {
-    "index": "lineage-hold-person",
-    "url": "/api/2024/traits/lineage-hold-person",
+    "index": "lineage-spell-hold-person",
+    "url": "/api/2024/traits/lineage-spell-hold-person",
     "name": "Hold Person",
     "description": "You know the spell Hold Person.",
     "spells": [
@@ -968,8 +962,8 @@
     ]
   },
   {
-    "index": "lineage-longstrider",
-    "url": "/api/2024/traits/lineage-longstrider",
+    "index": "lineage-spell-longstrider",
+    "url": "/api/2024/traits/lineage-spell-longstrider",
     "name": "Longstrider",
     "description": "You learn the spell Longstrider.",
     "spells": [
@@ -993,8 +987,58 @@
     ]
   },
   {
-    "index": "lineage-misty-step",
-    "url": "/api/2024/traits/lineage-misty-step",
+    "index": "lineage-spell-mending",
+    "url": "/api/2024/traits/lineage-spell-mending",
+    "name": "Mending",
+    "description": "You know the cantrip Mending.",
+    "spells": [
+      {
+        "nyi": "Mending"
+      }
+    ],
+    "species": [
+      {
+        "index": "gnome",
+        "url": "/api/2024/species/gnome",
+        "name": "Gnome"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "gnomish-lineage-rock-gnome",
+        "url" : "/api/2024/subspecies/gnomish-lineage-rock-gnome",
+        "name": "Gnomish Lineage: Rock Gnome"
+      }
+    ]
+  },
+  {
+    "index": "lineage-spell-minor-illusion",
+    "url": "/api/2024/traits/lineage-spell-minor-illusion",
+    "name": "Minor Illusion",
+    "description": "You know the spell Minor Illusion.",
+    "spells": [
+      {
+        "nyi": "Minor Illusion"
+      }
+    ],
+    "species": [
+      {
+        "index": "gnome",
+        "url": "/api/2024/species/gnome",
+        "name": "Gnome"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "gnomish-lineage-forest-gnome",
+        "url" : "/api/2024/subspecies/gnomish-lineage-forest-gnome",
+        "name": "Gnomish Lineage: Forest Gnome"
+      }
+    ]
+  },
+  {
+    "index": "lineage-spell-misty-step",
+    "url": "/api/2024/traits/lineage-spell-misty-step",
     "name": "Misty Step",
     "description": "You know the spell Misty Step.",
     "spells": [
@@ -1018,8 +1062,8 @@
     ]
   },
   {
-    "index": "lineage-pass-without-trace",
-    "url": "/api/2024/traits/lineage-pass-without-trace",
+    "index": "lineage-spell-pass-without-trace",
+    "url": "/api/2024/traits/lineage-spell-pass-without-trace",
     "name": "Pass without Trace",
     "description": "You learn the spell Pass without Trace.",
     "spells": [
@@ -1043,8 +1087,8 @@
     ]
   },
   {
-    "index": "lineage-poison-spray",
-    "url": "/api/2024/traits/lineage-poison-spray",
+    "index": "lineage-spell-poison-spray",
+    "url": "/api/2024/traits/lineage-spell-poison-spray",
     "name": "Poison Spray",
     "description": "You know the spell Poison Spray.",
     "spells": [
@@ -1068,8 +1112,8 @@
     ]
   },
   {
-    "index": "lineage-ray-of-enfeeblement",
-    "url": "/api/2024/traits/lineage-ray-of-enfeeblement",
+    "index": "lineage-spell-ray-of-enfeeblement",
+    "url": "/api/2024/traits/lineage-spell-ray-of-enfeeblement",
     "name": "Ray of Enfeeblement",
     "description": "You know the spell Ray of Enfeeblement.",
     "spells": [
@@ -1093,8 +1137,8 @@
     ]
   },
   {
-    "index": "lineage-ray-of-sickness",
-    "url": "/api/2024/traits/lineage-ray-of-sickness",
+    "index": "lineage-spell-ray-of-sickness",
+    "url": "/api/2024/traits/lineage-spell-ray-of-sickness",
     "name": "Ray of Sickness",
     "description": "You know the spell Ray of Sickness.",
     "spells": [

--- a/src/2024/5e-SRD-Traits.json
+++ b/src/2024/5e-SRD-Traits.json
@@ -575,6 +575,60 @@
     ]
   },
   {
+    "index": "gnomish-lineage-forest-gnome",
+    "url" : "/api/2024/traits/gnomish-lineage-forest-gnome",
+    "name": "Gnomish Lineage: Forest Gnome",
+    "description": "You know the Minor Illusion cantrip. You also always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
+    "spells": [
+      {
+        "nyi": "Minor Illusion"
+      },
+      {
+        "nyi": "Speak with Animals",
+        "uses": "Proficiency Bonus",
+        "recovery": "Long Rest"
+      }
+    ],
+    "species" : {
+      "index": "gnome",
+      "name": "Gnome",
+      "url": "/api/2024/species/gnome"
+    },
+    "subspecies": [
+      {
+        "index": "gnomish-lineage-forest-gnome",
+        "url" : "/api/2024/subspecies/gnomish-lineage-forest-gnome",
+        "name": "Gnomish Lineage: Forest Gnome"
+      }
+    ]
+  },
+  {
+    "index": "gnomish-lineage-rock-gnome",
+    "url" : "/api/2024/traits/gnomish-lineage-rock-gnome",
+    "name": "Gnomish Lineage: Rock Gnome",
+    "description": "You know the Mending and Prestidigitation cantrips. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell’s ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn’t do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.",
+    "spells": [
+      {
+        "nyi": "Mending"
+      },
+      {
+        "nyi": "Prestidigitation"
+      }
+    ],
+    "species" : {
+      "index": "gnome",
+      "name": "Gnome",
+      "url": "/api/2024/species/gnome"
+    },
+    "subspecies": [
+      {
+        "index": "gnomish-lineage-rock-gnome",
+        "url" : "/api/2024/subspecies/gnomish-lineage-rock-gnome",
+        "name": "Gnomish Lineage: Rock Gnome"
+      }
+    ]
+	},
+  {
     "index": "halfling-nimbleness",
     "url": "/api/2024/traits/halfling-nimbleness",
     "name": "Halfling Nimbleness",

--- a/src/2024/5e-SRD-Traits.json
+++ b/src/2024/5e-SRD-Traits.json
@@ -336,81 +336,6 @@
     ]
   },
   {
-    "index": "drow-dancing-lights",
-    "url": "/api/2024/traits/drow-dancing-lights",
-    "name": "Drow: Dancing Lights",
-    "description": "You know the spell Dancing Lights.",
-    "spells": [
-      {
-        "nyi": "Dancing Lights"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-drow",
-        "url" : "/api/2024/subspecies/elven-lineage-drow",
-        "name": "Elven Lineage: Drow"
-      }
-    ]
-  },
-  {
-    "index": "drow-faerie-fire",
-    "url": "/api/2024/traits/drow-faerie-fire",
-    "name": "Drow: Faerie Fire",
-    "description": "You know the spell Faerie Fire.",
-    "spells": [
-      {
-        "nyi": "Faerie Fire"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-drow",
-        "url" : "/api/2024/subspecies/elven-lineage-drow",
-        "name": "Elven Lineage: Drow"
-      }
-    ]
-  },
-  {
-    "index": "drow-darkness",
-    "url": "/api/2024/traits/drow-darkness",
-    "name": "Drow: Darkness",
-    "description": "You know the spell Darkness.",
-    "spells": [
-      {
-        "nyi": "Darkness"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-drow",
-        "url" : "/api/2024/subspecies/elven-lineage-drow",
-        "name": "Elven Lineage: Drow"
-      }
-    ]
-  },
-  {
     "index": "dwarven-resilience",
     "url": "/api/2024/traits/dwarven-resilience",
     "name": "Dwarven Resilience",
@@ -478,7 +403,7 @@
       {
         "index": "fiendish-legacy-infernal",
         "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
-        "name": "Fiendish Lineage: Infernal"
+        "name": "Fiendish Legacy: Infernal"
       }
     ]
   },
@@ -498,7 +423,7 @@
       {
         "index": "fiendish-legacy-chthonic",
         "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
-        "name": "Fiendish Lineage: Chthonic"
+        "name": "Fiendish Legacy: Chthonic"
       }
     ]
   },
@@ -518,7 +443,7 @@
       {
         "index": "fiendish-legacy-abyssal",
         "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
-        "name": "Fiendish Lineage: Abyssal"
+        "name": "Fiendish Legacy: Abyssal"
       }
     ]
   },
@@ -775,56 +700,6 @@
     ]
   },
   {
-    "index": "high-elf-detect-magic",
-    "url": "/api/2024/traits/high-elf-detect-magic",
-    "name": "High Elf: Detect Magic",
-    "description": "You know the spell Detect Magic.",
-    "spells": [
-      {
-        "nyi": "Detect Magic"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-high-elf",
-        "url" : "/api/2024/subspecies/elven-lineage-high-elf",
-        "name": "Elven Lineage: High Elf"
-      }
-    ]
-  },
-  {
-    "index": "high-elf-misty-step",
-    "url": "/api/2024/traits/high-elf-misty-step",
-    "name": "High Elf: Misty Step",
-    "description": "You know the spell Misty Step.",
-    "spells": [
-      {
-        "nyi": "Misty Step"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-high-elf",
-        "url" : "/api/2024/subspecies/elven-lineage-high-elf",
-        "name": "Elven Lineage: High Elf"
-      }
-    ]
-  },
-  {
     "index": "keen-senses",
     "url": "/api/2024/traits/keen-senses",
     "name": "Keen Senses",
@@ -864,6 +739,381 @@
         "index": "goliath",
         "url": "/api/2024/species/goliath",
         "name": "Goliath"
+      }
+    ]
+  },
+  {
+    "index": "lineage-chill-touch",
+    "url": "/api/2024/traits/lineage-chill-touch",
+    "name": "Chill Touch",
+    "description": "You know the spell Chill Touch.",
+    "spells": [
+      {
+        "nyi": "Chill Touch"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-chthonic",
+        "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
+        "name": "Fiendish Legacy: Chthonic"
+      }
+    ]
+  },
+  {
+    "index": "lineage-dancing-lights",
+    "url": "/api/2024/traits/lineage-dancing-lights",
+    "name": "Dancing Lights",
+    "description": "You know the spell Dancing Lights.",
+    "spells": [
+      {
+        "nyi": "Dancing Lights"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-drow",
+        "url" : "/api/2024/subspecies/elven-lineage-drow",
+        "name": "Elven Lineage: Drow"
+      }
+    ]
+  },
+  {
+    "index": "lineage-darkness",
+    "url": "/api/2024/traits/lineage-darkness",
+    "name": "Darkness",
+    "description": "You know the spell Darkness.",
+    "spells": [
+      {
+        "nyi": "Darkness"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-drow",
+        "url" : "/api/2024/subspecies/elven-lineage-drow",
+        "name": "Elven Lineage: Drow"
+      }
+    ]
+  },
+  {
+    "index": "lineage-detect-magic",
+    "url": "/api/2024/traits/lineage-detect-magic",
+    "name": "Detect Magic",
+    "description": "You know the spell Detect Magic.",
+    "spells": [
+      {
+        "nyi": "Detect Magic"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-high-elf",
+        "url" : "/api/2024/subspecies/elven-lineage-high-elf",
+        "name": "Elven Lineage: High Elf"
+      }
+    ]
+  },
+  {
+    "index": "lineage-faerie-fire",
+    "url": "/api/2024/traits/lineage-faerie-fire",
+    "name": "Faerie Fire",
+    "description": "You know the spell Faerie Fire.",
+    "spells": [
+      {
+        "nyi": "Faerie Fire"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-drow",
+        "url" : "/api/2024/subspecies/elven-lineage-drow",
+        "name": "Elven Lineage: Drow"
+      }
+    ]
+  },
+  {
+    "index": "lineage-false-life",
+    "url": "/api/2024/traits/lineage-false-life",
+    "name": "False Life",
+    "description": "You know the spell False Life.",
+    "spells": [
+      {
+        "nyi": "False Life"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-chthonic",
+        "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
+        "name": "Fiendish Legacy: Chthonic"
+      }
+    ]
+  },
+  {
+    "index": "lineage-fire-bolt",
+    "url": "/api/2024/traits/lineage-fire-bolt",
+    "name": "Fire Bolt",
+    "description": "You know the spell Fire Bolt.",
+    "spells": [
+      {
+        "nyi": "Fire Bolt"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-infernal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
+        "name": "Fiendish Legacy: Infernal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-hellish-rebuke",
+    "url": "/api/2024/traits/lineage-hellish-rebuke",
+    "name": "Hellish Rebuke",
+    "description": "You know the spell Hellish Rebuke.",
+    "spells": [
+      {
+        "nyi": "Hellish Rebuke"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-infernal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
+        "name": "Fiendish Legacy: Infernal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-hold-person",
+    "url": "/api/2024/traits/lineage-hold-person",
+    "name": "Hold Person",
+    "description": "You know the spell Hold Person.",
+    "spells": [
+      {
+        "nyi": "Hold Person"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-abyssal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
+        "name": "Fiendish Legacy: Abyssal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-longstrider",
+    "url": "/api/2024/traits/lineage-longstrider",
+    "name": "Longstrider",
+    "description": "You learn the spell Longstrider.",
+    "spells": [
+      {
+        "nyi": "Longstrider"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-wood-elf",
+        "url" : "/api/2024/subspecies/elven-lineage-wood-elf",
+        "name": "Elven Lineage: Wood Elf"
+      }
+    ]
+  },
+  {
+    "index": "lineage-misty-step",
+    "url": "/api/2024/traits/lineage-misty-step",
+    "name": "Misty Step",
+    "description": "You know the spell Misty Step.",
+    "spells": [
+      {
+        "nyi": "Misty Step"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-high-elf",
+        "url" : "/api/2024/subspecies/elven-lineage-high-elf",
+        "name": "Elven Lineage: High Elf"
+      }
+    ]
+  },
+  {
+    "index": "lineage-pass-without-trace",
+    "url": "/api/2024/traits/lineage-pass-without-trace",
+    "name": "Pass without Trace",
+    "description": "You learn the spell Pass without Trace.",
+    "spells": [
+      {
+        "nyi": "Pass without Trace"
+      }
+    ],
+    "species": [
+      {
+        "index": "elf",
+        "url": "/api/2024/species/elf",
+        "name": "Elf"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "elven-lineage-wood-elf",
+        "url" : "/api/2024/subspecies/elven-lineage-wood-elf",
+        "name": "Elven Lineage: Wood Elf"
+      }
+    ]
+  },
+  {
+    "index": "lineage-poison-spray",
+    "url": "/api/2024/traits/lineage-poison-spray",
+    "name": "Poison Spray",
+    "description": "You know the spell Poison Spray.",
+    "spells": [
+      {
+        "nyi": "Poison Spray"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-abyssal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
+        "name": "Fiendish Legacy: Abyssal"
+      }
+    ]
+  },
+  {
+    "index": "lineage-ray-of-enfeeblement",
+    "url": "/api/2024/traits/lineage-ray-of-enfeeblement",
+    "name": "Ray of Enfeeblement",
+    "description": "You know the spell Ray of Enfeeblement.",
+    "spells": [
+      {
+        "nyi": "Ray of Enfeeblement"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-chthonic",
+        "url" : "/api/2024/subspecies/fiendish-legacy-chthonic",
+        "name": "Fiendish Legacy: Chthonic"
+      }
+    ]
+  },
+  {
+    "index": "lineage-ray-of-sickness",
+    "url": "/api/2024/traits/lineage-ray-of-sickness",
+    "name": "Ray of Sickness",
+    "description": "You know the spell Ray of Sickness.",
+    "spells": [
+      {
+        "nyi": "Ray of Sickness"
+      }
+    ],
+    "species": [
+      {
+        "index": "tiefling",
+        "url": "/api/2024/species/tiefling",
+        "name": "Tiefling"
+      }
+    ],
+    "subspecies": [
+      {
+        "index": "fiendish-legacy-abyssal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-abyssal",
+        "name": "Fiendish Legacy: Abyssal"
       }
     ]
   },
@@ -1093,56 +1343,6 @@
     "name": "Wood Elf: Movement Speed Increase",
     "description": "Your Movement Speed increases to 35 feet.",
     "speed": 35,
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-wood-elf",
-        "url" : "/api/2024/subspecies/elven-lineage-wood-elf",
-        "name": "Elven Lineage: Wood Elf"
-      }
-    ]
-  },
-  {
-    "index": "wood-elf-longstrider",
-    "url": "/api/2024/traits/wood-elf-longstrider",
-    "name": "Wood Elf: Longstrider",
-    "description": "You learn the spell Longstrider.",
-    "spells": [
-      {
-        "nyi": "Longstrider"
-      }
-    ],
-    "species": [
-      {
-        "index": "elf",
-        "url": "/api/2024/species/elf",
-        "name": "Elf"
-      }
-    ],
-    "subspecies": [
-      {
-        "index": "elven-lineage-wood-elf",
-        "url" : "/api/2024/subspecies/elven-lineage-wood-elf",
-        "name": "Elven Lineage: Wood Elf"
-      }
-    ]
-  },
-  {
-    "index": "wood-elf-pass-without-trace",
-    "url": "/api/2024/traits/wood-elf-pass-without-trace",
-    "name": "Wood Elf: Pass without Trace",
-    "description": "You learn the spell Pass without Trace.",
-    "spells": [
-      {
-        "nyi": "Pass without Trace"
-      }
-    ],
     "species": [
       {
         "index": "elf",

--- a/src/2024/5e-SRD-Traits.json
+++ b/src/2024/5e-SRD-Traits.json
@@ -801,6 +801,11 @@
         "index": "elf",
         "url": "/api/2024/species/elf",
         "name": "Elf"
+      },
+      {
+        "index": "tiefling",
+        "name": "Tiefling",
+        "url": "/api/2024/species/tiefling"
       }
     ],
     "subspecies": [
@@ -808,6 +813,11 @@
         "index": "elven-lineage-drow",
         "url" : "/api/2024/subspecies/elven-lineage-drow",
         "name": "Elven Lineage: Drow"
+      },
+      {
+        "index": "fiendish-legacy-infernal",
+        "url" : "/api/2024/subspecies/fiendish-legacy-infernal",
+        "name": "Fiendish Legacy: Infernal"
       }
     ]
   },

--- a/src/2024/5e-SRD-Traits.json
+++ b/src/2024/5e-SRD-Traits.json
@@ -549,6 +549,114 @@
     ]
   },
   {
+    "index": "giant-ancestry-clouds-jaunt",
+    "url" : "/api/2024/traits/giant-ancestry-clouds-jaunt",
+    "name": "Giant Ancestry: Cloud's Jaunt",
+    "description": "As a Bonus Action, you magically teleport up to 30 feet to an unoccupied space you can see.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-clouds-jaunt",
+        "url" : "/api/2024/subspecies/giant-ancestry-clouds-jaunt",
+        "name": "Giant Ancestry: Cloud's Jaunt"
+      }
+    ]
+  },
+  {
+    "index": "giant-ancestry-fires-burn",
+    "url" : "/api/2024/traits/giant-ancestry-fires-burn",
+    "name": "Giant Ancestry: Fire's Burn",
+    "description": "When you hit a target with an attack roll and deal damage to it, you can also deal 1d10 Fire damage to that target.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-fires-burn",
+        "url" : "/api/2024/subspecies/giant-ancestry-fires-burn",
+        "name": "Giant Ancestry: Fire's Burn"
+      }
+    ]
+  },
+  {
+    "index": "giant-ancestry-frosts-chill",
+    "url" : "/api/2024/traits/giant-ancestry-frosts-chill",
+    "name": "Giant Ancestry: Frost's Chill",
+    "description": "When you hit a target with an attack roll and deal damage to it, you can also deal 1d6 Cold damage to that target and reduce its Speed by 10 feet until the start of your next turn.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-frosts-chill",
+        "url" : "/api/2024/subspecies/giant-ancestry-frosts-chill",
+        "name": "Giant Ancestry: Frost's Chill"
+      }
+    ]
+  },
+  {
+    "index": "giant-ancestry-hills-tumble",
+    "url" : "/api/2024/traits/giant-ancestry-hills-tumble",
+    "name": "Giant Ancestry: Hill's Tumble",
+    "description": "When you hit a Large or smaller creature with an attack roll and deal damage to it, you can give that target the Prone condition.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-hills-tumble",
+        "url" : "/api/2024/subspecies/giant-ancestry-hills-tumble",
+        "name": "Giant Ancestry: Hill's Tumble"
+      }
+    ]
+  },
+  {
+    "index": "giant-ancestry-stones-endurance",
+    "url" : "/api/2024/traits/giant-ancestry-stones-endurance",
+    "name": "Giant Ancestry: Stone's Endurance",
+    "description": "When you take damage, you can take a Reaction to roll 1d12. Add your Constitution modifier to the number rolled and reduce the damage by that total.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-stones-endurance",
+        "url" : "/api/2024/subspecies/giant-ancestry-stones-endurance",
+        "name": "Giant Ancestry: Stone's Endurance"
+      }
+    ]
+  },
+  {
+    "index": "giant-ancestry-storms-thunder",
+    "url" : "/api/2024/traits/giant-ancestry-storms-thunder",
+    "name": "Giant Ancestry: Storm's Thunder",
+    "description": "When you take damage from a creature within 60 feet of you, you can take a Reaction to deal 1d8 Thunder damage to that creature.",
+    "species" : {
+      "index": "goliath",
+      "name": "Goliath",
+      "url": "/api/2024/species/goliath"
+    },
+    "subspecies": [
+      {
+        "index": "giant-ancestry-storms-thunder",
+        "url" : "/api/2024/subspecies/giant-ancestry-storms-thunder",
+        "name": "Giant Ancestry: Storm's Thunder"
+      }
+    ]
+  },
+  {
     "index": "gnomish-cunning",
     "url": "/api/2024/traits/gnomish-cunning",
     "name": "Gnomish Cunning",


### PR DESCRIPTION
## What does this do?

This PR finishes changing `level_effects` to `traits` arrays for Gnome, Goliath, and Tiefling subspecies.
It also standardizes the naming of spell and resistances granted by lineage when no modification is made to that trait.

## How was it tested?

Local testing using `npm test` and `npm db:refresh`.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

I made this a while ago, in the midst of the _Live, Laugh, Love_ craze.
<img width="786" height="566" alt="Live_Laugh_Roll_Initiative" src="https://github.com/user-attachments/assets/4a61a692-43e2-41fb-968d-4b548f5da623" />

