### PR TITLE
feat(2024): Add Magic Items

### DIFF
--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -1356,6 +1356,12 @@
     "url": "/api/2024/equipment-categories/other-tools"
   },
   {
+    "name": "Potions",
+    "index": "potions",
+    "equipment": [],
+    "url": "/api/2024/equipment-categories/potions"
+  },
+  {
     "index": "ranged-weapons",
     "name": "Ranged Weapons",
     "equipment": [
@@ -1411,6 +1417,12 @@
       }
     ],
     "url": "/api/2024/equipment-categories/ranged-weapons"
+  },
+  {
+    "name": "Rings",
+    "index": "rings",
+    "equipment": [],
+    "url": "/api/2024/equipment-categories/rings"
   },
   {
     "index": "shields",
@@ -1584,6 +1596,12 @@
       }
     ],
     "url": "/api/2024/equipment-categories/simple-weapons"
+  },
+  {
+    "name": "Staffs",
+    "index": "staffs",
+    "equipment": [],
+    "url": "/api/2024/equipment-categories/staffs"
   },
   {
     "index": "tools",
@@ -1771,6 +1789,12 @@
       }
     ],
     "url": "/api/2024/equipment-categories/tools"
+  },
+  {
+    "name": "Wands",
+    "index": "wands",
+    "equipment": [],
+    "url": "/api/2024/equipment-categories/wands"
   },
   {
     "index": "weapons",
@@ -1968,5 +1992,11 @@
       }
     ],
     "url": "/api/2024/equipment-categories/weapons"
+  },
+  {
+    "name": "Wondrous Items",
+    "index": "wondrous-items",
+    "equipment": [],
+    "url": "/api/2024/equipment-categories/wondrous-items"
   }
 ]

--- a/src/2024/5e-SRD-Equipment-Categories.json
+++ b/src/2024/5e-SRD-Equipment-Categories.json
@@ -1358,7 +1358,108 @@
   {
     "name": "Potions",
     "index": "potions",
-    "equipment": [],
+    "equipment": [
+      {
+        "index": "oil-of-etherealness",
+        "name": "Oil of Etherealness",
+        "url": "/api/2024/magic-items/oil-of-etherealness"
+      },
+      {
+        "index": "oil-of-sharpness",
+        "name": "Oil of Sharpness",
+        "url": "/api/2024/magic-items/oil-of-sharpness"
+      },
+      {
+        "index": "oil-of-slipperiness",
+        "name": "Oil of Slipperiness",
+        "url": "/api/2024/magic-items/oil-of-slipperiness"
+      },
+      {
+        "index": "philter-of-love",
+        "name": "Philter of Love",
+        "url": "/api/2024/magic-items/philter-of-love"
+      },
+      {
+        "index": "potion-of-animal-friendship",
+        "name": "Potion of Animal Friendship",
+        "url": "/api/2024/magic-items/potion-of-animal-friendship"
+      },
+      {
+        "index": "potion-of-clairvoyance",
+        "name": "Potion of Clairvoyance",
+        "url": "/api/2024/magic-items/potion-of-clairvoyance"
+      },
+      {
+        "index": "potion-of-climbing",
+        "name": "Potion of Climbing",
+        "url": "/api/2024/magic-items/potion-of-climbing"
+      },
+      {
+        "index": "potion-of-diminution",
+        "name": "Potion of Diminution",
+        "url": "/api/2024/magic-items/potion-of-diminution"
+      },
+      {
+        "index": "potion-of-flying",
+        "name": "Potion of Flying",
+        "url": "/api/2024/magic-items/potion-of-flying"
+      },
+      {
+        "index": "potion-of-growth",
+        "name": "Potion of Growth",
+        "url": "/api/2024/magic-items/potion-of-growth"
+      },
+      {
+        "index": "potions-of-healing",
+        "name": "Potions of Healing",
+        "url": "/api/2024/magic-items/potions-of-healing"
+      },
+      {
+        "index": "potion-of-gaseous-form",
+        "name": "Potion of Gaseous Form",
+        "url": "/api/2024/magic-items/potion-of-gaseous-form"
+      },
+      {
+        "index": "potion-of-heroism",
+        "name": "Potion of Heroism",
+        "url": "/api/2024/magic-items/potion-of-heroism"
+      },
+      {
+        "index": "potion-of-giant-strength",
+        "name": "Potion of Giant Strength",
+        "url": "/api/2024/magic-items/potion-of-giant-strength"
+      },
+      {
+        "index": "potion-of-invisibility",
+        "name": "Potion of Invisibility",
+        "url": "/api/2024/magic-items/potion-of-invisibility"
+      },
+      {
+        "index": "potion-of-mind-reading",
+        "name": "Potion of Mind Reading",
+        "url": "/api/2024/magic-items/potion-of-mind-reading"
+      },
+      {
+        "index": "potion-of-poison",
+        "name": "Potion of Poison",
+        "url": "/api/2024/magic-items/potion-of-poison"
+      },
+      {
+        "index": "potion-of-resistance",
+        "name": "Potion of Resistance",
+        "url": "/api/2024/magic-items/potion-of-resistance"
+      },
+      {
+        "index": "potion-of-speed",
+        "name": "Potion of Speed",
+        "url": "/api/2024/magic-items/potion-of-speed"
+      },
+      {
+        "index": "potion-of-water-breathing",
+        "name": "Potion of Water Breathing",
+        "url": "/api/2024/magic-items/potion-of-water-breathing"
+      }
+    ],
     "url": "/api/2024/equipment-categories/potions"
   },
   {
@@ -1421,7 +1522,118 @@
   {
     "name": "Rings",
     "index": "rings",
-    "equipment": [],
+    "equipment": [
+      {
+        "index": "ring-of-animal-influence",
+        "name": "Ring of Animal Influence",
+        "url": "/api/2024/magic-items/ring-of-animal-influence"
+      },
+      {
+        "index": "ring-of-djinni-summoning",
+        "name": "Ring of Djinni Summoning",
+        "url": "/api/2024/magic-items/ring-of-djinni-summoning"
+      },
+      {
+        "index": "ring-of-elemental-command",
+        "name": "Ring of Elemental Command",
+        "url": "/api/2024/magic-items/ring-of-elemental-command"
+      },
+      {
+        "index": "ring-of-evasion",
+        "name": "Ring of Evasion",
+        "url": "/api/2024/magic-items/ring-of-evasion"
+      },
+      {
+        "index": "ring-of-feather-falling",
+        "name": "Ring of Feather Falling",
+        "url": "/api/2024/magic-items/ring-of-feather-falling"
+      },
+      {
+        "index": "ring-of-free-action",
+        "name": "Ring of Free Action",
+        "url": "/api/2024/magic-items/ring-of-free-action"
+      },
+      {
+        "index": "ring-of-invisibility",
+        "name": "Ring of Invisibility",
+        "url": "/api/2024/magic-items/ring-of-invisibility"
+      },
+      {
+        "index": "ring-of-jumping",
+        "name": "Ring of Jumping",
+        "url": "/api/2024/magic-items/ring-of-jumping"
+      },
+      {
+        "index": "ring-of-mind-shielding",
+        "name": "Ring of Mind Shielding",
+        "url": "/api/2024/magic-items/ring-of-mind-shielding"
+      },
+      {
+        "index": "ring-of-protection",
+        "name": "Ring of Protection",
+        "url": "/api/2024/magic-items/ring-of-protection"
+      },
+      {
+        "index": "ring-of-regeneration",
+        "name": "Ring of Regeneration",
+        "url": "/api/2024/magic-items/ring-of-regeneration"
+      },
+      {
+        "index": "ring-of-resistance",
+        "name": "Ring of Resistance",
+        "url": "/api/2024/magic-items/ring-of-resistance"
+      },
+      {
+        "index": "ring-of-shooting-stars",
+        "name": "Ring of Shooting Stars",
+        "url": "/api/2024/magic-items/ring-of-shooting-stars"
+      },
+      {
+        "index": "ring-of-spell-storing",
+        "name": "Ring of Spell Storing",
+        "url": "/api/2024/magic-items/ring-of-spell-storing"
+      },
+      {
+        "index": "ring-of-spell-turning",
+        "name": "Ring of Spell Turning",
+        "url": "/api/2024/magic-items/ring-of-spell-turning"
+      },
+      {
+        "index": "ring-of-swimming",
+        "name": "Ring of Swimming",
+        "url": "/api/2024/magic-items/ring-of-swimming"
+      },
+      {
+        "index": "ring-of-telekinesis",
+        "name": "Ring of Telekinesis",
+        "url": "/api/2024/magic-items/ring-of-telekinesis"
+      },
+      {
+        "index": "ring-of-the-ram",
+        "name": "Ring of the Ram",
+        "url": "/api/2024/magic-items/ring-of-the-ram"
+      },
+      {
+        "index": "ring-of-three-wishes",
+        "name": "Ring of Three Wishes",
+        "url": "/api/2024/magic-items/ring-of-three-wishes"
+      },
+      {
+        "index": "ring-of-warmth",
+        "name": "Ring of Warmth",
+        "url": "/api/2024/magic-items/ring-of-warmth"
+      },
+      {
+        "index": "ring-of-water-walking",
+        "name": "Ring of Water Walking",
+        "url": "/api/2024/magic-items/ring-of-water-walking"
+      },
+      {
+        "index": "ring-of-x-ray-vision",
+        "name": "Ring of X-ray Vision",
+        "url": "/api/2024/magic-items/ring-of-x-ray-vision"
+      }
+    ],
     "url": "/api/2024/equipment-categories/rings"
   },
   {
@@ -1600,7 +1812,68 @@
   {
     "name": "Staffs",
     "index": "staffs",
-    "equipment": [],
+    "equipment": [
+      {
+        "index": "staff-of-charming",
+        "name": "Staff of Charming",
+        "url": "/api/2024/magic-items/staff-of-charming"
+      },
+      {
+        "index": "staff-of-fire",
+        "name": "Staff of Fire",
+        "url": "/api/2024/magic-items/staff-of-fire"
+      },
+      {
+        "index": "staff-of-frost",
+        "name": "Staff of Frost",
+        "url": "/api/2024/magic-items/staff-of-frost"
+      },
+      {
+        "index": "staff-of-healing",
+        "name": "Staff of Healing",
+        "url": "/api/2024/magic-items/staff-of-healing"
+      },
+      {
+        "index": "staff-of-power",
+        "name": "Staff of Power",
+        "url": "/api/2024/magic-items/staff-of-power"
+      },
+      {
+        "index": "staff-of-striking",
+        "name": "Staff of Striking",
+        "url": "/api/2024/magic-items/staff-of-striking"
+      },
+      {
+        "index": "staff-of-swarming-insects",
+        "name": "Staff of Swarming Insects",
+        "url": "/api/2024/magic-items/staff-of-swarming-insects"
+      },
+      {
+        "index": "staff-of-the-magi",
+        "name": "Staff of the Magi",
+        "url": "/api/2024/magic-items/staff-of-the-magi"
+      },
+      {
+        "index": "staff-of-the-python",
+        "name": "Staff of the Python",
+        "url": "/api/2024/magic-items/staff-of-the-python"
+      },
+      {
+        "index": "staff-of-the-woodlands",
+        "name": "Staff of the Woodlands",
+        "url": "/api/2024/magic-items/staff-of-the-woodlands"
+      },
+      {
+        "index": "staff-of-thunder-and-lightning",
+        "name": "Staff of Thunder and Lightning",
+        "url": "/api/2024/magic-items/staff-of-thunder-and-lightning"
+      },
+      {
+        "index": "staff-of-withering",
+        "name": "Staff of Withering",
+        "url": "/api/2024/magic-items/staff-of-withering"
+      }
+    ],
     "url": "/api/2024/equipment-categories/staffs"
   },
   {
@@ -1793,7 +2066,88 @@
   {
     "name": "Wands",
     "index": "wands",
-    "equipment": [],
+    "equipment": [
+      {
+        "index": "wand-of-binding",
+        "name": "Wand of Binding",
+        "url": "/api/2024/magic-items/wand-of-binding"
+      },
+      {
+        "index": "wand-of-enemy-detection",
+        "name": "Wand of Enemy Detection",
+        "url": "/api/2024/magic-items/wand-of-enemy-detection"
+      },
+      {
+        "index": "wand-of-fear",
+        "name": "Wand of Fear",
+        "url": "/api/2024/magic-items/wand-of-fear"
+      },
+      {
+        "index": "wand-of-fireballs",
+        "name": "Wand of Fireballs",
+        "url": "/api/2024/magic-items/wand-of-fireballs"
+      },
+      {
+        "index": "wand-of-lightning-bolts",
+        "name": "Wand of Lightning Bolts",
+        "url": "/api/2024/magic-items/wand-of-lightning-bolts"
+      },
+      {
+        "index": "wand-of-magic-detection",
+        "name": "Wand of Magic Detection",
+        "url": "/api/2024/magic-items/wand-of-magic-detection"
+      },
+      {
+        "index": "wand-of-magic-missiles",
+        "name": "Wand of Magic Missiles",
+        "url": "/api/2024/magic-items/wand-of-magic-missiles"
+      },
+      {
+        "index": "wand-of-paralysis",
+        "name": "Wand of Paralysis",
+        "url": "/api/2024/magic-items/wand-of-paralysis"
+      },
+      {
+        "index": "wand-of-polymorph",
+        "name": "Wand of Polymorph",
+        "url": "/api/2024/magic-items/wand-of-polymorph"
+      },
+      {
+        "index": "wand-of-secrets",
+        "name": "Wand of Secrets",
+        "url": "/api/2024/magic-items/wand-of-secrets"
+      },
+      {
+        "index": "wand-of-the-war-mage",
+        "name": "Wand of the War Mage",
+        "url": "/api/2024/magic-items/wand-of-the-war-mage"
+      },
+      {
+        "index": "wand-of-the-war-mage-1",
+        "name": "Wand of the War Mage +1",
+        "url": "/api/2024/magic-items/wand-of-the-war-mage-1"
+      },
+      {
+        "index": "wand-of-the-war-mage-2",
+        "name": "Wand of the War Mage +2",
+        "url": "/api/2024/magic-items/wand-of-the-war-mage-2"
+      },
+      {
+        "index": "wand-of-the-war-mage-3",
+        "name": "Wand of the War Mage +3",
+        "url": "/api/2024/magic-items/wand-of-the-war-mage-3"
+      },
+      {
+        "index": "wand-of-web",
+        "name": "Wand of Web",
+        "url": "/api/2024/magic-items/wand-of-web"
+      },
+      {
+        "index": "wand-of-wonder",
+        "name": "Wand of Wonder",
+        "url": "/api/2024/magic-items/wand-of-wonder"
+      }
+    ],
     "url": "/api/2024/equipment-categories/wands"
   },
   {
@@ -1996,7 +2350,673 @@
   {
     "name": "Wondrous Items",
     "index": "wondrous-items",
-    "equipment": [],
+    "equipment": [
+      {
+        "index": "amulet-of-health",
+        "name": "Amulet of Health",
+        "url": "/api/2024/magic-items/amulet-of-health"
+      },
+      {
+        "index": "amulet-of-proof-against-detection-and-location",
+        "name": "Amulet of Proof against Detection and Location",
+        "url": "/api/2024/magic-items/amulet-of-proof-against-detection-and-location"
+      },
+      {
+        "index": "amulet-of-the-planes",
+        "name": "Amulet of the Planes",
+        "url": "/api/2024/magic-items/amulet-of-the-planes"
+      },
+      {
+        "index": "apparatus-of-the-crab",
+        "name": "Apparatus of the Crab",
+        "url": "/api/2024/magic-items/apparatus-of-the-crab"
+      },
+      {
+        "index": "bag-of-beans",
+        "name": "Bag of Beans",
+        "url": "/api/2024/magic-items/bag-of-beans"
+      },
+      {
+        "index": "bag-of-devouring",
+        "name": "Bag of Devouring",
+        "url": "/api/2024/magic-items/bag-of-devouring"
+      },
+      {
+        "index": "bag-of-holding",
+        "name": "Bag of Holding",
+        "url": "/api/2024/magic-items/bag-of-holding"
+      },
+      {
+        "index": "bag-of-tricks",
+        "name": "Bag of Tricks",
+        "url": "/api/2024/magic-items/bag-of-tricks"
+      },
+      {
+        "index": "bead-of-force",
+        "name": "Bead of Force",
+        "url": "/api/2024/magic-items/bead-of-force"
+      },
+      {
+        "index": "belt-of-dwarvenkind",
+        "name": "Belt of Dwarvenkind",
+        "url": "/api/2024/magic-items/belt-of-dwarvenkind"
+      },
+      {
+        "index": "belt-of-giant-strength",
+        "name": "Belt of Giant Strength",
+        "url": "/api/2024/magic-items/belt-of-giant-strength"
+      },
+      {
+        "index": "boots-of-elvenkind",
+        "name": "Boots of Elvenkind",
+        "url": "/api/2024/magic-items/boots-of-elvenkind"
+      },
+      {
+        "index": "boots-of-levitation",
+        "name": "Boots of Levitation",
+        "url": "/api/2024/magic-items/boots-of-levitation"
+      },
+      {
+        "index": "boots-of-speed",
+        "name": "Boots of Speed",
+        "url": "/api/2024/magic-items/boots-of-speed"
+      },
+      {
+        "index": "boots-of-striding-and-springing",
+        "name": "Boots of Striding and Springing",
+        "url": "/api/2024/magic-items/boots-of-striding-and-springing"
+      },
+      {
+        "index": "boots-of-the-winterlands",
+        "name": "Boots of the Winterlands",
+        "url": "/api/2024/magic-items/boots-of-the-winterlands"
+      },
+      {
+        "index": "bowl-of-commanding-water-elementals",
+        "name": "Bowl of Commanding Water Elementals",
+        "url": "/api/2024/magic-items/bowl-of-commanding-water-elementals"
+      },
+      {
+        "index": "bracers-of-archery",
+        "name": "Bracers of Archery",
+        "url": "/api/2024/magic-items/bracers-of-archery"
+      },
+      {
+        "index": "bracers-of-defense",
+        "name": "Bracers of Defense",
+        "url": "/api/2024/magic-items/bracers-of-defense"
+      },
+      {
+        "index": "brazier-of-commanding-fire-elementals",
+        "name": "Brazier of Commanding Fire Elementals",
+        "url": "/api/2024/magic-items/brazier-of-commanding-fire-elementals"
+      },
+      {
+        "index": "brooch-of-shielding",
+        "name": "Brooch of Shielding",
+        "url": "/api/2024/magic-items/brooch-of-shielding"
+      },
+      {
+        "index": "broom-of-flying",
+        "name": "Broom of Flying",
+        "url": "/api/2024/magic-items/broom-of-flying"
+      },
+      {
+        "index": "candle-of-invocation",
+        "name": "Candle of Invocation",
+        "url": "/api/2024/magic-items/candle-of-invocation"
+      },
+      {
+        "index": "cape-of-the-mountebank",
+        "name": "Cape of the Mountebank",
+        "url": "/api/2024/magic-items/cape-of-the-mountebank"
+      },
+      {
+        "index": "carpet-of-flying",
+        "name": "Carpet of Flying",
+        "url": "/api/2024/magic-items/carpet-of-flying"
+      },
+      {
+        "index": "censer-of-controlling-air-elementals",
+        "name": "Censer of Controlling Air Elementals",
+        "url": "/api/2024/magic-items/censer-of-controlling-air-elementals"
+      },
+      {
+        "index": "chime-of-opening",
+        "name": "Chime of Opening",
+        "url": "/api/2024/magic-items/chime-of-opening"
+      },
+      {
+        "index": "circlet-of-blasting",
+        "name": "Circlet of Blasting",
+        "url": "/api/2024/magic-items/circlet-of-blasting"
+      },
+      {
+        "index": "cloak-of-arachnida",
+        "name": "Cloak of Arachnida",
+        "url": "/api/2024/magic-items/cloak-of-arachnida"
+      },
+      {
+        "index": "cloak-of-displacement",
+        "name": "Cloak of Displacement",
+        "url": "/api/2024/magic-items/cloak-of-displacement"
+      },
+      {
+        "index": "cloak-of-elvenkind",
+        "name": "Cloak of Elvenkind",
+        "url": "/api/2024/magic-items/cloak-of-elvenkind"
+      },
+      {
+        "index": "cloak-of-protection",
+        "name": "Cloak of Protection",
+        "url": "/api/2024/magic-items/cloak-of-protection"
+      },
+      {
+        "index": "cloak-of-the-bat",
+        "name": "Cloak of the Bat",
+        "url": "/api/2024/magic-items/cloak-of-the-bat"
+      },
+      {
+        "index": "cloak-of-the-manta-ray",
+        "name": "Cloak of the Manta Ray",
+        "url": "/api/2024/magic-items/cloak-of-the-manta-ray"
+      },
+      {
+        "index": "crystal-ball",
+        "name": "Crystal Ball",
+        "url": "/api/2024/magic-items/crystal-ball"
+      },
+      {
+        "index": "crystal-ball-of-mind-reading",
+        "name": "Crystal Ball of Mind Reading",
+        "url": "/api/2024/magic-items/crystal-ball-of-mind-reading"
+      },
+      {
+        "index": "crystal-ball-of-telepathy",
+        "name": "Crystal Ball of Telepathy",
+        "url": "/api/2024/magic-items/crystal-ball-of-telepathy"
+      },
+      {
+        "index": "crystal-ball-of-true-seeing",
+        "name": "Crystal Ball of True Seeing",
+        "url": "/api/2024/magic-items/crystal-ball-of-true-seeing"
+      },
+      {
+        "index": "cube-of-force",
+        "name": "Cube of Force",
+        "url": "/api/2024/magic-items/cube-of-force"
+      },
+      {
+        "index": "cubic-gate",
+        "name": "Cubic Gate",
+        "url": "/api/2024/magic-items/cubic-gate"
+      },
+      {
+        "index": "decanter-of-endless-water",
+        "name": "Decanter of Endless Water",
+        "url": "/api/2024/magic-items/decanter-of-endless-water"
+      },
+      {
+        "index": "deck-of-illusions",
+        "name": "Deck of Illusions",
+        "url": "/api/2024/magic-items/deck-of-illusions"
+      },
+      {
+        "index": "dimensional-shackles",
+        "name": "Dimensional Shackles",
+        "url": "/api/2024/magic-items/dimensional-shackles"
+      },
+      {
+        "index": "dragon-orb",
+        "name": "Dragon Orb",
+        "url": "/api/2024/magic-items/dragon-orb"
+      },
+      {
+        "index": "dust-of-disappearance",
+        "name": "Dust of Disappearance",
+        "url": "/api/2024/magic-items/dust-of-disappearance"
+      },
+      {
+        "index": "dust-of-dryness",
+        "name": "Dust of Dryness",
+        "url": "/api/2024/magic-items/dust-of-dryness"
+      },
+      {
+        "index": "dust-of-sneezing-and-choking",
+        "name": "Dust of Sneezing and Choking",
+        "url": "/api/2024/magic-items/dust-of-sneezing-and-choking"
+      },
+      {
+        "index": "efficient-quiver",
+        "name": "Efficient Quiver",
+        "url": "/api/2024/magic-items/efficient-quiver"
+      },
+      {
+        "index": "efreeti-bottle",
+        "name": "Efreeti Bottle",
+        "url": "/api/2024/magic-items/efreeti-bottle"
+      },
+      {
+        "index": "elemental-gem",
+        "name": "Elemental Gem",
+        "url": "/api/2024/magic-items/elemental-gem"
+      },
+      {
+        "index": "eversmoking-bottle",
+        "name": "Eversmoking Bottle",
+        "url": "/api/2024/magic-items/eversmoking-bottle"
+      },
+      {
+        "index": "eyes-of-charming",
+        "name": "Eyes of Charming",
+        "url": "/api/2024/magic-items/eyes-of-charming"
+      },
+      {
+        "index": "eyes-of-minute-seeing",
+        "name": "Eyes of Minute Seeing",
+        "url": "/api/2024/magic-items/eyes-of-minute-seeing"
+      },
+      {
+        "index": "eyes-of-the-eagle",
+        "name": "Eyes of the Eagle",
+        "url": "/api/2024/magic-items/eyes-of-the-eagle"
+      },
+      {
+        "index": "feather-token",
+        "name": "Feather Token",
+        "url": "/api/2024/magic-items/feather-token"
+      },
+      {
+        "index": "figurine-of-wondrous-power",
+        "name": "Figurine of Wondrous Power",
+        "url": "/api/2024/magic-items/figurine-of-wondrous-power"
+      },
+      {
+        "index": "folding-boat",
+        "name": "Folding Boat",
+        "url": "/api/2024/magic-items/folding-boat"
+      },
+      {
+        "index": "gauntlets-of-ogre-power",
+        "name": "Gauntlets of Ogre Power",
+        "url": "/api/2024/magic-items/gauntlets-of-ogre-power"
+      },
+      {
+        "index": "gem-of-brightness",
+        "name": "Gem of Brightness",
+        "url": "/api/2024/magic-items/gem-of-brightness"
+      },
+      {
+        "index": "gem-of-seeing",
+        "name": "Gem of Seeing",
+        "url": "/api/2024/magic-items/gem-of-seeing"
+      },
+      {
+        "index": "gloves-of-missile-snaring",
+        "name": "Gloves of Missile Snaring",
+        "url": "/api/2024/magic-items/gloves-of-missile-snaring"
+      },
+      {
+        "index": "gloves-of-swimming-and-climbing",
+        "name": "Gloves of Swimming and Climbing",
+        "url": "/api/2024/magic-items/gloves-of-swimming-and-climbing"
+      },
+      {
+        "index": "goggles-of-night",
+        "name": "Goggles of Night",
+        "url": "/api/2024/magic-items/goggles-of-night"
+      },
+      {
+        "index": "handy-haversack",
+        "name": "Handy Haversack",
+        "url": "/api/2024/magic-items/handy-haversack"
+      },
+      {
+        "index": "hat-of-disguise",
+        "name": "Hat of Disguise",
+        "url": "/api/2024/magic-items/hat-of-disguise"
+      },
+      {
+        "index": "headband-of-intellect",
+        "name": "Headband of Intellect",
+        "url": "/api/2024/magic-items/headband-of-intellect"
+      },
+      {
+        "index": "helm-of-brilliance",
+        "name": "Helm of Brilliance",
+        "url": "/api/2024/magic-items/helm-of-brilliance"
+      },
+      {
+        "index": "helm-of-comprehending-languages",
+        "name": "Helm of Comprehending Languages",
+        "url": "/api/2024/magic-items/helm-of-comprehending-languages"
+      },
+      {
+        "index": "helm-of-telepathy",
+        "name": "Helm of Telepathy",
+        "url": "/api/2024/magic-items/helm-of-telepathy"
+      },
+      {
+        "index": "helm-of-teleportation",
+        "name": "Helm of Teleportation",
+        "url": "/api/2024/magic-items/helm-of-teleportation"
+      },
+      {
+        "index": "horn-of-blasting",
+        "name": "Horn of Blasting",
+        "url": "/api/2024/magic-items/horn-of-blasting"
+      },
+      {
+        "index": "horn-of-valhalla",
+        "name": "Horn of Valhalla",
+        "url": "/api/2024/magic-items/horn-of-valhalla"
+      },
+      {
+        "index": "horn-of-valhalla-1",
+        "name": "Silver Horn of Valhalla",
+        "url": "/api/2024/magic-items/horn-of-valhalla-1"
+      },
+      {
+        "index": "horn-of-valhalla-2",
+        "name": "Brass Horn of Valhalla",
+        "url": "/api/2024/magic-items/horn-of-valhalla-2"
+      },
+      {
+        "index": "horn-of-valhalla-3",
+        "name": "Bronze Horn of Valhalla",
+        "url": "/api/2024/magic-items/horn-of-valhalla-3"
+      },
+      {
+        "index": "horn-of-valhalla-4",
+        "name": "Iron Horn of Valhalla",
+        "url": "/api/2024/magic-items/horn-of-valhalla-4"
+      },
+      {
+        "index": "horseshoes-of-a-zephyr",
+        "name": "Horseshoes of a Zephyr",
+        "url": "/api/2024/magic-items/horseshoes-of-a-zephyr"
+      },
+      {
+        "index": "horseshoes-of-speed",
+        "name": "Horseshoes of Speed",
+        "url": "/api/2024/magic-items/horseshoes-of-speed"
+      },
+      {
+        "index": "immovable-rod",
+        "name": "Immovable Rod",
+        "url": "/api/2024/magic-items/immovable-rod"
+      },
+      {
+        "index": "instant-fortress",
+        "name": "Instant Fortress",
+        "url": "/api/2024/magic-items/instant-fortress"
+      },
+      {
+        "index": "ioun-stone",
+        "name": "Ioun Stone",
+        "url": "/api/2024/magic-items/ioun-stone"
+      },
+      {
+        "index": "iron-bands",
+        "name": "Iron Bands",
+        "url": "/api/2024/magic-items/iron-bands"
+      },
+      {
+        "index": "iron-flask",
+        "name": "Iron Flask",
+        "url": "/api/2024/magic-items/iron-flask"
+      },
+      {
+        "index": "lantern-of-revealing",
+        "name": "Lantern of Revealing",
+        "url": "/api/2024/magic-items/lantern-of-revealing"
+      },
+      {
+        "index": "mantle-of-spell-resistance",
+        "name": "Mantle of Spell Resistance",
+        "url": "/api/2024/magic-items/mantle-of-spell-resistance"
+      },
+      {
+        "index": "manual-of-bodily-health",
+        "name": "Manual of Bodily Health",
+        "url": "/api/2024/magic-items/manual-of-bodily-health"
+      },
+      {
+        "index": "manual-of-gainful-exercise",
+        "name": "Manual of Gainful Exercise",
+        "url": "/api/2024/magic-items/manual-of-gainful-exercise"
+      },
+      {
+        "index": "manual-of-golems",
+        "name": "Manual of Golems",
+        "url": "/api/2024/magic-items/manual-of-golems"
+      },
+      {
+        "index": "manual-of-quickness-of-action",
+        "name": "Manual of Quickness of Action",
+        "url": "/api/2024/magic-items/manual-of-quickness-of-action"
+      },
+      {
+        "index": "marvelous-pigments",
+        "name": "Marvelous Pigments",
+        "url": "/api/2024/magic-items/marvelous-pigments"
+      },
+      {
+        "index": "medallion-of-thoughts",
+        "name": "Medallion of Thoughts",
+        "url": "/api/2024/magic-items/medallion-of-thoughts"
+      },
+      {
+        "index": "mirror-of-life-trapping",
+        "name": "Mirror of Life Trapping",
+        "url": "/api/2024/magic-items/mirror-of-life-trapping"
+      },
+      {
+        "index": "mysterious-deck",
+        "name": "Mysterious Deck",
+        "url": "/api/2024/magic-items/mysterious-deck"
+      },
+      {
+        "index": "necklace-of-adaptation",
+        "name": "Necklace of Adaptation",
+        "url": "/api/2024/magic-items/necklace-of-adaptation"
+      },
+      {
+        "index": "necklace-of-fireballs",
+        "name": "Necklace of Fireballs",
+        "url": "/api/2024/magic-items/necklace-of-fireballs"
+      },
+      {
+        "index": "necklace-of-prayer-beads",
+        "name": "Necklace of Prayer Beads",
+        "url": "/api/2024/magic-items/necklace-of-prayer-beads"
+      },
+      {
+        "index": "pearl-of-power",
+        "name": "Pearl of Power",
+        "url": "/api/2024/magic-items/pearl-of-power"
+      },
+      {
+        "index": "periapt-of-health",
+        "name": "Periapt of Health",
+        "url": "/api/2024/magic-items/periapt-of-health"
+      },
+      {
+        "index": "periapt-of-proof-against-poison",
+        "name": "Periapt of Proof against Poison",
+        "url": "/api/2024/magic-items/periapt-of-proof-against-poison"
+      },
+      {
+        "index": "periapt-of-wound-closure",
+        "name": "Periapt of Wound Closure",
+        "url": "/api/2024/magic-items/periapt-of-wound-closure"
+      },
+      {
+        "index": "pipes-of-haunting",
+        "name": "Pipes of Haunting",
+        "url": "/api/2024/magic-items/pipes-of-haunting"
+      },
+      {
+        "index": "pipes-of-the-sewers",
+        "name": "Pipes of the Sewers",
+        "url": "/api/2024/magic-items/pipes-of-the-sewers"
+      },
+      {
+        "index": "portable-hole",
+        "name": "Portable Hole",
+        "url": "/api/2024/magic-items/portable-hole"
+      },
+      {
+        "index": "robe-of-eyes",
+        "name": "Robe of Eyes",
+        "url": "/api/2024/magic-items/robe-of-eyes"
+      },
+      {
+        "index": "robe-of-scintillating-colors",
+        "name": "Robe of Scintillating Colors",
+        "url": "/api/2024/magic-items/robe-of-scintillating-colors"
+      },
+      {
+        "index": "robe-of-stars",
+        "name": "Robe of Stars",
+        "url": "/api/2024/magic-items/robe-of-stars"
+      },
+      {
+        "index": "robe-of-the-archmagi",
+        "name": "Robe of the Archmagi",
+        "url": "/api/2024/magic-items/robe-of-the-archmagi"
+      },
+      {
+        "index": "robe-of-useful-items",
+        "name": "Robe of Useful Items",
+        "url": "/api/2024/magic-items/robe-of-useful-items"
+      },
+      {
+        "index": "rod-of-absorption",
+        "name": "Rod of Absorption",
+        "url": "/api/2024/magic-items/rod-of-absorption"
+      },
+      {
+        "index": "rod-of-alertness",
+        "name": "Rod of Alertness",
+        "url": "/api/2024/magic-items/rod-of-alertness"
+      },
+      {
+        "index": "rod-of-lordly-might",
+        "name": "Rod of Lordly Might",
+        "url": "/api/2024/magic-items/rod-of-lordly-might"
+      },
+      {
+        "index": "rod-of-rulership",
+        "name": "Rod of Rulership",
+        "url": "/api/2024/magic-items/rod-of-rulership"
+      },
+      {
+        "index": "rod-of-security",
+        "name": "Rod of Security",
+        "url": "/api/2024/magic-items/rod-of-security"
+      },
+      {
+        "index": "rope-of-climbing",
+        "name": "Rope of Climbing",
+        "url": "/api/2024/magic-items/rope-of-climbing"
+      },
+      {
+        "index": "rope-of-entanglement",
+        "name": "Rope of Entanglement",
+        "url": "/api/2024/magic-items/rope-of-entanglement"
+      },
+      {
+        "index": "scarab-of-protection",
+        "name": "Scarab of Protection",
+        "url": "/api/2024/magic-items/scarab-of-protection"
+      },
+      {
+        "index": "slippers-of-spider-climbing",
+        "name": "Slippers of Spider Climbing",
+        "url": "/api/2024/magic-items/slippers-of-spider-climbing"
+      },
+      {
+        "index": "sovereign-glue",
+        "name": "Sovereign Glue",
+        "url": "/api/2024/magic-items/sovereign-glue"
+      },
+      {
+        "index": "spell-scroll",
+        "name": "Spell Scroll",
+        "url": "/api/2024/magic-items/spell-scroll"
+      },
+      {
+        "index": "sphere-of-annihilation",
+        "name": "Sphere of Annihilation",
+        "url": "/api/2024/magic-items/sphere-of-annihilation"
+      },
+      {
+        "index": "stone-of-controlling-earth-elementals",
+        "name": "Stone of Controlling Earth Elementals",
+        "url": "/api/2024/magic-items/stone-of-controlling-earth-elementals"
+      },
+      {
+        "index": "stone-of-good-luck-(luckstone)",
+        "name": "Stone of Good Luck (Luckstone)",
+        "url": "/api/2024/magic-items/stone-of-good-luck-(luckstone)"
+      },
+      {
+        "index": "talisman-of-pure-good",
+        "name": "Talisman of Pure Good",
+        "url": "/api/2024/magic-items/talisman-of-pure-good"
+      },
+      {
+        "index": "talisman-of-the-sphere",
+        "name": "Talisman of the Sphere",
+        "url": "/api/2024/magic-items/talisman-of-the-sphere"
+      },
+      {
+        "index": "talisman-of-ultimate-evil",
+        "name": "Talisman of Ultimate Evil",
+        "url": "/api/2024/magic-items/talisman-of-ultimate-evil"
+      },
+      {
+        "index": "tome-of-clear-thought",
+        "name": "Tome of Clear Thought",
+        "url": "/api/2024/magic-items/tome-of-clear-thought"
+      },
+      {
+        "index": "tome-of-leadership-and-influence",
+        "name": "Tome of Leadership and Influence",
+        "url": "/api/2024/magic-items/tome-of-leadership-and-influence"
+      },
+      {
+        "index": "tome-of-understanding",
+        "name": "Tome of Understanding",
+        "url": "/api/2024/magic-items/tome-of-understanding"
+      },
+      {
+        "index": "universal-solvent",
+        "name": "Universal Solvent",
+        "url": "/api/2024/magic-items/universal-solvent"
+      },
+      {
+        "index": "well-of-many-worlds",
+        "name": "Well of Many Worlds",
+        "url": "/api/2024/magic-items/well-of-many-worlds"
+      },
+      {
+        "index": "wind-fan",
+        "name": "Wind Fan",
+        "url": "/api/2024/magic-items/wind-fan"
+      },
+      {
+        "index": "winged-boots",
+        "name": "Winged Boots",
+        "url": "/api/2024/magic-items/winged-boots"
+      },
+      {
+        "index": "wings-of-flying",
+        "name": "Wings of Flying",
+        "url": "/api/2024/magic-items/wings-of-flying"
+      }
+    ],
     "url": "/api/2024/equipment-categories/wondrous-items"
   }
 ]

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -5,7 +5,9 @@
 		"name": "Adamantine Armor",
 		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
 	},
 	{
@@ -14,7 +16,9 @@
 		"name": "Ammunition",
 		"type": "Weapon (Any Ammunition)",
 		"attunement": false,
-		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"rarity" : {
+			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
+		},
 		"description": "You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.\nThis ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 	},
 	{
@@ -23,7 +27,9 @@
 		"name": "Ammunition of Slaying",
 		"type": "Weapon (Any Ammunition)",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.\nAfter dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
 	},
 	{
@@ -32,7 +38,9 @@
 		"name": "Amulet of Health",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
 	},
 	{
@@ -41,7 +49,9 @@
 		"name": "Amulet of Proof against Detection and Location",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
 	},
 	{
@@ -50,7 +60,9 @@
 		"name": "Amulet of the Planes",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
 	},
 	{
@@ -59,7 +71,9 @@
 		"name": "Animated Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
 	},
 	{
@@ -68,7 +82,9 @@
 		"name": "Apparatus of the Crab",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.\nThe Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.\nTo be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.\nThe apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.\nA creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
 	},
 	{
@@ -77,7 +93,9 @@
 		"name": "Armor",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": false,
-		"rarity": "Rare (+1), Very Rare (+2), or Legendary (+3)",
+		"rarity" : {
+			"name": "Rare (+1), Very Rare (+2), or Legendary (+3)"
+		},
 		"description": "You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
 	},
 	{
@@ -86,7 +104,9 @@
 		"name": "Armor of Invulnerability",
 		"type": "Armor (Plate Armor)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.\nMetal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
 	},
 	{
@@ -95,7 +115,9 @@
 		"name": "Armor of Resistance",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
 	},
 	{
@@ -104,7 +126,9 @@
 		"name": "Armor of Vulnerability",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.\nCurse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
 	},
 	{
@@ -113,7 +137,9 @@
 		"name": "Arrow-Catching Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.\nWhenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
 	},
 	{
@@ -122,7 +148,9 @@
 		"name": "Bag of Beans",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.\nIf you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.\nIf you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
 	},
 	{
@@ -131,7 +159,9 @@
 		"name": "Bag of Devouring",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.\nThe extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.\nInanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.\nIf the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
 	},
 	{
@@ -140,7 +170,9 @@
 		"name": "Bag of Holding",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.\nIf the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
 	},
 	{
@@ -149,7 +181,9 @@
 		"name": "Bag of Tricks",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.\nYou can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.\nThe creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.\nOnce three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.\nGray Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nWeasel\n5\nPanther\n2\nGiant Rat\n6\nGiant Badger\n3\nBadger\n7\nDire Wolf\n4\nBoar\n8\nGiant Elk\nRust Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nRat\n5\nGiant Goat\n2\nOwl\n6\nGiant Boar\n3\nMastiff\n7\nLion\n4\nGoat\n8\nBrown Bear\nTan Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nJackal\n5\nBlack Bear\n2\nApe\n6\nGiant Weasel\n3\nBaboon\n7\nGiant Hyena\n4\nAxe Beak\n8\nTiger"
 	},
 	{
@@ -158,7 +192,9 @@
 		"name": "Bead of Force",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.\nYou can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.\nAn enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
 	},
 	{
@@ -167,7 +203,9 @@
 		"name": "Belt of Dwarvenkind",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
 	},
 	{
@@ -176,7 +214,9 @@
 		"name": "Belt of Giant Strength",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
 	},
 	{
@@ -185,7 +225,9 @@
 		"name": "Berserker Axe",
 		"type": "Weapon (Battleaxe, Greataxe, or Halberd)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.\nCurse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.\nWhenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.\nWhile berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
 	},
 	{
@@ -194,7 +236,9 @@
 		"name": "Boots of Elvenkind",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
 	},
 	{
@@ -203,7 +247,9 @@
 		"name": "Boots of Levitation",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While you wear these boots, you can cast Levitate on yourself."
 	},
 	{
@@ -212,7 +258,9 @@
 		"name": "Boots of Speed",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.\nWhen you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
 	},
 	{
@@ -221,7 +269,9 @@
 		"name": "Boots of Striding and Springing",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.\nOnce on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
 	},
 	{
@@ -230,7 +280,9 @@
 		"name": "Boots of the Winterlands",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.\nCold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.\nWinter Strider. You ignore Difficult Terrain created by ice or snow."
 	},
 	{
@@ -239,7 +291,9 @@
 		"name": "Bowl of Commanding Water Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.\nThe bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
 	},
 	{
@@ -248,7 +302,9 @@
 		"name": "Bracers of Archery",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
 	},
 	{
@@ -257,7 +313,9 @@
 		"name": "Bracers of Defense",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
 	},
 	{
@@ -266,7 +324,9 @@
 		"name": "Brazier of Commanding Fire Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
 	},
 	{
@@ -275,7 +335,9 @@
 		"name": "Brooch of Shielding",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
 	},
 	{
@@ -284,7 +346,9 @@
 		"name": "Broom of Flying",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.\nAs a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
 	},
 	{
@@ -293,7 +357,9 @@
 		"name": "Candle of Invocation",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.\nWhile lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.\nAlternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
 	},
 	{
@@ -302,7 +368,9 @@
 		"name": "Cape of the Mountebank",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.\nWhen you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
 	},
 	{
@@ -311,7 +379,9 @@
 		"name": "Carpet of Flying",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.\nFour sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
 	},
 	{
@@ -320,7 +390,9 @@
 		"name": "Censer of Controlling Air Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
 	},
 	{
@@ -329,7 +401,9 @@
 		"name": "Chime of Opening",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.\nThe chime can be used 10 times. After the tenth time, it cracks and becomes useless."
 	},
 	{
@@ -338,7 +412,9 @@
 		"name": "Circlet of Blasting",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
 	},
 	{
@@ -347,7 +423,9 @@
 		"name": "Cloak of Arachnida",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.\nPoison Resistance. You have Resistance to Poison damage.\nSpider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.\nSpider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.\nWeb. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
 	},
 	{
@@ -356,7 +434,9 @@
 		"name": "Cloak of Displacement",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
 	},
 	{
@@ -365,7 +445,9 @@
 		"name": "Cloak of Elvenkind",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
 	},
 	{
@@ -374,7 +456,9 @@
 		"name": "Cloak of Protection",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
 	},
 	{
@@ -383,7 +467,9 @@
 		"name": "Cloak of the Bat",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.\nWhile wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
 	},
 	{
@@ -392,7 +478,9 @@
 		"name": "Cloak of the Manta Ray",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
 	},
 	{
@@ -401,7 +489,9 @@
 		"name": "Crystal Ball",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While touching this crystal orb, you can cast Scrying(save DC 17) with it."
 	},
 	{
@@ -410,7 +500,9 @@
 		"name": "Crystal Ball of Mind Reading",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
 	},
 	{
@@ -419,7 +511,9 @@
 		"name": "Crystal Ball of Telepathy",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
 	},
 	{
@@ -428,7 +522,9 @@
 		"name": "Crystal Ball of True Seeing",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
 	},
 	{
@@ -437,7 +533,9 @@
 		"name": "Cube of Force",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.\nThe cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
 	},
 	{
@@ -446,7 +544,9 @@
 		"name": "Cubic Gate",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.\nThe cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.\nGate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.\nPlane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
 	},
 	{
@@ -455,7 +555,9 @@
 		"name": "Dagger of Venom",
 		"type": "Weapon (Dagger)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nYou can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
 	},
 	{
@@ -464,7 +566,9 @@
 		"name": "Dancing Sword",
 		"type": "Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.\nWhile the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
 	},
 	{
@@ -473,7 +577,9 @@
 		"name": "Decanter of Endless Water",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.\nYou can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
 	},
 	{
@@ -482,7 +588,9 @@
 		"name": "Deck of Illusions",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.\nThe magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.\nAny physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
 	},
 	{
@@ -491,7 +599,9 @@
 		"name": "Defender",
 		"type": "Weapon (Any Melee Weapon)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.\nThe first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
 	},
 	{
@@ -500,7 +610,9 @@
 		"name": "Demon Armor",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.\nCurse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
 	},
 	{
@@ -509,7 +621,9 @@
 		"name": "Dimensional Shackles",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.\nYou and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
 	},
 	{
@@ -518,7 +632,9 @@
 		"name": "Dragon Orb",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Artifact",
+		"rarity" : {
+			"name": "Artifact"
+		},
 		"description": "An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.\nWhile attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.\nWhile you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.\nSpells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3\nCall Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.\nDestroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
 	},
 	{
@@ -527,7 +643,9 @@
 		"name": "Dragon Scale Mail",
 		"type": "Armor (Scale Mail)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.\nWhile wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).\nAdditionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
 	},
 	{
@@ -536,7 +654,9 @@
 		"name": "Dragon Slayer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
 	},
 	{
@@ -545,7 +665,9 @@
 		"name": "Dust of Disappearance",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
 	},
 	{
@@ -554,7 +676,9 @@
 		"name": "Dust of Dryness",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.\nAs a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
 	},
 	{
@@ -563,7 +687,9 @@
 		"name": "Dust of Sneezing and Choking",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.\nAs a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.\nOn a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
 	},
 	{
@@ -572,7 +698,9 @@
 		"name": "Dwarven Plate",
 		"type": "Armor (Half Plate Armor or Plate Armor)",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
 	},
 	{
@@ -582,7 +710,9 @@
 		"type": "Weapon (Warhammer)",
 		"attunement": true,
 		"limited-to": "Dwarf or a Creature Attuned to a Belt of Dwarvenkind",
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
 	},
 	{
@@ -591,7 +721,9 @@
 		"name": "Efficient Quiver",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.\nYou can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
 	},
 	{
@@ -600,7 +732,9 @@
 		"name": "Efreeti Bottle",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
 	},
 	{
@@ -609,7 +743,9 @@
 		"name": "Elemental Gem",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
 	},
 	{
@@ -618,7 +754,9 @@
 		"name": "Elven Chain",
 		"type": "Armor (Chain Mail or Chain Shirt)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
 	},
 	{
@@ -627,7 +765,9 @@
 		"name": "Eversmoking Bottle",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.\nEach minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.\nClosing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
 	},
 	{
@@ -636,7 +776,9 @@
 		"name": "Eyes of Charming",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
 	},
 	{
@@ -645,7 +787,9 @@
 		"name": "Eyes of Minute Seeing",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
 	},
 	{
@@ -654,7 +798,9 @@
 		"name": "Eyes of the Eagle",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
 	},
 	{
@@ -663,7 +809,9 @@
 		"name": "Feather Token",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.\nAnchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.\nBird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.\nFan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.\nSwan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.\nTree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.\nWhip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.\nAs a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
 	},
 	{
@@ -672,7 +820,9 @@
 		"name": "Figurine of Wondrous Power",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.\nThe creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.\nThe creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.\nBronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.\nEbony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)\nGolden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.\nIvory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.\nMarble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.\nObsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.\nThe figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.\nOnyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.\nSerpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.\nSilver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
 	},
 	{
@@ -681,7 +831,9 @@
 		"name": "Flame Tongue",
 		"type": "Weapon (Any Melee Weapon)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
 	},
 	{
@@ -690,7 +842,9 @@
 		"name": "Folding Boat",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.\nStatistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
 	},
 	{
@@ -699,7 +853,9 @@
 		"name": "Frost Brand",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.\nIn freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.\nWhen you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
 	},
 	{
@@ -708,7 +864,9 @@
 		"name": "Gauntlets of Ogre Power",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
 	},
 	{
@@ -717,7 +875,9 @@
 		"name": "Gem of Brightness",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
 	},
 	{
@@ -726,7 +886,9 @@
 		"name": "Gem of Seeing",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.\nThe gem regains 1d3 expended charges daily at dawn."
 	},
 	{
@@ -735,7 +897,9 @@
 		"name": "Giant Slayer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nWhen you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
 	},
 	{
@@ -744,7 +908,9 @@
 		"name": "Glamoured Studded Leather",
 		"type": "Armor (Studded Leather Armor)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
 	},
 	{
@@ -753,7 +919,9 @@
 		"name": "Gloves of Missile Snaring",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
 	},
 	{
@@ -762,7 +930,9 @@
 		"name": "Gloves of Swimming and Climbing",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
 	},
 	{
@@ -771,7 +941,9 @@
 		"name": "Goggles of Night",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
 	},
 	{
@@ -780,7 +952,9 @@
 		"name": "Hammer of Thunderbolts",
 		"type": "Weapon (Maul or Warhammer)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.\nGiant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
 	},
 	{
@@ -789,7 +963,9 @@
 		"name": "Handy Haversack",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.\nRetrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.\nIf any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.\nEach pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
@@ -798,7 +974,9 @@
 		"name": "Hat of Disguise",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
 	},
 	{
@@ -807,7 +985,9 @@
 		"name": "Headband of Intellect",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
 	},
 	{
@@ -816,7 +996,9 @@
 		"name": "Helm of Brilliance",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.\nDiamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.\nFire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.\nRuby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.\nSpells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.\nTaking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
 	},
 	{
@@ -825,7 +1007,9 @@
 		"name": "Helm of Comprehending Languages",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this helm, you can cast Comprehend Languages from it."
 	},
 	{
@@ -834,7 +1018,9 @@
 		"name": "Helm of Telepathy",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
 	},
 	{
@@ -843,7 +1029,9 @@
 		"name": "Helm of Teleportation",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
 	},
 	{
@@ -853,7 +1041,9 @@
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
 		"limited-to": "Paladin",
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
 	},
 	{
@@ -862,7 +1052,9 @@
 		"name": "Horn of Blasting",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.\nEach use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
 	},
 	{
@@ -871,7 +1063,9 @@
 		"name": "Horn of Valhalla",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)",
+		"rarity" : {
+			"name": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)"
+		},
 		"description": "You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.\nFour types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.\nIf you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
@@ -880,7 +1074,9 @@
 		"name": "Horseshoes of a Zephyr",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
 	},
 	{
@@ -889,7 +1085,9 @@
 		"name": "Horseshoes of Speed",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
 	},
 	{
@@ -898,7 +1096,9 @@
 		"name": "Immovable Rod",
 		"type": "Rod",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
 	},
 	{
@@ -907,7 +1107,9 @@
 		"name": "Instant Fortress",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.\nThe tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.\nMagic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
 	},
 	{
@@ -916,7 +1118,9 @@
 		"name": "Ioun Stone",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.\nWhen you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.\nEach Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.\nAs a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.\nThe type of stone determines its rarity and effects.\nAbsorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nAgility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.\nAwareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.\nFortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.\nGreater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nInsight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.\nIntellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.\nLeadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.\nMastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.\nProtection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.\nRegeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.\nReserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.\nStrength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.\nSustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
 	},
 	{
@@ -925,7 +1129,9 @@
 		"name": "Iron Bands",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.\nMake a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.\nA creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.\nOnce the bands are used, they can't be used again until the next dawn."
 	},
 	{
@@ -934,7 +1140,9 @@
 		"name": "Iron Flask",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.\nYou can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.\nAn Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
 	},
 	{
@@ -943,7 +1151,9 @@
 		"name": "Javelin of Lightning",
 		"type": "Weapon (Javelin)",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.\nLightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
 	},
 	{
@@ -952,7 +1162,9 @@
 		"name": "Lantern of Revealing",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
 	},
 	{
@@ -961,7 +1173,9 @@
 		"name": "Luck Blade",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.\nLuck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.\nWish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
 	},
 	{
@@ -970,7 +1184,9 @@
 		"name": "Mace of Disruption",
 		"type": "Weapon (Mace)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.\nLight. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
 	},
 	{
@@ -979,7 +1195,9 @@
 		"name": "Mace of Smiting",
 		"type": "Weapon (Mace)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.\nWhen you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
 	},
 	{
@@ -988,7 +1206,9 @@
 		"name": "Mace of Terror",
 		"type": "Weapon (Mace)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
 	},
 	{
@@ -997,7 +1217,9 @@
 		"name": "Mantle of Spell Resistance",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You have Advantage on saving throws against spells while you wear this cloak."
 	},
 	{
@@ -1006,7 +1228,9 @@
 		"name": "Manual of Bodily Health",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
@@ -1015,7 +1239,9 @@
 		"name": "Manual of Gainful Exercise",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
@@ -1024,7 +1250,9 @@
 		"name": "Manual of Golems",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.\nTo create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.\nOnce you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
 	},
 	{
@@ -1033,7 +1261,9 @@
 		"name": "Manual of Quickness of Action",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
@@ -1042,7 +1272,9 @@
 		"name": "Marvelous Pigments",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).\nUsing the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.\nWhen the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.\nNo object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.\nIf you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
 	},
 	{
@@ -1051,7 +1283,9 @@
 		"name": "Medallion of Thoughts",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
 	},
 	{
@@ -1060,7 +1294,9 @@
 		"name": "Mirror of Life Trapping",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.\nIf the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.\nAny creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.\nAn extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.\nIf the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.\nWhile within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.\nIn a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.\nPlacing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
@@ -1069,7 +1305,9 @@
 		"name": "Mithral Armor",
 		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
 	},
 	{
@@ -1078,7 +1316,9 @@
 		"name": "Mysterious Deck",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.\nBefore you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.\nOnce a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.\nEuryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.\nBalance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.\nComet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.\nDonjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.\nFates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.\nFlames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.\nFool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.\nGem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.\nJester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.\nKey. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.\nKnight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.\nPuzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.\nRogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.\nRuin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.\nSage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.\nSkull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.\nStar. Increase one of your ability scores by 2, to a maximum of 24.\nSun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.\nTalons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.\nThrone. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.\nVoid. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
 	},
 	{
@@ -1087,7 +1327,9 @@
 		"name": "Necklace of Adaptation",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
 	},
 	{
@@ -1096,7 +1338,9 @@
 		"name": "Necklace of Fireballs",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).\nYou can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
 	},
 	{
@@ -1106,7 +1350,9 @@
 		"type": "Wondrous Item",
 		"attunement": true,
 		"limited-to": "Cleric, Druid, or Paladin",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.\nSix types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
 	},
 	{
@@ -1115,7 +1361,9 @@
 		"name": "Nine Lives Stealer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.\nLife Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
 	},
 	{
@@ -1124,7 +1372,9 @@
 		"name": "Oathbow",
 		"type": "Weapon (Longbow or Shortbow)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.\nWhen you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.\nWhile your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
 	},
 	{
@@ -1133,7 +1383,9 @@
 		"name": "Oil of Etherealness",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.\nBeads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
 	},
 	{
@@ -1142,7 +1394,9 @@
 		"name": "Oil of Sharpness",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.\nThis clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
 	},
 	{
@@ -1151,7 +1405,9 @@
 		"name": "Oil of Slipperiness",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.\nAlternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
 	},
 	{
@@ -1161,7 +1417,9 @@
 		"type": "Wondrous Item",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
 	},
 	{
@@ -1170,7 +1428,9 @@
 		"name": "Periapt of Health",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.\nIn addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
 	},
 	{
@@ -1179,7 +1439,9 @@
 		"name": "Periapt of Proof against Poison",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
 	},
 	{
@@ -1188,7 +1450,9 @@
 		"name": "Periapt of Wound Closure",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this pendant, you gain the followingbenefits.\nLife Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.\nNatural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
 	},
 	{
@@ -1197,7 +1461,9 @@
 		"name": "Philter of Love",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.\nThis rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
 	},
 	{
@@ -1206,7 +1472,9 @@
 		"name": "Pipes of Haunting",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
 	},
 	{
@@ -1215,7 +1483,9 @@
 		"name": "Pipes of the Sewers",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.\nThe pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.\nWhenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
 	},
 	{
@@ -1224,7 +1494,9 @@
 		"name": "Plate Armor of Etherealness",
 		"type": "Armor (Half Plate Armor or Plate Armor)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
 	},
 	{
@@ -1233,7 +1505,9 @@
 		"name": "Portable Hole",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.\nYou can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.\nIf the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.\nPlacing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
@@ -1242,7 +1516,9 @@
 		"name": "Potion of Animal Friendship",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
 	},
 	{
@@ -1251,7 +1527,9 @@
 		"name": "Potion of Clairvoyance",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).\nAn eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
 	},
 	{
@@ -1260,7 +1538,9 @@
 		"name": "Potion of Climbing",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Common",
+		"rarity" : {
+			"name": "Common"
+		},
 		"description": "When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.\nThis potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
 	},
 	{
@@ -1269,7 +1549,9 @@
 		"name": "Potion of Diminution",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).\nThe red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
 	},
 	{
@@ -1278,7 +1560,9 @@
 		"name": "Potion of Flying",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
 	},
 	{
@@ -1287,7 +1571,9 @@
 		"name": "Potion of Growth",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).\nThe red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
 	},
 	{
@@ -1296,7 +1582,9 @@
 		"name": "Potions of Healing",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.\nWhatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
 	},
 	{
@@ -1305,7 +1593,9 @@
 		"name": "Potion of Gaseous Form",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "Potion of Healing    (supreme)"
 	},
 	{
@@ -1314,7 +1604,9 @@
 		"name": "Potion of Heroism",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.\nThis potion's container seems to hold fog that moves and pours like water."
 	},
 	{
@@ -1323,7 +1615,9 @@
 		"name": "Potion of Giant Strength",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.\nThis potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).\nThis potion's blue liquid bubbles and steams as if boiling."
 	},
 	{
@@ -1332,7 +1626,9 @@
 		"name": "Potion of Invisibility",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
 	},
 	{
@@ -1341,7 +1637,9 @@
 		"name": "Potion of Mind Reading",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
 	},
 	{
@@ -1350,7 +1648,9 @@
 		"name": "Potion of Poison",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.\nIf you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
 	},
 	{
@@ -1359,7 +1659,9 @@
 		"name": "Potion of Resistance",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
 	},
 	{
@@ -1368,7 +1670,9 @@
 		"name": "Potion of Speed",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
 	},
 	{
@@ -1377,7 +1681,9 @@
 		"name": "Potion of Water Breathing",
 		"type": "Potion",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "You can breathe underwater for 24 hours after drinking this potion.\nThis potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
 	},
 	{
@@ -1386,7 +1692,9 @@
 		"name": "Ring of Animal Influence",
 		"type": "Ring",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
 	},
 	{
@@ -1395,7 +1703,9 @@
 		"name": "Ring of Djinni Summoning",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.\nWhile summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.\nAfter the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.\nRings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
 	},
 	{
@@ -1404,7 +1714,9 @@
 		"name": "Ring of Elemental Command",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.\nEvery Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.\nElemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.\nSpellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
 	},
 	{
@@ -1413,7 +1725,9 @@
 		"name": "Ring of Evasion",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
 	},
 	{
@@ -1422,7 +1736,9 @@
 		"name": "Ring of Feather Falling",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
 	},
 	{
@@ -1431,7 +1747,9 @@
 		"name": "Ring of Free Action",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
 	},
 	{
@@ -1440,7 +1758,9 @@
 		"name": "Ring of Invisibility",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
 	},
 	{
@@ -1449,7 +1769,9 @@
 		"name": "Ring of Jumping",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
 	},
 	{
@@ -1458,7 +1780,9 @@
 		"name": "Ring of Mind Shielding",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.\nYou can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.\nIf you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
 	},
 	{
@@ -1467,7 +1791,9 @@
 		"name": "Ring of Protection",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
 	},
 	{
@@ -1476,7 +1802,9 @@
 		"name": "Ring of Regeneration",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
 	},
 	{
@@ -1485,7 +1813,9 @@
 		"name": "Ring of Resistance",
 		"type": "Ring",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
 	},
 	{
@@ -1494,7 +1824,9 @@
 		"name": "Ring of Shooting Stars",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You can cast Dancing Lights or Light from the ring.\nThe ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.\nFaerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.\nLightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.\nEach sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.\nAs a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4\nShooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
 	},
 	{
@@ -1503,7 +1835,9 @@
 		"name": "Ring of Spell Storing",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
 	},
 	{
@@ -1512,7 +1846,9 @@
 		"name": "Ring of Spell Turning",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
 	},
 	{
@@ -1521,7 +1857,9 @@
 		"name": "Ring of Swimming",
 		"type": "Ring",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "You have a Swim Speed of 40 feet while wearing this ring."
 	},
 	{
@@ -1530,7 +1868,9 @@
 		"name": "Ring of Telekinesis",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While wearing this ring, you can cast Telekinesisfrom it."
 	},
 	{
@@ -1539,7 +1879,9 @@
 		"name": "Ring of the Ram",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.\nAlternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
 	},
 	{
@@ -1548,7 +1890,9 @@
 		"name": "Ring of Three Wishes",
 		"type": "Ring",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
 	},
 	{
@@ -1557,7 +1901,9 @@
 		"name": "Ring of Warmth",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.\nIn addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
 	},
 	{
@@ -1566,7 +1912,9 @@
 		"name": "Ring of Water Walking",
 		"type": "Ring",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While wearing this ring, you cast Water Walk from it, targeting only yourself."
 	},
 	{
@@ -1575,7 +1923,9 @@
 		"name": "Ring of X-ray Vision",
 		"type": "Ring",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.\nWhenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
 	},
 	{
@@ -1584,7 +1934,9 @@
 		"name": "Robe of Eyes",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.\nDrawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
 	},
 	{
@@ -1593,7 +1945,9 @@
 		"name": "Robe of Scintillating Colors",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
 	},
 	{
@@ -1602,7 +1956,9 @@
 		"name": "Robe of Stars",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.\nSix stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.\nWhile you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
 	},
 	{
@@ -1612,7 +1968,9 @@
 		"type": "Wondrous Item",
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This elegant garment is made from exquisite cloth and adorned with runes.\nYou gain these benefits while wearing the robe.\nArmor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.\nMagic Resistance. You have Advantage on saving throws against spells and other magical effects.\nWar Mage. Your spell save DC and spell attack bonus each increase by 2."
 	},
 	{
@@ -1621,7 +1979,9 @@
 		"name": "Robe of Useful Items",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
 	},
 	{
@@ -1630,7 +1990,9 @@
 		"name": "Rod of Absorption",
 		"type": "Rod",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.\nWhen you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.\nIf you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.\nA newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
 	},
 	{
@@ -1639,7 +2001,9 @@
 		"name": "Rod of Alertness",
 		"type": "Rod",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This rod has the following properties.\nAlertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.\nSpells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility\nProtective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.\nThe rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
 	},
 	{
@@ -1648,7 +2012,9 @@
 		"name": "Rod of Lordly Might",
 		"type": "Rod",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.\nButtons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.\nDrain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.\nParalyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.\nTerrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
 	},
 	{
@@ -1657,7 +2023,9 @@
 		"name": "Rod of Rulership",
 		"type": "Rod",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
 	},
 	{
@@ -1666,7 +2034,9 @@
 		"name": "Rod of Security",
 		"type": "Rod",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.\nFor each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).\nWhen the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
 	},
 	{
@@ -1675,7 +2045,9 @@
 		"name": "Rope of Climbing",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.\nIf you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
 	},
 	{
@@ -1684,7 +2056,9 @@
 		"name": "Rope of Entanglement",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).\nA target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.\nThe rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
 	},
 	{
@@ -1693,7 +2067,9 @@
 		"name": "Scarab of Protection",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.\nPreservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.\nSpell Resistance. You have Advantage on saving throws against spells."
 	},
 	{
@@ -1702,7 +2078,9 @@
 		"name": "Scimitar of Speed",
 		"type": "Weapon (Scimitar)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
 	},
 	{
@@ -1711,7 +2089,9 @@
 		"name": "Shield",
 		"type": "Armor (Shield)",
 		"attunement": false,
-		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"rarity" : {
+			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
+		},
 		"description": "While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
 	},
 	{
@@ -1720,7 +2100,9 @@
 		"name": "Shield of Missile Attraction",
 		"type": "Armor (Shield)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.\nCurse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
 	},
 	{
@@ -1729,7 +2111,9 @@
 		"name": "Slippers of Spider Climbing",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
 	},
 	{
@@ -1738,7 +2122,9 @@
 		"name": "Sovereign Glue",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.\nOne ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
 	},
 	{
@@ -1747,7 +2133,9 @@
 		"name": "Spellguard Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
 	},
 	{
@@ -1756,7 +2144,9 @@
 		"name": "Spell Scroll",
 		"type": "Scroll",
 		"attunement": false,
-		"rarity": "Rarity Varies",
+		"rarity" : {
+			"name": "Rarity Varies"
+		},
 		"description": "A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.\nIf the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.\nThe level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11\nCopying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
 	},
 	{
@@ -1765,7 +2155,9 @@
 		"name": "Sphere of Annihilation",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.\nThe sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.\nControlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.\nWhile in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.\nSphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
 	},
 	{
@@ -1775,7 +2167,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.\nRegaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
 	},
 	{
@@ -1785,7 +2179,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You have Resistance to Fire damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
 	},
 	{
@@ -1795,7 +2191,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "You have Resistance to Cold damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
 	},
 	{
@@ -1805,7 +2203,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Bard, Cleric, or Druid",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
 	},
 	{
@@ -1815,7 +2215,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
 	},
 	{
@@ -1824,7 +2226,9 @@
 		"name": "Staff of Striking",
 		"type": "Staff",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.\nThe staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
 	},
 	{
@@ -1834,7 +2238,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This staff has 10 charges.\nInsect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
 	},
 	{
@@ -1844,7 +2250,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.\nSpell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge\nRegaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
 	},
 	{
@@ -1853,7 +2261,9 @@
 		"name": "Staff of the Python",
 		"type": "Staff",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.\nOn your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.\nAs a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
 	},
 	{
@@ -1863,7 +2273,9 @@
 		"type": "Staff",
 		"attunement": true,
 		"limited-to": "Druid",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6\nTree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.\nRegaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
 	},
 	{
@@ -1872,7 +2284,9 @@
 		"name": "Staff of Thunder and Lightning",
 		"type": "Staff",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.\nLightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).\nThunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.\nThunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.\nLightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.\nThunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
 	},
 	{
@@ -1881,7 +2295,9 @@
 		"name": "Staff of Withering",
 		"type": "Staff",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This staff has 3 charges and regains 1d3 expended charges daily at dawn.\nThe staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
 	},
 	{
@@ -1890,7 +2306,9 @@
 		"name": "Stone of Controlling Earth Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
 	},
 	{
@@ -1899,7 +2317,9 @@
 		"name": "Stone of Good Luck (Luckstone)",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
 	},
 	{
@@ -1908,7 +2328,9 @@
 		"name": "Sun Blade",
 		"type": "Weapon (Longsword)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This item appears to be a sword hilt.\nBlade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.\nYou gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.\nSunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
 	},
 	{
@@ -1917,7 +2339,9 @@
 		"name": "Sword of Life Stealing",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
 	},
 	{
@@ -1926,7 +2350,9 @@
 		"name": "Sword of Sharpness",
 		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 		"attunement": true,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.\nWhen you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
 	},
 	{
@@ -1935,7 +2361,9 @@
 		"name": "Sword of Wounding",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
 	},
 	{
@@ -1945,7 +2373,9 @@
 		"type": "Wondrous Item",
 		"attunement": true,
 		"limited-to": "Cleric or Paladin",
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nPure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
 	},
 	{
@@ -1954,7 +2384,9 @@
 		"name": "Talisman of the Sphere",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
 	},
 	{
@@ -1963,7 +2395,9 @@
 		"name": "Talisman of Ultimate Evil",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nUltimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
 	},
 	{
@@ -1972,7 +2406,9 @@
 		"name": "Tome of Clear Thought",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
 	},
 	{
@@ -1981,7 +2417,9 @@
 		"name": "Tome of Leadership and Influence",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
@@ -1990,7 +2428,9 @@
 		"name": "Tome of Understanding",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
 	},
 	{
@@ -1999,7 +2439,9 @@
 		"name": "Trident of Fish Command",
 		"type": "Weapon (Trident)",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
 	},
 	{
@@ -2008,7 +2450,9 @@
 		"name": "Universal Solvent",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.\nYou can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
 	},
 	{
@@ -2017,7 +2461,9 @@
 		"name": "Vicious Weapon",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
 	},
 	{
@@ -2026,7 +2472,9 @@
 		"name": "Vorpal Sword",
 		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 		"attunement": true,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.\nWhen you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
 	},
 	{
@@ -2035,7 +2483,9 @@
 		"name": "Wand of Binding",
 		"type": "Wand",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2044,7 +2494,9 @@
 		"name": "Wand of Enemy Detection",
 		"type": "Wand",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2053,7 +2505,9 @@
 		"name": "Wand of Fear",
 		"type": "Wand",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
 	},
 	{
@@ -2063,7 +2517,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2073,7 +2529,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2082,7 +2540,9 @@
 		"name": "Wand of Magic Detection",
 		"type": "Wand",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
 	},
 	{
@@ -2091,7 +2551,9 @@
 		"name": "Wand of Magic Missiles",
 		"type": "Wand",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2101,7 +2563,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2111,7 +2575,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Very Rare",
+		"rarity" : {
+			"name": "Very Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2120,7 +2586,9 @@
 		"name": "Wand of Secrets",
 		"type": "Wand",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
 	},
 	{
@@ -2130,7 +2598,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"rarity" : {
+			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
+		},
 		"description": "While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
 	},
 	{
@@ -2140,7 +2610,9 @@
 		"type": "Wand",
 		"attunement": true,
 		"limited-to": "Spellcaster",
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
@@ -2149,7 +2621,9 @@
 		"name": "Wand of Wonder",
 		"type": "Wand",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
 	},
 	{
@@ -2158,7 +2632,9 @@
 		"name": "Weapon",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
-		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"rarity" : {
+			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
+		},
 		"description": "You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
 	},
 	{
@@ -2167,7 +2643,9 @@
 		"name": "Weapon of Warning",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.\nAlarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.\nSupernatural Readiness. Each subject has Advantage on its Initiative rolls."
 	},
 	{
@@ -2176,7 +2654,9 @@
 		"name": "Well of Many Worlds",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Legendary",
+		"rarity" : {
+			"name": "Legendary"
+		},
 		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.\nOnce the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
 	},
 	{
@@ -2185,7 +2665,9 @@
 		"name": "Wind Fan",
 		"type": "Wondrous Item",
 		"attunement": false,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
 	},
 	{
@@ -2194,7 +2676,9 @@
 		"name": "Winged Boots",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Uncommon",
+		"rarity" : {
+			"name": "Uncommon"
+		},
 		"description": "These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
 	},
 	{
@@ -2203,7 +2687,9 @@
 		"name": "Wings of Flying",
 		"type": "Wondrous Item",
 		"attunement": true,
-		"rarity": "Rare",
+		"rarity" : {
+			"name": "Rare"
+		},
 		"description": "While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
 	}
 ]

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -15,10 +15,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Armor (Any Medium or Heavy, Except Hide Armor)",
-			"This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
-		]
+		"desc": "Armor (Any Medium or Heavy, Except Hide Armor)  \n This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
 	},
 	{
 		"index": "ammunition",
@@ -52,11 +49,7 @@
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"desc": [
-			"Weapon (Any Ammunition)",
-			"You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
-			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
-		]
+		"desc": "Weapon (Any Ammunition)  \n You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.  \n This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 	},{
 		"index": "ammunition-1",
 		"url": "/api/2024/magic-items/ammunition-1",
@@ -73,11 +66,7 @@
 		"rarity" : {
 			"name": "Uncommon (+1)"
 		},
-		"desc": [
-			"Weapon (Uncommon)",
-			"You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
-			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
-		]
+		"desc": "Weapon (Uncommon)  \n You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.  \n This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 	},
 	{
 		"index": "ammunition-2",
@@ -95,11 +84,7 @@
 		"rarity" : {
 			"name": "Rare (+2)"
 		},
-		"desc": [
-			"Weapon (Rare)",
-			"You have a +2 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
-			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
-		]
+		"desc": "Weapon (Rare)  \n You have a +2 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.  \n This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 	},
 	{
 		"index": "ammunition-3",
@@ -117,11 +102,7 @@
 		"rarity" : {
 			"name": "Very Rare (+3)"
 		},
-		"desc": [
-			"Weapon (Very Rare)",
-			"You have a +3 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
-			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
-		]
+		"desc": "Weapon (Very Rare)  \n You have a +3 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.  \n This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 	},
 	{
 		"index": "ammunition-of-slaying",
@@ -139,11 +120,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Any Ammunition)",
-			"This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.",
-			"After dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
-		]
+		"desc": "Weapon (Any Ammunition)  \n This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.  \n After dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
 	},
 	{
 		"index": "amulet-of-health",
@@ -161,10 +138,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
-		]
+		"desc": "Wondrous Item  \n Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
 	},
 	{
 		"index": "amulet-of-proof-against-detection-and-location",
@@ -182,10 +156,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
-		]
+		"desc": "Wondrous Item  \n While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
 	},
 	{
 		"index": "amulet-of-the-planes",
@@ -203,10 +174,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
-		]
+		"desc": "Wondrous Item  \n While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
 	},
 	{
 		"index": "animated-shield",
@@ -224,10 +192,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
 	},
 	{
 		"index": "apparatus-of-the-crab",
@@ -245,14 +210,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.",
-			"The Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.",
-			"To be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.",
-			"The apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.",
-			"A creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
-		]
+		"desc": "Wondrous Item  \n This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.  \n The Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.  \n To be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.  \n The apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.  \n A creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
 	},
 	{
 		"index": "armor",
@@ -286,10 +244,7 @@
 		"rarity" : {
 			"name": "Rare (+1), Very Rare (+2), or Legendary (+3)"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
 	},
 	{
 		"index": "armor-1",
@@ -307,10 +262,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"You have a +1 bonus to Armor Class while wearing this armor."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n You have a +1 bonus to Armor Class while wearing this armor."
 	},
 	{
 		"index": "armor-2",
@@ -328,10 +280,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"You have a +2 bonus to Armor Class while wearing this armor."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n You have a +2 bonus to Armor Class while wearing this armor."
 	},
 	{
 		"index": "armor-3",
@@ -349,10 +298,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"You have a +3 bonus to Armor Class while wearing this armor."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n You have a +3 bonus to Armor Class while wearing this armor."
 	},
 	{
 		"index": "armor-of-invulnerability",
@@ -370,11 +316,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Armor (Plate Armor)",
-			"You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.",
-			"Metal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
-		]
+		"desc": "Armor (Plate Armor)  \n You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.  \n Metal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
 	},
 	{
 		"index": "armor-of-resistance",
@@ -392,10 +334,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
 	},
 	{
 		"index": "armor-of-vulnerability",
@@ -413,11 +352,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.",
-			"Curse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.  \n Curse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
 	},
 	{
 		"index": "arrow-catching-shield",
@@ -435,11 +370,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.",
-			"Whenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
-		]
+		"desc": "Armor (Shield)  \n You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.  \n Whenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
 	},
 	{
 		"index": "bag-of-beans",
@@ -457,12 +388,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.",
-			"If you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.",
-			"If you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
-		]
+		"desc": "Wondrous Item  \n This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.  \n If you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.  \n If you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
 	},
 	{
 		"index": "bag-of-devouring",
@@ -480,13 +406,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.",
-			"The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.",
-			"Inanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.",
-			"If the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
-		]
+		"desc": "Wondrous Item  \n This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.  \n The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.  \n Inanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.  \n If the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
 	},
 	{
 		"index": "bag-of-holding",
@@ -504,12 +424,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.",
-			"If the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.",
-			"Placing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
-		]
+		"desc": "Wondrous Item  \n This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.  \n If the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.  \n Placing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
 	},
 	{
 		"index": "bag-of-tricks",
@@ -527,76 +442,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.",
-			"You can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.",
-			"The creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.",
-			"Once three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.",
-			"Gray Bag of Tricks",
-			"1d8",
-			"Creature",
-			"1d8",
-			"Creature",
-			"1",
-			"Weasel",
-			"5",
-			"Panther",
-			"2",
-			"Giant Rat",
-			"6",
-			"Giant Badger",
-			"3",
-			"Badger",
-			"7",
-			"Dire Wolf",
-			"4",
-			"Boar",
-			"8",
-			"Giant Elk",
-			"Rust Bag of Tricks",
-			"1d8",
-			"Creature",
-			"1d8",
-			"Creature",
-			"1",
-			"Rat",
-			"5",
-			"Giant Goat",
-			"2",
-			"Owl",
-			"6",
-			"Giant Boar",
-			"3",
-			"Mastiff",
-			"7",
-			"Lion",
-			"4",
-			"Goat",
-			"8",
-			"Brown Bear",
-			"Tan Bag of Tricks",
-			"1d8",
-			"Creature",
-			"1d8",
-			"Creature",
-			"1",
-			"Jackal",
-			"5",
-			"Black Bear",
-			"2",
-			"Ape",
-			"6",
-			"Giant Weasel",
-			"3",
-			"Baboon",
-			"7",
-			"Giant Hyena",
-			"4",
-			"Axe Beak",
-			"8",
-			"Tiger"
-		]
+		"desc": "Wondrous Item  \n This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.  \n You can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.  \n The creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.  \n Once three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.  \n Gray Bag of Tricks  \n 1d8  \n Creature  \n 1d8  \n Creature  \n 1  \n Weasel  \n 5  \n Panther  \n 2  \n Giant Rat  \n 6  \n Giant Badger  \n 3  \n Badger  \n 7  \n Dire Wolf  \n 4  \n Boar  \n 8  \n Giant Elk  \n Rust Bag of Tricks  \n 1d8  \n Creature  \n 1d8  \n Creature  \n 1  \n Rat  \n 5  \n Giant Goat  \n 2  \n Owl  \n 6  \n Giant Boar  \n 3  \n Mastiff  \n 7  \n Lion  \n 4  \n Goat  \n 8  \n Brown Bear  \n Tan Bag of Tricks  \n 1d8  \n Creature  \n 1d8  \n Creature  \n 1  \n Jackal  \n 5  \n Black Bear  \n 2  \n Ape  \n 6  \n Giant Weasel  \n 3  \n Baboon  \n 7  \n Giant Hyena  \n 4  \n Axe Beak  \n 8  \n Tiger"
 	},
 	{
 		"index": "bead-of-force",
@@ -614,12 +460,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.",
-			"You can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.",
-			"An enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
-		]
+		"desc": "Wondrous Item  \n This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.  \n You can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.  \n An enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
 	},
 	{
 		"index": "belt-of-dwarvenkind",
@@ -637,10 +478,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
-		]
+		"desc": "Wondrous Item  \n While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
 	},
 	{
 		"index": "belt-of-giant-strength",
@@ -658,10 +496,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
-		]
+		"desc": "Wondrous Item  \n While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
 	},
 	{
 		"index": "berserker-axe",
@@ -679,13 +514,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Battleaxe, Greataxe, or Halberd)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.",
-			"Curse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.",
-			"Whenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.",
-			"While berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
-		]
+		"desc": "Weapon (Battleaxe, Greataxe, or Halberd)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.  \n Curse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.  \n Whenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.  \n While berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
 	},
 	{
 		"index": "boots-of-elvenkind",
@@ -703,10 +532,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
-		]
+		"desc": "Wondrous Item  \n While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
 	},
 	{
 		"index": "boots-of-levitation",
@@ -724,10 +550,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear these boots, you can cast Levitate on yourself."
-		]
+		"desc": "Wondrous Item  \n While you wear these boots, you can cast Levitate on yourself."
 	},
 	{
 		"index": "boots-of-speed",
@@ -745,11 +568,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.",
-			"When you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
-		]
+		"desc": "Wondrous Item  \n While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.  \n When you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
 	},
 	{
 		"index": "boots-of-striding-and-springing",
@@ -767,11 +586,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.",
-			"Once on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
-		]
+		"desc": "Wondrous Item  \n While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.  \n Once on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
 	},
 	{
 		"index": "boots-of-the-winterlands",
@@ -789,12 +604,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.",
-			"Cold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.",
-			"Winter Strider. You ignore Difficult Terrain created by ice or snow."
-		]
+		"desc": "Wondrous Item  \n These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.  \n Cold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.  \n Winter Strider. You ignore Difficult Terrain created by ice or snow."
 	},
 	{
 		"index": "bowl-of-commanding-water-elementals",
@@ -812,11 +622,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.",
-			"The bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
-		]
+		"desc": "Wondrous Item  \n While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.  \n The bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
 	},
 	{
 		"index": "bracers-of-archery",
@@ -834,10 +640,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
-		]
+		"desc": "Wondrous Item  \n While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
 	},
 	{
 		"index": "bracers-of-defense",
@@ -855,10 +658,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
-		]
+		"desc": "Wondrous Item  \n While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
 	},
 	{
 		"index": "brazier-of-commanding-fire-elementals",
@@ -876,10 +676,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
 	},
 	{
 		"index": "brooch-of-shielding",
@@ -897,10 +694,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
-		]
+		"desc": "Wondrous Item  \n While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
 	},
 	{
 		"index": "broom-of-flying",
@@ -918,11 +712,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.",
-			"As a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
-		]
+		"desc": "Wondrous Item  \n This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.  \n As a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
 	},
 	{
 		"index": "candle-of-invocation",
@@ -940,12 +730,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.",
-			"While lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.",
-			"Alternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
-		]
+		"desc": "Wondrous Item  \n This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.  \n While lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.  \n Alternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
 	},
 	{
 		"index": "cape-of-the-mountebank",
@@ -963,11 +748,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.",
-			"When you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
-		]
+		"desc": "Wondrous Item  \n This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.  \n When you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
 	},
 	{
 		"index": "carpet-of-flying",
@@ -985,11 +766,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.",
-			"Four sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
-		]
+		"desc": "Wondrous Item  \n You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.  \n Four sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
 	},
 	{
 		"index": "censer-of-controlling-air-elementals",
@@ -1007,10 +784,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
 	},
 	{
 		"index": "chime-of-opening",
@@ -1028,11 +802,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.",
-			"The chime can be used 10 times. After the tenth time, it cracks and becomes useless."
-		]
+		"desc": "Wondrous Item  \n This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.  \n The chime can be used 10 times. After the tenth time, it cracks and becomes useless."
 	},
 	{
 		"index": "circlet-of-blasting",
@@ -1050,10 +820,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
 	},
 	{
 		"index": "cloak-of-arachnida",
@@ -1071,14 +838,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.",
-			"Poison Resistance. You have Resistance to Poison damage.",
-			"Spider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.",
-			"Spider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.",
-			"Web. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.  \n Poison Resistance. You have Resistance to Poison damage.  \n Spider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.  \n Spider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.  \n Web. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
 	},
 	{
 		"index": "cloak-of-displacement",
@@ -1096,10 +856,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
-		]
+		"desc": "Wondrous Item  \n While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
 	},
 	{
 		"index": "cloak-of-elvenkind",
@@ -1117,10 +874,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
-		]
+		"desc": "Wondrous Item  \n While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
 	},
 	{
 		"index": "cloak-of-protection",
@@ -1138,10 +892,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
-		]
+		"desc": "Wondrous Item  \n You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
 	},
 	{
 		"index": "cloak-of-the-bat",
@@ -1159,11 +910,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.",
-			"While wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.  \n While wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
 	},
 	{
 		"index": "cloak-of-the-manta-ray",
@@ -1181,10 +928,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
-		]
+		"desc": "Wondrous Item  \n While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
 	},
 	{
 		"index": "crystal-ball",
@@ -1202,10 +946,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While touching this crystal orb, you can cast Scrying(save DC 17) with it."
-		]
+		"desc": "Wondrous Item  \n While touching this crystal orb, you can cast Scrying(save DC 17) with it."
 	},
 	{
 		"index": "crystal-ball-of-mind-reading",
@@ -1223,10 +964,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
-		]
+		"desc": "Wondrous Item  \n While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
 	},
 	{
 		"index": "crystal-ball-of-telepathy",
@@ -1244,10 +982,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
 	},
 	{
 		"index": "crystal-ball-of-true-seeing",
@@ -1265,10 +1000,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
-		]
+		"desc": "Wondrous Item  \n While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
 	},
 	{
 		"index": "cube-of-force",
@@ -1286,11 +1018,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.",
-			"The cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
-		]
+		"desc": "Wondrous Item  \n This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.  \n The cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
 	},
 	{
 		"index": "cubic-gate",
@@ -1308,13 +1036,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.",
-			"The cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.",
-			"Gate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.",
-			"Plane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
-		]
+		"desc": "Wondrous Item  \n     This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.  \n The cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.  \n Gate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.  \n Plane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
 	},
 	{
 		"index": "dagger-of-venom",
@@ -1332,11 +1054,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Dagger)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"You can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
-		]
+		"desc": "Weapon (Dagger)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.  \n You can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
 	},
 	{
 		"index": "dancing-sword",
@@ -1354,11 +1072,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
-			"You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.",
-			"While the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
-		]
+		"desc": "Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)  \n You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.  \n While the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
 	},
 	{
 		"index": "decanter-of-endless-water",
@@ -1376,11 +1090,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.",
-			"You can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
-		]
+		"desc": "Wondrous Item  \n This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.  \n You can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
 	},
 	{
 		"index": "deck-of-illusions",
@@ -1398,12 +1108,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.",
-			"The magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.",
-			"Any physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
-		]
+		"desc": "Wondrous Item  \n This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.  \n The magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.  \n Any physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
 	},
 	{
 		"index": "defender",
@@ -1421,11 +1126,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Weapon (Any Melee Weapon)",
-			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"The first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
-		]
+		"desc": "Weapon (Any Melee Weapon)  \n You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.  \n The first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
 	},
 	{
 		"index": "demon-armor",
@@ -1443,11 +1144,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Any Light, Medium, or Heavy)",
-			"While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.",
-			"Curse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
-		]
+		"desc": "Armor (Any Light, Medium, or Heavy)  \n While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.  \n Curse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
 	},
 	{
 		"index": "dimensional-shackles",
@@ -1465,11 +1162,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.",
-			"You and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
-		]
+		"desc": "Wondrous Item  \n You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.  \n You and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
 	},
 	{
 		"index": "dragon-orb",
@@ -1487,15 +1180,7 @@
 		"rarity" : {
 			"name": "Artifact"
 		},
-		"desc": [
-			"Wondrous Item",
-			"An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.",
-			"While attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.",
-			"While you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.",
-			"Spells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3",
-			"Call Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.",
-			"Destroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
-		]
+		"desc": "Wondrous Item  \n An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.  \n While attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.  \n While you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.  \n Spells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3  \n Call Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.  \n Destroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
 	},
 	{
 		"index": "dragon-scale-mail",
@@ -1513,12 +1198,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Scale Mail)",
-			"Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.",
-			"While wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).",
-			"Additionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
-		]
+		"desc": "Armor (Scale Mail)  \n Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.  \n While wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).  \n Additionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
 	},
 	{
 		"index": "dragon-slayer",
@@ -1536,11 +1216,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"The weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.  \n The weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
 	},
 	{
 		"index": "dust-of-disappearance",
@@ -1558,10 +1234,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
-		]
+		"desc": "Wondrous Item  \n This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
 	},
 	{
 		"index": "dust-of-dryness",
@@ -1579,11 +1252,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.",
-			"As a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
-		]
+		"desc": "Wondrous Item  \n This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.  \n As a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
 	},
 	{
 		"index": "dust-of-sneezing-and-choking",
@@ -1601,12 +1270,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.",
-			"As a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.",
-			"On a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
-		]
+		"desc": "Wondrous Item  \n Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.  \n As a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.  \n On a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
 	},
 	{
 		"index": "dwarven-plate",
@@ -1624,10 +1288,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Half Plate Armor or Plate Armor)",
-			"While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
-		]
+		"desc": "Armor (Half Plate Armor or Plate Armor)  \n While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
 	},
 	{
 		"index": "dwarven-thrower",
@@ -1646,10 +1307,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Warhammer)",
-			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
-		]
+		"desc": "Weapon (Warhammer)  \n You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
 	},
 	{
 		"index": "efficient-quiver",
@@ -1667,11 +1325,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.",
-			"You can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
-		]
+		"desc": "Wondrous Item  \n Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.  \n You can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
 	},
 	{
 		"index": "efreeti-bottle",
@@ -1689,10 +1343,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
-		]
+		"desc": "Wondrous Item  \n When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
 	},
 	{
 		"index": "elemental-gem",
@@ -1710,10 +1361,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
-		]
+		"desc": "Wondrous Item  \n This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
 	},
 	{
 		"index": "elven-chain",
@@ -1731,10 +1379,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Chain Mail or Chain Shirt)",
-			"You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
-		]
+		"desc": "Armor (Chain Mail or Chain Shirt)  \n You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
 	},
 	{
 		"index": "eversmoking-bottle",
@@ -1752,12 +1397,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.",
-			"Each minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.",
-			"Closing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
-		]
+		"desc": "Wondrous Item  \n As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.  \n Each minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.  \n Closing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
 	},
 	{
 		"index": "eyes-of-charming",
@@ -1775,10 +1415,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
-		]
+		"desc": "Wondrous Item  \n These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
 	},
 	{
 		"index": "eyes-of-minute-seeing",
@@ -1796,10 +1433,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
-		]
+		"desc": "Wondrous Item  \n These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
 	},
 	{
 		"index": "eyes-of-the-eagle",
@@ -1817,10 +1451,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
-		]
+		"desc": "Wondrous Item  \n These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
 	},
 	{
 		"index": "feather-token",
@@ -1838,17 +1469,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.",
-			"Anchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.",
-			"Bird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.",
-			"Fan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.",
-			"Swan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.",
-			"Tree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.",
-			"Whip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.",
-			"As a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
-		]
+		"desc": "Wondrous Item  \n This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.  \n Anchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.  \n Bird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.  \n Fan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.  \n Swan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.  \n Tree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.  \n Whip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.  \n As a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
 	},
 	{
 		"index": "figurine-of-wondrous-power",
@@ -1866,22 +1487,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Wondrous Item",
-			"A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.",
-			"The creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.",
-			"The creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.",
-			"Bronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.",
-			"Ebony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)",
-			"Golden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.",
-			"Ivory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.",
-			"Marble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.",
-			"Obsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.",
-			"The figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.",
-			"Onyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.",
-			"Serpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.",
-			"Silver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
-		]
+		"desc": "Wondrous Item  \n A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.  \n The creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.  \n The creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.  \n Bronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.  \n Ebony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)  \n Golden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.  \n Ivory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.  \n Marble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.  \n Obsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.  \n The figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.  \n Onyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.  \n Serpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.  \n Silver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
 	},
 	{
 		"index": "flame-tongue",
@@ -1899,10 +1505,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Any Melee Weapon)",
-			"While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
-		]
+		"desc": "Weapon (Any Melee Weapon)  \n While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
 	},
 	{
 		"index": "folding-boat",
@@ -1920,11 +1523,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.",
-			"Statistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
-		]
+		"desc": "Wondrous Item  \n This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.  \n Statistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
 	},
 	{
 		"index": "frost-brand",
@@ -1942,12 +1541,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
-			"When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.",
-			"In freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.",
-			"When you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)  \n When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.  \n In freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.  \n When you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
 	},
 	{
 		"index": "gauntlets-of-ogre-power",
@@ -1965,10 +1559,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
-		]
+		"desc": "Wondrous Item  \n Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
 	},
 	{
 		"index": "gem-of-brightness",
@@ -1986,10 +1577,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
-		]
+		"desc": "Wondrous Item  \n This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
 	},
 	{
 		"index": "gem-of-seeing",
@@ -2007,11 +1595,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.",
-			"The gem regains 1d3 expended charges daily at dawn."
-		]
+		"desc": "Wondrous Item  \n This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.  \n The gem regains 1d3 expended charges daily at dawn."
 	},
 	{
 		"index": "giant-slayer",
@@ -2029,11 +1613,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"When you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.  \n When you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
 	},
 	{
 		"index": "glamoured-studded-leather",
@@ -2051,10 +1631,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Studded Leather Armor)",
-			"While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
-		]
+		"desc": "Armor (Studded Leather Armor)  \n While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
 	},
 	{
 		"index": "gloves-of-missile-snaring",
@@ -2072,10 +1649,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
-		]
+		"desc": "Wondrous Item  \n If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
 	},
 	{
 		"index": "gloves-of-swimming-and-climbing",
@@ -2093,10 +1667,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
-		]
+		"desc": "Wondrous Item  \n While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
 	},
 	{
 		"index": "goggles-of-night",
@@ -2114,10 +1685,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
-		]
+		"desc": "Wondrous Item  \n While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
 	},
 	{
 		"index": "hammer-of-thunderbolts",
@@ -2135,12 +1703,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Weapon (Maul or Warhammer)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"The weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.",
-			"Giant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
-		]
+		"desc": "Weapon (Maul or Warhammer)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.  \n The weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.  \n Giant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
 	},
 	{
 		"index": "handy-haversack",
@@ -2158,14 +1721,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.",
-			"Retrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.",
-			"If any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.",
-			"Each pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.",
-			"Placing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
-		]
+		"desc": "Wondrous Item  \n This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.  \n Retrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.  \n If any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.  \n Each pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.  \n Placing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
 		"index": "hat-of-disguise",
@@ -2183,10 +1739,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
-		]
+		"desc": "Wondrous Item  \n While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
 	},
 	{
 		"index": "headband-of-intellect",
@@ -2204,10 +1757,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
-		]
+		"desc": "Wondrous Item  \n Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
 	},
 	{
 		"index": "helm-of-brilliance",
@@ -2225,15 +1775,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.",
-			"Diamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.",
-			"Fire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.",
-			"Ruby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.",
-			"Spells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.",
-			"Taking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
-		]
+		"desc": "Wondrous Item  \n This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.  \n Diamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.  \n Fire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.  \n Ruby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.  \n Spells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.  \n Taking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
 	},
 	{
 		"index": "helm-of-comprehending-languages",
@@ -2251,10 +1793,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this helm, you can cast Comprehend Languages from it."
-		]
+		"desc": "Wondrous Item  \n While wearing this helm, you can cast Comprehend Languages from it."
 	},
 	{
 		"index": "helm-of-telepathy",
@@ -2272,10 +1811,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
 	},
 	{
 		"index": "helm-of-teleportation",
@@ -2293,10 +1829,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
-		]
+		"desc": "Wondrous Item  \n This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
 	},
 	{
 		"index": "holy-avenger",
@@ -2315,10 +1848,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
 	},
 	{
 		"index": "horn-of-blasting",
@@ -2336,11 +1866,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.",
-			"Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
-		]
+		"desc": "Wondrous Item  \n You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.  \n Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
 	},
 	{
 		"index": "horn-of-valhalla",
@@ -2379,12 +1905,7 @@
 		"rarity" : {
 			"name": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
-			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
-			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
-		]
+		"desc": "Wondrous Item  \n You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.  \n Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.  \n If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
 		"index": "horn-of-valhalla-1",
@@ -2402,13 +1923,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Rare (Silver)",
-			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
-			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
-			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
-		]
+		"desc": "Wondrous Item  \n Rare (Silver)  \n You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.  \n Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.  \n If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
 		"index": "horn-of-valhalla-2",
@@ -2426,13 +1941,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Rare (Brass)",
-			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
-			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
-			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
-		]
+		"desc": "Wondrous Item  \n Rare (Brass)  \n You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.  \n Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.  \n If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
 		"index": "horn-of-valhalla-3",
@@ -2450,13 +1959,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Very Rare (Bronze)",
-			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
-			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
-			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
-		]
+		"desc": "Wondrous Item  \n Very Rare (Bronze)  \n You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.  \n Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.  \n If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
 		"index": "horn-of-valhalla-4",
@@ -2474,13 +1977,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Legendary (Iron)",
-			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
-			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
-			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
-		]
+		"desc": "Wondrous Item  \n Legendary (Iron)  \n You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.  \n Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.  \n If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
 	},
 	{
 		"index": "horseshoes-of-a-zephyr",
@@ -2498,11 +1995,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
-			"While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
-		]
+		"desc": "Wondrous Item  \n These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.  \n While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
 	},
 	{
 		"index": "horseshoes-of-speed",
@@ -2520,11 +2013,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
-			"While all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
-		]
+		"desc": "Wondrous Item  \n These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.  \n While all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
 	},
 	{
 		"index": "immovable-rod",
@@ -2542,10 +2031,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Rod",
-			"This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
-		]
+		"desc": "Rod  \n This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
 	},
 	{
 		"index": "instant-fortress",
@@ -2563,12 +2049,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.",
-			"The tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.",
-			"Magic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
-		]
+		"desc": "Wondrous Item  \n As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.  \n The tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.  \n Magic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
 	},
 	{
 		"index": "ioun-stone",
@@ -2586,30 +2067,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.",
-			"When you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.",
-			"Each Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.",
-			"As a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.",
-			"The type of stone determines its rarity and effects.",
-			"Absorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.",
-			"Agility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.",
-			"Awareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.",
-			"Fortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.",
-			"Greater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.",
-			"Insight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.",
-			"Intellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.",
-			"Leadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.",
-			"Mastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.",
-			"Protection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.",
-			"Regeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.",
-			"Reserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.",
-			"Any creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.",
-			"While this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.",
-			"Strength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.",
-			"Sustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
-		]
+		"desc": "Wondrous Item  \n Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.  \n When you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.  \n Each Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.  \n As a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.  \n The type of stone determines its rarity and effects.  \n Absorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.  \n Agility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.  \n Awareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.  \n Fortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.  \n Greater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.  \n Insight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.  \n Intellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.  \n Leadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.  \n Mastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.  \n Protection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.  \n Regeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.  \n Reserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.  \n Any creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.  \n While this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.  \n Strength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.  \n Sustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
 	},
 	{
 		"index": "iron-bands",
@@ -2627,13 +2085,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.",
-			"Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.",
-			"A creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.",
-			"Once the bands are used, they can't be used again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.  \n Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.  \n A creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.  \n Once the bands are used, they can't be used again until the next dawn."
 	},
 	{
 		"index": "iron-flask",
@@ -2651,12 +2103,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.",
-			"You can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.",
-			"An Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
-		]
+		"desc": "Wondrous Item  \n While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.  \n You can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.  \n An Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
 	},
 	{
 		"index": "javelin-of-lightning",
@@ -2674,11 +2121,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Weapon (Javelin)",
-			"Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.",
-			"Lightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
-		]
+		"desc": "Weapon (Javelin)  \n Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.  \n Lightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
 	},
 	{
 		"index": "lantern-of-revealing",
@@ -2696,10 +2139,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
-		]
+		"desc": "Wondrous Item  \n While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
 	},
 	{
 		"index": "luck-blade",
@@ -2717,12 +2157,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.",
-			"Luck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.",
-			"Wish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.  \n Luck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.  \n Wish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
 	},
 	{
 		"index": "mace-of-disruption",
@@ -2740,11 +2175,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Mace)",
-			"When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.",
-			"Light. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
-		]
+		"desc": "Weapon (Mace)  \n When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.  \n Light. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
 	},
 	{
 		"index": "mace-of-smiting",
@@ -2762,11 +2193,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Mace)",
-			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.",
-			"When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
-		]
+		"desc": "Weapon (Mace)  \n You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.  \n When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
 	},
 	{
 		"index": "mace-of-terror",
@@ -2784,10 +2211,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Mace)",
-			"This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
-		]
+		"desc": "Weapon (Mace)  \n This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
 	},
 	{
 		"index": "mantle-of-spell-resistance",
@@ -2805,10 +2229,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"You have Advantage on saving throws against spells while you wear this cloak."
-		]
+		"desc": "Wondrous Item  \n You have Advantage on saving throws against spells while you wear this cloak."
 	},
 	{
 		"index": "manual-of-bodily-health",
@@ -2826,10 +2247,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
 		"index": "manual-of-gainful-exercise",
@@ -2847,10 +2265,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
 		"index": "manual-of-golems",
@@ -2868,12 +2283,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.",
-			"To create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.",
-			"Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
-		]
+		"desc": "Wondrous Item  \n This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.  \n To create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.  \n Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
 	},
 	{
 		"index": "manual-of-quickness-of-action",
@@ -2891,10 +2301,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
 		"index": "marvelous-pigments",
@@ -2912,14 +2319,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).",
-			"Using the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.",
-			"When the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.",
-			"No object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.",
-			"If you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
-		]
+		"desc": "Wondrous Item  \n This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).  \n Using the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.  \n When the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.  \n No object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.  \n If you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
 	},
 	{
 		"index": "medallion-of-thoughts",
@@ -2937,10 +2337,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
-		]
+		"desc": "Wondrous Item  \n The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
 	},
 	{
 		"index": "mirror-of-life-trapping",
@@ -2958,17 +2355,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.",
-			"If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.",
-			"Any creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.",
-			"An extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.",
-			"If the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.",
-			"While within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.",
-			"In a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.",
-			"Placing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
-		]
+		"desc": "Wondrous Item  \n When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.  \n If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.  \n Any creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.  \n An extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.  \n If the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.  \n While within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.  \n In a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.  \n Placing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
 		"index": "mithral-armor",
@@ -2986,10 +2373,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Armor (Any Medium or Heavy, Except Hide Armor)",
-			"Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
-		]
+		"desc": "Armor (Any Medium or Heavy, Except Hide Armor)  \n Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
 	},
 	{
 		"index": "mysterious-deck",
@@ -3007,33 +2391,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.",
-			"Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.",
-			"Once a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.",
-			"Euryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.",
-			"Balance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.",
-			"Comet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.",
-			"Donjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.",
-			"Fates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.",
-			"Flames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.",
-			"Fool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.",
-			"Gem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.",
-			"Jester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.",
-			"Key. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.",
-			"Knight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.",
-			"Puzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.",
-			"Rogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.",
-			"Ruin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.",
-			"Sage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.",
-			"Skull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.",
-			"Star. Increase one of your ability scores by 2, to a maximum of 24.",
-			"Sun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.",
-			"Talons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.",
-			"Throne. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.",
-			"Void. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
-		]
+		"desc": "Wondrous Item  \n Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.  \n Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.  \n Once a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.  \n Euryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.  \n Balance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.  \n Comet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.  \n Donjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.  \n Fates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.  \n Flames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.  \n Fool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.  \n Gem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.  \n Jester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.  \n Key. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.  \n Knight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.  \n Puzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.  \n Rogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.  \n Ruin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.  \n Sage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.  \n Skull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.  \n Star. Increase one of your ability scores by 2, to a maximum of 24.  \n Sun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.  \n Talons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.  \n Throne. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.  \n Void. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
 	},
 	{
 		"index": "necklace-of-adaptation",
@@ -3051,10 +2409,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
-		]
+		"desc": "Wondrous Item  \n While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
 	},
 	{
 		"index": "necklace-of-fireballs",
@@ -3072,11 +2427,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).",
-			"You can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
-		]
+		"desc": "Wondrous Item  \n This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).  \n You can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
 	},
 	{
 		"index": "necklace-of-prayer-beads",
@@ -3095,11 +2446,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.",
-			"Six types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.  \n Six types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
 	},
 	{
 		"index": "nine-lives-stealer",
@@ -3117,11 +2464,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.",
-			"Life Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.  \n Life Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
 	},
 	{
 		"index": "oathbow",
@@ -3139,12 +2482,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Longbow or Shortbow)",
-			"When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.",
-			"When you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.",
-			"While your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
-		]
+		"desc": "Weapon (Longbow or Shortbow)  \n When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.  \n When you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.  \n While your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
 	},
 	{
 		"index": "oil-of-etherealness",
@@ -3162,11 +2500,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.",
-			"Beads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
-		]
+		"desc": "Potion  \n One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.  \n Beads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
 	},
 	{
 		"index": "oil-of-sharpness",
@@ -3184,11 +2518,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Potion",
-			"One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.",
-			"This clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
-		]
+		"desc": "Potion  \n One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.  \n This clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
 	},
 	{
 		"index": "oil-of-slipperiness",
@@ -3206,11 +2536,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.",
-			"Alternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
-		]
+		"desc": "Potion  \n One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.  \n Alternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
 	},
 	{
 		"index": "pearl-of-power",
@@ -3229,10 +2555,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
 	},
 	{
 		"index": "periapt-of-health",
@@ -3250,11 +2573,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.",
-			"In addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
-		]
+		"desc": "Wondrous Item  \n While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.  \n In addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
 	},
 	{
 		"index": "periapt-of-proof-against-poison",
@@ -3272,10 +2591,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
-		]
+		"desc": "Wondrous Item  \n This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
 	},
 	{
 		"index": "periapt-of-wound-closure",
@@ -3293,12 +2609,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this pendant, you gain the followingbenefits.",
-			"Life Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.",
-			"Natural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
-		]
+		"desc": "Wondrous Item  \n While wearing this pendant, you gain the followingbenefits.  \n Life Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.  \n Natural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
 	},
 	{
 		"index": "philter-of-love",
@@ -3316,11 +2627,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.",
-			"This rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
-		]
+		"desc": "Potion  \n The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.  \n This rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
 	},
 	{
 		"index": "pipes-of-haunting",
@@ -3338,10 +2645,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
-		]
+		"desc": "Wondrous Item  \n These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
 	},
 	{
 		"index": "pipes-of-the-sewers",
@@ -3359,12 +2663,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.",
-			"The pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.",
-			"Whenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
-		]
+		"desc": "Wondrous Item  \n While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.  \n The pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.  \n Whenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
 	},
 	{
 		"index": "plate-armor-of-etherealness",
@@ -3382,10 +2681,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Armor (Half Plate Armor or Plate Armor)",
-			"While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
-		]
+		"desc": "Armor (Half Plate Armor or Plate Armor)  \n While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
 	},
 	{
 		"index": "portable-hole",
@@ -3403,14 +2699,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
-			"You can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.",
-			"You can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.",
-			"If the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.",
-			"Placing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
-		]
+		"desc": "Wondrous Item  \n This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.  \n You can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.  \n You can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.  \n If the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.  \n Placing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
 	},
 	{
 		"index": "potion-of-animal-friendship",
@@ -3428,10 +2717,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
-		]
+		"desc": "Potion  \n When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
 	},
 	{
 		"index": "potion-of-clairvoyance",
@@ -3449,11 +2735,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).",
-			"An eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).  \n An eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
 	},
 	{
 		"index": "potion-of-climbing",
@@ -3471,11 +2753,7 @@
 		"rarity" : {
 			"name": "Common"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.",
-			"This potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.  \n This potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
 	},
 	{
 		"index": "potion-of-diminution",
@@ -3493,11 +2771,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).",
-			"The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).  \n The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
 	},
 	{
 		"index": "potion-of-flying",
@@ -3515,10 +2789,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
-		]
+		"desc": "Potion  \n When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
 	},
 	{
 		"index": "potion-of-growth",
@@ -3536,11 +2807,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).",
-			"The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).  \n The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
 	},
 	{
 		"index": "potions-of-healing",
@@ -3558,11 +2825,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Potion",
-			"You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.",
-			"Whatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
-		]
+		"desc": "Potion  \n You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.  \n Whatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
 	},
 	{
 		"index": "potion-of-gaseous-form",
@@ -3580,10 +2843,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"Potion of Healing    (supreme)"
-		]
+		"desc": "Potion  \n Potion of Healing    (supreme)"
 	},
 	{
 		"index": "potion-of-heroism",
@@ -3601,11 +2861,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.",
-			"This potion's container seems to hold fog that moves and pours like water."
-		]
+		"desc": "Potion  \n     10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.  \n This potion's container seems to hold fog that moves and pours like water."
 	},
 	{
 		"index": "potion-of-giant-strength",
@@ -3623,12 +2879,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.",
-			"This potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).",
-			"This potion's blue liquid bubbles and steams as if boiling."
-		]
+		"desc": "Potion  \n When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.  \n This potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).  \n This potion's blue liquid bubbles and steams as if boiling."
 	},
 	{
 		"index": "potion-of-invisibility",
@@ -3646,10 +2897,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
-		]
+		"desc": "Potion  \n This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
 	},
 	{
 		"index": "potion-of-mind-reading",
@@ -3667,10 +2915,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
 	},
 	{
 		"index": "potion-of-poison",
@@ -3688,11 +2933,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.",
-			"If you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
-		]
+		"desc": "Potion  \n This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.  \n If you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
 	},
 	{
 		"index": "potion-of-resistance",
@@ -3710,10 +2951,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
-		]
+		"desc": "Potion  \n When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
 	},
 	{
 		"index": "potion-of-speed",
@@ -3731,10 +2969,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Potion",
-			"When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
-		]
+		"desc": "Potion  \n When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
 	},
 	{
 		"index": "potion-of-water-breathing",
@@ -3752,11 +2987,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Potion",
-			"You can breathe underwater for 24 hours after drinking this potion.",
-			"This potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
-		]
+		"desc": "Potion  \n You can breathe underwater for 24 hours after drinking this potion.  \n This potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
 	},
 	{
 		"index": "ring-of-animal-influence",
@@ -3774,10 +3005,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
-		]
+		"desc": "Ring  \n This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
 	},
 	{
 		"index": "ring-of-djinni-summoning",
@@ -3795,13 +3023,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.",
-			"While summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.",
-			"After the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.",
-			"Rings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
-		]
+		"desc": "Ring  \n While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.  \n While summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.  \n After the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.  \n Rings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
 	},
 	{
 		"index": "ring-of-elemental-command",
@@ -3819,13 +3041,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Ring",
-			"Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.",
-			"Every Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.",
-			"Elemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.",
-			"Spellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
-		]
+		"desc": "Ring  \n Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.  \n Every Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.  \n Elemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.  \n Spellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
 	},
 	{
 		"index": "ring-of-evasion",
@@ -3843,10 +3059,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
-		]
+		"desc": "Ring  \n This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
 	},
 	{
 		"index": "ring-of-feather-falling",
@@ -3864,10 +3077,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
-		]
+		"desc": "Ring  \n When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
 	},
 	{
 		"index": "ring-of-free-action",
@@ -3885,10 +3095,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
-		]
+		"desc": "Ring  \n While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
 	},
 	{
 		"index": "ring-of-invisibility",
@@ -3906,10 +3113,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
-		]
+		"desc": "Ring  \n While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
 	},
 	{
 		"index": "ring-of-jumping",
@@ -3927,10 +3131,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
-		]
+		"desc": "Ring  \n While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
 	},
 	{
 		"index": "ring-of-mind-shielding",
@@ -3948,12 +3149,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.",
-			"You can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.",
-			"If you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
-		]
+		"desc": "Ring  \n While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.  \n You can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.  \n If you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
 	},
 	{
 		"index": "ring-of-protection",
@@ -3971,10 +3167,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
-		]
+		"desc": "Ring  \n You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
 	},
 	{
 		"index": "ring-of-regeneration",
@@ -3992,10 +3185,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
-		]
+		"desc": "Ring  \n While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
 	},
 	{
 		"index": "ring-of-resistance",
@@ -4013,10 +3203,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
-		]
+		"desc": "Ring  \n You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
 	},
 	{
 		"index": "ring-of-shooting-stars",
@@ -4034,16 +3221,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Ring",
-			"You can cast Dancing Lights or Light from the ring.",
-			"The ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.",
-			"Faerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.",
-			"Lightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.",
-			"Each sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.",
-			"As a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4",
-			"Shooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
-		]
+		"desc": "Ring  \n You can cast Dancing Lights or Light from the ring.  \n The ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.  \n Faerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.  \n Lightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.  \n Each sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.  \n As a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4  \n Shooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
 	},
 	{
 		"index": "ring-of-spell-storing",
@@ -4061,12 +3239,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.",
-			"Any creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.",
-			"While wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
-		]
+		"desc": "Ring  \n This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.  \n Any creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.  \n While wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
 	},
 	{
 		"index": "ring-of-spell-turning",
@@ -4084,10 +3257,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
-		]
+		"desc": "Ring  \n While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
 	},
 	{
 		"index": "ring-of-swimming",
@@ -4105,10 +3275,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Ring",
-			"You have a Swim Speed of 40 feet while wearing this ring."
-		]
+		"desc": "Ring  \n You have a Swim Speed of 40 feet while wearing this ring."
 	},
 	{
 		"index": "ring-of-telekinesis",
@@ -4126,10 +3293,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can cast Telekinesisfrom it."
-		]
+		"desc": "Ring  \n While wearing this ring, you can cast Telekinesisfrom it."
 	},
 	{
 		"index": "ring-of-the-ram",
@@ -4147,11 +3311,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.",
-			"Alternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
-		]
+		"desc": "Ring  \n This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.  \n Alternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
 	},
 	{
 		"index": "ring-of-three-wishes",
@@ -4169,10 +3329,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
-		]
+		"desc": "Ring  \n While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
 	},
 	{
 		"index": "ring-of-warmth",
@@ -4190,11 +3347,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Ring",
-			"If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.",
-			"In addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
-		]
+		"desc": "Ring  \n If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.  \n In addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
 	},
 	{
 		"index": "ring-of-water-walking",
@@ -4212,10 +3365,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you cast Water Walk from it, targeting only yourself."
-		]
+		"desc": "Ring  \n While wearing this ring, you cast Water Walk from it, targeting only yourself."
 	},
 	{
 		"index": "ring-of-x-ray-vision",
@@ -4233,11 +3383,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Ring",
-			"While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.",
-			"Whenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
-		]
+		"desc": "Ring  \n While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.  \n Whenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
 	},
 	{
 		"index": "robe-of-eyes",
@@ -4255,11 +3401,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.",
-			"Drawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
-		]
+		"desc": "Wondrous Item  \n This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.  \n Drawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
 	},
 	{
 		"index": "robe-of-scintillating-colors",
@@ -4277,10 +3419,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
-		]
+		"desc": "Wondrous Item  \n This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
 	},
 	{
 		"index": "robe-of-stars",
@@ -4298,12 +3437,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.",
-			"Six stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.",
-			"While you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
-		]
+		"desc": "Wondrous Item  \n This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.  \n Six stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.  \n While you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
 	},
 	{
 		"index": "robe-of-the-archmagi",
@@ -4322,14 +3456,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This elegant garment is made from exquisite cloth and adorned with runes.",
-			"You gain these benefits while wearing the robe.",
-			"Armor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.",
-			"Magic Resistance. You have Advantage on saving throws against spells and other magical effects.",
-			"War Mage. Your spell save DC and spell attack bonus each increase by 2."
-		]
+		"desc": "Wondrous Item  \n This elegant garment is made from exquisite cloth and adorned with runes.  \n You gain these benefits while wearing the robe.  \n Armor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.  \n Magic Resistance. You have Advantage on saving throws against spells and other magical effects.  \n War Mage. Your spell save DC and spell attack bonus each increase by 2."
 	},
 	{
 		"index": "robe-of-useful-items",
@@ -4347,10 +3474,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
-		]
+		"desc": "Wondrous Item  \n This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
 	},
 	{
 		"index": "rod-of-absorption",
@@ -4368,13 +3492,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Rod",
-			"While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.",
-			"When you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.",
-			"If you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.",
-			"A newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
-		]
+		"desc": "Rod  \n While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.  \n When you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.  \n If you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.  \n A newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
 	},
 	{
 		"index": "rod-of-alertness",
@@ -4392,14 +3510,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Rod",
-			"This rod has the following properties.",
-			"Alertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.",
-			"Spells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility",
-			"Protective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.",
-			"The rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
-		]
+		"desc": "Rod  \n This rod has the following properties.  \n Alertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.  \n Spells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility  \n Protective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.  \n The rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
 	},
 	{
 		"index": "rod-of-lordly-might",
@@ -4417,14 +3528,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Rod",
-			"This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.",
-			"Buttons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.",
-			"Drain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.",
-			"Paralyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.",
-			"Terrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
-		]
+		"desc": "Rod  \n This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.  \n Buttons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.  \n Drain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.  \n Paralyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.  \n Terrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
 	},
 	{
 		"index": "rod-of-rulership",
@@ -4442,10 +3546,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Rod",
-			"You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
-		]
+		"desc": "Rod  \n You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
 	},
 	{
 		"index": "rod-of-security",
@@ -4463,12 +3564,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Rod",
-			"While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.",
-			"For each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).",
-			"When the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
-		]
+		"desc": "Rod  \n While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.  \n For each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).  \n When the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
 	},
 	{
 		"index": "rope-of-climbing",
@@ -4486,11 +3582,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.",
-			"If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
-		]
+		"desc": "Wondrous Item  \n This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.  \n If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
 	},
 	{
 		"index": "rope-of-entanglement",
@@ -4508,12 +3600,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).",
-			"A target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.",
-			"The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
-		]
+		"desc": "Wondrous Item  \n This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).  \n A target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.  \n The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
 	},
 	{
 		"index": "scarab-of-protection",
@@ -4531,12 +3618,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.",
-			"Preservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.",
-			"Spell Resistance. You have Advantage on saving throws against spells."
-		]
+		"desc": "Wondrous Item  \n This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.  \n Preservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.  \n Spell Resistance. You have Advantage on saving throws against spells."
 	},
 	{
 		"index": "scimitar-of-speed",
@@ -4554,10 +3636,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Scimitar)",
-			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
-		]
+		"desc": "Weapon (Scimitar)  \n You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
 	},
 	{
 		"index": "shield",
@@ -4591,10 +3670,7 @@
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
 	},
 	{
 		"index": "shield-1",
@@ -4612,10 +3688,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have a +1 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have a +1 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
 	},
 	{
 		"index": "shield-2",
@@ -4633,10 +3706,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have a +2 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have a +2 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
 	},
 	{
 		"index": "shield-3",
@@ -4654,10 +3724,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have a +3 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have a +3 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
 	},
 	{
 		"index": "shield-of-missile-attraction",
@@ -4675,11 +3742,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.",
-			"Curse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.  \n Curse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
 	},
 	{
 		"index": "slippers-of-spider-climbing",
@@ -4697,10 +3760,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
-		]
+		"desc": "Wondrous Item  \n While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
 	},
 	{
 		"index": "sovereign-glue",
@@ -4718,11 +3778,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.",
-			"One ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
-		]
+		"desc": "Wondrous Item  \n This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.  \n One ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
 	},
 	{
 		"index": "spellguard-shield",
@@ -4740,10 +3796,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Armor (Shield)",
-			"While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
-		]
+		"desc": "Armor (Shield)  \n While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
 	},
 	{
 		"index": "spell-scroll",
@@ -4761,13 +3814,7 @@
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"desc": [
-			"Scroll",
-			"A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.",
-			"If the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.",
-			"The level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11",
-			"Copying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
-		]
+		"desc": "Scroll  \n A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.  \n If the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.  \n The level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11  \n Copying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
 	},
 	{
 		"index": "sphere-of-annihilation",
@@ -4785,14 +3832,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.",
-			"The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.",
-			"Controlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.",
-			"While in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.",
-			"Sphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
-		]
+		"desc": "Wondrous Item  \n This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.  \n The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.  \n Controlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.  \n While in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.  \n Sphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
 	},
 	{
 		"index": "staff-of-charming",
@@ -4811,11 +3851,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.",
-			"Regaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
-		]
+		"desc": "Staff  \n This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.  \n Regaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
 	},
 	{
 		"index": "staff-of-fire",
@@ -4834,12 +3870,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Staff",
-			"You have Resistance to Fire damage while you hold this staff.",
-			"Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3",
-			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
-		]
+		"desc": "Staff  \n You have Resistance to Fire damage while you hold this staff.  \n Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3  \n Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
 	},
 	{
 		"index": "staff-of-frost",
@@ -4858,12 +3889,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Staff",
-			"You have Resistance to Cold damage while you hold this staff.",
-			"Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4",
-			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
-		]
+		"desc": "Staff  \n You have Resistance to Cold damage while you hold this staff.  \n Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4  \n Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
 	},
 	{
 		"index": "staff-of-healing",
@@ -4882,11 +3908,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2",
-			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
-		]
+		"desc": "Staff  \n This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2  \n Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
 	},
 	{
 		"index": "staff-of-power",
@@ -4905,12 +3927,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.",
-			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.",
-			"Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
-		]
+		"desc": "Staff  \n This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.  \n Spells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.  \n Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
 	},
 	{
 		"index": "staff-of-striking",
@@ -4928,12 +3945,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.",
-			"The staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.",
-			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
-		]
+		"desc": "Staff  \n This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.  \n The staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.  \n Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
 	},
 	{
 		"index": "staff-of-swarming-insects",
@@ -4952,13 +3964,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 10 charges.",
-			"Insect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.",
-			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5",
-			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
-		]
+		"desc": "Staff  \n This staff has 10 charges.  \n Insect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.  \n Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5  \n Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
 	},
 	{
 		"index": "staff-of-the-magi",
@@ -4977,14 +3983,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.",
-			"Spell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).",
-			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge",
-			"Regaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.",
-			"Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
-		]
+		"desc": "Staff  \n This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.  \n Spell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).  \n Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge  \n Regaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.  \n Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
 	},
 	{
 		"index": "staff-of-the-python",
@@ -5002,12 +4001,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Staff",
-			"As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.",
-			"On your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.",
-			"As a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
-		]
+		"desc": "Staff  \n As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.  \n On your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.  \n As a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
 	},
 	{
 		"index": "staff-of-the-woodlands",
@@ -5026,13 +4020,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.",
-			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6",
-			"Tree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.",
-			"Regaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
-		]
+		"desc": "Staff  \n This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.  \n Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6  \n Tree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.  \n Regaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
 	},
 	{
 		"index": "staff-of-thunder-and-lightning",
@@ -5050,15 +4038,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.",
-			"Lightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).",
-			"Thunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.",
-			"Thunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.",
-			"Lightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.",
-			"Thunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
-		]
+		"desc": "Staff  \n This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.  \n Lightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).  \n Thunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.  \n Thunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.  \n Lightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.  \n Thunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
 	},
 	{
 		"index": "staff-of-withering",
@@ -5076,11 +4056,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Staff",
-			"This staff has 3 charges and regains 1d3 expended charges daily at dawn.",
-			"The staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
-		]
+		"desc": "Staff  \n This staff has 3 charges and regains 1d3 expended charges daily at dawn.  \n The staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
 	},
 	{
 		"index": "stone-of-controlling-earth-elementals",
@@ -5098,10 +4074,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
-		]
+		"desc": "Wondrous Item  \n While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
 	},
 	{
 		"index": "stone-of-good-luck-(luckstone)",
@@ -5119,10 +4092,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
-		]
+		"desc": "Wondrous Item  \n While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
 	},
 	{
 		"index": "sun-blade",
@@ -5140,13 +4110,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Longsword)",
-			"This item appears to be a sword hilt.",
-			"Blade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.",
-			"You gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.",
-			"Sunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
-		]
+		"desc": "Weapon (Longsword)  \n This item appears to be a sword hilt.  \n Blade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.  \n You gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.  \n Sunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
 	},
 	{
 		"index": "sword-of-life-stealing",
@@ -5164,10 +4128,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
-			"When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)  \n When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
 	},
 	{
 		"index": "sword-of-sharpness",
@@ -5185,11 +4146,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
-			"When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.",
-			"When you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)  \n When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.  \n When you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
 	},
 	{
 		"index": "sword-of-wounding",
@@ -5207,10 +4164,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
-			"When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)  \n When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
 	},
 	{
 		"index": "talisman-of-pure-good",
@@ -5229,12 +4183,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
-			"Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.",
-			"Pure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
-		]
+		"desc": "Wondrous Item  \n This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.  \n Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.  \n Pure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
 	},
 	{
 		"index": "talisman-of-the-sphere",
@@ -5252,10 +4201,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
-		]
+		"desc": "Wondrous Item  \n While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
 	},
 	{
 		"index": "talisman-of-ultimate-evil",
@@ -5273,12 +4219,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
-			"Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.",
-			"Ultimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
-		]
+		"desc": "Wondrous Item  \n This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.  \n Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.  \n Ultimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
 	},
 	{
 		"index": "tome-of-clear-thought",
@@ -5296,10 +4237,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
 	},
 	{
 		"index": "tome-of-leadership-and-influence",
@@ -5317,10 +4255,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
 	},
 	{
 		"index": "tome-of-understanding",
@@ -5338,10 +4273,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
-		]
+		"desc": "Wondrous Item  \n This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
 	},
 	{
 		"index": "trident-of-fish-command",
@@ -5359,10 +4291,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Weapon (Trident)",
-			"This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
-		]
+		"desc": "Weapon (Trident)  \n This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
 	},
 	{
 		"index": "universal-solvent",
@@ -5380,11 +4309,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.",
-			"You can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
-		]
+		"desc": "Wondrous Item  \n This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.  \n You can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
 	},
 	{
 		"index": "vicious-weapon",
@@ -5402,10 +4327,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
 	},
 	{
 		"index": "vorpal-sword",
@@ -5423,11 +4345,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
-			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.",
-			"When you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
-		]
+		"desc": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)  \n You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.  \n When you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
 	},
 	{
 		"index": "wand-of-binding",
@@ -5445,12 +4363,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges.",
-			"Spells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges.  \n Spells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-enemy-detection",
@@ -5468,11 +4381,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-fear",
@@ -5490,11 +4399,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges.",
-			"Spells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
-		]
+		"desc": "Wand  \n This wand has 7 charges.  \n Spells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
 	},
 	{
 		"index": "wand-of-fireballs",
@@ -5513,11 +4418,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-lightning-bolts",
@@ -5536,11 +4437,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-magic-detection",
@@ -5558,10 +4455,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
-		]
+		"desc": "Wand  \n This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
 	},
 	{
 		"index": "wand-of-magic-missiles",
@@ -5579,11 +4473,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-paralysis",
@@ -5602,11 +4492,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-polymorph",
@@ -5625,11 +4511,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-secrets",
@@ -5647,10 +4529,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
-		]
+		"desc": "Wand  \n This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
 	},
 	{
 		"index": "wand-of-the-war-mage",
@@ -5685,10 +4564,7 @@
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"desc": [
-			"Wand",
-			"While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
-		]
+		"desc": "Wand  \n While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
 	},
 	{
 		"index": "wand-of-the-war-mage-1",
@@ -5707,11 +4583,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wand",
-			"Uncommon (+1)",
-			"While holding this wand, you gain a +1 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
-		]
+		"desc": "Wand  \n Uncommon (+1)  \n While holding this wand, you gain a +1 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
 	},
 	{
 		"index": "wand-of-the-war-mage-2",
@@ -5730,11 +4602,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"Rare (+2)",
-			"While holding this wand, you gain a +2 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
-		]
+		"desc": "Wand  \n Rare (+2)  \n While holding this wand, you gain a +2 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
 	},
 	{
 		"index": "wand-of-the-war-mage-3",
@@ -5753,11 +4621,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Wand",
-			"Very Rare (+3)",
-			"While holding this wand, you gain a +3 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
-		]
+		"desc": "Wand  \n Very Rare (+3)  \n While holding this wand, you gain a +3 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
 	},
 	{
 		"index": "wand-of-web",
@@ -5776,11 +4640,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
 	},
 	{
 		"index": "wand-of-wonder",
@@ -5798,11 +4658,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wand",
-			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.",
-			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
-		]
+		"desc": "Wand  \n This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.  \n Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
 	},
 	{
 		"index": "weapon",
@@ -5836,10 +4692,7 @@
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
 	},
 	{
 		"index": "weapon-1",
@@ -5857,11 +4710,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"Uncommon (+1)",
-			"You have a +1 bonus to attack rolls and damage rolls made with this magic weapon."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n Uncommon (+1)  \n You have a +1 bonus to attack rolls and damage rolls made with this magic weapon."
 	},
 	{
 		"index": "weapon-2",
@@ -5879,11 +4728,7 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"Rare (+2)",
-			"You have a +2 bonus to attack rolls and damage rolls made with this magic weapon."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n Rare (+2)  \n You have a +2 bonus to attack rolls and damage rolls made with this magic weapon."
 	},
 	{
 		"index": "weapon-3",
@@ -5901,11 +4746,7 @@
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"Very Rare (+3)",
-			"You have a +3 bonus to attack rolls and damage rolls made with this magic weapon."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n Very Rare (+3)  \n You have a +3 bonus to attack rolls and damage rolls made with this magic weapon."
 	},
 	{
 		"index": "weapon-of-warning",
@@ -5923,12 +4764,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Weapon (Any Simple or Martial)",
-			"As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.",
-			"Alarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.",
-			"Supernatural Readiness. Each subject has Advantage on its Initiative rolls."
-		]
+		"desc": "Weapon (Any Simple or Martial)  \n As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.  \n Alarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.  \n Supernatural Readiness. Each subject has Advantage on its Initiative rolls."
 	},
 	{
 		"index": "well-of-many-worlds",
@@ -5946,12 +4782,7 @@
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"desc": [
-			"Wondrous Item",
-			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
-			"You can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.",
-			"Once the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
-		]
+		"desc": "Wondrous Item  \n This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.  \n You can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.  \n Once the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
 	},
 	{
 		"index": "wind-fan",
@@ -5969,10 +4800,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
-		]
+		"desc": "Wondrous Item  \n While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
 	},
 	{
 		"index": "winged-boots",
@@ -5990,10 +4818,7 @@
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"desc": [
-			"Wondrous Item",
-			"These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
-		]
+		"desc": "Wondrous Item  \n These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
 	},
 	{
 		"index": "wings-of-flying",
@@ -6011,9 +4836,6 @@
 		"rarity" : {
 			"name": "Rare"
 		},
-		"desc": [
-			"Wondrous Item",
-			"While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
-		]
+		"desc": "Wondrous Item  \n While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
 	}
 ]

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -2,6 +2,7 @@
 	{
 		"index": "adamantine-armor",
 		"url": "/api/2024/magic-items/adamantine-armor",
+		"image" : "/api/images/magic-items/adamantine-armor.png",
 		"name": "Adamantine Armor",
 		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
 		"attunement": false,
@@ -13,6 +14,7 @@
 	{
 		"index": "ammunition",
 		"url": "/api/2024/magic-items/ammunition",
+		"image" : "/api/images/magic-items/ammunition.png",
 		"name": "Ammunition",
 		"type": "Weapon (Any Ammunition)",
 		"attunement": false,
@@ -24,6 +26,7 @@
 	{
 		"index": "ammunition-of-slaying",
 		"url": "/api/2024/magic-items/ammunition-of-slaying",
+		"image" : "/api/images/magic-items/ammunition-of-slaying.png",
 		"name": "Ammunition of Slaying",
 		"type": "Weapon (Any Ammunition)",
 		"attunement": false,
@@ -35,6 +38,7 @@
 	{
 		"index": "amulet-of-health",
 		"url": "/api/2024/magic-items/amulet-of-health",
+		"image" : "/api/images/magic-items/amulet-of-health.png",
 		"name": "Amulet of Health",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -46,6 +50,7 @@
 	{
 		"index": "amulet-of-proof-against-detection-and-location",
 		"url": "/api/2024/magic-items/amulet-of-proof-against-detection-and-location",
+		"image" : "/api/images/magic-items/amulet-of-proof-against-detection-and-location.png",
 		"name": "Amulet of Proof against Detection and Location",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -57,6 +62,7 @@
 	{
 		"index": "amulet-of-the-planes",
 		"url": "/api/2024/magic-items/amulet-of-the-planes",
+		"image" : "/api/images/magic-items/amulet-of-the-planes.png",
 		"name": "Amulet of the Planes",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -68,6 +74,7 @@
 	{
 		"index": "animated-shield",
 		"url": "/api/2024/magic-items/animated-shield",
+		"image" : "/api/images/magic-items/animated-shield.png",
 		"name": "Animated Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
@@ -79,6 +86,7 @@
 	{
 		"index": "apparatus-of-the-crab",
 		"url": "/api/2024/magic-items/apparatus-of-the-crab",
+		"image" : "/api/images/magic-items/apparatus-of-the-crab.png",
 		"name": "Apparatus of the Crab",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -90,6 +98,7 @@
 	{
 		"index": "armor",
 		"url": "/api/2024/magic-items/armor",
+		"image" : "/api/images/magic-items/armor.png",
 		"name": "Armor",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": false,
@@ -101,6 +110,7 @@
 	{
 		"index": "armor-of-invulnerability",
 		"url": "/api/2024/magic-items/armor-of-invulnerability",
+		"image" : "/api/images/magic-items/armor-of-invulnerability.png",
 		"name": "Armor of Invulnerability",
 		"type": "Armor (Plate Armor)",
 		"attunement": true,
@@ -112,6 +122,7 @@
 	{
 		"index": "armor-of-resistance",
 		"url": "/api/2024/magic-items/armor-of-resistance",
+		"image" : "/api/images/magic-items/armor-of-resistance.png",
 		"name": "Armor of Resistance",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
@@ -123,6 +134,7 @@
 	{
 		"index": "armor-of-vulnerability",
 		"url": "/api/2024/magic-items/armor-of-vulnerability",
+		"image" : "/api/images/magic-items/armor-of-vulnerability.png",
 		"name": "Armor of Vulnerability",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
@@ -134,6 +146,7 @@
 	{
 		"index": "arrow-catching-shield",
 		"url": "/api/2024/magic-items/arrow-catching-shield",
+		"image" : "/api/images/magic-items/arrow-catching-shield.png",
 		"name": "Arrow-Catching Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
@@ -145,6 +158,7 @@
 	{
 		"index": "bag-of-beans",
 		"url": "/api/2024/magic-items/bag-of-beans",
+		"image" : "/api/images/magic-items/bag-of-beans.png",
 		"name": "Bag of Beans",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -156,6 +170,7 @@
 	{
 		"index": "bag-of-devouring",
 		"url": "/api/2024/magic-items/bag-of-devouring",
+		"image" : "/api/images/magic-items/bag-of-devouring.png",
 		"name": "Bag of Devouring",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -167,6 +182,7 @@
 	{
 		"index": "bag-of-holding",
 		"url": "/api/2024/magic-items/bag-of-holding",
+		"image" : "/api/images/magic-items/bag-of-holding.png",
 		"name": "Bag of Holding",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -178,6 +194,7 @@
 	{
 		"index": "bag-of-tricks",
 		"url": "/api/2024/magic-items/bag-of-tricks",
+		"image" : "/api/images/magic-items/bag-of-tricks.png",
 		"name": "Bag of Tricks",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -189,6 +206,7 @@
 	{
 		"index": "bead-of-force",
 		"url": "/api/2024/magic-items/bead-of-force",
+		"image" : "/api/images/magic-items/bead-of-force.png",
 		"name": "Bead of Force",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -200,6 +218,7 @@
 	{
 		"index": "belt-of-dwarvenkind",
 		"url": "/api/2024/magic-items/belt-of-dwarvenkind",
+		"image" : "/api/images/magic-items/belt-of-dwarvenkind.png",
 		"name": "Belt of Dwarvenkind",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -211,6 +230,7 @@
 	{
 		"index": "belt-of-giant-strength",
 		"url": "/api/2024/magic-items/belt-of-giant-strength",
+		"image" : "/api/images/magic-items/belt-of-giant-strength.png",
 		"name": "Belt of Giant Strength",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -222,6 +242,7 @@
 	{
 		"index": "berserker-axe",
 		"url": "/api/2024/magic-items/berserker-axe",
+		"image" : "/api/images/magic-items/berserker-axe.png",
 		"name": "Berserker Axe",
 		"type": "Weapon (Battleaxe, Greataxe, or Halberd)",
 		"attunement": true,
@@ -233,6 +254,7 @@
 	{
 		"index": "boots-of-elvenkind",
 		"url": "/api/2024/magic-items/boots-of-elvenkind",
+		"image" : "/api/images/magic-items/boots-of-elvenkind.png",
 		"name": "Boots of Elvenkind",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -244,6 +266,7 @@
 	{
 		"index": "boots-of-levitation",
 		"url": "/api/2024/magic-items/boots-of-levitation",
+		"image" : "/api/images/magic-items/boots-of-levitation.png",
 		"name": "Boots of Levitation",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -255,6 +278,7 @@
 	{
 		"index": "boots-of-speed",
 		"url": "/api/2024/magic-items/boots-of-speed",
+		"image" : "/api/images/magic-items/boots-of-speed.png",
 		"name": "Boots of Speed",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -266,6 +290,7 @@
 	{
 		"index": "boots-of-striding-and-springing",
 		"url": "/api/2024/magic-items/boots-of-striding-and-springing",
+		"image" : "/api/images/magic-items/boots-of-striding-and-springing.png",
 		"name": "Boots of Striding and Springing",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -277,6 +302,7 @@
 	{
 		"index": "boots-of-the-winterlands",
 		"url": "/api/2024/magic-items/boots-of-the-winterlands",
+		"image" : "/api/images/magic-items/boots-of-the-winterlands.png",
 		"name": "Boots of the Winterlands",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -288,6 +314,7 @@
 	{
 		"index": "bowl-of-commanding-water-elementals",
 		"url": "/api/2024/magic-items/bowl-of-commanding-water-elementals",
+		"image" : "/api/images/magic-items/bowl-of-commanding-water-elementals.png",
 		"name": "Bowl of Commanding Water Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -299,6 +326,7 @@
 	{
 		"index": "bracers-of-archery",
 		"url": "/api/2024/magic-items/bracers-of-archery",
+		"image" : "/api/images/magic-items/bracers-of-archery.png",
 		"name": "Bracers of Archery",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -310,6 +338,7 @@
 	{
 		"index": "bracers-of-defense",
 		"url": "/api/2024/magic-items/bracers-of-defense",
+		"image" : "/api/images/magic-items/bracers-of-defense.png",
 		"name": "Bracers of Defense",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -321,6 +350,7 @@
 	{
 		"index": "brazier-of-commanding-fire-elementals",
 		"url": "/api/2024/magic-items/brazier-of-commanding-fire-elementals",
+		"image" : "/api/images/magic-items/brazier-of-commanding-fire-elementals.png",
 		"name": "Brazier of Commanding Fire Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -332,6 +362,7 @@
 	{
 		"index": "brooch-of-shielding",
 		"url": "/api/2024/magic-items/brooch-of-shielding",
+		"image" : "/api/images/magic-items/brooch-of-shielding.png",
 		"name": "Brooch of Shielding",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -343,6 +374,7 @@
 	{
 		"index": "broom-of-flying",
 		"url": "/api/2024/magic-items/broom-of-flying",
+		"image" : "/api/images/magic-items/broom-of-flying.png",
 		"name": "Broom of Flying",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -354,6 +386,7 @@
 	{
 		"index": "candle-of-invocation",
 		"url": "/api/2024/magic-items/candle-of-invocation",
+		"image" : "/api/images/magic-items/candle-of-invocation.png",
 		"name": "Candle of Invocation",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -365,6 +398,7 @@
 	{
 		"index": "cape-of-the-mountebank",
 		"url": "/api/2024/magic-items/cape-of-the-mountebank",
+		"image" : "/api/images/magic-items/cape-of-the-mountebank.png",
 		"name": "Cape of the Mountebank",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -376,6 +410,7 @@
 	{
 		"index": "carpet-of-flying",
 		"url": "/api/2024/magic-items/carpet-of-flying",
+		"image" : "/api/images/magic-items/carpet-of-flying.png",
 		"name": "Carpet of Flying",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -387,6 +422,7 @@
 	{
 		"index": "censer-of-controlling-air-elementals",
 		"url": "/api/2024/magic-items/censer-of-controlling-air-elementals",
+		"image" : "/api/images/magic-items/censer-of-controlling-air-elementals.png",
 		"name": "Censer of Controlling Air Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -398,6 +434,7 @@
 	{
 		"index": "chime-of-opening",
 		"url": "/api/2024/magic-items/chime-of-opening",
+		"image" : "/api/images/magic-items/chime-of-opening.png",
 		"name": "Chime of Opening",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -409,6 +446,7 @@
 	{
 		"index": "circlet-of-blasting",
 		"url": "/api/2024/magic-items/circlet-of-blasting",
+		"image" : "/api/images/magic-items/circlet-of-blasting.png",
 		"name": "Circlet of Blasting",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -420,6 +458,7 @@
 	{
 		"index": "cloak-of-arachnida",
 		"url": "/api/2024/magic-items/cloak-of-arachnida",
+		"image" : "/api/images/magic-items/cloak-of-arachnida.png",
 		"name": "Cloak of Arachnida",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -431,6 +470,7 @@
 	{
 		"index": "cloak-of-displacement",
 		"url": "/api/2024/magic-items/cloak-of-displacement",
+		"image" : "/api/images/magic-items/cloak-of-displacement.png",
 		"name": "Cloak of Displacement",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -442,6 +482,7 @@
 	{
 		"index": "cloak-of-elvenkind",
 		"url": "/api/2024/magic-items/cloak-of-elvenkind",
+		"image" : "/api/images/magic-items/cloak-of-elvenkind.png",
 		"name": "Cloak of Elvenkind",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -453,6 +494,7 @@
 	{
 		"index": "cloak-of-protection",
 		"url": "/api/2024/magic-items/cloak-of-protection",
+		"image" : "/api/images/magic-items/cloak-of-protection.png",
 		"name": "Cloak of Protection",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -464,6 +506,7 @@
 	{
 		"index": "cloak-of-the-bat",
 		"url": "/api/2024/magic-items/cloak-of-the-bat",
+		"image" : "/api/images/magic-items/cloak-of-the-bat.png",
 		"name": "Cloak of the Bat",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -475,6 +518,7 @@
 	{
 		"index": "cloak-of-the-manta-ray",
 		"url": "/api/2024/magic-items/cloak-of-the-manta-ray",
+		"image" : "/api/images/magic-items/cloak-of-the-manta-ray.png",
 		"name": "Cloak of the Manta Ray",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -486,6 +530,7 @@
 	{
 		"index": "crystal-ball",
 		"url": "/api/2024/magic-items/crystal-ball",
+		"image" : "/api/images/magic-items/crystal-ball.png",
 		"name": "Crystal Ball",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -497,6 +542,7 @@
 	{
 		"index": "crystal-ball-of-mind-reading",
 		"url": "/api/2024/magic-items/crystal-ball-of-mind-reading",
+		"image" : "/api/images/magic-items/crystal-ball-of-mind-reading.png",
 		"name": "Crystal Ball of Mind Reading",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -508,6 +554,7 @@
 	{
 		"index": "crystal-ball-of-telepathy",
 		"url": "/api/2024/magic-items/crystal-ball-of-telepathy",
+		"image" : "/api/images/magic-items/crystal-ball-of-telepathy.png",
 		"name": "Crystal Ball of Telepathy",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -519,6 +566,7 @@
 	{
 		"index": "crystal-ball-of-true-seeing",
 		"url": "/api/2024/magic-items/crystal-ball-of-true-seeing",
+		"image" : "/api/images/magic-items/crystal-ball-of-true-seeing.png",
 		"name": "Crystal Ball of True Seeing",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -530,6 +578,7 @@
 	{
 		"index": "cube-of-force",
 		"url": "/api/2024/magic-items/cube-of-force",
+		"image" : "/api/images/magic-items/cube-of-force.png",
 		"name": "Cube of Force",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -541,6 +590,7 @@
 	{
 		"index": "cubic-gate",
 		"url": "/api/2024/magic-items/cubic-gate",
+		"image" : "/api/images/magic-items/cubic-gate.png",
 		"name": "Cubic Gate",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -552,6 +602,7 @@
 	{
 		"index": "dagger-of-venom",
 		"url": "/api/2024/magic-items/dagger-of-venom",
+		"image" : "/api/images/magic-items/dagger-of-venom.png",
 		"name": "Dagger of Venom",
 		"type": "Weapon (Dagger)",
 		"attunement": false,
@@ -563,6 +614,7 @@
 	{
 		"index": "dancing-sword",
 		"url": "/api/2024/magic-items/dancing-sword",
+		"image" : "/api/images/magic-items/dancing-sword.png",
 		"name": "Dancing Sword",
 		"type": "Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
@@ -574,6 +626,7 @@
 	{
 		"index": "decanter-of-endless-water",
 		"url": "/api/2024/magic-items/decanter-of-endless-water",
+		"image" : "/api/images/magic-items/decanter-of-endless-water.png",
 		"name": "Decanter of Endless Water",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -585,6 +638,7 @@
 	{
 		"index": "deck-of-illusions",
 		"url": "/api/2024/magic-items/deck-of-illusions",
+		"image" : "/api/images/magic-items/deck-of-illusions.png",
 		"name": "Deck of Illusions",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -596,6 +650,7 @@
 	{
 		"index": "defender",
 		"url": "/api/2024/magic-items/defender",
+		"image" : "/api/images/magic-items/defender.png",
 		"name": "Defender",
 		"type": "Weapon (Any Melee Weapon)",
 		"attunement": true,
@@ -607,6 +662,7 @@
 	{
 		"index": "demon-armor",
 		"url": "/api/2024/magic-items/demon-armor",
+		"image" : "/api/images/magic-items/demon-armor.png",
 		"name": "Demon Armor",
 		"type": "Armor (Any Light, Medium, or Heavy)",
 		"attunement": true,
@@ -618,6 +674,7 @@
 	{
 		"index": "dimensional-shackles",
 		"url": "/api/2024/magic-items/dimensional-shackles",
+		"image" : "/api/images/magic-items/dimensional-shackles.png",
 		"name": "Dimensional Shackles",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -629,6 +686,7 @@
 	{
 		"index": "dragon-orb",
 		"url": "/api/2024/magic-items/dragon-orb",
+		"image" : "/api/images/magic-items/dragon-orb.png",
 		"name": "Dragon Orb",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -640,6 +698,7 @@
 	{
 		"index": "dragon-scale-mail",
 		"url": "/api/2024/magic-items/dragon-scale-mail",
+		"image" : "/api/images/magic-items/dragon-scale-mail.png",
 		"name": "Dragon Scale Mail",
 		"type": "Armor (Scale Mail)",
 		"attunement": true,
@@ -651,6 +710,7 @@
 	{
 		"index": "dragon-slayer",
 		"url": "/api/2024/magic-items/dragon-slayer",
+		"image" : "/api/images/magic-items/dragon-slayer.png",
 		"name": "Dragon Slayer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
@@ -662,6 +722,7 @@
 	{
 		"index": "dust-of-disappearance",
 		"url": "/api/2024/magic-items/dust-of-disappearance",
+		"image" : "/api/images/magic-items/dust-of-disappearance.png",
 		"name": "Dust of Disappearance",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -673,6 +734,7 @@
 	{
 		"index": "dust-of-dryness",
 		"url": "/api/2024/magic-items/dust-of-dryness",
+		"image" : "/api/images/magic-items/dust-of-dryness.png",
 		"name": "Dust of Dryness",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -684,6 +746,7 @@
 	{
 		"index": "dust-of-sneezing-and-choking",
 		"url": "/api/2024/magic-items/dust-of-sneezing-and-choking",
+		"image" : "/api/images/magic-items/dust-of-sneezing-and-choking.png",
 		"name": "Dust of Sneezing and Choking",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -695,6 +758,7 @@
 	{
 		"index": "dwarven-plate",
 		"url": "/api/2024/magic-items/dwarven-plate",
+		"image" : "/api/images/magic-items/dwarven-plate.png",
 		"name": "Dwarven Plate",
 		"type": "Armor (Half Plate Armor or Plate Armor)",
 		"attunement": false,
@@ -706,6 +770,7 @@
 	{
 		"index": "dwarven-thrower",
 		"url": "/api/2024/magic-items/dwarven-thrower",
+		"image" : "/api/images/magic-items/dwarven-thrower.png",
 		"name": "Dwarven Thrower",
 		"type": "Weapon (Warhammer)",
 		"attunement": true,
@@ -718,6 +783,7 @@
 	{
 		"index": "efficient-quiver",
 		"url": "/api/2024/magic-items/efficient-quiver",
+		"image" : "/api/images/magic-items/efficient-quiver.png",
 		"name": "Efficient Quiver",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -729,6 +795,7 @@
 	{
 		"index": "efreeti-bottle",
 		"url": "/api/2024/magic-items/efreeti-bottle",
+		"image" : "/api/images/magic-items/efreeti-bottle.png",
 		"name": "Efreeti Bottle",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -740,6 +807,7 @@
 	{
 		"index": "elemental-gem",
 		"url": "/api/2024/magic-items/elemental-gem",
+		"image" : "/api/images/magic-items/elemental-gem.png",
 		"name": "Elemental Gem",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -751,6 +819,7 @@
 	{
 		"index": "elven-chain",
 		"url": "/api/2024/magic-items/elven-chain",
+		"image" : "/api/images/magic-items/elven-chain.png",
 		"name": "Elven Chain",
 		"type": "Armor (Chain Mail or Chain Shirt)",
 		"attunement": false,
@@ -762,6 +831,7 @@
 	{
 		"index": "eversmoking-bottle",
 		"url": "/api/2024/magic-items/eversmoking-bottle",
+		"image" : "/api/images/magic-items/eversmoking-bottle.png",
 		"name": "Eversmoking Bottle",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -773,6 +843,7 @@
 	{
 		"index": "eyes-of-charming",
 		"url": "/api/2024/magic-items/eyes-of-charming",
+		"image" : "/api/images/magic-items/eyes-of-charming.png",
 		"name": "Eyes of Charming",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -784,6 +855,7 @@
 	{
 		"index": "eyes-of-minute-seeing",
 		"url": "/api/2024/magic-items/eyes-of-minute-seeing",
+		"image" : "/api/images/magic-items/eyes-of-minute-seeing.png",
 		"name": "Eyes of Minute Seeing",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -795,6 +867,7 @@
 	{
 		"index": "eyes-of-the-eagle",
 		"url": "/api/2024/magic-items/eyes-of-the-eagle",
+		"image" : "/api/images/magic-items/eyes-of-the-eagle.png",
 		"name": "Eyes of the Eagle",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -806,6 +879,7 @@
 	{
 		"index": "feather-token",
 		"url": "/api/2024/magic-items/feather-token",
+		"image" : "/api/images/magic-items/feather-token.png",
 		"name": "Feather Token",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -817,6 +891,7 @@
 	{
 		"index": "figurine-of-wondrous-power",
 		"url": "/api/2024/magic-items/figurine-of-wondrous-power",
+		"image" : "/api/images/magic-items/figurine-of-wondrous-power.png",
 		"name": "Figurine of Wondrous Power",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -828,6 +903,7 @@
 	{
 		"index": "flame-tongue",
 		"url": "/api/2024/magic-items/flame-tongue",
+		"image" : "/api/images/magic-items/flame-tongue.png",
 		"name": "Flame Tongue",
 		"type": "Weapon (Any Melee Weapon)",
 		"attunement": true,
@@ -839,6 +915,7 @@
 	{
 		"index": "folding-boat",
 		"url": "/api/2024/magic-items/folding-boat",
+		"image" : "/api/images/magic-items/folding-boat.png",
 		"name": "Folding Boat",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -850,6 +927,7 @@
 	{
 		"index": "frost-brand",
 		"url": "/api/2024/magic-items/frost-brand",
+		"image" : "/api/images/magic-items/frost-brand.png",
 		"name": "Frost Brand",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
@@ -861,6 +939,7 @@
 	{
 		"index": "gauntlets-of-ogre-power",
 		"url": "/api/2024/magic-items/gauntlets-of-ogre-power",
+		"image" : "/api/images/magic-items/gauntlets-of-ogre-power.png",
 		"name": "Gauntlets of Ogre Power",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -872,6 +951,7 @@
 	{
 		"index": "gem-of-brightness",
 		"url": "/api/2024/magic-items/gem-of-brightness",
+		"image" : "/api/images/magic-items/gem-of-brightness.png",
 		"name": "Gem of Brightness",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -883,6 +963,7 @@
 	{
 		"index": "gem-of-seeing",
 		"url": "/api/2024/magic-items/gem-of-seeing",
+		"image" : "/api/images/magic-items/gem-of-seeing.png",
 		"name": "Gem of Seeing",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -894,6 +975,7 @@
 	{
 		"index": "giant-slayer",
 		"url": "/api/2024/magic-items/giant-slayer",
+		"image" : "/api/images/magic-items/giant-slayer.png",
 		"name": "Giant Slayer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
@@ -905,6 +987,7 @@
 	{
 		"index": "glamoured-studded-leather",
 		"url": "/api/2024/magic-items/glamoured-studded-leather",
+		"image" : "/api/images/magic-items/glamoured-studded-leather.png",
 		"name": "Glamoured Studded Leather",
 		"type": "Armor (Studded Leather Armor)",
 		"attunement": false,
@@ -916,6 +999,7 @@
 	{
 		"index": "gloves-of-missile-snaring",
 		"url": "/api/2024/magic-items/gloves-of-missile-snaring",
+		"image" : "/api/images/magic-items/gloves-of-missile-snaring.png",
 		"name": "Gloves of Missile Snaring",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -927,6 +1011,7 @@
 	{
 		"index": "gloves-of-swimming-and-climbing",
 		"url": "/api/2024/magic-items/gloves-of-swimming-and-climbing",
+		"image" : "/api/images/magic-items/gloves-of-swimming-and-climbing.png",
 		"name": "Gloves of Swimming and Climbing",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -938,6 +1023,7 @@
 	{
 		"index": "goggles-of-night",
 		"url": "/api/2024/magic-items/goggles-of-night",
+		"image" : "/api/images/magic-items/goggles-of-night.png",
 		"name": "Goggles of Night",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -949,6 +1035,7 @@
 	{
 		"index": "hammer-of-thunderbolts",
 		"url": "/api/2024/magic-items/hammer-of-thunderbolts",
+		"image" : "/api/images/magic-items/hammer-of-thunderbolts.png",
 		"name": "Hammer of Thunderbolts",
 		"type": "Weapon (Maul or Warhammer)",
 		"attunement": true,
@@ -960,6 +1047,7 @@
 	{
 		"index": "handy-haversack",
 		"url": "/api/2024/magic-items/handy-haversack",
+		"image" : "/api/images/magic-items/handy-haversack.png",
 		"name": "Handy Haversack",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -971,6 +1059,7 @@
 	{
 		"index": "hat-of-disguise",
 		"url": "/api/2024/magic-items/hat-of-disguise",
+		"image" : "/api/images/magic-items/hat-of-disguise.png",
 		"name": "Hat of Disguise",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -982,6 +1071,7 @@
 	{
 		"index": "headband-of-intellect",
 		"url": "/api/2024/magic-items/headband-of-intellect",
+		"image" : "/api/images/magic-items/headband-of-intellect.png",
 		"name": "Headband of Intellect",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -993,6 +1083,7 @@
 	{
 		"index": "helm-of-brilliance",
 		"url": "/api/2024/magic-items/helm-of-brilliance",
+		"image" : "/api/images/magic-items/helm-of-brilliance.png",
 		"name": "Helm of Brilliance",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1004,6 +1095,7 @@
 	{
 		"index": "helm-of-comprehending-languages",
 		"url": "/api/2024/magic-items/helm-of-comprehending-languages",
+		"image" : "/api/images/magic-items/helm-of-comprehending-languages.png",
 		"name": "Helm of Comprehending Languages",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1015,6 +1107,7 @@
 	{
 		"index": "helm-of-telepathy",
 		"url": "/api/2024/magic-items/helm-of-telepathy",
+		"image" : "/api/images/magic-items/helm-of-telepathy.png",
 		"name": "Helm of Telepathy",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1026,6 +1119,7 @@
 	{
 		"index": "helm-of-teleportation",
 		"url": "/api/2024/magic-items/helm-of-teleportation",
+		"image" : "/api/images/magic-items/helm-of-teleportation.png",
 		"name": "Helm of Teleportation",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1037,6 +1131,7 @@
 	{
 		"index": "holy-avenger",
 		"url": "/api/2024/magic-items/holy-avenger",
+		"image" : "/api/images/magic-items/holy-avenger.png",
 		"name": "Holy Avenger",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
@@ -1049,6 +1144,7 @@
 	{
 		"index": "horn-of-blasting",
 		"url": "/api/2024/magic-items/horn-of-blasting",
+		"image" : "/api/images/magic-items/horn-of-blasting.png",
 		"name": "Horn of Blasting",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1060,6 +1156,7 @@
 	{
 		"index": "horn-of-valhalla",
 		"url": "/api/2024/magic-items/horn-of-valhalla",
+		"image" : "/api/images/magic-items/horn-of-valhalla.png",
 		"name": "Horn of Valhalla",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1071,6 +1168,7 @@
 	{
 		"index": "horseshoes-of-a-zephyr",
 		"url": "/api/2024/magic-items/horseshoes-of-a-zephyr",
+		"image" : "/api/images/magic-items/horseshoes-of-a-zephyr.png",
 		"name": "Horseshoes of a Zephyr",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1082,6 +1180,7 @@
 	{
 		"index": "horseshoes-of-speed",
 		"url": "/api/2024/magic-items/horseshoes-of-speed",
+		"image" : "/api/images/magic-items/horseshoes-of-speed.png",
 		"name": "Horseshoes of Speed",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1093,6 +1192,7 @@
 	{
 		"index": "immovable-rod",
 		"url": "/api/2024/magic-items/immovable-rod",
+		"image" : "/api/images/magic-items/immovable-rod.png",
 		"name": "Immovable Rod",
 		"type": "Rod",
 		"attunement": false,
@@ -1104,6 +1204,7 @@
 	{
 		"index": "instant-fortress",
 		"url": "/api/2024/magic-items/instant-fortress",
+		"image" : "/api/images/magic-items/instant-fortress.png",
 		"name": "Instant Fortress",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1115,6 +1216,7 @@
 	{
 		"index": "ioun-stone",
 		"url": "/api/2024/magic-items/ioun-stone",
+		"image" : "/api/images/magic-items/ioun-stone.png",
 		"name": "Ioun Stone",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1126,6 +1228,7 @@
 	{
 		"index": "iron-bands",
 		"url": "/api/2024/magic-items/iron-bands",
+		"image" : "/api/images/magic-items/iron-bands.png",
 		"name": "Iron Bands",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1137,6 +1240,7 @@
 	{
 		"index": "iron-flask",
 		"url": "/api/2024/magic-items/iron-flask",
+		"image" : "/api/images/magic-items/iron-flask.png",
 		"name": "Iron Flask",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1148,6 +1252,7 @@
 	{
 		"index": "javelin-of-lightning",
 		"url": "/api/2024/magic-items/javelin-of-lightning",
+		"image" : "/api/images/magic-items/javelin-of-lightning.png",
 		"name": "Javelin of Lightning",
 		"type": "Weapon (Javelin)",
 		"attunement": false,
@@ -1159,6 +1264,7 @@
 	{
 		"index": "lantern-of-revealing",
 		"url": "/api/2024/magic-items/lantern-of-revealing",
+		"image" : "/api/images/magic-items/lantern-of-revealing.png",
 		"name": "Lantern of Revealing",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1170,6 +1276,7 @@
 	{
 		"index": "luck-blade",
 		"url": "/api/2024/magic-items/luck-blade",
+		"image" : "/api/images/magic-items/luck-blade.png",
 		"name": "Luck Blade",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
 		"attunement": true,
@@ -1181,6 +1288,7 @@
 	{
 		"index": "mace-of-disruption",
 		"url": "/api/2024/magic-items/mace-of-disruption",
+		"image" : "/api/images/magic-items/mace-of-disruption.png",
 		"name": "Mace of Disruption",
 		"type": "Weapon (Mace)",
 		"attunement": true,
@@ -1192,6 +1300,7 @@
 	{
 		"index": "mace-of-smiting",
 		"url": "/api/2024/magic-items/mace-of-smiting",
+		"image" : "/api/images/magic-items/mace-of-smiting.png",
 		"name": "Mace of Smiting",
 		"type": "Weapon (Mace)",
 		"attunement": false,
@@ -1203,6 +1312,7 @@
 	{
 		"index": "mace-of-terror",
 		"url": "/api/2024/magic-items/mace-of-terror",
+		"image" : "/api/images/magic-items/mace-of-terror.png",
 		"name": "Mace of Terror",
 		"type": "Weapon (Mace)",
 		"attunement": true,
@@ -1214,6 +1324,7 @@
 	{
 		"index": "mantle-of-spell-resistance",
 		"url": "/api/2024/magic-items/mantle-of-spell-resistance",
+		"image" : "/api/images/magic-items/mantle-of-spell-resistance.png",
 		"name": "Mantle of Spell Resistance",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1225,6 +1336,7 @@
 	{
 		"index": "manual-of-bodily-health",
 		"url": "/api/2024/magic-items/manual-of-bodily-health",
+		"image" : "/api/images/magic-items/manual-of-bodily-health.png",
 		"name": "Manual of Bodily Health",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1236,6 +1348,7 @@
 	{
 		"index": "manual-of-gainful-exercise",
 		"url": "/api/2024/magic-items/manual-of-gainful-exercise",
+		"image" : "/api/images/magic-items/manual-of-gainful-exercise.png",
 		"name": "Manual of Gainful Exercise",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1247,6 +1360,7 @@
 	{
 		"index": "manual-of-golems",
 		"url": "/api/2024/magic-items/manual-of-golems",
+		"image" : "/api/images/magic-items/manual-of-golems.png",
 		"name": "Manual of Golems",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1258,6 +1372,7 @@
 	{
 		"index": "manual-of-quickness-of-action",
 		"url": "/api/2024/magic-items/manual-of-quickness-of-action",
+		"image" : "/api/images/magic-items/manual-of-quickness-of-action.png",
 		"name": "Manual of Quickness of Action",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1269,6 +1384,7 @@
 	{
 		"index": "marvelous-pigments",
 		"url": "/api/2024/magic-items/marvelous-pigments",
+		"image" : "/api/images/magic-items/marvelous-pigments.png",
 		"name": "Marvelous Pigments",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1280,6 +1396,7 @@
 	{
 		"index": "medallion-of-thoughts",
 		"url": "/api/2024/magic-items/medallion-of-thoughts",
+		"image" : "/api/images/magic-items/medallion-of-thoughts.png",
 		"name": "Medallion of Thoughts",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1291,6 +1408,7 @@
 	{
 		"index": "mirror-of-life-trapping",
 		"url": "/api/2024/magic-items/mirror-of-life-trapping",
+		"image" : "/api/images/magic-items/mirror-of-life-trapping.png",
 		"name": "Mirror of Life Trapping",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1302,6 +1420,7 @@
 	{
 		"index": "mithral-armor",
 		"url": "/api/2024/magic-items/mithral-armor",
+		"image" : "/api/images/magic-items/mithral-armor.png",
 		"name": "Mithral Armor",
 		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
 		"attunement": false,
@@ -1313,6 +1432,7 @@
 	{
 		"index": "mysterious-deck",
 		"url": "/api/2024/magic-items/mysterious-deck",
+		"image" : "/api/images/magic-items/mysterious-deck.png",
 		"name": "Mysterious Deck",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1324,6 +1444,7 @@
 	{
 		"index": "necklace-of-adaptation",
 		"url": "/api/2024/magic-items/necklace-of-adaptation",
+		"image" : "/api/images/magic-items/necklace-of-adaptation.png",
 		"name": "Necklace of Adaptation",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1335,6 +1456,7 @@
 	{
 		"index": "necklace-of-fireballs",
 		"url": "/api/2024/magic-items/necklace-of-fireballs",
+		"image" : "/api/images/magic-items/necklace-of-fireballs.png",
 		"name": "Necklace of Fireballs",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1346,6 +1468,7 @@
 	{
 		"index": "necklace-of-prayer-beads",
 		"url": "/api/2024/magic-items/necklace-of-prayer-beads",
+		"image" : "/api/images/magic-items/necklace-of-prayer-beads.png",
 		"name": "Necklace of Prayer Beads",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1358,6 +1481,7 @@
 	{
 		"index": "nine-lives-stealer",
 		"url": "/api/2024/magic-items/nine-lives-stealer",
+		"image" : "/api/images/magic-items/nine-lives-stealer.png",
 		"name": "Nine Lives Stealer",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
@@ -1369,6 +1493,7 @@
 	{
 		"index": "oathbow",
 		"url": "/api/2024/magic-items/oathbow",
+		"image" : "/api/images/magic-items/oathbow.png",
 		"name": "Oathbow",
 		"type": "Weapon (Longbow or Shortbow)",
 		"attunement": true,
@@ -1380,6 +1505,7 @@
 	{
 		"index": "oil-of-etherealness",
 		"url": "/api/2024/magic-items/oil-of-etherealness",
+		"image" : "/api/images/magic-items/oil-of-etherealness.png",
 		"name": "Oil of Etherealness",
 		"type": "Potion",
 		"attunement": false,
@@ -1391,6 +1517,7 @@
 	{
 		"index": "oil-of-sharpness",
 		"url": "/api/2024/magic-items/oil-of-sharpness",
+		"image" : "/api/images/magic-items/oil-of-sharpness.png",
 		"name": "Oil of Sharpness",
 		"type": "Potion",
 		"attunement": false,
@@ -1402,6 +1529,7 @@
 	{
 		"index": "oil-of-slipperiness",
 		"url": "/api/2024/magic-items/oil-of-slipperiness",
+		"image" : "/api/images/magic-items/oil-of-slipperiness.png",
 		"name": "Oil of Slipperiness",
 		"type": "Potion",
 		"attunement": false,
@@ -1413,6 +1541,7 @@
 	{
 		"index": "pearl-of-power",
 		"url": "/api/2024/magic-items/pearl-of-power",
+		"image" : "/api/images/magic-items/pearl-of-power.png",
 		"name": "Pearl of Power",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1425,6 +1554,7 @@
 	{
 		"index": "periapt-of-health",
 		"url": "/api/2024/magic-items/periapt-of-health",
+		"image" : "/api/images/magic-items/periapt-of-health.png",
 		"name": "Periapt of Health",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1436,6 +1566,7 @@
 	{
 		"index": "periapt-of-proof-against-poison",
 		"url": "/api/2024/magic-items/periapt-of-proof-against-poison",
+		"image" : "/api/images/magic-items/periapt-of-proof-against-poison.png",
 		"name": "Periapt of Proof against Poison",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1447,6 +1578,7 @@
 	{
 		"index": "periapt-of-wound-closure",
 		"url": "/api/2024/magic-items/periapt-of-wound-closure",
+		"image" : "/api/images/magic-items/periapt-of-wound-closure.png",
 		"name": "Periapt of Wound Closure",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1458,6 +1590,7 @@
 	{
 		"index": "philter-of-love",
 		"url": "/api/2024/magic-items/philter-of-love",
+		"image" : "/api/images/magic-items/philter-of-love.png",
 		"name": "Philter of Love",
 		"type": "Potion",
 		"attunement": false,
@@ -1469,6 +1602,7 @@
 	{
 		"index": "pipes-of-haunting",
 		"url": "/api/2024/magic-items/pipes-of-haunting",
+		"image" : "/api/images/magic-items/pipes-of-haunting.png",
 		"name": "Pipes of Haunting",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1480,6 +1614,7 @@
 	{
 		"index": "pipes-of-the-sewers",
 		"url": "/api/2024/magic-items/pipes-of-the-sewers",
+		"image" : "/api/images/magic-items/pipes-of-the-sewers.png",
 		"name": "Pipes of the Sewers",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1491,6 +1626,7 @@
 	{
 		"index": "plate-armor-of-etherealness",
 		"url": "/api/2024/magic-items/plate-armor-of-etherealness",
+		"image" : "/api/images/magic-items/plate-armor-of-etherealness.png",
 		"name": "Plate Armor of Etherealness",
 		"type": "Armor (Half Plate Armor or Plate Armor)",
 		"attunement": true,
@@ -1502,6 +1638,7 @@
 	{
 		"index": "portable-hole",
 		"url": "/api/2024/magic-items/portable-hole",
+		"image" : "/api/images/magic-items/portable-hole.png",
 		"name": "Portable Hole",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1513,6 +1650,7 @@
 	{
 		"index": "potion-of-animal-friendship",
 		"url": "/api/2024/magic-items/potion-of-animal-friendship",
+		"image" : "/api/images/magic-items/potion-of-animal-friendship.png",
 		"name": "Potion of Animal Friendship",
 		"type": "Potion",
 		"attunement": false,
@@ -1524,6 +1662,7 @@
 	{
 		"index": "potion-of-clairvoyance",
 		"url": "/api/2024/magic-items/potion-of-clairvoyance",
+		"image" : "/api/images/magic-items/potion-of-clairvoyance.png",
 		"name": "Potion of Clairvoyance",
 		"type": "Potion",
 		"attunement": false,
@@ -1535,6 +1674,7 @@
 	{
 		"index": "potion-of-climbing",
 		"url": "/api/2024/magic-items/potion-of-climbing",
+		"image" : "/api/images/magic-items/potion-of-climbing.png",
 		"name": "Potion of Climbing",
 		"type": "Potion",
 		"attunement": false,
@@ -1546,6 +1686,7 @@
 	{
 		"index": "potion-of-diminution",
 		"url": "/api/2024/magic-items/potion-of-diminution",
+		"image" : "/api/images/magic-items/potion-of-diminution.png",
 		"name": "Potion of Diminution",
 		"type": "Potion",
 		"attunement": false,
@@ -1557,6 +1698,7 @@
 	{
 		"index": "potion-of-flying",
 		"url": "/api/2024/magic-items/potion-of-flying",
+		"image" : "/api/images/magic-items/potion-of-flying.png",
 		"name": "Potion of Flying",
 		"type": "Potion",
 		"attunement": false,
@@ -1568,6 +1710,7 @@
 	{
 		"index": "potion-of-growth",
 		"url": "/api/2024/magic-items/potion-of-growth",
+		"image" : "/api/images/magic-items/potion-of-growth.png",
 		"name": "Potion of Growth",
 		"type": "Potion",
 		"attunement": false,
@@ -1579,6 +1722,7 @@
 	{
 		"index": "potions-of-healing",
 		"url": "/api/2024/magic-items/potions-of-healing",
+		"image" : "/api/images/magic-items/potions-of-healing.png",
 		"name": "Potions of Healing",
 		"type": "Potion",
 		"attunement": false,
@@ -1590,6 +1734,7 @@
 	{
 		"index": "potion-of-gaseous-form",
 		"url": "/api/2024/magic-items/potion-of-gaseous-form",
+		"image" : "/api/images/magic-items/potion-of-gaseous-form.png",
 		"name": "Potion of Gaseous Form",
 		"type": "Potion",
 		"attunement": false,
@@ -1601,6 +1746,7 @@
 	{
 		"index": "potion-of-heroism",
 		"url": "/api/2024/magic-items/potion-of-heroism",
+		"image" : "/api/images/magic-items/potion-of-heroism.png",
 		"name": "Potion of Heroism",
 		"type": "Potion",
 		"attunement": false,
@@ -1612,6 +1758,7 @@
 	{
 		"index": "potion-of-giant-strength",
 		"url": "/api/2024/magic-items/potion-of-giant-strength",
+		"image" : "/api/images/magic-items/potion-of-giant-strength.png",
 		"name": "Potion of Giant Strength",
 		"type": "Potion",
 		"attunement": false,
@@ -1623,6 +1770,7 @@
 	{
 		"index": "potion-of-invisibility",
 		"url": "/api/2024/magic-items/potion-of-invisibility",
+		"image" : "/api/images/magic-items/potion-of-invisibility.png",
 		"name": "Potion of Invisibility",
 		"type": "Potion",
 		"attunement": false,
@@ -1634,6 +1782,7 @@
 	{
 		"index": "potion-of-mind-reading",
 		"url": "/api/2024/magic-items/potion-of-mind-reading",
+		"image" : "/api/images/magic-items/potion-of-mind-reading.png",
 		"name": "Potion of Mind Reading",
 		"type": "Potion",
 		"attunement": false,
@@ -1645,6 +1794,7 @@
 	{
 		"index": "potion-of-poison",
 		"url": "/api/2024/magic-items/potion-of-poison",
+		"image" : "/api/images/magic-items/potion-of-poison.png",
 		"name": "Potion of Poison",
 		"type": "Potion",
 		"attunement": false,
@@ -1656,6 +1806,7 @@
 	{
 		"index": "potion-of-resistance",
 		"url": "/api/2024/magic-items/potion-of-resistance",
+		"image" : "/api/images/magic-items/potion-of-resistance.png",
 		"name": "Potion of Resistance",
 		"type": "Potion",
 		"attunement": false,
@@ -1667,6 +1818,7 @@
 	{
 		"index": "potion-of-speed",
 		"url": "/api/2024/magic-items/potion-of-speed",
+		"image" : "/api/images/magic-items/potion-of-speed.png",
 		"name": "Potion of Speed",
 		"type": "Potion",
 		"attunement": false,
@@ -1678,6 +1830,7 @@
 	{
 		"index": "potion-of-water-breathing",
 		"url": "/api/2024/magic-items/potion-of-water-breathing",
+		"image" : "/api/images/magic-items/potion-of-water-breathing.png",
 		"name": "Potion of Water Breathing",
 		"type": "Potion",
 		"attunement": false,
@@ -1689,6 +1842,7 @@
 	{
 		"index": "ring-of-animal-influence",
 		"url": "/api/2024/magic-items/ring-of-animal-influence",
+		"image" : "/api/images/magic-items/ring-of-animal-influence.png",
 		"name": "Ring of Animal Influence",
 		"type": "Ring",
 		"attunement": false,
@@ -1700,6 +1854,7 @@
 	{
 		"index": "ring-of-djinni-summoning",
 		"url": "/api/2024/magic-items/ring-of-djinni-summoning",
+		"image" : "/api/images/magic-items/ring-of-djinni-summoning.png",
 		"name": "Ring of Djinni Summoning",
 		"type": "Ring",
 		"attunement": true,
@@ -1711,6 +1866,7 @@
 	{
 		"index": "ring-of-elemental-command",
 		"url": "/api/2024/magic-items/ring-of-elemental-command",
+		"image" : "/api/images/magic-items/ring-of-elemental-command.png",
 		"name": "Ring of Elemental Command",
 		"type": "Ring",
 		"attunement": true,
@@ -1722,6 +1878,7 @@
 	{
 		"index": "ring-of-evasion",
 		"url": "/api/2024/magic-items/ring-of-evasion",
+		"image" : "/api/images/magic-items/ring-of-evasion.png",
 		"name": "Ring of Evasion",
 		"type": "Ring",
 		"attunement": true,
@@ -1733,6 +1890,7 @@
 	{
 		"index": "ring-of-feather-falling",
 		"url": "/api/2024/magic-items/ring-of-feather-falling",
+		"image" : "/api/images/magic-items/ring-of-feather-falling.png",
 		"name": "Ring of Feather Falling",
 		"type": "Ring",
 		"attunement": true,
@@ -1744,6 +1902,7 @@
 	{
 		"index": "ring-of-free-action",
 		"url": "/api/2024/magic-items/ring-of-free-action",
+		"image" : "/api/images/magic-items/ring-of-free-action.png",
 		"name": "Ring of Free Action",
 		"type": "Ring",
 		"attunement": true,
@@ -1755,6 +1914,7 @@
 	{
 		"index": "ring-of-invisibility",
 		"url": "/api/2024/magic-items/ring-of-invisibility",
+		"image" : "/api/images/magic-items/ring-of-invisibility.png",
 		"name": "Ring of Invisibility",
 		"type": "Ring",
 		"attunement": true,
@@ -1766,6 +1926,7 @@
 	{
 		"index": "ring-of-jumping",
 		"url": "/api/2024/magic-items/ring-of-jumping",
+		"image" : "/api/images/magic-items/ring-of-jumping.png",
 		"name": "Ring of Jumping",
 		"type": "Ring",
 		"attunement": true,
@@ -1777,6 +1938,7 @@
 	{
 		"index": "ring-of-mind-shielding",
 		"url": "/api/2024/magic-items/ring-of-mind-shielding",
+		"image" : "/api/images/magic-items/ring-of-mind-shielding.png",
 		"name": "Ring of Mind Shielding",
 		"type": "Ring",
 		"attunement": true,
@@ -1788,6 +1950,7 @@
 	{
 		"index": "ring-of-protection",
 		"url": "/api/2024/magic-items/ring-of-protection",
+		"image" : "/api/images/magic-items/ring-of-protection.png",
 		"name": "Ring of Protection",
 		"type": "Ring",
 		"attunement": true,
@@ -1799,6 +1962,7 @@
 	{
 		"index": "ring-of-regeneration",
 		"url": "/api/2024/magic-items/ring-of-regeneration",
+		"image" : "/api/images/magic-items/ring-of-regeneration.png",
 		"name": "Ring of Regeneration",
 		"type": "Ring",
 		"attunement": true,
@@ -1810,6 +1974,7 @@
 	{
 		"index": "ring-of-resistance",
 		"url": "/api/2024/magic-items/ring-of-resistance",
+		"image" : "/api/images/magic-items/ring-of-resistance.png",
 		"name": "Ring of Resistance",
 		"type": "Ring",
 		"attunement": false,
@@ -1821,6 +1986,7 @@
 	{
 		"index": "ring-of-shooting-stars",
 		"url": "/api/2024/magic-items/ring-of-shooting-stars",
+		"image" : "/api/images/magic-items/ring-of-shooting-stars.png",
 		"name": "Ring of Shooting Stars",
 		"type": "Ring",
 		"attunement": true,
@@ -1832,6 +1998,7 @@
 	{
 		"index": "ring-of-spell-storing",
 		"url": "/api/2024/magic-items/ring-of-spell-storing",
+		"image" : "/api/images/magic-items/ring-of-spell-storing.png",
 		"name": "Ring of Spell Storing",
 		"type": "Ring",
 		"attunement": true,
@@ -1843,6 +2010,7 @@
 	{
 		"index": "ring-of-spell-turning",
 		"url": "/api/2024/magic-items/ring-of-spell-turning",
+		"image" : "/api/images/magic-items/ring-of-spell-turning.png",
 		"name": "Ring of Spell Turning",
 		"type": "Ring",
 		"attunement": true,
@@ -1854,6 +2022,7 @@
 	{
 		"index": "ring-of-swimming",
 		"url": "/api/2024/magic-items/ring-of-swimming",
+		"image" : "/api/images/magic-items/ring-of-swimming.png",
 		"name": "Ring of Swimming",
 		"type": "Ring",
 		"attunement": false,
@@ -1865,6 +2034,7 @@
 	{
 		"index": "ring-of-telekinesis",
 		"url": "/api/2024/magic-items/ring-of-telekinesis",
+		"image" : "/api/images/magic-items/ring-of-telekinesis.png",
 		"name": "Ring of Telekinesis",
 		"type": "Ring",
 		"attunement": true,
@@ -1876,6 +2046,7 @@
 	{
 		"index": "ring-of-the-ram",
 		"url": "/api/2024/magic-items/ring-of-the-ram",
+		"image" : "/api/images/magic-items/ring-of-the-ram.png",
 		"name": "Ring of the Ram",
 		"type": "Ring",
 		"attunement": true,
@@ -1887,6 +2058,7 @@
 	{
 		"index": "ring-of-three-wishes",
 		"url": "/api/2024/magic-items/ring-of-three-wishes",
+		"image" : "/api/images/magic-items/ring-of-three-wishes.png",
 		"name": "Ring of Three Wishes",
 		"type": "Ring",
 		"attunement": false,
@@ -1898,6 +2070,7 @@
 	{
 		"index": "ring-of-warmth",
 		"url": "/api/2024/magic-items/ring-of-warmth",
+		"image" : "/api/images/magic-items/ring-of-warmth.png",
 		"name": "Ring of Warmth",
 		"type": "Ring",
 		"attunement": true,
@@ -1909,6 +2082,7 @@
 	{
 		"index": "ring-of-water-walking",
 		"url": "/api/2024/magic-items/ring-of-water-walking",
+		"image" : "/api/images/magic-items/ring-of-water-walking.png",
 		"name": "Ring of Water Walking",
 		"type": "Ring",
 		"attunement": false,
@@ -1920,6 +2094,7 @@
 	{
 		"index": "ring-of-x-ray-vision",
 		"url": "/api/2024/magic-items/ring-of-x-ray-vision",
+		"image" : "/api/images/magic-items/ring-of-x-ray-vision.png",
 		"name": "Ring of X-ray Vision",
 		"type": "Ring",
 		"attunement": true,
@@ -1931,6 +2106,7 @@
 	{
 		"index": "robe-of-eyes",
 		"url": "/api/2024/magic-items/robe-of-eyes",
+		"image" : "/api/images/magic-items/robe-of-eyes.png",
 		"name": "Robe of Eyes",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1942,6 +2118,7 @@
 	{
 		"index": "robe-of-scintillating-colors",
 		"url": "/api/2024/magic-items/robe-of-scintillating-colors",
+		"image" : "/api/images/magic-items/robe-of-scintillating-colors.png",
 		"name": "Robe of Scintillating Colors",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1953,6 +2130,7 @@
 	{
 		"index": "robe-of-stars",
 		"url": "/api/2024/magic-items/robe-of-stars",
+		"image" : "/api/images/magic-items/robe-of-stars.png",
 		"name": "Robe of Stars",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1964,6 +2142,7 @@
 	{
 		"index": "robe-of-the-archmagi",
 		"url": "/api/2024/magic-items/robe-of-the-archmagi",
+		"image" : "/api/images/magic-items/robe-of-the-archmagi.png",
 		"name": "Robe of the Archmagi",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -1976,6 +2155,7 @@
 	{
 		"index": "robe-of-useful-items",
 		"url": "/api/2024/magic-items/robe-of-useful-items",
+		"image" : "/api/images/magic-items/robe-of-useful-items.png",
 		"name": "Robe of Useful Items",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -1987,6 +2167,7 @@
 	{
 		"index": "rod-of-absorption",
 		"url": "/api/2024/magic-items/rod-of-absorption",
+		"image" : "/api/images/magic-items/rod-of-absorption.png",
 		"name": "Rod of Absorption",
 		"type": "Rod",
 		"attunement": true,
@@ -1998,6 +2179,7 @@
 	{
 		"index": "rod-of-alertness",
 		"url": "/api/2024/magic-items/rod-of-alertness",
+		"image" : "/api/images/magic-items/rod-of-alertness.png",
 		"name": "Rod of Alertness",
 		"type": "Rod",
 		"attunement": true,
@@ -2009,6 +2191,7 @@
 	{
 		"index": "rod-of-lordly-might",
 		"url": "/api/2024/magic-items/rod-of-lordly-might",
+		"image" : "/api/images/magic-items/rod-of-lordly-might.png",
 		"name": "Rod of Lordly Might",
 		"type": "Rod",
 		"attunement": true,
@@ -2020,6 +2203,7 @@
 	{
 		"index": "rod-of-rulership",
 		"url": "/api/2024/magic-items/rod-of-rulership",
+		"image" : "/api/images/magic-items/rod-of-rulership.png",
 		"name": "Rod of Rulership",
 		"type": "Rod",
 		"attunement": true,
@@ -2031,6 +2215,7 @@
 	{
 		"index": "rod-of-security",
 		"url": "/api/2024/magic-items/rod-of-security",
+		"image" : "/api/images/magic-items/rod-of-security.png",
 		"name": "Rod of Security",
 		"type": "Rod",
 		"attunement": false,
@@ -2042,6 +2227,7 @@
 	{
 		"index": "rope-of-climbing",
 		"url": "/api/2024/magic-items/rope-of-climbing",
+		"image" : "/api/images/magic-items/rope-of-climbing.png",
 		"name": "Rope of Climbing",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2053,6 +2239,7 @@
 	{
 		"index": "rope-of-entanglement",
 		"url": "/api/2024/magic-items/rope-of-entanglement",
+		"image" : "/api/images/magic-items/rope-of-entanglement.png",
 		"name": "Rope of Entanglement",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2064,6 +2251,7 @@
 	{
 		"index": "scarab-of-protection",
 		"url": "/api/2024/magic-items/scarab-of-protection",
+		"image" : "/api/images/magic-items/scarab-of-protection.png",
 		"name": "Scarab of Protection",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2075,6 +2263,7 @@
 	{
 		"index": "scimitar-of-speed",
 		"url": "/api/2024/magic-items/scimitar-of-speed",
+		"image" : "/api/images/magic-items/scimitar-of-speed.png",
 		"name": "Scimitar of Speed",
 		"type": "Weapon (Scimitar)",
 		"attunement": true,
@@ -2086,6 +2275,7 @@
 	{
 		"index": "shield",
 		"url": "/api/2024/magic-items/shield",
+		"image" : "/api/images/magic-items/shield.png",
 		"name": "Shield",
 		"type": "Armor (Shield)",
 		"attunement": false,
@@ -2097,6 +2287,7 @@
 	{
 		"index": "shield-of-missile-attraction",
 		"url": "/api/2024/magic-items/shield-of-missile-attraction",
+		"image" : "/api/images/magic-items/shield-of-missile-attraction.png",
 		"name": "Shield of Missile Attraction",
 		"type": "Armor (Shield)",
 		"attunement": true,
@@ -2108,6 +2299,7 @@
 	{
 		"index": "slippers-of-spider-climbing",
 		"url": "/api/2024/magic-items/slippers-of-spider-climbing",
+		"image" : "/api/images/magic-items/slippers-of-spider-climbing.png",
 		"name": "Slippers of Spider Climbing",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2119,6 +2311,7 @@
 	{
 		"index": "sovereign-glue",
 		"url": "/api/2024/magic-items/sovereign-glue",
+		"image" : "/api/images/magic-items/sovereign-glue.png",
 		"name": "Sovereign Glue",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2130,6 +2323,7 @@
 	{
 		"index": "spellguard-shield",
 		"url": "/api/2024/magic-items/spellguard-shield",
+		"image" : "/api/images/magic-items/spellguard-shield.png",
 		"name": "Spellguard Shield",
 		"type": "Armor (Shield)",
 		"attunement": true,
@@ -2141,6 +2335,7 @@
 	{
 		"index": "spell-scroll",
 		"url": "/api/2024/magic-items/spell-scroll",
+		"image" : "/api/images/magic-items/spell-scroll.png",
 		"name": "Spell Scroll",
 		"type": "Scroll",
 		"attunement": false,
@@ -2152,6 +2347,7 @@
 	{
 		"index": "sphere-of-annihilation",
 		"url": "/api/2024/magic-items/sphere-of-annihilation",
+		"image" : "/api/images/magic-items/sphere-of-annihilation.png",
 		"name": "Sphere of Annihilation",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2163,6 +2359,7 @@
 	{
 		"index": "staff-of-charming",
 		"url": "/api/2024/magic-items/staff-of-charming",
+		"image" : "/api/images/magic-items/staff-of-charming.png",
 		"name": "Staff of Charming",
 		"type": "Staff",
 		"attunement": true,
@@ -2175,6 +2372,7 @@
 	{
 		"index": "staff-of-fire",
 		"url": "/api/2024/magic-items/staff-of-fire",
+		"image" : "/api/images/magic-items/staff-of-fire.png",
 		"name": "Staff of Fire",
 		"type": "Staff",
 		"attunement": true,
@@ -2187,6 +2385,7 @@
 	{
 		"index": "staff-of-frost",
 		"url": "/api/2024/magic-items/staff-of-frost",
+		"image" : "/api/images/magic-items/staff-of-frost.png",
 		"name": "Staff of Frost",
 		"type": "Staff",
 		"attunement": true,
@@ -2199,6 +2398,7 @@
 	{
 		"index": "staff-of-healing",
 		"url": "/api/2024/magic-items/staff-of-healing",
+		"image" : "/api/images/magic-items/staff-of-healing.png",
 		"name": "Staff of Healing",
 		"type": "Staff",
 		"attunement": true,
@@ -2211,6 +2411,7 @@
 	{
 		"index": "staff-of-power",
 		"url": "/api/2024/magic-items/staff-of-power",
+		"image" : "/api/images/magic-items/staff-of-power.png",
 		"name": "Staff of Power",
 		"type": "Staff",
 		"attunement": true,
@@ -2223,6 +2424,7 @@
 	{
 		"index": "staff-of-striking",
 		"url": "/api/2024/magic-items/staff-of-striking",
+		"image" : "/api/images/magic-items/staff-of-striking.png",
 		"name": "Staff of Striking",
 		"type": "Staff",
 		"attunement": true,
@@ -2234,6 +2436,7 @@
 	{
 		"index": "staff-of-swarming-insects",
 		"url": "/api/2024/magic-items/staff-of-swarming-insects",
+		"image" : "/api/images/magic-items/staff-of-swarming-insects.png",
 		"name": "Staff of Swarming Insects",
 		"type": "Staff",
 		"attunement": true,
@@ -2246,6 +2449,7 @@
 	{
 		"index": "staff-of-the-magi",
 		"url": "/api/2024/magic-items/staff-of-the-magi",
+		"image" : "/api/images/magic-items/staff-of-the-magi.png",
 		"name": "Staff of the Magi",
 		"type": "Staff",
 		"attunement": true,
@@ -2258,6 +2462,7 @@
 	{
 		"index": "staff-of-the-python",
 		"url": "/api/2024/magic-items/staff-of-the-python",
+		"image" : "/api/images/magic-items/staff-of-the-python.png",
 		"name": "Staff of the Python",
 		"type": "Staff",
 		"attunement": true,
@@ -2269,6 +2474,7 @@
 	{
 		"index": "staff-of-the-woodlands",
 		"url": "/api/2024/magic-items/staff-of-the-woodlands",
+		"image" : "/api/images/magic-items/staff-of-the-woodlands.png",
 		"name": "Staff of the Woodlands",
 		"type": "Staff",
 		"attunement": true,
@@ -2281,6 +2487,7 @@
 	{
 		"index": "staff-of-thunder-and-lightning",
 		"url": "/api/2024/magic-items/staff-of-thunder-and-lightning",
+		"image" : "/api/images/magic-items/staff-of-thunder-and-lightning.png",
 		"name": "Staff of Thunder and Lightning",
 		"type": "Staff",
 		"attunement": true,
@@ -2292,6 +2499,7 @@
 	{
 		"index": "staff-of-withering",
 		"url": "/api/2024/magic-items/staff-of-withering",
+		"image" : "/api/images/magic-items/staff-of-withering.png",
 		"name": "Staff of Withering",
 		"type": "Staff",
 		"attunement": true,
@@ -2303,6 +2511,7 @@
 	{
 		"index": "stone-of-controlling-earth-elementals",
 		"url": "/api/2024/magic-items/stone-of-controlling-earth-elementals",
+		"image" : "/api/images/magic-items/stone-of-controlling-earth-elementals.png",
 		"name": "Stone of Controlling Earth Elementals",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2314,6 +2523,7 @@
 	{
 		"index": "stone-of-good-luck-(luckstone)",
 		"url": "/api/2024/magic-items/stone-of-good-luck-(luckstone)",
+		"image" : "/api/images/magic-items/stone-of-good-luck-(luckstone).png",
 		"name": "Stone of Good Luck (Luckstone)",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2325,6 +2535,7 @@
 	{
 		"index": "sun-blade",
 		"url": "/api/2024/magic-items/sun-blade",
+		"image" : "/api/images/magic-items/sun-blade.png",
 		"name": "Sun Blade",
 		"type": "Weapon (Longsword)",
 		"attunement": true,
@@ -2336,6 +2547,7 @@
 	{
 		"index": "sword-of-life-stealing",
 		"url": "/api/2024/magic-items/sword-of-life-stealing",
+		"image" : "/api/images/magic-items/sword-of-life-stealing.png",
 		"name": "Sword of Life Stealing",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
@@ -2347,6 +2559,7 @@
 	{
 		"index": "sword-of-sharpness",
 		"url": "/api/2024/magic-items/sword-of-sharpness",
+		"image" : "/api/images/magic-items/sword-of-sharpness.png",
 		"name": "Sword of Sharpness",
 		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 		"attunement": true,
@@ -2358,6 +2571,7 @@
 	{
 		"index": "sword-of-wounding",
 		"url": "/api/2024/magic-items/sword-of-wounding",
+		"image" : "/api/images/magic-items/sword-of-wounding.png",
 		"name": "Sword of Wounding",
 		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 		"attunement": true,
@@ -2369,6 +2583,7 @@
 	{
 		"index": "talisman-of-pure-good",
 		"url": "/api/2024/magic-items/talisman-of-pure-good",
+		"image" : "/api/images/magic-items/talisman-of-pure-good.png",
 		"name": "Talisman of Pure Good",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2381,6 +2596,7 @@
 	{
 		"index": "talisman-of-the-sphere",
 		"url": "/api/2024/magic-items/talisman-of-the-sphere",
+		"image" : "/api/images/magic-items/talisman-of-the-sphere.png",
 		"name": "Talisman of the Sphere",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2392,6 +2608,7 @@
 	{
 		"index": "talisman-of-ultimate-evil",
 		"url": "/api/2024/magic-items/talisman-of-ultimate-evil",
+		"image" : "/api/images/magic-items/talisman-of-ultimate-evil.png",
 		"name": "Talisman of Ultimate Evil",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2403,6 +2620,7 @@
 	{
 		"index": "tome-of-clear-thought",
 		"url": "/api/2024/magic-items/tome-of-clear-thought",
+		"image" : "/api/images/magic-items/tome-of-clear-thought.png",
 		"name": "Tome of Clear Thought",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2414,6 +2632,7 @@
 	{
 		"index": "tome-of-leadership-and-influence",
 		"url": "/api/2024/magic-items/tome-of-leadership-and-influence",
+		"image" : "/api/images/magic-items/tome-of-leadership-and-influence.png",
 		"name": "Tome of Leadership and Influence",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2425,6 +2644,7 @@
 	{
 		"index": "tome-of-understanding",
 		"url": "/api/2024/magic-items/tome-of-understanding",
+		"image" : "/api/images/magic-items/tome-of-understanding.png",
 		"name": "Tome of Understanding",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2436,6 +2656,7 @@
 	{
 		"index": "trident-of-fish-command",
 		"url": "/api/2024/magic-items/trident-of-fish-command",
+		"image" : "/api/images/magic-items/trident-of-fish-command.png",
 		"name": "Trident of Fish Command",
 		"type": "Weapon (Trident)",
 		"attunement": true,
@@ -2447,6 +2668,7 @@
 	{
 		"index": "universal-solvent",
 		"url": "/api/2024/magic-items/universal-solvent",
+		"image" : "/api/images/magic-items/universal-solvent.png",
 		"name": "Universal Solvent",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2458,6 +2680,7 @@
 	{
 		"index": "vicious-weapon",
 		"url": "/api/2024/magic-items/vicious-weapon",
+		"image" : "/api/images/magic-items/vicious-weapon.png",
 		"name": "Vicious Weapon",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
@@ -2469,6 +2692,7 @@
 	{
 		"index": "vorpal-sword",
 		"url": "/api/2024/magic-items/vorpal-sword",
+		"image" : "/api/images/magic-items/vorpal-sword.png",
 		"name": "Vorpal Sword",
 		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 		"attunement": true,
@@ -2480,6 +2704,7 @@
 	{
 		"index": "wand-of-binding",
 		"url": "/api/2024/magic-items/wand-of-binding",
+		"image" : "/api/images/magic-items/wand-of-binding.png",
 		"name": "Wand of Binding",
 		"type": "Wand",
 		"attunement": true,
@@ -2491,6 +2716,7 @@
 	{
 		"index": "wand-of-enemy-detection",
 		"url": "/api/2024/magic-items/wand-of-enemy-detection",
+		"image" : "/api/images/magic-items/wand-of-enemy-detection.png",
 		"name": "Wand of Enemy Detection",
 		"type": "Wand",
 		"attunement": true,
@@ -2502,6 +2728,7 @@
 	{
 		"index": "wand-of-fear",
 		"url": "/api/2024/magic-items/wand-of-fear",
+		"image" : "/api/images/magic-items/wand-of-fear.png",
 		"name": "Wand of Fear",
 		"type": "Wand",
 		"attunement": true,
@@ -2513,6 +2740,7 @@
 	{
 		"index": "wand-of-fireballs",
 		"url": "/api/2024/magic-items/wand-of-fireballs",
+		"image" : "/api/images/magic-items/wand-of-fireballs.png",
 		"name": "Wand of Fireballs",
 		"type": "Wand",
 		"attunement": true,
@@ -2525,6 +2753,7 @@
 	{
 		"index": "wand-of-lightning-bolts",
 		"url": "/api/2024/magic-items/wand-of-lightning-bolts",
+		"image" : "/api/images/magic-items/wand-of-lightning-bolts.png",
 		"name": "Wand of Lightning Bolts",
 		"type": "Wand",
 		"attunement": true,
@@ -2537,6 +2766,7 @@
 	{
 		"index": "wand-of-magic-detection",
 		"url": "/api/2024/magic-items/wand-of-magic-detection",
+		"image" : "/api/images/magic-items/wand-of-magic-detection.png",
 		"name": "Wand of Magic Detection",
 		"type": "Wand",
 		"attunement": false,
@@ -2548,6 +2778,7 @@
 	{
 		"index": "wand-of-magic-missiles",
 		"url": "/api/2024/magic-items/wand-of-magic-missiles",
+		"image" : "/api/images/magic-items/wand-of-magic-missiles.png",
 		"name": "Wand of Magic Missiles",
 		"type": "Wand",
 		"attunement": false,
@@ -2559,6 +2790,7 @@
 	{
 		"index": "wand-of-paralysis",
 		"url": "/api/2024/magic-items/wand-of-paralysis",
+		"image" : "/api/images/magic-items/wand-of-paralysis.png",
 		"name": "Wand of Paralysis",
 		"type": "Wand",
 		"attunement": true,
@@ -2571,6 +2803,7 @@
 	{
 		"index": "wand-of-polymorph",
 		"url": "/api/2024/magic-items/wand-of-polymorph",
+		"image" : "/api/images/magic-items/wand-of-polymorph.png",
 		"name": "Wand of Polymorph",
 		"type": "Wand",
 		"attunement": true,
@@ -2583,6 +2816,7 @@
 	{
 		"index": "wand-of-secrets",
 		"url": "/api/2024/magic-items/wand-of-secrets",
+		"image" : "/api/images/magic-items/wand-of-secrets.png",
 		"name": "Wand of Secrets",
 		"type": "Wand",
 		"attunement": false,
@@ -2594,6 +2828,7 @@
 	{
 		"index": "wand-of-the-war-mage",
 		"url": "/api/2024/magic-items/wand-of-the-war-mage",
+		"image" : "/api/images/magic-items/wand-of-the-war-mage.png",
 		"name": "Wand of the War Mage",
 		"type": "Wand",
 		"attunement": true,
@@ -2606,6 +2841,7 @@
 	{
 		"index": "wand-of-web",
 		"url": "/api/2024/magic-items/wand-of-web",
+		"image" : "/api/images/magic-items/wand-of-web.png",
 		"name": "Wand of Web",
 		"type": "Wand",
 		"attunement": true,
@@ -2618,6 +2854,7 @@
 	{
 		"index": "wand-of-wonder",
 		"url": "/api/2024/magic-items/wand-of-wonder",
+		"image" : "/api/images/magic-items/wand-of-wonder.png",
 		"name": "Wand of Wonder",
 		"type": "Wand",
 		"attunement": true,
@@ -2629,6 +2866,7 @@
 	{
 		"index": "weapon",
 		"url": "/api/2024/magic-items/weapon",
+		"image" : "/api/images/magic-items/weapon.png",
 		"name": "Weapon",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": false,
@@ -2640,6 +2878,7 @@
 	{
 		"index": "weapon-of-warning",
 		"url": "/api/2024/magic-items/weapon-of-warning",
+		"image" : "/api/images/magic-items/weapon-of-warning.png",
 		"name": "Weapon of Warning",
 		"type": "Weapon (Any Simple or Martial)",
 		"attunement": true,
@@ -2651,6 +2890,7 @@
 	{
 		"index": "well-of-many-worlds",
 		"url": "/api/2024/magic-items/well-of-many-worlds",
+		"image" : "/api/images/magic-items/well-of-many-worlds.png",
 		"name": "Well of Many Worlds",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2662,6 +2902,7 @@
 	{
 		"index": "wind-fan",
 		"url": "/api/2024/magic-items/wind-fan",
+		"image" : "/api/images/magic-items/wind-fan.png",
 		"name": "Wind Fan",
 		"type": "Wondrous Item",
 		"attunement": false,
@@ -2673,6 +2914,7 @@
 	{
 		"index": "winged-boots",
 		"url": "/api/2024/magic-items/winged-boots",
+		"image" : "/api/images/magic-items/winged-boots.png",
 		"name": "Winged Boots",
 		"type": "Wondrous Item",
 		"attunement": true,
@@ -2684,6 +2926,7 @@
 	{
 		"index": "wings-of-flying",
 		"url": "/api/2024/magic-items/wings-of-flying",
+		"image" : "/api/images/magic-items/wings-of-flying.png",
 		"name": "Wings of Flying",
 		"type": "Wondrous Item",
 		"attunement": true,

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -1,0 +1,2209 @@
+[
+	{
+		"index": "adamantine-armor",
+		"url": "/api/2024/magic-items/adamantine-armor",
+		"name": "Adamantine Armor",
+		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
+	},
+	{
+		"index": "ammunition",
+		"url": "/api/2024/magic-items/ammunition",
+		"name": "Ammunition",
+		"type": "Weapon (Any Ammunition)",
+		"attunement": false,
+		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"description": "You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.\nThis ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+	},
+	{
+		"index": "ammunition-of-slaying",
+		"url": "/api/2024/magic-items/ammunition-of-slaying",
+		"name": "Ammunition of Slaying",
+		"type": "Weapon (Any Ammunition)",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.\nAfter dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
+	},
+	{
+		"index": "amulet-of-health",
+		"url": "/api/2024/magic-items/amulet-of-health",
+		"name": "Amulet of Health",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
+	},
+	{
+		"index": "amulet-of-proof-against-detection-and-location",
+		"url": "/api/2024/magic-items/amulet-of-proof-against-detection-and-location",
+		"name": "Amulet of Proof against Detection and Location",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
+	},
+	{
+		"index": "amulet-of-the-planes",
+		"url": "/api/2024/magic-items/amulet-of-the-planes",
+		"name": "Amulet of the Planes",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
+	},
+	{
+		"index": "animated-shield",
+		"url": "/api/2024/magic-items/animated-shield",
+		"name": "Animated Shield",
+		"type": "Armor (Shield)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
+	},
+	{
+		"index": "apparatus-of-the-crab",
+		"url": "/api/2024/magic-items/apparatus-of-the-crab",
+		"name": "Apparatus of the Crab",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.\nThe Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.\nTo be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.\nThe apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.\nA creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
+	},
+	{
+		"index": "armor",
+		"url": "/api/2024/magic-items/armor",
+		"name": "Armor",
+		"type": "Armor (Any Light, Medium, or Heavy)",
+		"attunement": false,
+		"rarity": "Rare (+1), Very Rare (+2), or Legendary (+3)",
+		"description": "You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
+	},
+	{
+		"index": "armor-of-invulnerability",
+		"url": "/api/2024/magic-items/armor-of-invulnerability",
+		"name": "Armor of Invulnerability",
+		"type": "Armor (Plate Armor)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.\nMetal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
+	},
+	{
+		"index": "armor-of-resistance",
+		"url": "/api/2024/magic-items/armor-of-resistance",
+		"name": "Armor of Resistance",
+		"type": "Armor (Any Light, Medium, or Heavy)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
+	},
+	{
+		"index": "armor-of-vulnerability",
+		"url": "/api/2024/magic-items/armor-of-vulnerability",
+		"name": "Armor of Vulnerability",
+		"type": "Armor (Any Light, Medium, or Heavy)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.\nCurse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
+	},
+	{
+		"index": "arrow-catching-shield",
+		"url": "/api/2024/magic-items/arrow-catching-shield",
+		"name": "Arrow-Catching Shield",
+		"type": "Armor (Shield)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.\nWhenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
+	},
+	{
+		"index": "bag-of-beans",
+		"url": "/api/2024/magic-items/bag-of-beans",
+		"name": "Bag of Beans",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.\nIf you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.\nIf you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
+	},
+	{
+		"index": "bag-of-devouring",
+		"url": "/api/2024/magic-items/bag-of-devouring",
+		"name": "Bag of Devouring",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.\nThe extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.\nInanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.\nIf the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
+	},
+	{
+		"index": "bag-of-holding",
+		"url": "/api/2024/magic-items/bag-of-holding",
+		"name": "Bag of Holding",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.\nIf the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
+	},
+	{
+		"index": "bag-of-tricks",
+		"url": "/api/2024/magic-items/bag-of-tricks",
+		"name": "Bag of Tricks",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.\nYou can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.\nThe creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.\nOnce three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.\nGray Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nWeasel\n5\nPanther\n2\nGiant Rat\n6\nGiant Badger\n3\nBadger\n7\nDire Wolf\n4\nBoar\n8\nGiant Elk\nRust Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nRat\n5\nGiant Goat\n2\nOwl\n6\nGiant Boar\n3\nMastiff\n7\nLion\n4\nGoat\n8\nBrown Bear\nTan Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nJackal\n5\nBlack Bear\n2\nApe\n6\nGiant Weasel\n3\nBaboon\n7\nGiant Hyena\n4\nAxe Beak\n8\nTiger"
+	},
+	{
+		"index": "bead-of-force",
+		"url": "/api/2024/magic-items/bead-of-force",
+		"name": "Bead of Force",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.\nYou can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.\nAn enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
+	},
+	{
+		"index": "belt-of-dwarvenkind",
+		"url": "/api/2024/magic-items/belt-of-dwarvenkind",
+		"name": "Belt of Dwarvenkind",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
+	},
+	{
+		"index": "belt-of-giant-strength",
+		"url": "/api/2024/magic-items/belt-of-giant-strength",
+		"name": "Belt of Giant Strength",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rarity Varies",
+		"description": "While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
+	},
+	{
+		"index": "berserker-axe",
+		"url": "/api/2024/magic-items/berserker-axe",
+		"name": "Berserker Axe",
+		"type": "Weapon (Battleaxe, Greataxe, or Halberd)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.\nCurse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.\nWhenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.\nWhile berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
+	},
+	{
+		"index": "boots-of-elvenkind",
+		"url": "/api/2024/magic-items/boots-of-elvenkind",
+		"name": "Boots of Elvenkind",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
+	},
+	{
+		"index": "boots-of-levitation",
+		"url": "/api/2024/magic-items/boots-of-levitation",
+		"name": "Boots of Levitation",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While you wear these boots, you can cast Levitate on yourself."
+	},
+	{
+		"index": "boots-of-speed",
+		"url": "/api/2024/magic-items/boots-of-speed",
+		"name": "Boots of Speed",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.\nWhen you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
+	},
+	{
+		"index": "boots-of-striding-and-springing",
+		"url": "/api/2024/magic-items/boots-of-striding-and-springing",
+		"name": "Boots of Striding and Springing",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.\nOnce on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
+	},
+	{
+		"index": "boots-of-the-winterlands",
+		"url": "/api/2024/magic-items/boots-of-the-winterlands",
+		"name": "Boots of the Winterlands",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.\nCold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.\nWinter Strider. You ignore Difficult Terrain created by ice or snow."
+	},
+	{
+		"index": "bowl-of-commanding-water-elementals",
+		"url": "/api/2024/magic-items/bowl-of-commanding-water-elementals",
+		"name": "Bowl of Commanding Water Elementals",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.\nThe bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
+	},
+	{
+		"index": "bracers-of-archery",
+		"url": "/api/2024/magic-items/bracers-of-archery",
+		"name": "Bracers of Archery",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
+	},
+	{
+		"index": "bracers-of-defense",
+		"url": "/api/2024/magic-items/bracers-of-defense",
+		"name": "Bracers of Defense",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
+	},
+	{
+		"index": "brazier-of-commanding-fire-elementals",
+		"url": "/api/2024/magic-items/brazier-of-commanding-fire-elementals",
+		"name": "Brazier of Commanding Fire Elementals",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
+	},
+	{
+		"index": "brooch-of-shielding",
+		"url": "/api/2024/magic-items/brooch-of-shielding",
+		"name": "Brooch of Shielding",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
+	},
+	{
+		"index": "broom-of-flying",
+		"url": "/api/2024/magic-items/broom-of-flying",
+		"name": "Broom of Flying",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.\nAs a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
+	},
+	{
+		"index": "candle-of-invocation",
+		"url": "/api/2024/magic-items/candle-of-invocation",
+		"name": "Candle of Invocation",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.\nWhile lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.\nAlternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
+	},
+	{
+		"index": "cape-of-the-mountebank",
+		"url": "/api/2024/magic-items/cape-of-the-mountebank",
+		"name": "Cape of the Mountebank",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.\nWhen you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
+	},
+	{
+		"index": "carpet-of-flying",
+		"url": "/api/2024/magic-items/carpet-of-flying",
+		"name": "Carpet of Flying",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.\nFour sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
+	},
+	{
+		"index": "censer-of-controlling-air-elementals",
+		"url": "/api/2024/magic-items/censer-of-controlling-air-elementals",
+		"name": "Censer of Controlling Air Elementals",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
+	},
+	{
+		"index": "chime-of-opening",
+		"url": "/api/2024/magic-items/chime-of-opening",
+		"name": "Chime of Opening",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.\nThe chime can be used 10 times. After the tenth time, it cracks and becomes useless."
+	},
+	{
+		"index": "circlet-of-blasting",
+		"url": "/api/2024/magic-items/circlet-of-blasting",
+		"name": "Circlet of Blasting",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
+	},
+	{
+		"index": "cloak-of-arachnida",
+		"url": "/api/2024/magic-items/cloak-of-arachnida",
+		"name": "Cloak of Arachnida",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.\nPoison Resistance. You have Resistance to Poison damage.\nSpider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.\nSpider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.\nWeb. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
+	},
+	{
+		"index": "cloak-of-displacement",
+		"url": "/api/2024/magic-items/cloak-of-displacement",
+		"name": "Cloak of Displacement",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
+	},
+	{
+		"index": "cloak-of-elvenkind",
+		"url": "/api/2024/magic-items/cloak-of-elvenkind",
+		"name": "Cloak of Elvenkind",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
+	},
+	{
+		"index": "cloak-of-protection",
+		"url": "/api/2024/magic-items/cloak-of-protection",
+		"name": "Cloak of Protection",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
+	},
+	{
+		"index": "cloak-of-the-bat",
+		"url": "/api/2024/magic-items/cloak-of-the-bat",
+		"name": "Cloak of the Bat",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.\nWhile wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
+	},
+	{
+		"index": "cloak-of-the-manta-ray",
+		"url": "/api/2024/magic-items/cloak-of-the-manta-ray",
+		"name": "Cloak of the Manta Ray",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
+	},
+	{
+		"index": "crystal-ball",
+		"url": "/api/2024/magic-items/crystal-ball",
+		"name": "Crystal Ball",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While touching this crystal orb, you can cast Scrying(save DC 17) with it."
+	},
+	{
+		"index": "crystal-ball-of-mind-reading",
+		"url": "/api/2024/magic-items/crystal-ball-of-mind-reading",
+		"name": "Crystal Ball of Mind Reading",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
+	},
+	{
+		"index": "crystal-ball-of-telepathy",
+		"url": "/api/2024/magic-items/crystal-ball-of-telepathy",
+		"name": "Crystal Ball of Telepathy",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
+	},
+	{
+		"index": "crystal-ball-of-true-seeing",
+		"url": "/api/2024/magic-items/crystal-ball-of-true-seeing",
+		"name": "Crystal Ball of True Seeing",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
+	},
+	{
+		"index": "cube-of-force",
+		"url": "/api/2024/magic-items/cube-of-force",
+		"name": "Cube of Force",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.\nThe cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
+	},
+	{
+		"index": "cubic-gate",
+		"url": "/api/2024/magic-items/cubic-gate",
+		"name": "Cubic Gate",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.\nThe cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.\nGate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.\nPlane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
+	},
+	{
+		"index": "dagger-of-venom",
+		"url": "/api/2024/magic-items/dagger-of-venom",
+		"name": "Dagger of Venom",
+		"type": "Weapon (Dagger)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nYou can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
+	},
+	{
+		"index": "dancing-sword",
+		"url": "/api/2024/magic-items/dancing-sword",
+		"name": "Dancing Sword",
+		"type": "Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.\nWhile the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
+	},
+	{
+		"index": "decanter-of-endless-water",
+		"url": "/api/2024/magic-items/decanter-of-endless-water",
+		"name": "Decanter of Endless Water",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.\nYou can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
+	},
+	{
+		"index": "deck-of-illusions",
+		"url": "/api/2024/magic-items/deck-of-illusions",
+		"name": "Deck of Illusions",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.\nThe magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.\nAny physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
+	},
+	{
+		"index": "defender",
+		"url": "/api/2024/magic-items/defender",
+		"name": "Defender",
+		"type": "Weapon (Any Melee Weapon)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.\nThe first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
+	},
+	{
+		"index": "demon-armor",
+		"url": "/api/2024/magic-items/demon-armor",
+		"name": "Demon Armor",
+		"type": "Armor (Any Light, Medium, or Heavy)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.\nCurse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
+	},
+	{
+		"index": "dimensional-shackles",
+		"url": "/api/2024/magic-items/dimensional-shackles",
+		"name": "Dimensional Shackles",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.\nYou and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
+	},
+	{
+		"index": "dragon-orb",
+		"url": "/api/2024/magic-items/dragon-orb",
+		"name": "Dragon Orb",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Artifact",
+		"description": "An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.\nWhile attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.\nWhile you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.\nSpells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3\nCall Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.\nDestroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
+	},
+	{
+		"index": "dragon-scale-mail",
+		"url": "/api/2024/magic-items/dragon-scale-mail",
+		"name": "Dragon Scale Mail",
+		"type": "Armor (Scale Mail)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.\nWhile wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).\nAdditionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
+	},
+	{
+		"index": "dragon-slayer",
+		"url": "/api/2024/magic-items/dragon-slayer",
+		"name": "Dragon Slayer",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
+	},
+	{
+		"index": "dust-of-disappearance",
+		"url": "/api/2024/magic-items/dust-of-disappearance",
+		"name": "Dust of Disappearance",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
+	},
+	{
+		"index": "dust-of-dryness",
+		"url": "/api/2024/magic-items/dust-of-dryness",
+		"name": "Dust of Dryness",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.\nAs a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
+	},
+	{
+		"index": "dust-of-sneezing-and-choking",
+		"url": "/api/2024/magic-items/dust-of-sneezing-and-choking",
+		"name": "Dust of Sneezing and Choking",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.\nAs a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.\nOn a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
+	},
+	{
+		"index": "dwarven-plate",
+		"url": "/api/2024/magic-items/dwarven-plate",
+		"name": "Dwarven Plate",
+		"type": "Armor (Half Plate Armor or Plate Armor)",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
+	},
+	{
+		"index": "dwarven-thrower",
+		"url": "/api/2024/magic-items/dwarven-thrower",
+		"name": "Dwarven Thrower",
+		"type": "Weapon (Warhammer)",
+		"attunement": true,
+		"limited-to": "Dwarf or a Creature Attuned to a Belt of Dwarvenkind",
+		"rarity": "Very Rare",
+		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
+	},
+	{
+		"index": "efficient-quiver",
+		"url": "/api/2024/magic-items/efficient-quiver",
+		"name": "Efficient Quiver",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.\nYou can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
+	},
+	{
+		"index": "efreeti-bottle",
+		"url": "/api/2024/magic-items/efreeti-bottle",
+		"name": "Efreeti Bottle",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
+	},
+	{
+		"index": "elemental-gem",
+		"url": "/api/2024/magic-items/elemental-gem",
+		"name": "Elemental Gem",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
+	},
+	{
+		"index": "elven-chain",
+		"url": "/api/2024/magic-items/elven-chain",
+		"name": "Elven Chain",
+		"type": "Armor (Chain Mail or Chain Shirt)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
+	},
+	{
+		"index": "eversmoking-bottle",
+		"url": "/api/2024/magic-items/eversmoking-bottle",
+		"name": "Eversmoking Bottle",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.\nEach minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.\nClosing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
+	},
+	{
+		"index": "eyes-of-charming",
+		"url": "/api/2024/magic-items/eyes-of-charming",
+		"name": "Eyes of Charming",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
+	},
+	{
+		"index": "eyes-of-minute-seeing",
+		"url": "/api/2024/magic-items/eyes-of-minute-seeing",
+		"name": "Eyes of Minute Seeing",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
+	},
+	{
+		"index": "eyes-of-the-eagle",
+		"url": "/api/2024/magic-items/eyes-of-the-eagle",
+		"name": "Eyes of the Eagle",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
+	},
+	{
+		"index": "feather-token",
+		"url": "/api/2024/magic-items/feather-token",
+		"name": "Feather Token",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rarity Varies",
+		"description": "This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.\nAnchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.\nBird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.\nFan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.\nSwan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.\nTree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.\nWhip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.\nAs a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
+	},
+	{
+		"index": "figurine-of-wondrous-power",
+		"url": "/api/2024/magic-items/figurine-of-wondrous-power",
+		"name": "Figurine of Wondrous Power",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rarity Varies",
+		"description": "A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.\nThe creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.\nThe creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.\nBronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.\nEbony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)\nGolden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.\nIvory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.\nMarble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.\nObsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.\nThe figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.\nOnyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.\nSerpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.\nSilver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
+	},
+	{
+		"index": "flame-tongue",
+		"url": "/api/2024/magic-items/flame-tongue",
+		"name": "Flame Tongue",
+		"type": "Weapon (Any Melee Weapon)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
+	},
+	{
+		"index": "folding-boat",
+		"url": "/api/2024/magic-items/folding-boat",
+		"name": "Folding Boat",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.\nStatistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
+	},
+	{
+		"index": "frost-brand",
+		"url": "/api/2024/magic-items/frost-brand",
+		"name": "Frost Brand",
+		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.\nIn freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.\nWhen you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
+	},
+	{
+		"index": "gauntlets-of-ogre-power",
+		"url": "/api/2024/magic-items/gauntlets-of-ogre-power",
+		"name": "Gauntlets of Ogre Power",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
+	},
+	{
+		"index": "gem-of-brightness",
+		"url": "/api/2024/magic-items/gem-of-brightness",
+		"name": "Gem of Brightness",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
+	},
+	{
+		"index": "gem-of-seeing",
+		"url": "/api/2024/magic-items/gem-of-seeing",
+		"name": "Gem of Seeing",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.\nThe gem regains 1d3 expended charges daily at dawn."
+	},
+	{
+		"index": "giant-slayer",
+		"url": "/api/2024/magic-items/giant-slayer",
+		"name": "Giant Slayer",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nWhen you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
+	},
+	{
+		"index": "glamoured-studded-leather",
+		"url": "/api/2024/magic-items/glamoured-studded-leather",
+		"name": "Glamoured Studded Leather",
+		"type": "Armor (Studded Leather Armor)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
+	},
+	{
+		"index": "gloves-of-missile-snaring",
+		"url": "/api/2024/magic-items/gloves-of-missile-snaring",
+		"name": "Gloves of Missile Snaring",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
+	},
+	{
+		"index": "gloves-of-swimming-and-climbing",
+		"url": "/api/2024/magic-items/gloves-of-swimming-and-climbing",
+		"name": "Gloves of Swimming and Climbing",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
+	},
+	{
+		"index": "goggles-of-night",
+		"url": "/api/2024/magic-items/goggles-of-night",
+		"name": "Goggles of Night",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
+	},
+	{
+		"index": "hammer-of-thunderbolts",
+		"url": "/api/2024/magic-items/hammer-of-thunderbolts",
+		"name": "Hammer of Thunderbolts",
+		"type": "Weapon (Maul or Warhammer)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.\nGiant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
+	},
+	{
+		"index": "handy-haversack",
+		"url": "/api/2024/magic-items/handy-haversack",
+		"name": "Handy Haversack",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.\nRetrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.\nIf any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.\nEach pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+	},
+	{
+		"index": "hat-of-disguise",
+		"url": "/api/2024/magic-items/hat-of-disguise",
+		"name": "Hat of Disguise",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
+	},
+	{
+		"index": "headband-of-intellect",
+		"url": "/api/2024/magic-items/headband-of-intellect",
+		"name": "Headband of Intellect",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
+	},
+	{
+		"index": "helm-of-brilliance",
+		"url": "/api/2024/magic-items/helm-of-brilliance",
+		"name": "Helm of Brilliance",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.\nDiamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.\nFire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.\nRuby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.\nSpells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.\nTaking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
+	},
+	{
+		"index": "helm-of-comprehending-languages",
+		"url": "/api/2024/magic-items/helm-of-comprehending-languages",
+		"name": "Helm of Comprehending Languages",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While wearing this helm, you can cast Comprehend Languages from it."
+	},
+	{
+		"index": "helm-of-telepathy",
+		"url": "/api/2024/magic-items/helm-of-telepathy",
+		"name": "Helm of Telepathy",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
+	},
+	{
+		"index": "helm-of-teleportation",
+		"url": "/api/2024/magic-items/helm-of-teleportation",
+		"name": "Helm of Teleportation",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
+	},
+	{
+		"index": "holy-avenger",
+		"url": "/api/2024/magic-items/holy-avenger",
+		"name": "Holy Avenger",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": true,
+		"limited-to": "Paladin",
+		"rarity": "Legendary",
+		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
+	},
+	{
+		"index": "horn-of-blasting",
+		"url": "/api/2024/magic-items/horn-of-blasting",
+		"name": "Horn of Blasting",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.\nEach use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
+	},
+	{
+		"index": "horn-of-valhalla",
+		"url": "/api/2024/magic-items/horn-of-valhalla",
+		"name": "Horn of Valhalla",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)",
+		"description": "You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.\nFour types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.\nIf you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+	},
+	{
+		"index": "horseshoes-of-a-zephyr",
+		"url": "/api/2024/magic-items/horseshoes-of-a-zephyr",
+		"name": "Horseshoes of a Zephyr",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
+	},
+	{
+		"index": "horseshoes-of-speed",
+		"url": "/api/2024/magic-items/horseshoes-of-speed",
+		"name": "Horseshoes of Speed",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
+	},
+	{
+		"index": "immovable-rod",
+		"url": "/api/2024/magic-items/immovable-rod",
+		"name": "Immovable Rod",
+		"type": "Rod",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
+	},
+	{
+		"index": "instant-fortress",
+		"url": "/api/2024/magic-items/instant-fortress",
+		"name": "Instant Fortress",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.\nThe tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.\nMagic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
+	},
+	{
+		"index": "ioun-stone",
+		"url": "/api/2024/magic-items/ioun-stone",
+		"name": "Ioun Stone",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rarity Varies",
+		"description": "Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.\nWhen you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.\nEach Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.\nAs a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.\nThe type of stone determines its rarity and effects.\nAbsorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nAgility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.\nAwareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.\nFortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.\nGreater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nInsight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.\nIntellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.\nLeadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.\nMastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.\nProtection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.\nRegeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.\nReserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.\nStrength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.\nSustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
+	},
+	{
+		"index": "iron-bands",
+		"url": "/api/2024/magic-items/iron-bands",
+		"name": "Iron Bands",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.\nMake a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.\nA creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.\nOnce the bands are used, they can't be used again until the next dawn."
+	},
+	{
+		"index": "iron-flask",
+		"url": "/api/2024/magic-items/iron-flask",
+		"name": "Iron Flask",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.\nYou can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.\nAn Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
+	},
+	{
+		"index": "javelin-of-lightning",
+		"url": "/api/2024/magic-items/javelin-of-lightning",
+		"name": "Javelin of Lightning",
+		"type": "Weapon (Javelin)",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.\nLightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
+	},
+	{
+		"index": "lantern-of-revealing",
+		"url": "/api/2024/magic-items/lantern-of-revealing",
+		"name": "Lantern of Revealing",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
+	},
+	{
+		"index": "luck-blade",
+		"url": "/api/2024/magic-items/luck-blade",
+		"name": "Luck Blade",
+		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.\nLuck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.\nWish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
+	},
+	{
+		"index": "mace-of-disruption",
+		"url": "/api/2024/magic-items/mace-of-disruption",
+		"name": "Mace of Disruption",
+		"type": "Weapon (Mace)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.\nLight. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
+	},
+	{
+		"index": "mace-of-smiting",
+		"url": "/api/2024/magic-items/mace-of-smiting",
+		"name": "Mace of Smiting",
+		"type": "Weapon (Mace)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.\nWhen you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
+	},
+	{
+		"index": "mace-of-terror",
+		"url": "/api/2024/magic-items/mace-of-terror",
+		"name": "Mace of Terror",
+		"type": "Weapon (Mace)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
+	},
+	{
+		"index": "mantle-of-spell-resistance",
+		"url": "/api/2024/magic-items/mantle-of-spell-resistance",
+		"name": "Mantle of Spell Resistance",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You have Advantage on saving throws against spells while you wear this cloak."
+	},
+	{
+		"index": "manual-of-bodily-health",
+		"url": "/api/2024/magic-items/manual-of-bodily-health",
+		"name": "Manual of Bodily Health",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+	},
+	{
+		"index": "manual-of-gainful-exercise",
+		"url": "/api/2024/magic-items/manual-of-gainful-exercise",
+		"name": "Manual of Gainful Exercise",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+	},
+	{
+		"index": "manual-of-golems",
+		"url": "/api/2024/magic-items/manual-of-golems",
+		"name": "Manual of Golems",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.\nTo create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.\nOnce you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
+	},
+	{
+		"index": "manual-of-quickness-of-action",
+		"url": "/api/2024/magic-items/manual-of-quickness-of-action",
+		"name": "Manual of Quickness of Action",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+	},
+	{
+		"index": "marvelous-pigments",
+		"url": "/api/2024/magic-items/marvelous-pigments",
+		"name": "Marvelous Pigments",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).\nUsing the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.\nWhen the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.\nNo object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.\nIf you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
+	},
+	{
+		"index": "medallion-of-thoughts",
+		"url": "/api/2024/magic-items/medallion-of-thoughts",
+		"name": "Medallion of Thoughts",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
+	},
+	{
+		"index": "mirror-of-life-trapping",
+		"url": "/api/2024/magic-items/mirror-of-life-trapping",
+		"name": "Mirror of Life Trapping",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.\nIf the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.\nAny creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.\nAn extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.\nIf the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.\nWhile within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.\nIn a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.\nPlacing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+	},
+	{
+		"index": "mithral-armor",
+		"url": "/api/2024/magic-items/mithral-armor",
+		"name": "Mithral Armor",
+		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
+	},
+	{
+		"index": "mysterious-deck",
+		"url": "/api/2024/magic-items/mysterious-deck",
+		"name": "Mysterious Deck",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.\nBefore you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.\nOnce a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.\nEuryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.\nBalance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.\nComet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.\nDonjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.\nFates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.\nFlames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.\nFool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.\nGem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.\nJester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.\nKey. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.\nKnight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.\nPuzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.\nRogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.\nRuin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.\nSage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.\nSkull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.\nStar. Increase one of your ability scores by 2, to a maximum of 24.\nSun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.\nTalons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.\nThrone. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.\nVoid. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
+	},
+	{
+		"index": "necklace-of-adaptation",
+		"url": "/api/2024/magic-items/necklace-of-adaptation",
+		"name": "Necklace of Adaptation",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
+	},
+	{
+		"index": "necklace-of-fireballs",
+		"url": "/api/2024/magic-items/necklace-of-fireballs",
+		"name": "Necklace of Fireballs",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).\nYou can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
+	},
+	{
+		"index": "necklace-of-prayer-beads",
+		"url": "/api/2024/magic-items/necklace-of-prayer-beads",
+		"name": "Necklace of Prayer Beads",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"limited-to": "Cleric, Druid, or Paladin",
+		"rarity": "Rare",
+		"description": "This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.\nSix types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
+	},
+	{
+		"index": "nine-lives-stealer",
+		"url": "/api/2024/magic-items/nine-lives-stealer",
+		"name": "Nine Lives Stealer",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.\nLife Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
+	},
+	{
+		"index": "oathbow",
+		"url": "/api/2024/magic-items/oathbow",
+		"name": "Oathbow",
+		"type": "Weapon (Longbow or Shortbow)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.\nWhen you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.\nWhile your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
+	},
+	{
+		"index": "oil-of-etherealness",
+		"url": "/api/2024/magic-items/oil-of-etherealness",
+		"name": "Oil of Etherealness",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.\nBeads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
+	},
+	{
+		"index": "oil-of-sharpness",
+		"url": "/api/2024/magic-items/oil-of-sharpness",
+		"name": "Oil of Sharpness",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.\nThis clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
+	},
+	{
+		"index": "oil-of-slipperiness",
+		"url": "/api/2024/magic-items/oil-of-slipperiness",
+		"name": "Oil of Slipperiness",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.\nAlternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
+	},
+	{
+		"index": "pearl-of-power",
+		"url": "/api/2024/magic-items/pearl-of-power",
+		"name": "Pearl of Power",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Uncommon",
+		"description": "While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
+	},
+	{
+		"index": "periapt-of-health",
+		"url": "/api/2024/magic-items/periapt-of-health",
+		"name": "Periapt of Health",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.\nIn addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
+	},
+	{
+		"index": "periapt-of-proof-against-poison",
+		"url": "/api/2024/magic-items/periapt-of-proof-against-poison",
+		"name": "Periapt of Proof against Poison",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
+	},
+	{
+		"index": "periapt-of-wound-closure",
+		"url": "/api/2024/magic-items/periapt-of-wound-closure",
+		"name": "Periapt of Wound Closure",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this pendant, you gain the followingbenefits.\nLife Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.\nNatural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
+	},
+	{
+		"index": "philter-of-love",
+		"url": "/api/2024/magic-items/philter-of-love",
+		"name": "Philter of Love",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.\nThis rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
+	},
+	{
+		"index": "pipes-of-haunting",
+		"url": "/api/2024/magic-items/pipes-of-haunting",
+		"name": "Pipes of Haunting",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
+	},
+	{
+		"index": "pipes-of-the-sewers",
+		"url": "/api/2024/magic-items/pipes-of-the-sewers",
+		"name": "Pipes of the Sewers",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.\nThe pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.\nWhenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
+	},
+	{
+		"index": "plate-armor-of-etherealness",
+		"url": "/api/2024/magic-items/plate-armor-of-etherealness",
+		"name": "Plate Armor of Etherealness",
+		"type": "Armor (Half Plate Armor or Plate Armor)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
+	},
+	{
+		"index": "portable-hole",
+		"url": "/api/2024/magic-items/portable-hole",
+		"name": "Portable Hole",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.\nYou can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.\nIf the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.\nPlacing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+	},
+	{
+		"index": "potion-of-animal-friendship",
+		"url": "/api/2024/magic-items/potion-of-animal-friendship",
+		"name": "Potion of Animal Friendship",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
+	},
+	{
+		"index": "potion-of-clairvoyance",
+		"url": "/api/2024/magic-items/potion-of-clairvoyance",
+		"name": "Potion of Clairvoyance",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).\nAn eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
+	},
+	{
+		"index": "potion-of-climbing",
+		"url": "/api/2024/magic-items/potion-of-climbing",
+		"name": "Potion of Climbing",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Common",
+		"description": "When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.\nThis potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
+	},
+	{
+		"index": "potion-of-diminution",
+		"url": "/api/2024/magic-items/potion-of-diminution",
+		"name": "Potion of Diminution",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).\nThe red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
+	},
+	{
+		"index": "potion-of-flying",
+		"url": "/api/2024/magic-items/potion-of-flying",
+		"name": "Potion of Flying",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
+	},
+	{
+		"index": "potion-of-growth",
+		"url": "/api/2024/magic-items/potion-of-growth",
+		"name": "Potion of Growth",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).\nThe red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
+	},
+	{
+		"index": "potions-of-healing",
+		"url": "/api/2024/magic-items/potions-of-healing",
+		"name": "Potions of Healing",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rarity Varies",
+		"description": "You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.\nWhatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
+	},
+	{
+		"index": "potion-of-gaseous-form",
+		"url": "/api/2024/magic-items/potion-of-gaseous-form",
+		"name": "Potion of Gaseous Form",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "Potion of Healing    (supreme)"
+	},
+	{
+		"index": "potion-of-heroism",
+		"url": "/api/2024/magic-items/potion-of-heroism",
+		"name": "Potion of Heroism",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.\nThis potion's container seems to hold fog that moves and pours like water."
+	},
+	{
+		"index": "potion-of-giant-strength",
+		"url": "/api/2024/magic-items/potion-of-giant-strength",
+		"name": "Potion of Giant Strength",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rarity Varies",
+		"description": "When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.\nThis potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).\nThis potion's blue liquid bubbles and steams as if boiling."
+	},
+	{
+		"index": "potion-of-invisibility",
+		"url": "/api/2024/magic-items/potion-of-invisibility",
+		"name": "Potion of Invisibility",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
+	},
+	{
+		"index": "potion-of-mind-reading",
+		"url": "/api/2024/magic-items/potion-of-mind-reading",
+		"name": "Potion of Mind Reading",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
+	},
+	{
+		"index": "potion-of-poison",
+		"url": "/api/2024/magic-items/potion-of-poison",
+		"name": "Potion of Poison",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.\nIf you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
+	},
+	{
+		"index": "potion-of-resistance",
+		"url": "/api/2024/magic-items/potion-of-resistance",
+		"name": "Potion of Resistance",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
+	},
+	{
+		"index": "potion-of-speed",
+		"url": "/api/2024/magic-items/potion-of-speed",
+		"name": "Potion of Speed",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
+	},
+	{
+		"index": "potion-of-water-breathing",
+		"url": "/api/2024/magic-items/potion-of-water-breathing",
+		"name": "Potion of Water Breathing",
+		"type": "Potion",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "You can breathe underwater for 24 hours after drinking this potion.\nThis potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
+	},
+	{
+		"index": "ring-of-animal-influence",
+		"url": "/api/2024/magic-items/ring-of-animal-influence",
+		"name": "Ring of Animal Influence",
+		"type": "Ring",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
+	},
+	{
+		"index": "ring-of-djinni-summoning",
+		"url": "/api/2024/magic-items/ring-of-djinni-summoning",
+		"name": "Ring of Djinni Summoning",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.\nWhile summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.\nAfter the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.\nRings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
+	},
+	{
+		"index": "ring-of-elemental-command",
+		"url": "/api/2024/magic-items/ring-of-elemental-command",
+		"name": "Ring of Elemental Command",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.\nEvery Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.\nElemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.\nSpellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
+	},
+	{
+		"index": "ring-of-evasion",
+		"url": "/api/2024/magic-items/ring-of-evasion",
+		"name": "Ring of Evasion",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
+	},
+	{
+		"index": "ring-of-feather-falling",
+		"url": "/api/2024/magic-items/ring-of-feather-falling",
+		"name": "Ring of Feather Falling",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
+	},
+	{
+		"index": "ring-of-free-action",
+		"url": "/api/2024/magic-items/ring-of-free-action",
+		"name": "Ring of Free Action",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
+	},
+	{
+		"index": "ring-of-invisibility",
+		"url": "/api/2024/magic-items/ring-of-invisibility",
+		"name": "Ring of Invisibility",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
+	},
+	{
+		"index": "ring-of-jumping",
+		"url": "/api/2024/magic-items/ring-of-jumping",
+		"name": "Ring of Jumping",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
+	},
+	{
+		"index": "ring-of-mind-shielding",
+		"url": "/api/2024/magic-items/ring-of-mind-shielding",
+		"name": "Ring of Mind Shielding",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.\nYou can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.\nIf you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
+	},
+	{
+		"index": "ring-of-protection",
+		"url": "/api/2024/magic-items/ring-of-protection",
+		"name": "Ring of Protection",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
+	},
+	{
+		"index": "ring-of-regeneration",
+		"url": "/api/2024/magic-items/ring-of-regeneration",
+		"name": "Ring of Regeneration",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
+	},
+	{
+		"index": "ring-of-resistance",
+		"url": "/api/2024/magic-items/ring-of-resistance",
+		"name": "Ring of Resistance",
+		"type": "Ring",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
+	},
+	{
+		"index": "ring-of-shooting-stars",
+		"url": "/api/2024/magic-items/ring-of-shooting-stars",
+		"name": "Ring of Shooting Stars",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "You can cast Dancing Lights or Light from the ring.\nThe ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.\nFaerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.\nLightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.\nEach sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.\nAs a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4\nShooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
+	},
+	{
+		"index": "ring-of-spell-storing",
+		"url": "/api/2024/magic-items/ring-of-spell-storing",
+		"name": "Ring of Spell Storing",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
+	},
+	{
+		"index": "ring-of-spell-turning",
+		"url": "/api/2024/magic-items/ring-of-spell-turning",
+		"name": "Ring of Spell Turning",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
+	},
+	{
+		"index": "ring-of-swimming",
+		"url": "/api/2024/magic-items/ring-of-swimming",
+		"name": "Ring of Swimming",
+		"type": "Ring",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "You have a Swim Speed of 40 feet while wearing this ring."
+	},
+	{
+		"index": "ring-of-telekinesis",
+		"url": "/api/2024/magic-items/ring-of-telekinesis",
+		"name": "Ring of Telekinesis",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While wearing this ring, you can cast Telekinesisfrom it."
+	},
+	{
+		"index": "ring-of-the-ram",
+		"url": "/api/2024/magic-items/ring-of-the-ram",
+		"name": "Ring of the Ram",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.\nAlternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
+	},
+	{
+		"index": "ring-of-three-wishes",
+		"url": "/api/2024/magic-items/ring-of-three-wishes",
+		"name": "Ring of Three Wishes",
+		"type": "Ring",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
+	},
+	{
+		"index": "ring-of-warmth",
+		"url": "/api/2024/magic-items/ring-of-warmth",
+		"name": "Ring of Warmth",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.\nIn addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
+	},
+	{
+		"index": "ring-of-water-walking",
+		"url": "/api/2024/magic-items/ring-of-water-walking",
+		"name": "Ring of Water Walking",
+		"type": "Ring",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While wearing this ring, you cast Water Walk from it, targeting only yourself."
+	},
+	{
+		"index": "ring-of-x-ray-vision",
+		"url": "/api/2024/magic-items/ring-of-x-ray-vision",
+		"name": "Ring of X-ray Vision",
+		"type": "Ring",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.\nWhenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
+	},
+	{
+		"index": "robe-of-eyes",
+		"url": "/api/2024/magic-items/robe-of-eyes",
+		"name": "Robe of Eyes",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.\nDrawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
+	},
+	{
+		"index": "robe-of-scintillating-colors",
+		"url": "/api/2024/magic-items/robe-of-scintillating-colors",
+		"name": "Robe of Scintillating Colors",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
+	},
+	{
+		"index": "robe-of-stars",
+		"url": "/api/2024/magic-items/robe-of-stars",
+		"name": "Robe of Stars",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.\nSix stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.\nWhile you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
+	},
+	{
+		"index": "robe-of-the-archmagi",
+		"url": "/api/2024/magic-items/robe-of-the-archmagi",
+		"name": "Robe of the Archmagi",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"limited-to": "Sorcerer, Warlock, or Wizard",
+		"rarity": "Legendary",
+		"description": "This elegant garment is made from exquisite cloth and adorned with runes.\nYou gain these benefits while wearing the robe.\nArmor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.\nMagic Resistance. You have Advantage on saving throws against spells and other magical effects.\nWar Mage. Your spell save DC and spell attack bonus each increase by 2."
+	},
+	{
+		"index": "robe-of-useful-items",
+		"url": "/api/2024/magic-items/robe-of-useful-items",
+		"name": "Robe of Useful Items",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
+	},
+	{
+		"index": "rod-of-absorption",
+		"url": "/api/2024/magic-items/rod-of-absorption",
+		"name": "Rod of Absorption",
+		"type": "Rod",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.\nWhen you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.\nIf you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.\nA newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
+	},
+	{
+		"index": "rod-of-alertness",
+		"url": "/api/2024/magic-items/rod-of-alertness",
+		"name": "Rod of Alertness",
+		"type": "Rod",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This rod has the following properties.\nAlertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.\nSpells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility\nProtective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.\nThe rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
+	},
+	{
+		"index": "rod-of-lordly-might",
+		"url": "/api/2024/magic-items/rod-of-lordly-might",
+		"name": "Rod of Lordly Might",
+		"type": "Rod",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.\nButtons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.\nDrain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.\nParalyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.\nTerrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
+	},
+	{
+		"index": "rod-of-rulership",
+		"url": "/api/2024/magic-items/rod-of-rulership",
+		"name": "Rod of Rulership",
+		"type": "Rod",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
+	},
+	{
+		"index": "rod-of-security",
+		"url": "/api/2024/magic-items/rod-of-security",
+		"name": "Rod of Security",
+		"type": "Rod",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.\nFor each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).\nWhen the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
+	},
+	{
+		"index": "rope-of-climbing",
+		"url": "/api/2024/magic-items/rope-of-climbing",
+		"name": "Rope of Climbing",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.\nIf you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+	},
+	{
+		"index": "rope-of-entanglement",
+		"url": "/api/2024/magic-items/rope-of-entanglement",
+		"name": "Rope of Entanglement",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).\nA target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.\nThe rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+	},
+	{
+		"index": "scarab-of-protection",
+		"url": "/api/2024/magic-items/scarab-of-protection",
+		"name": "Scarab of Protection",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.\nPreservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.\nSpell Resistance. You have Advantage on saving throws against spells."
+	},
+	{
+		"index": "scimitar-of-speed",
+		"url": "/api/2024/magic-items/scimitar-of-speed",
+		"name": "Scimitar of Speed",
+		"type": "Weapon (Scimitar)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
+	},
+	{
+		"index": "shield",
+		"url": "/api/2024/magic-items/shield",
+		"name": "Shield",
+		"type": "Armor (Shield)",
+		"attunement": false,
+		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"description": "While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
+	},
+	{
+		"index": "shield-of-missile-attraction",
+		"url": "/api/2024/magic-items/shield-of-missile-attraction",
+		"name": "Shield of Missile Attraction",
+		"type": "Armor (Shield)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.\nCurse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
+	},
+	{
+		"index": "slippers-of-spider-climbing",
+		"url": "/api/2024/magic-items/slippers-of-spider-climbing",
+		"name": "Slippers of Spider Climbing",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
+	},
+	{
+		"index": "sovereign-glue",
+		"url": "/api/2024/magic-items/sovereign-glue",
+		"name": "Sovereign Glue",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.\nOne ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
+	},
+	{
+		"index": "spellguard-shield",
+		"url": "/api/2024/magic-items/spellguard-shield",
+		"name": "Spellguard Shield",
+		"type": "Armor (Shield)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
+	},
+	{
+		"index": "spell-scroll",
+		"url": "/api/2024/magic-items/spell-scroll",
+		"name": "Spell Scroll",
+		"type": "Scroll",
+		"attunement": false,
+		"rarity": "Rarity Varies",
+		"description": "A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.\nIf the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.\nThe level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11\nCopying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
+	},
+	{
+		"index": "sphere-of-annihilation",
+		"url": "/api/2024/magic-items/sphere-of-annihilation",
+		"name": "Sphere of Annihilation",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.\nThe sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.\nControlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.\nWhile in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.\nSphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
+	},
+	{
+		"index": "staff-of-charming",
+		"url": "/api/2024/magic-items/staff-of-charming",
+		"name": "Staff of Charming",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
+		"rarity": "Rare",
+		"description": "This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.\nRegaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
+	},
+	{
+		"index": "staff-of-fire",
+		"url": "/api/2024/magic-items/staff-of-fire",
+		"name": "Staff of Fire",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
+		"rarity": "Very Rare",
+		"description": "You have Resistance to Fire damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
+	},
+	{
+		"index": "staff-of-frost",
+		"url": "/api/2024/magic-items/staff-of-frost",
+		"name": "Staff of Frost",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
+		"rarity": "Very Rare",
+		"description": "You have Resistance to Cold damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
+	},
+	{
+		"index": "staff-of-healing",
+		"url": "/api/2024/magic-items/staff-of-healing",
+		"name": "Staff of Healing",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Bard, Cleric, or Druid",
+		"rarity": "Rare",
+		"description": "This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
+	},
+	{
+		"index": "staff-of-power",
+		"url": "/api/2024/magic-items/staff-of-power",
+		"name": "Staff of Power",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Sorcerer, Warlock, or Wizard",
+		"rarity": "Very Rare",
+		"description": "This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+	},
+	{
+		"index": "staff-of-striking",
+		"url": "/api/2024/magic-items/staff-of-striking",
+		"name": "Staff of Striking",
+		"type": "Staff",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.\nThe staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
+	},
+	{
+		"index": "staff-of-swarming-insects",
+		"url": "/api/2024/magic-items/staff-of-swarming-insects",
+		"name": "Staff of Swarming Insects",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
+		"rarity": "Rare",
+		"description": "This staff has 10 charges.\nInsect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
+	},
+	{
+		"index": "staff-of-the-magi",
+		"url": "/api/2024/magic-items/staff-of-the-magi",
+		"name": "Staff of the Magi",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Sorcerer, Warlock, or Wizard",
+		"rarity": "Legendary",
+		"description": "This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.\nSpell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge\nRegaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+	},
+	{
+		"index": "staff-of-the-python",
+		"url": "/api/2024/magic-items/staff-of-the-python",
+		"name": "Staff of the Python",
+		"type": "Staff",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.\nOn your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.\nAs a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
+	},
+	{
+		"index": "staff-of-the-woodlands",
+		"url": "/api/2024/magic-items/staff-of-the-woodlands",
+		"name": "Staff of the Woodlands",
+		"type": "Staff",
+		"attunement": true,
+		"limited-to": "Druid",
+		"rarity": "Rare",
+		"description": "This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6\nTree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.\nRegaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
+	},
+	{
+		"index": "staff-of-thunder-and-lightning",
+		"url": "/api/2024/magic-items/staff-of-thunder-and-lightning",
+		"name": "Staff of Thunder and Lightning",
+		"type": "Staff",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.\nLightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).\nThunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.\nThunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.\nLightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.\nThunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
+	},
+	{
+		"index": "staff-of-withering",
+		"url": "/api/2024/magic-items/staff-of-withering",
+		"name": "Staff of Withering",
+		"type": "Staff",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This staff has 3 charges and regains 1d3 expended charges daily at dawn.\nThe staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
+	},
+	{
+		"index": "stone-of-controlling-earth-elementals",
+		"url": "/api/2024/magic-items/stone-of-controlling-earth-elementals",
+		"name": "Stone of Controlling Earth Elementals",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
+	},
+	{
+		"index": "stone-of-good-luck-(luckstone)",
+		"url": "/api/2024/magic-items/stone-of-good-luck-(luckstone)",
+		"name": "Stone of Good Luck (Luckstone)",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
+	},
+	{
+		"index": "sun-blade",
+		"url": "/api/2024/magic-items/sun-blade",
+		"name": "Sun Blade",
+		"type": "Weapon (Longsword)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This item appears to be a sword hilt.\nBlade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.\nYou gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.\nSunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
+	},
+	{
+		"index": "sword-of-life-stealing",
+		"url": "/api/2024/magic-items/sword-of-life-stealing",
+		"name": "Sword of Life Stealing",
+		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
+	},
+	{
+		"index": "sword-of-sharpness",
+		"url": "/api/2024/magic-items/sword-of-sharpness",
+		"name": "Sword of Sharpness",
+		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+		"attunement": true,
+		"rarity": "Very Rare",
+		"description": "When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.\nWhen you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
+	},
+	{
+		"index": "sword-of-wounding",
+		"url": "/api/2024/magic-items/sword-of-wounding",
+		"name": "Sword of Wounding",
+		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
+	},
+	{
+		"index": "talisman-of-pure-good",
+		"url": "/api/2024/magic-items/talisman-of-pure-good",
+		"name": "Talisman of Pure Good",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"limited-to": "Cleric or Paladin",
+		"rarity": "Legendary",
+		"description": "This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nPure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
+	},
+	{
+		"index": "talisman-of-the-sphere",
+		"url": "/api/2024/magic-items/talisman-of-the-sphere",
+		"name": "Talisman of the Sphere",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
+	},
+	{
+		"index": "talisman-of-ultimate-evil",
+		"url": "/api/2024/magic-items/talisman-of-ultimate-evil",
+		"name": "Talisman of Ultimate Evil",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nUltimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
+	},
+	{
+		"index": "tome-of-clear-thought",
+		"url": "/api/2024/magic-items/tome-of-clear-thought",
+		"name": "Tome of Clear Thought",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
+	},
+	{
+		"index": "tome-of-leadership-and-influence",
+		"url": "/api/2024/magic-items/tome-of-leadership-and-influence",
+		"name": "Tome of Leadership and Influence",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+	},
+	{
+		"index": "tome-of-understanding",
+		"url": "/api/2024/magic-items/tome-of-understanding",
+		"name": "Tome of Understanding",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Very Rare",
+		"description": "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
+	},
+	{
+		"index": "trident-of-fish-command",
+		"url": "/api/2024/magic-items/trident-of-fish-command",
+		"name": "Trident of Fish Command",
+		"type": "Weapon (Trident)",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
+	},
+	{
+		"index": "universal-solvent",
+		"url": "/api/2024/magic-items/universal-solvent",
+		"name": "Universal Solvent",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.\nYou can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
+	},
+	{
+		"index": "vicious-weapon",
+		"url": "/api/2024/magic-items/vicious-weapon",
+		"name": "Vicious Weapon",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": false,
+		"rarity": "Rare",
+		"description": "This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
+	},
+	{
+		"index": "vorpal-sword",
+		"url": "/api/2024/magic-items/vorpal-sword",
+		"name": "Vorpal Sword",
+		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+		"attunement": true,
+		"rarity": "Legendary",
+		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.\nWhen you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
+	},
+	{
+		"index": "wand-of-binding",
+		"url": "/api/2024/magic-items/wand-of-binding",
+		"name": "Wand of Binding",
+		"type": "Wand",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-enemy-detection",
+		"url": "/api/2024/magic-items/wand-of-enemy-detection",
+		"name": "Wand of Enemy Detection",
+		"type": "Wand",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-fear",
+		"url": "/api/2024/magic-items/wand-of-fear",
+		"name": "Wand of Fear",
+		"type": "Wand",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
+	},
+	{
+		"index": "wand-of-fireballs",
+		"url": "/api/2024/magic-items/wand-of-fireballs",
+		"name": "Wand of Fireballs",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Rare",
+		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-lightning-bolts",
+		"url": "/api/2024/magic-items/wand-of-lightning-bolts",
+		"name": "Wand of Lightning Bolts",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Rare",
+		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-magic-detection",
+		"url": "/api/2024/magic-items/wand-of-magic-detection",
+		"name": "Wand of Magic Detection",
+		"type": "Wand",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
+	},
+	{
+		"index": "wand-of-magic-missiles",
+		"url": "/api/2024/magic-items/wand-of-magic-missiles",
+		"name": "Wand of Magic Missiles",
+		"type": "Wand",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-paralysis",
+		"url": "/api/2024/magic-items/wand-of-paralysis",
+		"name": "Wand of Paralysis",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Rare",
+		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-polymorph",
+		"url": "/api/2024/magic-items/wand-of-polymorph",
+		"name": "Wand of Polymorph",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Very Rare",
+		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-secrets",
+		"url": "/api/2024/magic-items/wand-of-secrets",
+		"name": "Wand of Secrets",
+		"type": "Wand",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
+	},
+	{
+		"index": "wand-of-the-war-mage",
+		"url": "/api/2024/magic-items/wand-of-the-war-mage",
+		"name": "Wand of the War Mage",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"description": "While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
+	},
+	{
+		"index": "wand-of-web",
+		"url": "/api/2024/magic-items/wand-of-web",
+		"name": "Wand of Web",
+		"type": "Wand",
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity": "Uncommon",
+		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+	},
+	{
+		"index": "wand-of-wonder",
+		"url": "/api/2024/magic-items/wand-of-wonder",
+		"name": "Wand of Wonder",
+		"type": "Wand",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
+	},
+	{
+		"index": "weapon",
+		"url": "/api/2024/magic-items/weapon",
+		"name": "Weapon",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": false,
+		"rarity": "Uncommon (+1), Rare (+2), or Very Rare (+3)",
+		"description": "You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
+	},
+	{
+		"index": "weapon-of-warning",
+		"url": "/api/2024/magic-items/weapon-of-warning",
+		"name": "Weapon of Warning",
+		"type": "Weapon (Any Simple or Martial)",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.\nAlarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.\nSupernatural Readiness. Each subject has Advantage on its Initiative rolls."
+	},
+	{
+		"index": "well-of-many-worlds",
+		"url": "/api/2024/magic-items/well-of-many-worlds",
+		"name": "Well of Many Worlds",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Legendary",
+		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.\nOnce the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
+	},
+	{
+		"index": "wind-fan",
+		"url": "/api/2024/magic-items/wind-fan",
+		"name": "Wind Fan",
+		"type": "Wondrous Item",
+		"attunement": false,
+		"rarity": "Uncommon",
+		"description": "While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
+	},
+	{
+		"index": "winged-boots",
+		"url": "/api/2024/magic-items/winged-boots",
+		"name": "Winged Boots",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Uncommon",
+		"description": "These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
+	},
+	{
+		"index": "wings-of-flying",
+		"url": "/api/2024/magic-items/wings-of-flying",
+		"name": "Wings of Flying",
+		"type": "Wondrous Item",
+		"attunement": true,
+		"rarity": "Rare",
+		"description": "While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
+	}
+]

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -9,11 +9,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Armor (Any Medium or Heavy, Except Hide Armor)",
 			"This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
@@ -29,14 +30,96 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [  
+			{  
+				"index": "ammunition-1",  
+				"name": "Ammunition, +1",  
+				"url": "/api/2014/magic-items/ammunition-1"  
+			},  
+			{  
+				"index": "ammunition-2",  
+				"name": "Ammunition, +2",  
+				"url": "/api/2014/magic-items/ammunition-2"  
+			},  
+			{  
+				"index": "ammunition-3",  
+				"name": "Ammunition, +3",  
+				"url": "/api/2014/magic-items/ammunition-3"  
+			}  
+		],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-
 		"desc": [
 			"Weapon (Any Ammunition)",
 			"You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
+			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+		]
+	},{
+		"index": "ammunition-1",
+		"url": "/api/2024/magic-items/ammunition-1",
+		"image" : "/api/images/magic-items/ammunition.png",
+		"name": "Ammunition +1",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Uncommon (+1)"
+		},
+		"desc": [
+			"Weapon (Uncommon)",
+			"You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
+			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+		]
+	},
+	{
+		"index": "ammunition-2",
+		"url": "/api/2024/magic-items/ammunition-2",
+		"image" : "/api/images/magic-items/ammunition.png",
+		"name": "Ammunition +2",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare (+2)"
+		},
+		"desc": [
+			"Weapon (Rare)",
+			"You have a +2 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
+			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+		]
+	},
+	{
+		"index": "ammunition-3",
+		"url": "/api/2024/magic-items/ammunition-3",
+		"image" : "/api/images/magic-items/ammunition.png",
+		"name": "Ammunition +3",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Very Rare (+3)"
+		},
+		"desc": [
+			"Weapon (Very Rare)",
+			"You have a +3 bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
 			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
 		]
 	},
@@ -50,11 +133,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Ammunition)",
 			"This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.",
@@ -71,11 +155,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
@@ -91,11 +176,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
@@ -111,11 +197,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
@@ -131,11 +218,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Armor (Shield)",
 			"While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
@@ -151,11 +239,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.",
@@ -175,14 +264,94 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [
+			{
+				"index": "armor-1",
+				"url": "/api/2024/magic-items/armor-1",
+				"name": "Armor +1"
+			},
+			{
+				"index": "armor-2",
+				"url": "/api/2024/magic-items/armor-2",
+				"name": "Armor +2"
+			},
+			{
+				"index": "armor-3",
+				"url": "/api/2024/magic-items/armor-3",
+				"name": "Armor +3"
+			}
+		],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare (+1), Very Rare (+2), or Legendary (+3)"
 		},
-
 		"desc": [
 			"Armor (Any Light, Medium, or Heavy)",
 			"You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
+		]
+	},
+	{
+		"index": "armor-1",
+		"url": "/api/2024/magic-items/armor-1",
+		"image" : "/api/images/magic-items/armor.png",
+		"name": "Armor +1",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"You have a +1 bonus to Armor Class while wearing this armor."
+		]
+	},
+	{
+		"index": "armor-2",
+		"url": "/api/2024/magic-items/armor-2",
+		"image" : "/api +2/images/magic-items/armor.png",
+		"name": "Armor +2",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Very Rare"
+		},
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"You have a +2 bonus to Armor Class while wearing this armor."
+		]
+	},
+	{
+		"index": "armor-3",
+		"url": "/api/2024/magic-items/armor-3",
+		"image" : "/api/images/magic-items/armor.png",
+		"name": "Armor +3",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Legendary"
+		},
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"You have a +3 bonus to Armor Class while wearing this armor."
 		]
 	},
 	{
@@ -195,11 +364,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Armor (Plate Armor)",
 			"You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.",
@@ -216,11 +386,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Any Light, Medium, or Heavy)",
 			"You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
@@ -236,11 +407,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Any Light, Medium, or Heavy)",
 			"While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.",
@@ -257,11 +429,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Shield)",
 			"You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.",
@@ -278,11 +451,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.",
@@ -300,11 +474,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.",
@@ -323,11 +498,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.",
@@ -345,11 +521,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.",
@@ -431,11 +608,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.",
@@ -453,11 +631,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
@@ -473,11 +652,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
@@ -493,11 +673,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Battleaxe, Greataxe, or Halberd)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.",
@@ -516,11 +697,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
@@ -536,11 +718,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear these boots, you can cast Levitate on yourself."
@@ -556,11 +739,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.",
@@ -577,11 +761,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.",
@@ -598,11 +783,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.",
@@ -620,11 +806,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.",
@@ -641,11 +828,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
@@ -661,11 +849,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
@@ -681,11 +870,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
@@ -701,11 +891,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
@@ -721,11 +912,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.",
@@ -742,11 +934,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.",
@@ -764,11 +957,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.",
@@ -785,11 +979,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.",
@@ -806,11 +1001,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
@@ -826,11 +1022,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.",
@@ -847,11 +1044,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
@@ -867,11 +1065,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.",
@@ -891,11 +1090,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
@@ -911,11 +1111,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
@@ -931,11 +1132,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
@@ -951,11 +1153,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.",
@@ -972,11 +1175,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
@@ -992,11 +1196,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While touching this crystal orb, you can cast Scrying(save DC 17) with it."
@@ -1012,11 +1217,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
@@ -1032,11 +1238,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
@@ -1052,11 +1259,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
@@ -1072,11 +1280,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.",
@@ -1093,11 +1302,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.",
@@ -1116,11 +1326,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Dagger)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -1137,11 +1348,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 			"You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.",
@@ -1158,11 +1370,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.",
@@ -1179,11 +1392,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.",
@@ -1201,11 +1415,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Weapon (Any Melee Weapon)",
 			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -1222,11 +1437,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Armor (Any Light, Medium, or Heavy)",
 			"While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.",
@@ -1243,11 +1459,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.",
@@ -1264,11 +1481,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Artifact"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.",
@@ -1289,11 +1507,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Armor (Scale Mail)",
 			"Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.",
@@ -1311,11 +1530,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -1332,11 +1552,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
@@ -1352,11 +1573,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.",
@@ -1373,11 +1595,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.",
@@ -1395,11 +1618,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Armor (Half Plate Armor or Plate Armor)",
 			"While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
@@ -1415,12 +1639,13 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Dwarf or a Creature Attuned to a Belt of Dwarvenkind",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Warhammer)",
 			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
@@ -1436,11 +1661,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.",
@@ -1457,11 +1683,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
@@ -1477,11 +1704,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
@@ -1497,11 +1725,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Chain Mail or Chain Shirt)",
 			"You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
@@ -1517,11 +1746,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.",
@@ -1539,11 +1769,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
@@ -1559,11 +1790,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
@@ -1579,11 +1811,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
@@ -1599,11 +1832,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.",
@@ -1626,11 +1860,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.",
@@ -1658,11 +1893,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Melee Weapon)",
 			"While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
@@ -1678,11 +1914,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.",
@@ -1699,11 +1936,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 			"When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.",
@@ -1721,11 +1959,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
@@ -1741,11 +1980,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
@@ -1761,11 +2001,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.",
@@ -1782,11 +2023,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -1803,11 +2045,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Studded Leather Armor)",
 			"While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
@@ -1823,11 +2066,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
@@ -1843,11 +2087,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
@@ -1863,11 +2108,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
@@ -1883,11 +2129,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Weapon (Maul or Warhammer)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -1905,11 +2152,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.",
@@ -1929,11 +2177,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
@@ -1949,11 +2198,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
@@ -1969,11 +2219,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.",
@@ -1994,11 +2245,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this helm, you can cast Comprehend Languages from it."
@@ -2014,11 +2266,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
@@ -2034,11 +2287,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
@@ -2054,12 +2308,13 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Paladin",
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
@@ -2075,11 +2330,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.",
@@ -2096,13 +2352,131 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [
+			{
+				"index": "horn-of-valhalla-1",
+				"url": "/api/2024/magic-items/horn-of-valhalla-1",
+				"name": "Silver Horn of Valhalla"
+			},
+			{
+				"index": "horn-of-valhalla-2",
+				"url": "/api/2024/magic-items/horn-of-valhalla-2",
+				"name": "Brass Horn of Valhalla"
+			},
+			{
+				"index": "horn-of-valhalla-3",
+				"url": "/api/2024/magic-items/horn-of-valhalla-3",
+				"name": "Bronze Horn of Valhalla"
+			},
+			{
+				"index": "horn-of-valhalla-4",
+				"url": "/api/2024/magic-items/horn-of-valhalla-4",
+				"name": "Iron Horn of Valhalla"
+			}
+		],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)"
 		},
-
 		"desc": [
 			"Wondrous Item",
+			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
+			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
+			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+		]
+	},
+	{
+		"index": "horn-of-valhalla-1",
+		"url": "/api/2024/magic-items/horn-of-valhalla-1",
+		"image" : "/api/images/magic-items/horn-of-valhalla.png",
+		"name": "Silver Horn of Valhalla",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Wondrous Item",
+			"Rare (Silver)",
+			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
+			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
+			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+		]
+	},
+	{
+		"index": "horn-of-valhalla-2",
+		"url": "/api/2024/magic-items/horn-of-valhalla-2",
+		"image" : "/api/images/magic-items/horn-of-valhalla.png",
+		"name": "Brass Horn of Valhalla",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Wondrous Item",
+			"Rare (Brass)",
+			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
+			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
+			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+		]
+	},
+	{
+		"index": "horn-of-valhalla-3",
+		"url": "/api/2024/magic-items/horn-of-valhalla-3",
+		"image" : "/api/images/magic-items/horn-of-valhalla.png",
+		"name": "Bronze Horn of Valhalla",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Very Rare"
+		},
+		"desc": [
+			"Wondrous Item",
+			"Very Rare (Bronze)",
+			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
+			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
+			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+		]
+	},
+	{
+		"index": "horn-of-valhalla-4",
+		"url": "/api/2024/magic-items/horn-of-valhalla-4",
+		"image" : "/api/images/magic-items/horn-of-valhalla.png",
+		"name": "Iron Horn of Valhalla",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Legendary"
+		},
+		"desc": [
+			"Wondrous Item",
+			"Legendary (Iron)",
 			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
 			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
 			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
@@ -2118,11 +2492,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
@@ -2139,11 +2514,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
@@ -2160,11 +2536,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Rod",
 			"This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
@@ -2180,11 +2557,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.",
@@ -2202,11 +2580,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.",
@@ -2242,11 +2621,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.",
@@ -2265,11 +2645,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.",
@@ -2287,11 +2668,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Weapon (Javelin)",
 			"Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.",
@@ -2308,11 +2690,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
@@ -2328,11 +2711,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.",
@@ -2350,11 +2734,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Mace)",
 			"When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.",
@@ -2371,11 +2756,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Mace)",
 			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.",
@@ -2392,11 +2778,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Mace)",
 			"This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
@@ -2412,11 +2799,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"You have Advantage on saving throws against spells while you wear this cloak."
@@ -2432,11 +2820,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
@@ -2452,11 +2841,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
@@ -2472,11 +2862,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.",
@@ -2494,11 +2885,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
@@ -2514,11 +2906,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).",
@@ -2538,11 +2931,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
@@ -2558,11 +2952,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.",
@@ -2585,11 +2980,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Armor (Any Medium or Heavy, Except Hide Armor)",
 			"Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
@@ -2605,11 +3001,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.",
@@ -2648,11 +3045,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
@@ -2668,11 +3066,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).",
@@ -2689,12 +3088,13 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Cleric, Druid, or Paladin",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.",
@@ -2711,11 +3111,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.",
@@ -2732,11 +3133,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Longbow or Shortbow)",
 			"When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.",
@@ -2754,11 +3156,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.",
@@ -2775,11 +3178,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.",
@@ -2796,11 +3200,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.",
@@ -2817,12 +3222,13 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
@@ -2838,11 +3244,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.",
@@ -2859,11 +3266,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
@@ -2879,11 +3287,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this pendant, you gain the followingbenefits.",
@@ -2901,11 +3310,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.",
@@ -2922,11 +3332,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
@@ -2942,11 +3353,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.",
@@ -2964,11 +3376,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Armor (Half Plate Armor or Plate Armor)",
 			"While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
@@ -2984,11 +3397,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
@@ -3008,11 +3422,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
@@ -3028,11 +3443,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).",
@@ -3049,11 +3465,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Common"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.",
@@ -3070,11 +3487,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).",
@@ -3091,11 +3509,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
@@ -3111,11 +3530,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).",
@@ -3132,11 +3552,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Potion",
 			"You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.",
@@ -3153,11 +3574,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"Potion of Healing    (supreme)"
@@ -3173,11 +3595,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.",
@@ -3194,11 +3617,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.",
@@ -3216,11 +3640,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
@@ -3236,11 +3661,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
@@ -3256,11 +3682,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.",
@@ -3277,11 +3704,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
@@ -3297,11 +3725,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Potion",
 			"When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
@@ -3317,11 +3746,12 @@
 			"name": "Potions",
 			"url": "/api/2024/equipment-categories/potions"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Potion",
 			"You can breathe underwater for 24 hours after drinking this potion.",
@@ -3338,11 +3768,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
@@ -3358,11 +3789,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.",
@@ -3381,11 +3813,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Ring",
 			"Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.",
@@ -3404,11 +3837,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
@@ -3424,11 +3858,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
@@ -3444,11 +3879,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
@@ -3464,11 +3900,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
@@ -3484,11 +3921,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
@@ -3504,11 +3942,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.",
@@ -3526,11 +3965,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
@@ -3546,11 +3986,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
@@ -3566,11 +4007,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
@@ -3586,11 +4028,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"You can cast Dancing Lights or Light from the ring.",
@@ -3612,11 +4055,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.",
@@ -3634,11 +4078,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
@@ -3654,11 +4099,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Ring",
 			"You have a Swim Speed of 40 feet while wearing this ring."
@@ -3674,11 +4120,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can cast Telekinesisfrom it."
@@ -3694,11 +4141,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.",
@@ -3715,11 +4163,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
@@ -3735,11 +4184,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Ring",
 			"If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.",
@@ -3756,11 +4206,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you cast Water Walk from it, targeting only yourself."
@@ -3776,11 +4227,12 @@
 			"name": "Rings",
 			"url": "/api/2024/equipment-categories/rings"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Ring",
 			"While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.",
@@ -3797,11 +4249,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.",
@@ -3818,11 +4271,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
@@ -3838,11 +4292,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.",
@@ -3860,12 +4315,13 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This elegant garment is made from exquisite cloth and adorned with runes.",
@@ -3885,11 +4341,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
@@ -3905,11 +4362,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Rod",
 			"While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.",
@@ -3928,11 +4386,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Rod",
 			"This rod has the following properties.",
@@ -3952,11 +4411,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Rod",
 			"This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.",
@@ -3976,11 +4436,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Rod",
 			"You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
@@ -3996,11 +4457,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Rod",
 			"While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.",
@@ -4018,11 +4480,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.",
@@ -4039,11 +4502,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).",
@@ -4061,11 +4525,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.",
@@ -4083,11 +4548,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Scimitar)",
 			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
@@ -4103,14 +4569,94 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [
+			{
+				"index": "shield-1",
+				"url": "/api/2024/magic-items/shield-1",
+				"name": "Shield +1"
+			},
+			{
+				"index": "shield-2",
+				"url": "/api/2024/magic-items/shield-2",
+				"name": "Shield +2"
+			},
+			{
+				"index": "shield-3",
+				"url": "/api/2024/magic-items/shield-3",
+				"name": "Shield +3"
+			}
+		],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-
 		"desc": [
 			"Armor (Shield)",
 			"While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
+		]
+	},
+	{
+		"index": "shield-1",
+		"url": "/api/2024/magic-items/shield-1",
+		"image" : "/api/images/magic-items/shield.png",
+		"name": "Shield +1",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Uncommon"
+		},
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have a +1 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
+		]
+	},
+	{
+		"index": "shield-2",
+		"url": "/api/2024/magic-items/shield-2",
+		"image" : "/api/images/magic-items/shield.png",
+		"name": "Shield +2",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have a +2 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
+		]
+	},
+	{
+		"index": "shield-3",
+		"url": "/api/2024/magic-items/shield-3",
+		"image" : "/api/images/magic-items/shield.png",
+		"name": "Shield +3",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Very Rare"
+		},
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have a +3 bonus to Armor Class, in addition to the Shield's normal bonus to AC."
 		]
 	},
 	{
@@ -4123,11 +4669,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Armor (Shield)",
 			"While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.",
@@ -4144,11 +4691,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
@@ -4164,11 +4712,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.",
@@ -4185,11 +4734,12 @@
 			"name": "Armor",
 			"url": "/api/2024/equipment-categories/armor"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Armor (Shield)",
 			"While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
@@ -4205,11 +4755,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-
 		"desc": [
 			"Scroll",
 			"A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.",
@@ -4228,11 +4779,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.",
@@ -4252,12 +4804,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.",
@@ -4274,12 +4827,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"You have Resistance to Fire damage while you hold this staff.",
@@ -4297,12 +4851,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"You have Resistance to Cold damage while you hold this staff.",
@@ -4320,12 +4875,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Bard, Cleric, or Druid",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2",
@@ -4342,12 +4898,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.",
@@ -4365,11 +4922,12 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.",
@@ -4387,12 +4945,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 10 charges.",
@@ -4411,12 +4970,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.",
@@ -4436,11 +4996,12 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Staff",
 			"As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.",
@@ -4458,12 +5019,13 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Druid",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.",
@@ -4482,11 +5044,12 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.",
@@ -4507,11 +5070,12 @@
 			"name": "Staffs",
 			"url": "/api/2024/equipment-categories/staffs"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Staff",
 			"This staff has 3 charges and regains 1d3 expended charges daily at dawn.",
@@ -4528,11 +5092,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
@@ -4548,11 +5113,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
@@ -4568,11 +5134,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Longsword)",
 			"This item appears to be a sword hilt.",
@@ -4591,11 +5158,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 			"When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
@@ -4611,11 +5179,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 			"When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.",
@@ -4632,11 +5201,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
 			"When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
@@ -4652,12 +5222,13 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Cleric or Paladin",
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
@@ -4675,11 +5246,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
@@ -4695,11 +5267,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
@@ -4717,11 +5290,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
@@ -4737,11 +5311,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
@@ -4757,11 +5332,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
@@ -4777,11 +5353,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Weapon (Trident)",
 			"This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
@@ -4797,11 +5374,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.",
@@ -4818,11 +5396,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
@@ -4838,11 +5417,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
 			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.",
@@ -4859,11 +5439,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges.",
@@ -4881,11 +5462,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.",
@@ -4902,11 +5484,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges.",
@@ -4923,12 +5506,13 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
@@ -4945,12 +5529,13 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
@@ -4967,11 +5552,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
@@ -4987,11 +5573,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
@@ -5008,12 +5595,13 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.",
@@ -5030,12 +5618,13 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.",
@@ -5052,11 +5641,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
@@ -5072,15 +5662,101 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [
+			{
+				"index": "wand-of-the-war-mage-1",
+				"url": "/api/2024/magic-items/wand-of-the-war-mage-1",
+				"name": "Wand of the War Mage +1"
+			},
+			{
+				"index": "wand-of-the-war-mage-2",
+				"url": "/api/2024/magic-items/wand-of-the-war-mage-2",
+				"name": "Wand of the War Mage +2"
+			},
+			{
+				"index": "wand-of-the-war-mage-3",
+				"url": "/api/2024/magic-items/wand-of-the-war-mage-3",
+				"name": "Wand of the War Mage +3"
+			}
+		],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-
 		"desc": [
 			"Wand",
 			"While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
+		]
+	},
+	{
+		"index": "wand-of-the-war-mage-1",
+		"url": "/api/2024/magic-items/wand-of-the-war-mage-1",
+		"image" : "/api/images/magic-items/wand-of-the-war-mage.png",
+		"name": "Wand of the War Mage +1",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity" : {
+			"name": "Uncommon"
+		},
+		"desc": [
+			"Wand",
+			"Uncommon (+1)",
+			"While holding this wand, you gain a +1 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
+		]
+	},
+	{
+		"index": "wand-of-the-war-mage-2",
+		"url": "/api/2024/magic-items/wand-of-the-war-mage-2",
+		"image" : "/api/images/magic-items/wand-of-the-war-mage.png",
+		"name": "Wand of the War Mage +2",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Wand",
+			"Rare (+2)",
+			"While holding this wand, you gain a +2 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
+		]
+	},
+	{
+		"index": "wand-of-the-war-mage-3",
+		"url": "/api/2024/magic-items/wand-of-the-war-mage-3",
+		"image" : "/api/images/magic-items/wand-of-the-war-mage.png",
+		"name": "Wand of the War Mage +3",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": true,
+		"limited-to": "Spellcaster",
+		"rarity" : {
+			"name": "Very Rare"
+		},
+		"desc": [
+			"Wand",
+			"Very Rare (+3)",
+			"While holding this wand, you gain a +3 bonus to spell attack rolls. In addition, you ignore Half Cover when making a spell attack roll."
 		]
 	},
 	{
@@ -5093,12 +5769,13 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.",
@@ -5115,11 +5792,12 @@
 			"name": "Wands",
 			"url": "/api/2024/equipment-categories/wands"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wand",
 			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.",
@@ -5136,14 +5814,97 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [
+			{
+				"index": "weapon-1",
+				"url": "/api/2024/magic-items/weapon-1",
+				"name": "Weapon +1"
+			},
+			{
+				"index": "weapon-2",
+				"url": "/api/2024/magic-items/weapon-2",
+				"name": "Weapon +2"
+			},
+			{
+				"index": "weapon-3",
+				"url": "/api/2024/magic-items/weapon-3",
+				"name": "Weapon +3"
+			}
+		],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
+		]
+	},
+	{
+		"index": "weapon-1",
+		"url": "/api/2024/magic-items/weapon-1",
+		"image" : "/api/images/magic-items/weapon.png",
+		"name": "Weapon +1",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Uncommon"
+		},
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"Uncommon (+1)",
+			"You have a +1 bonus to attack rolls and damage rolls made with this magic weapon."
+		]
+	},
+	{
+		"index": "weapon-2",
+		"url": "/api/2024/magic-items/weapon-2",
+		"image" : "/api/images/magic-items/weapon.png",
+		"name": "Weapon +2",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Rare"
+		},
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"Rare (+2)",
+			"You have a +2 bonus to attack rolls and damage rolls made with this magic weapon."
+		]
+	},
+	{
+		"index": "weapon-3",
+		"url": "/api/2024/magic-items/weapon-3",
+		"image" : "/api/images/magic-items/weapon.png",
+		"name": "Weapon +3",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
+		"variants": [],
+		"variant": true,
+		"attunement": false,
+		"rarity" : {
+			"name": "Very Rare"
+		},
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"Very Rare (+3)",
+			"You have a +3 bonus to attack rolls and damage rolls made with this magic weapon."
 		]
 	},
 	{
@@ -5156,11 +5917,12 @@
 			"name": "Weapons",
 			"url": "/api/2024/equipment-categories/weapons"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Weapon (Any Simple or Martial)",
 			"As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.",
@@ -5178,11 +5940,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
@@ -5200,11 +5963,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
@@ -5220,11 +5984,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
@@ -5240,11 +6005,12 @@
 			"name": "Wondrous Items",
 			"url": "/api/2024/equipment-categories/wondrous-items"
 		},
+		"variants": [],
+		"variant": false,
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-
 		"desc": [
 			"Wondrous Item",
 			"While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -4,2935 +4,5250 @@
 		"url": "/api/2024/magic-items/adamantine-armor",
 		"image" : "/api/images/magic-items/adamantine-armor.png",
 		"name": "Adamantine Armor",
-		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
+
+		"desc": [
+			"Armor (Any Medium or Heavy, Except Hide Armor)",
+			"This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any Critical Hit against you becomes a normal hit."
+		]
 	},
 	{
 		"index": "ammunition",
 		"url": "/api/2024/magic-items/ammunition",
 		"image" : "/api/images/magic-items/ammunition.png",
 		"name": "Ammunition",
-		"type": "Weapon (Any Ammunition)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"description": "You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.\nThis ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+
+		"desc": [
+			"Weapon (Any Ammunition)",
+			"You have a bonus to attack rolls and damage rolls made with this piece of magic ammunition. The bonus is determined by the rarity of the ammunition. Once it hits a target, the ammunition is no longer magical.",
+			"This ammunition is typically found or sold in quantities of ten or twenty pieces. Ten pieces of this ammunition are equivalent in value to a potion of the same rarity."
+		]
 	},
 	{
 		"index": "ammunition-of-slaying",
 		"url": "/api/2024/magic-items/ammunition-of-slaying",
 		"image" : "/api/images/magic-items/ammunition-of-slaying.png",
 		"name": "Ammunition of Slaying",
-		"type": "Weapon (Any Ammunition)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.\nAfter dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
+
+		"desc": [
+			"Weapon (Any Ammunition)",
+			"This magic ammunition is meant to slay creatures of a particular type, which the GM chooses or determines randomly by rolling on the table below. If a creature of that type takes damage from the ammunition, the creature makes a DC 17 Constitution saving throw, taking an extra 6d10 Force damage on a failed save or half as much extra damage on a successful one.",
+			"After dealing its extra damage to a creature, the ammunition becomes nonmagical.1d100 Creature Type  1d100 Creature Type 01-10 Aberrations    51-60 Fey   11-15 Beasts    61-70 Fiends 16-20 Celestials    71-75 Giants   21-25 Constructs    76-80 Monstrosities 26-35 Dragons    81-85 Oozes   36-45 Elementals    86-90 Plants 46-50  Humanoids    91-00 Undead"
+		]
 	},
 	{
 		"index": "amulet-of-health",
 		"url": "/api/2024/magic-items/amulet-of-health",
 		"image" : "/api/images/magic-items/amulet-of-health.png",
 		"name": "Amulet of Health",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
+
+		"desc": [
+			"Wondrous Item",
+			"Your Constitution is 19 while you wear this amulet. It has no effect on you if your Constitution is 19 or higher without it."
+		]
 	},
 	{
 		"index": "amulet-of-proof-against-detection-and-location",
 		"url": "/api/2024/magic-items/amulet-of-proof-against-detection-and-location",
 		"image" : "/api/images/magic-items/amulet-of-proof-against-detection-and-location.png",
 		"name": "Amulet of Proof against Detection and Location",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this amulet, you can't be targeted by Divination spells or perceived through magical scrying sensors unless you allow it."
+		]
 	},
 	{
 		"index": "amulet-of-the-planes",
 		"url": "/api/2024/magic-items/amulet-of-the-planes",
 		"image" : "/api/images/magic-items/amulet-of-the-planes.png",
 		"name": "Amulet of the Planes",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this amulet, you can take a Magic action to name a location that you are familiar with on another plane of existence. Then make a DC 15 Intelligence (Arcana) check. On a successful check, you cast Plane Shift. On a failed check, you and each creature and object within 15 feet of you travel toa random destination determined by rolling 1d100 and consulting the following table.1d100 Destination 01-60 Random location on the plane you named 61-70 Random location on an Inner Plane determined by rolling 1d6: on a 1, the Plane of Air; on a 2, the Plane of Earth; on a 3, the Plane of Fire; on a 4, the Plane of Water; on a 5, the Feywild; on a 6, the Shadowfell 81-90 Random location on an Outer Plane determined by rolling 1d8: on a 1, the Abyss; on a 2, Acheron; on a 3, Carceri; on a 4, Gehenna;on a 5, Hades; on a 6, Limbo; on a 7, the Nine Hells; on an 8, Pandemonium 91-00  Random location on the Astral Plane"
+		]
 	},
 	{
 		"index": "animated-shield",
 		"url": "/api/2024/magic-items/animated-shield",
 		"image" : "/api/images/magic-items/animated-shield.png",
 		"name": "Animated Shield",
-		"type": "Armor (Shield)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
+
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you can take a Bonus Action to cause it to animate. The Shield leaps into the air and hovers in your space to protect you as if you were wielding it, leaving your hands free. The Shield remains animate for 1 minute, until you take a Bonus Action to end this effect, or until you die or have the Incapacitated condition, at which point the Shield falls to the ground or into your hand if you have one free."
+		]
 	},
 	{
 		"index": "apparatus-of-the-crab",
 		"url": "/api/2024/magic-items/apparatus-of-the-crab",
 		"image" : "/api/images/magic-items/apparatus-of-the-crab.png",
 		"name": "Apparatus of the Crab",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.\nThe Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.\nTo be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.\nThe apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.\nA creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
+
+		"desc": [
+			"Wondrous Item",
+			"This item first appears to be a sealed iron barrel weighing 500 pounds. The barrel has a hidden catch, which can be found with a successful DC 20 Intelligence (Investigation) check. Releasing the catch unlocks a hatch at one end of the barrel, allowing two Medium or smaller creatures to crawl inside. Ten levers are set in a row at the far end, each in a neutral position, able to move up or down. When certain levers are used, the apparatus transforms to resemble a giant lobster.",
+			"The Apparatus of the Crab is a Large object with the following statistics: AC 20; HP 200; Speed 30 ft., Swim 30 ft. (or 0 ft. for both if the legs aren't extended); Immunity to Poison and Psychic damage.",
+			"To be used as a vehicle, the apparatus requires one pilot. While the apparatus's hatch is closed, the compartment is airtight and watertight. The compartment holds enough air for 10 hours of breathing, divided by the number of breathing creatures inside.",
+			"The apparatus floats on water. It can also go underwater to a depth of 900 feet. Below that, the vehicle takes 2d6 Bludgeoning damage each minute from pressure.",
+			"A creature in the compartment can take a Utilize action to move as many as two of the apparatus's levers up or down. After each use, a lever goes back to its neutral position. Each lever, from left to right, functions as shown in the Apparatus of the Crab Levers table.Apparatus of the Crab LeversLever Up  Down2  Forward window shutter opens.  Forward window shutter closes.4  Two claws extend from the front side of the apparatus.The claws retract.6  The apparatus walks or swims forward provided its legs are extended.The apparatus walks or swims backward provided its legs are extended.8  Eyelike fixtures emit Bright Light in a 30-foot radiusand Dim Light for an additional 30 feet.The light turns off.10  The rear hatch unseals and opens.  The rear hatch closes and seals."
+		]
 	},
 	{
 		"index": "armor",
 		"url": "/api/2024/magic-items/armor",
 		"image" : "/api/images/magic-items/armor.png",
 		"name": "Armor",
-		"type": "Armor (Any Light, Medium, or Heavy)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare (+1), Very Rare (+2), or Legendary (+3)"
 		},
-		"description": "You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
+
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"You have a bonus to Armor Class while wearing this armor. The bonus is determined by its rarity."
+		]
 	},
 	{
 		"index": "armor-of-invulnerability",
 		"url": "/api/2024/magic-items/armor-of-invulnerability",
 		"image" : "/api/images/magic-items/armor-of-invulnerability.png",
 		"name": "Armor of Invulnerability",
-		"type": "Armor (Plate Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.\nMetal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
+
+		"desc": [
+			"Armor (Plate Armor)",
+			"You have Resistance to Bludgeoning, Piercing, and Slashing damage while you wear this armor.",
+			"Metal Shell. You can take a Magic action to give yourself Immunity to Bludgeoning, Piercing, and Slashing damage for 10 minutes or until you are no longer wearing the armor. Once this property is used, it can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "armor-of-resistance",
 		"url": "/api/2024/magic-items/armor-of-resistance",
 		"image" : "/api/images/magic-items/armor-of-resistance.png",
 		"name": "Armor of Resistance",
-		"type": "Armor (Any Light, Medium, or Heavy)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
+
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"You have Resistance to one type of damage while you wear this armor. The GM chooses the type or determines it randomly by rolling on the following table.1d10Damage Type1d10Damage Type1Acid6Necrotic2Cold7Poison3Fire8Psychic4Force9Radiant5Lightning10Thunder"
+		]
 	},
 	{
 		"index": "armor-of-vulnerability",
 		"url": "/api/2024/magic-items/armor-of-vulnerability",
 		"image" : "/api/images/magic-items/armor-of-vulnerability.png",
 		"name": "Armor of Vulnerability",
-		"type": "Armor (Any Light, Medium, or Heavy)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.\nCurse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
+
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"While wearing this armor, you have Resistance to one of the following damage types: Bludgeoning, Piercing, or Slashing. The GM chooses the type or determines it randomly.",
+			"Curse. This armor is cursed, a fact that is revealed only when the Identify spell is cast on the armor or you attune to it. Attuning to the armor curses you until you are targeted by a Remove Curse spell or similar magic; removing the armor fails to end the curse. While cursed, you have Vulnerability to two of the three damage types associated with the armor (not the one to which it grants Resistance)."
+		]
 	},
 	{
 		"index": "arrow-catching-shield",
 		"url": "/api/2024/magic-items/arrow-catching-shield",
 		"image" : "/api/images/magic-items/arrow-catching-shield.png",
 		"name": "Arrow-Catching Shield",
-		"type": "Armor (Shield)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.\nWhenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
+
+		"desc": [
+			"Armor (Shield)",
+			"You gain a +2 bonus to Armor Class against ranged attack rolls while you wield this Shield. This bonus is in addition to the Shield's normal bonus to AC.",
+			"Whenever an attacker makes a ranged attack roll against a target within 5 feet of you, you can take a Reaction to become the target of the attack instead."
+		]
 	},
 	{
 		"index": "bag-of-beans",
 		"url": "/api/2024/magic-items/bag-of-beans",
 		"image" : "/api/images/magic-items/bag-of-beans.png",
 		"name": "Bag of Beans",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.\nIf you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.\nIf you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
+
+		"desc": [
+			"Wondrous Item",
+			"This heavy cloth bag contains 3d4 dry beans when found. The bag weighs half a pound regardless of how many beans it contains and becomes a non-magical item when it no longer contains any beans.",
+			"If you dump one or more beans out of the bag, they explode in a 10-foot-radius Sphere centered on them. All the dumped beans are destroyed in the explosion, and each creature in the Sphere, including you, makes a DC 15 Dexterity saving throw, taking 5d4 Force damage on a failed save or half as much damage on a successful one.",
+			"If you remove a bean from the bag, plant it in dirt or sand, and then water it, the bean disappears as it produces an effect 1 minute later from the ground where it was planted. The GM can choose an effect from the following table or determine it randomly. 1d100 Effect 1d100 Effect 21-30 An animate but immobile stone statue in your likeness rises and makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows whereyou are. The statue becomes inanimate after 24 hours.41-50  Three Shrieker Fungi sprout.61-70  A hungry Bulette burrows up and attacks.81-90  A nest of 1d4 + 3 rainbow-colored eggs springs up. Any creature that eats an egg makes a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores.On a failed save, the creature takes 10d6 Force damage from an internal explosion.96-00  A giant beanstalk sprouts, growing to a height of the GM's choice. The top leads where the GM chooses, such as to a great view, a cloud giant's castle, or another plane of existence.02-10  A geyser erupts and spouts water, beer, mayonnaise, tea, vinegar, wine, or oil (GM's choice) 30 feet into the air for 1d4 minutes."
+		]
 	},
 	{
 		"index": "bag-of-devouring",
 		"url": "/api/2024/magic-items/bag-of-devouring",
 		"image" : "/api/images/magic-items/bag-of-devouring.png",
 		"name": "Bag of Devouring",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.\nThe extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.\nInanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.\nIf the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
+
+		"desc": [
+			"Wondrous Item",
+			"This bag resembles a Bag of Holding but is a feedingorifice for a gigantic extradimensional creature. Turning the bag inside out closes the orifice.",
+			"The extradimensional creature attached to the bag can sense whatever is placed inside the bag. Animal or vegetable matter placed wholly in the bag is devoured and lost forever. When part of a living creature is placed in the bag, as happens when someone reaches inside it, there is a 50 percent chance that the creature is pulled inside the bag. A creature inside the bag can take an action to try to escape, doing so with a successful DC 15 Strength (Athletics) check. Another creature can take an action to reach into the bag to pull a creature out, doing so with a successful DC 20 Strength (Athletics) check, provided the puller isn't pulled inside the bag first. Any creature that starts its turn inside the bag is devoured, its body destroyed.",
+			"Inanimate objects can be stored in the bag, which can hold a cubic foot of such material. However, once each day, the bag swallows any objects inside it and spits them out into another plane of existence. The GM determines the time and plane.",
+			"If the bag is pierced or torn, it is destroyed, and anything contained within it is transported to a random location on the Astral Plane."
+		]
 	},
 	{
 		"index": "bag-of-holding",
 		"url": "/api/2024/magic-items/bag-of-holding",
 		"image" : "/api/images/magic-items/bag-of-holding.png",
 		"name": "Bag of Holding",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.\nIf the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
+
+		"desc": [
+			"Wondrous Item",
+			"This bag has an interior space considerably larger than its outside dimensions-roughly 2 feet square and 4 feet deep on the inside. The bag can hold up to 500 pounds, not exceeding a volume of 64 cubic feet. The bag weighs 5 pounds, regardless of its contents. Retrieving an item from the bag requires a Utilize action.",
+			"If the bag is overloaded, pierced, or torn, it is destroyed, and its contents are scattered in the Astral Plane. If the bag is turned inside out, its contents spill forth unharmed, but the bag must be put right before it can be used again. The bag holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.",
+			"Placing a Bag of Holding inside an extradimensional space created by a Handy Haversack, Portable Hole, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within a 10-foot-radius Sphere centered on the gate is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way and can't be reopened."
+		]
 	},
 	{
 		"index": "bag-of-tricks",
 		"url": "/api/2024/magic-items/bag-of-tricks",
 		"image" : "/api/images/magic-items/bag-of-tricks.png",
 		"name": "Bag of Tricks",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.\nYou can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.\nThe creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.\nOnce three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.\nGray Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nWeasel\n5\nPanther\n2\nGiant Rat\n6\nGiant Badger\n3\nBadger\n7\nDire Wolf\n4\nBoar\n8\nGiant Elk\nRust Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nRat\n5\nGiant Goat\n2\nOwl\n6\nGiant Boar\n3\nMastiff\n7\nLion\n4\nGoat\n8\nBrown Bear\nTan Bag of Tricks\n1d8\nCreature\n1d8\nCreature\n1\nJackal\n5\nBlack Bear\n2\nApe\n6\nGiant Weasel\n3\nBaboon\n7\nGiant Hyena\n4\nAxe Beak\n8\nTiger"
+
+		"desc": [
+			"Wondrous Item",
+			"This bag made from gray, rust, or tan cloth appears empty. Reaching inside the bag, however, reveals the presence of a small, fuzzy object.",
+			"You can take a Magic action to pull the fuzzy object from the bag and throw it up to 20 feet. When the object lands, it transforms into a creature you determine by rolling on the table that corresponds to the bag's color. See \"Monsters\" for the creature's stat block. The creature vanishes at the next dawn or when it is reduced to 0 Hit Points.",
+			"The creature is Friendly to you and your allies, and it acts immediately after you on your Initiative count. You can take a Bonus Action to command how the creature moves and what action it takes on its next turn, such as attacking an enemy. In the absence of such orders, the creature acts in a fashion appropriate to its nature.",
+			"Once three fuzzy objects have been pulled from the bag, the bag can't be used again until the next dawn.",
+			"Gray Bag of Tricks",
+			"1d8",
+			"Creature",
+			"1d8",
+			"Creature",
+			"1",
+			"Weasel",
+			"5",
+			"Panther",
+			"2",
+			"Giant Rat",
+			"6",
+			"Giant Badger",
+			"3",
+			"Badger",
+			"7",
+			"Dire Wolf",
+			"4",
+			"Boar",
+			"8",
+			"Giant Elk",
+			"Rust Bag of Tricks",
+			"1d8",
+			"Creature",
+			"1d8",
+			"Creature",
+			"1",
+			"Rat",
+			"5",
+			"Giant Goat",
+			"2",
+			"Owl",
+			"6",
+			"Giant Boar",
+			"3",
+			"Mastiff",
+			"7",
+			"Lion",
+			"4",
+			"Goat",
+			"8",
+			"Brown Bear",
+			"Tan Bag of Tricks",
+			"1d8",
+			"Creature",
+			"1d8",
+			"Creature",
+			"1",
+			"Jackal",
+			"5",
+			"Black Bear",
+			"2",
+			"Ape",
+			"6",
+			"Giant Weasel",
+			"3",
+			"Baboon",
+			"7",
+			"Giant Hyena",
+			"4",
+			"Axe Beak",
+			"8",
+			"Tiger"
+		]
 	},
 	{
 		"index": "bead-of-force",
 		"url": "/api/2024/magic-items/bead-of-force",
 		"image" : "/api/images/magic-items/bead-of-force.png",
 		"name": "Bead of Force",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.\nYou can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.\nAn enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
+
+		"desc": [
+			"Wondrous Item",
+			"This small black sphere measures 3/4 of an inch in diameter and weighs an ounce. Typically, 1d4 + 4 Beads of Force are found together.",
+			"You can take a Magic action to throw the bead up to 60 feet. The bead explodes in a 10-foot-radius Sphere on impact and is destroyed. Each creature in the Sphere must succeed on a DC 15 Dexterity saving throw or take 5d4 Force damage. A sphere of transparent force then encloses the area for 1 minute. Any creature that failed the save and is completely within the area is trapped inside this sphere. Creatures that succeeded on the save or are partially within the area are pushed away from the center of the sphere until they are no longer insideit. Only breathable air can pass through the sphere's wall. No attack or other effect can pass through.",
+			"An enclosed creature can take a Utilize action to push against the sphere's wall, moving the sphere up to half the creature's Speed. The sphere can be picked up, and its magic causes it to weigh only 1 pound, regardless of the weight of creatures inside."
+		]
 	},
 	{
 		"index": "belt-of-dwarvenkind",
 		"url": "/api/2024/magic-items/belt-of-dwarvenkind",
 		"image" : "/api/images/magic-items/belt-of-dwarvenkind.png",
 		"name": "Belt of Dwarvenkind",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this belt, you gain the followingbenefits:Dwarvish. You know Dwarvish.Friend of Dwarvenkind. You have Advantage on Charisma (Persuasion) checks made to interact with dwarves and duergar.Toughness. Your Constitution increases by 2, to a maximum of 20.In addition, while attuned to the belt, you have a 50 percent chance each day at dawn of growing a full beard if you can grow one, or a thicker beard if you already have one.If you aren't a dwarf or duergar, you gain the following additional benefits while wearing the belt:Darkvision. You have Darkvision with a range of 60 feet.Resilience. You have Resistance to Poison damage. You also have Advantage on saving throws you make to avoid or end the Poisoned condition."
+		]
 	},
 	{
 		"index": "belt-of-giant-strength",
 		"url": "/api/2024/magic-items/belt-of-giant-strength",
 		"image" : "/api/images/magic-items/belt-of-giant-strength.png",
 		"name": "Belt of Giant Strength",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this belt, your Strength changes to a score granted by the belt. The type of giant determines the score (see the table below). The item has no effect on you if your Strength without the belt is equal to or greater than the belt's score.BeltStr.RarityBelt of Giant Strength (hill)21RareBelt of Giant Strength (frost or stone)23Very RareBelt of Giant Strength (fire)25Very RareBelt of Giant Strength (cloud)27LegendaryBelt of Giant Strength (storm)29Legendary"
+		]
 	},
 	{
 		"index": "berserker-axe",
 		"url": "/api/2024/magic-items/berserker-axe",
 		"image" : "/api/images/magic-items/berserker-axe.png",
 		"name": "Berserker Axe",
-		"type": "Weapon (Battleaxe, Greataxe, or Halberd)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.\nCurse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.\nWhenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.\nWhile berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
+
+		"desc": [
+			"Weapon (Battleaxe, Greataxe, or Halberd)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. In addition, while you are attuned to this weapon, your Hit Point maximum increases by 1 for each level you have attained.",
+			"Curse. This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the weapon, keeping it within reach at all times. You also have Disadvantage on attack rolls with weapons other than this one.",
+			"Whenever another creature damages you while the weapon is in your possession, you must succeed on a DC 15 Wisdom saving throw or go berserk. This berserk state ends when you start your turn and there are no creatures within 60 feet of you that you can see or hear.",
+			"While berserk, you regard the creature nearest to you that you can see or hear as your enemy. If there are multiple possible creatures, choose one at random. On each of your turns, you must move asclose to the creature as possible and take the Attack action, targeting the creature. If you're unable to get close enough to the creature to attack it with the weapon, your turn ends after you've used up all your available movement. If the creature dies or can no longer be seen or heard by you, the next nearest creature that you can see or hear becomes your new target."
+		]
 	},
 	{
 		"index": "boots-of-elvenkind",
 		"url": "/api/2024/magic-items/boots-of-elvenkind",
 		"image" : "/api/images/magic-items/boots-of-elvenkind.png",
 		"name": "Boots of Elvenkind",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear these boots, your steps make no sound, regardless of the surface you are moving across. You also have Advantage on Dexterity (Stealth) checks."
+		]
 	},
 	{
 		"index": "boots-of-levitation",
 		"url": "/api/2024/magic-items/boots-of-levitation",
 		"image" : "/api/images/magic-items/boots-of-levitation.png",
 		"name": "Boots of Levitation",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While you wear these boots, you can cast Levitate on yourself."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear these boots, you can cast Levitate on yourself."
+		]
 	},
 	{
 		"index": "boots-of-speed",
 		"url": "/api/2024/magic-items/boots-of-speed",
 		"image" : "/api/images/magic-items/boots-of-speed.png",
 		"name": "Boots of Speed",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.\nWhen you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear these boots, you can take a Bonus Action to click the boots' heels together. If you do, the boots double your Speed, and any creature that makes an Opportunity Attack against you has Disadvantage on the attack roll. If you click your heels together again, you end the effect.",
+			"When you've used the boots' property for a total of 10 minutes, the magic ceases to function for you until you finish a Long Rest."
+		]
 	},
 	{
 		"index": "boots-of-striding-and-springing",
 		"url": "/api/2024/magic-items/boots-of-striding-and-springing",
 		"image" : "/api/images/magic-items/boots-of-striding-and-springing.png",
 		"name": "Boots of Striding and Springing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.\nOnce on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear these boots, your Speed becomes 30 feet unless your Speed is higher, and your Speed isn't reduced by you carrying weight in excess of your carrying capacity or wearing Heavy Armor.",
+			"Once on each of your turns, you can jump up to 30 feet by spending only 10 feet of movement."
+		]
 	},
 	{
 		"index": "boots-of-the-winterlands",
 		"url": "/api/2024/magic-items/boots-of-the-winterlands",
 		"image" : "/api/images/magic-items/boots-of-the-winterlands.png",
 		"name": "Boots of the Winterlands",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.\nCold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.\nWinter Strider. You ignore Difficult Terrain created by ice or snow."
+
+		"desc": [
+			"Wondrous Item",
+			"These furred boots are snug and feel warm. Whilewearing them, you gain the following benefits.",
+			"Cold Resistance. You have Resistance to Cold damage and can tolerate temperatures of 0 degrees Fahrenheit or lower without any additional protection.",
+			"Winter Strider. You ignore Difficult Terrain created by ice or snow."
+		]
 	},
 	{
 		"index": "bowl-of-commanding-water-elementals",
 		"url": "/api/2024/magic-items/bowl-of-commanding-water-elementals",
 		"image" : "/api/images/magic-items/bowl-of-commanding-water-elementals.png",
 		"name": "Bowl of Commanding Water Elementals",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.\nThe bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
+
+		"desc": [
+			"Wondrous Item",
+			"While this bowl is filled with water and you are within 5 feet of it, you can take a Magic action to summon a Water Elemental. The elemental appears in an unoccupied space as close to the bowl as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The bowl can't be used this way again until the next dawn.",
+			"The bowl is about 1 foot in diameter and half as deep. It holds about 3 gallons."
+		]
 	},
 	{
 		"index": "bracers-of-archery",
 		"url": "/api/2024/magic-items/bracers-of-archery",
 		"image" : "/api/images/magic-items/bracers-of-archery.png",
 		"name": "Bracers of Archery",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing these bracers, you have proficiency with the Longbow and Shortbow, and you gain a +2 bonus to damage rolls made with such weapons."
+		]
 	},
 	{
 		"index": "bracers-of-defense",
 		"url": "/api/2024/magic-items/bracers-of-defense",
 		"image" : "/api/images/magic-items/bracers-of-defense.png",
 		"name": "Bracers of Defense",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing these bracers, you gain a +2 bonus to Armor Class if you are wearing no armor and using no Shield."
+		]
 	},
 	{
 		"index": "brazier-of-commanding-fire-elementals",
 		"url": "/api/2024/magic-items/brazier-of-commanding-fire-elementals",
 		"image" : "/api/images/magic-items/brazier-of-commanding-fire-elementals.png",
 		"name": "Brazier of Commanding Fire Elementals",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While you are within 5 feet of this brazier, you can take a Magic action to summon a Fire Elemental. The elemental appears in an unoccupied space as close to the brazier as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The brazier can't be used this way again until the next dawn."
+		]
 	},
 	{
 		"index": "brooch-of-shielding",
 		"url": "/api/2024/magic-items/brooch-of-shielding",
 		"image" : "/api/images/magic-items/brooch-of-shielding.png",
 		"name": "Brooch of Shielding",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this brooch, you have Resistance to Force damage, and you have Immunity to damage from the Magic Missile spell."
+		]
 	},
 	{
 		"index": "broom-of-flying",
 		"url": "/api/2024/magic-items/broom-of-flying",
 		"image" : "/api/images/magic-items/broom-of-flying.png",
 		"name": "Broom of Flying",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.\nAs a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
+
+		"desc": [
+			"Wondrous Item",
+			"This wooden broom functions like a mundane broom until you stand astride it and take a Magic action to make it hover beneath you, at which time it can be ridden in the air. It has a Fly Speed of 50 feet. It can carry up to 400 pounds, but its Fly Speed becomes 30 feet while carrying over 200 pounds.The broom stops hovering when you land or when you're no longer riding it.",
+			"As a Magic action, you can send the broom to travel alone to a destination within 1 mile of you if you name the location and are familiar with it. The broom comes back to you when you take a Magic action and use a command word if the broom is still within 1 mile of you."
+		]
 	},
 	{
 		"index": "candle-of-invocation",
 		"url": "/api/2024/magic-items/candle-of-invocation",
 		"image" : "/api/images/magic-items/candle-of-invocation.png",
 		"name": "Candle of Invocation",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.\nWhile lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.\nAlternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
+
+		"desc": [
+			"Wondrous Item",
+			"This candle's magic is activated when the candle is lit, which requires a Magic action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time. Deduct the time it burned in increments of 1 minute from its total burn time.",
+			"While lit, the candle sheds Dim Light in a 30-foot radius. While you are within that light, you have Advantage on D20 Tests. In addition, a Cleric or Druid in the light can cast level 1 spells they have prepared without expending spell slots.",
+			"Alternatively, when you light the candle for the first time, you can cast Gate with it. Doing so destroys the candle. The portal created by the spell links to a particular Outer Plane chosen by the GM or determined by rolling on the following table.1d100  Outer Plane  1d100  Outer Plane 01-05 Abyss    55-59 Gehenna   06-10 Acheron    60-64 Hades 11-17 Arborea    65-69 Limbo   18-25 Arcadia    70-77 Mechanus 26-33 Beastlands    78-85 Mount Celestia   34-41 Bytopia    86-90 Nine Hells 42-46 Carceri    91-95 Pandemonium   47-54 Elysium    96-00 Ysgard"
+		]
 	},
 	{
 		"index": "cape-of-the-mountebank",
 		"url": "/api/2024/magic-items/cape-of-the-mountebank",
 		"image" : "/api/images/magic-items/cape-of-the-mountebank.png",
 		"name": "Cape of the Mountebank",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.\nWhen you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
+
+		"desc": [
+			"Wondrous Item",
+			"This cape smells faintly of brimstone. While wearing it, you can use it to cast Dimension Door as a Magic action. This property can't be used again until the next dawn.",
+			"When you teleport with that spell, you leave behind a cloud of smoke. The space you left is Lightly Obscured by that smoke until the end of yournext turn."
+		]
 	},
 	{
 		"index": "carpet-of-flying",
 		"url": "/api/2024/magic-items/carpet-of-flying",
 		"image" : "/api/images/magic-items/carpet-of-flying.png",
 		"name": "Carpet of Flying",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.\nFour sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
+
+		"desc": [
+			"Wondrous Item",
+			"You can make this carpet hover and fly by taking a Magic action and using the carpet's command word. It moves according to your directions if you are within 30 feet of it.",
+			"Four sizes of Carpet of Flying exist. The GM chooses the size of a given carpet or determines it randomly by rolling on the following table. A carpet can carry up to twice the weight shown on the table, but its Fly Speed is halved if it carries more than its normal capacity.1d100  Size  Capacity  Fly Speed21-55  4 ft. × 6 ft.  400 lb.  60 feet81-00  6 ft. × 9 ft.  800 lb.  30 feet"
+		]
 	},
 	{
 		"index": "censer-of-controlling-air-elementals",
 		"url": "/api/2024/magic-items/censer-of-controlling-air-elementals",
 		"image" : "/api/images/magic-items/censer-of-controlling-air-elementals.png",
 		"name": "Censer of Controlling Air Elementals",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While gently swinging this censer, you can take a Magic action to summon an Air Elemental. The elemental appears in an unoccupied space as close to the censer as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The censer can't be used this way again until the next dawn."
+		]
 	},
 	{
 		"index": "chime-of-opening",
 		"url": "/api/2024/magic-items/chime-of-opening",
 		"image" : "/api/images/magic-items/chime-of-opening.png",
 		"name": "Chime of Opening",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.\nThe chime can be used 10 times. After the tenth time, it cracks and becomes useless."
+
+		"desc": [
+			"Wondrous Item",
+			"This hollow metal tube measures about 1 foot long and weighs 1 pound. As a Magic action, you can strike the chime to cast Knock. The spell's customary knocking sound is replaced by the clear, ringing tone of the chime, which is audible out to 300 feet.",
+			"The chime can be used 10 times. After the tenth time, it cracks and becomes useless."
+		]
 	},
 	{
 		"index": "circlet-of-blasting",
 		"url": "/api/2024/magic-items/circlet-of-blasting",
 		"image" : "/api/images/magic-items/circlet-of-blasting.png",
 		"name": "Circlet of Blasting",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this circlet, you can cast Scorching Ray with it (+5 to hit). The circlet can't cast this spell again until the next dawn."
+		]
 	},
 	{
 		"index": "cloak-of-arachnida",
 		"url": "/api/2024/magic-items/cloak-of-arachnida",
 		"image" : "/api/images/magic-items/cloak-of-arachnida.png",
 		"name": "Cloak of Arachnida",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.\nPoison Resistance. You have Resistance to Poison damage.\nSpider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.\nSpider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.\nWeb. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"This fine garment is made of black silk interwoven with faint, silvery threads. While wearing it, you gain the following benefits.",
+			"Poison Resistance. You have Resistance to Poison damage.",
+			"Spider Climb. You have a Climb Speed equal to your Speed and can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free.",
+			"Spider Walk. You can't be caught in webs of any sort and can move through webs as if they were Difficult Terrain.",
+			"Web. You can cast Web (save DC 13). The web created by the spell fills twice its normal area. Once used, this property can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "cloak-of-displacement",
 		"url": "/api/2024/magic-items/cloak-of-displacement",
 		"image" : "/api/images/magic-items/cloak-of-displacement.png",
 		"name": "Cloak of Displacement",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear this cloak, it magically projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have Disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while your Speed is 0."
+		]
 	},
 	{
 		"index": "cloak-of-elvenkind",
 		"url": "/api/2024/magic-items/cloak-of-elvenkind",
 		"image" : "/api/images/magic-items/cloak-of-elvenkind.png",
 		"name": "Cloak of Elvenkind",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear this cloak, Wisdom (Perception) checks made to perceive you have Disadvantage, and you have Advantage on Dexterity (Stealth) checks."
+		]
 	},
 	{
 		"index": "cloak-of-protection",
 		"url": "/api/2024/magic-items/cloak-of-protection",
 		"image" : "/api/images/magic-items/cloak-of-protection.png",
 		"name": "Cloak of Protection",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
+
+		"desc": [
+			"Wondrous Item",
+			"You gain a +1 bonus to Armor Class and saving throws while you wear this cloak."
+		]
 	},
 	{
 		"index": "cloak-of-the-bat",
 		"url": "/api/2024/magic-items/cloak-of-the-bat",
 		"image" : "/api/images/magic-items/cloak-of-the-bat.png",
 		"name": "Cloak of the Bat",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.\nWhile wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this cloak, you have Advantage on Dexterity (Stealth) checks. In an area of Dim Light or Darkness, you can grip the edges of the cloak and use it to gain a Fly Speed of 40 feet. If you ever fail to grip the cloak's edges while flying in this way, or if you are no longer in Dim Light or Darkness, you lose this Fly Speed.",
+			"While wearing the cloak in an area of Dim Light or Darkness, you can cast Polymorph on yourself, shape-shifting into a Bat. While in that form, you retain your Intelligence, Wisdom, and Charisma scores. The cloak can't be used this way again until the next dawn."
+		]
 	},
 	{
 		"index": "cloak-of-the-manta-ray",
 		"url": "/api/2024/magic-items/cloak-of-the-manta-ray",
 		"image" : "/api/images/magic-items/cloak-of-the-manta-ray.png",
 		"name": "Cloak of the Manta Ray",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this cloak, you can breathe underwater, and you have a Swim Speed of 60 feet."
+		]
 	},
 	{
 		"index": "crystal-ball",
 		"url": "/api/2024/magic-items/crystal-ball",
 		"image" : "/api/images/magic-items/crystal-ball.png",
 		"name": "Crystal Ball",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While touching this crystal orb, you can cast Scrying(save DC 17) with it."
+
+		"desc": [
+			"Wondrous Item",
+			"While touching this crystal orb, you can cast Scrying(save DC 17) with it."
+		]
 	},
 	{
 		"index": "crystal-ball-of-mind-reading",
 		"url": "/api/2024/magic-items/crystal-ball-of-mind-reading",
 		"image" : "/api/images/magic-items/crystal-ball-of-mind-reading.png",
 		"name": "Crystal Ball of Mind Reading",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
+
+		"desc": [
+			"Wondrous Item",
+			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can cast Detect Thoughts (save DC 17) targeting creatures you can see within 30 feet of the spell's sensor. You don't need to concentrate on this Detect Thoughts spellto maintain it during its duration, but it ends if theScrying spell ends."
+		]
 	},
 	{
 		"index": "crystal-ball-of-telepathy",
 		"url": "/api/2024/magic-items/crystal-ball-of-telepathy",
 		"image" : "/api/images/magic-items/crystal-ball-of-telepathy.png",
 		"name": "Crystal Ball of Telepathy",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you can communicate telepathically with creatures you can see within 30 feet of the spell's sensor. You can also cast Suggestion (save DC 17) through the sensor on one of those creatures. You don't need to concentrate on this Suggestion to maintain it during its duration, but it ends if Scrying ends. You can't cast Suggestion in this way again until the next dawn."
+		]
 	},
 	{
 		"index": "crystal-ball-of-true-seeing",
 		"url": "/api/2024/magic-items/crystal-ball-of-true-seeing",
 		"image" : "/api/images/magic-items/crystal-ball-of-true-seeing.png",
 		"name": "Crystal Ball of True Seeing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
+
+		"desc": [
+			"Wondrous Item",
+			"While touching this crystal orb, you can cast Scrying (save DC 17) with it. In addition, you have Truesight with a range of 120 feet centered on the spell's sensor."
+		]
 	},
 	{
 		"index": "cube-of-force",
 		"url": "/api/2024/magic-items/cube-of-force",
 		"image" : "/api/images/magic-items/cube-of-force.png",
 		"name": "Cube of Force",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.\nThe cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
+
+		"desc": [
+			"Wondrous Item",
+			"This cube is about an inch across. Each face has a distinct marking on it. You can press one of those faces, expend the number of charges required for it, and thereby cast the spell associated with it (save DC 17), as shown in the Cube of Force Faces table.",
+			"The cube starts with 10 charges, and it regains 1d6 expended charges daily at dawn.Cube of Force FacesSpellCharge CostMage Armor1Shield1Tiny Hut3Private Sanctum4Resilient Sphere4Wall of Force5"
+		]
 	},
 	{
 		"index": "cubic-gate",
 		"url": "/api/2024/magic-items/cubic-gate",
 		"image" : "/api/images/magic-items/cubic-gate.png",
 		"name": "Cubic Gate",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.\nThe cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.\nGate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.\nPlane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
+
+		"desc": [
+			"Wondrous Item",
+			"    This cube is 3 inches across and radiates palpable magical energy. The six sides of the cube are each keyed to a different plane of existence, one of which is the Material Plane. The other sides are linked to planes determined by the GM.",
+			"The cube has 3 charges and regains 1d3 expended charges daily at dawn. As a Magic action, you can expend 1 of the cube's charges to cast one of the following spells using the cube.",
+			"Gate. Pressing one side of the cube, you cast Gate, opening a portal to the plane of existence keyed to that side.",
+			"Plane Shift. Pressing one side of the cube twice, you cast Plane Shift, transporting the targets to the plane of existence keyed to that side."
+		]
 	},
 	{
 		"index": "dagger-of-venom",
 		"url": "/api/2024/magic-items/dagger-of-venom",
 		"image" : "/api/images/magic-items/dagger-of-venom.png",
 		"name": "Dagger of Venom",
-		"type": "Weapon (Dagger)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nYou can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
+
+		"desc": [
+			"Weapon (Dagger)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"You can take a Bonus Action to magically coat the blade with poison. The poison remains for 1 minute or until an attack using this weapon hits a creature. That creature must succeed on a DC 15 Constitution saving throw or take 2d10 Poison damage and have the Poisoned condition for 1 minute. The weapon can't be used this way again until the next dawn."
+		]
 	},
 	{
 		"index": "dancing-sword",
 		"url": "/api/2024/magic-items/dancing-sword",
 		"image" : "/api/images/magic-items/dancing-sword.png",
 		"name": "Dancing Sword",
-		"type": "Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.\nWhile the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
+
+		"desc": [
+			"Weapon (Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+			"You can take a Bonus Action to toss this magic weapon into the air. When you do so, the weapon begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of itself. The weapon uses your attack roll and adds your ability modifier to damage rolls.",
+			"While the weapon hovers, you can take a Bonus Action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same Bonus Action, you can cause the weapon to attack one creature within 5 feet of the weapon.After the hovering weapon attacks for the fourthtime, it flies back to you and tries to return to yourhand. If you have no hand free, the weapon falls to the ground in your space. If the weapon has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or are more than 30 feet away from it."
+		]
 	},
 	{
 		"index": "decanter-of-endless-water",
 		"url": "/api/2024/magic-items/decanter-of-endless-water",
 		"image" : "/api/images/magic-items/decanter-of-endless-water.png",
 		"name": "Decanter of Endless Water",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.\nYou can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
+
+		"desc": [
+			"Wondrous Item",
+			"This stoppered flask sloshes when shaken, as if itcontains water. The decanter weighs 2 pounds.",
+			"You can take a Magic action to remove the stopper and issue one of three command words, whereupon an amount of fresh water or salt water (your choice) pours out of the flask. The water stops pouring out at the start of your next turn. Choose from the following command words:Splash. The decanter produces 1 gallon of water.Fountain. The decanter produces 5 gallons of water. Geyser. The decanter produces 30 gallons of water that gushes forth in a Line 30 feet long and 1 foot wide. If you're holding the decanter, you can aim the geyser in one direction (no action required).One creature of your choice in the Line must succeed on a DC 13 Strength saving throw or take 1d4 Bludgeoning damage and have the Prone condition. Instead of a creature, you can target one object in the Line that isn't being worn or carried and that weighs no more than 200 pounds. The object is knocked over by the geyser."
+		]
 	},
 	{
 		"index": "deck-of-illusions",
 		"url": "/api/2024/magic-items/deck-of-illusions",
 		"image" : "/api/images/magic-items/deck-of-illusions.png",
 		"name": "Deck of Illusions",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.\nThe magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.\nAny physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
+
+		"desc": [
+			"Wondrous Item",
+			"This box contains a set of cards. A full deck has 34 cards: 32 depicting specific creatures and two with a mirrored surface. A deck found as treasure is usually missing 1d20 1 cards.",
+			"The magic of the deck functions only if its cards are drawn at random. You can take a Magic action to draw a card at random from the deck and throw it to the ground at a point within 30 feet of yourself. An illusion of a creature, determined by rolling on the Deck of Illusions table, forms over the thrown card and remains until dispelled. The illusory creature created by the card looks and behaves like a real creature of its kind, except that it can do no harm. While you are within 120 feet of the illusory creature and can see it, you can take a Magic action to move it anywhere within 30 feet of its card.",
+			"Any physical interaction with the illusory creature reveals it to be false, because objects pass through it. A creature that takes a Study action to visually inspect the illusory creature identifies it as an illusion with a successful DC 15 Intelligence (Investigation) check. The illusion lasts until its card is moved or the illusion is dispelled (using a DispelMagic spell or a similar effect). When the illusion ends, the image on its card disappears, and that card can't be used again.Deck of Illusions1d100  Illusion*04-06  Archmage10-12  Bandit Captain16-18  Berserker22-24  Cloud Giant28-30  Erinyes34-36  Fire Giant40-42  Gnoll Warrior46-48  Guardian Naga52-54  Hobgoblin Warrior58-60  Iron Golem64-66  Kobold Warrior70-72  Medusa76-78  Ogre82-84  Priest88-90  Troll94-96  Wyvern*Stat blocks for these creatures (except the card drawer) appear in \"Monsters.\""
+		]
 	},
 	{
 		"index": "defender",
 		"url": "/api/2024/magic-items/defender",
 		"image" : "/api/images/magic-items/defender.png",
 		"name": "Defender",
-		"type": "Weapon (Any Melee Weapon)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.\nThe first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
+
+		"desc": [
+			"Weapon (Any Melee Weapon)",
+			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"The first time you attack with the weapon on each of your turns, you can transfer some or all of the weapon's bonus to your Armor Class. For example, you could reduce the bonus to your attack rolls and damage rolls to +1 and gain a +2 bonus to Armor Class. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the weapon to gain a bonus to AC from it."
+		]
 	},
 	{
 		"index": "demon-armor",
 		"url": "/api/2024/magic-items/demon-armor",
 		"image" : "/api/images/magic-items/demon-armor.png",
 		"name": "Demon Armor",
-		"type": "Armor (Any Light, Medium, or Heavy)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.\nCurse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
+
+		"desc": [
+			"Armor (Any Light, Medium, or Heavy)",
+			"While wearing this armor, you gain a +1 bonus to Armor Class, and you know Abyssal. In addition, the armor's clawed gauntlets allow your Unarmed Strikes to deal 1d8 Slashing damage instead of the usual Bludgeoning damage, and you gain a +1 bonus to the attack and damage rolls of your Unarmed Strikes.",
+			"Curse. Once you don this cursed armor, you can't doff it unless you are targeted by a Remove Curse spell or similar magic. While wearing the armor, you have Disadvantage on attack rolls against demons and on saving throws against their spells and special abilities."
+		]
 	},
 	{
 		"index": "dimensional-shackles",
 		"url": "/api/2024/magic-items/dimensional-shackles",
 		"image" : "/api/images/magic-items/dimensional-shackles.png",
 		"name": "Dimensional Shackles",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.\nYou and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
+
+		"desc": [
+			"Wondrous Item",
+			"You can take a Utilize action to place these shackles on a creature that has the Incapacitated condition. The shackles adjust to fit a creature of Small to Large size. The shackles prevent a creature bound by them from using any method of extradimensional movement, including teleportation or travel to a different plane of existence. They don't prevent the creature from passing through an interdimensional portal.",
+			"You and any creature you designate when you use the shackles can take a Utilize action to remove them. Once every 30 days, the bound creature can make a DC 30 Strength (Athletics) check. On a suc-cessful check, the creature breaks free and destroys the shackles."
+		]
 	},
 	{
 		"index": "dragon-orb",
 		"url": "/api/2024/magic-items/dragon-orb",
 		"image" : "/api/images/magic-items/dragon-orb.png",
 		"name": "Dragon Orb",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Artifact"
 		},
-		"description": "An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.\nWhile attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.\nWhile you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.\nSpells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3\nCall Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.\nDestroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
+
+		"desc": [
+			"Wondrous Item",
+			"An orb is an etched crystal globe about 10 inches in diameter. When used, it grows to about 20 inches in diameter, and mist swirls inside it.",
+			"While attuned to an orb, you can take a Magic action to peer into the orb's depths. You must then make a DC 15 Charisma saving throw. On a successful save, you control the orb for as long as you remain attuned to it. On a failed save, the orb imposes the Charmed condition on you for as long as you remain attuned to it.",
+			"While you are Charmed by the orb, you can't voluntarily end your Attunement to it, and the orb casts Suggestion on you at will (save DC 18), urging you to work toward the evil ends it desires. The dragon essence within the orb might want many things: the annihilation of a particular society or organization, freedom from the orb, to spread suffering in the world, to advance the worship of Tiamat, or something else the GM decides.",
+			"Spells. The orb has 7 charges and regains 1d4 + 3 expended charges daily at dawn. If you control the orb, you can cast one of the spells on the following table from it. The table indicates how many charges you must expend to cast the spell.SpellCharge CostCure Wounds (level 9 version)4Daylight1Death Ward2Detect Magic0Scrying (save DC 18)3",
+			"Call Dragons. While you control the orb, you can take a Magic action to cause the orb to issue a telepathic call that extends in all directions for 40 miles. Chromatic dragons in range feel compelled to come to the orb as soon as possible by the mostdirect route. Dragon deities such as Tiamat are unaffected by this call. Chromatic dragons drawn to the orb might be Hostile toward you for compelling them against their will. Once you have used this property, it can't be used again for 1 hour.",
+			"Destroying an Orb. A Dragon Orb has AC 20 and is destroyed if it takes damage from a +3 Weapon or a Disintegrate spell. Nothing else can harm it."
+		]
 	},
 	{
 		"index": "dragon-scale-mail",
 		"url": "/api/2024/magic-items/dragon-scale-mail",
 		"image" : "/api/images/magic-items/dragon-scale-mail.png",
 		"name": "Dragon Scale Mail",
-		"type": "Armor (Scale Mail)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.\nWhile wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).\nAdditionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
+
+		"desc": [
+			"Armor (Scale Mail)",
+			"Dragon Scale Mail is made of the scales of one kind of dragon. Sometimes dragons collect their cast-off scales and gift them. Other times, hunters carefully preserve the hide of a dead dragon. In either case, Dragon Scale Mail is highly valued.",
+			"While wearing this armor, you gain a +1 bonus to Armor Class, you have Advantage on saving throws against the breath weapons of Dragons, and you have Resistance to one damage type determined by the kind of dragon that provided the scales (see the accompanying table).",
+			"Additionally, you can focus your senses as a Magic action to discern the distance and direction to the closest dragon within 30 miles of yourself that isof the same type as the armor. This action can't be used again until the next dawn.Dragon  Resistance  Dragon  Resistance Blue  Lightning  Green   Poison Brass  Fire  Red  Fire Bronze  Lightning  Silver  Cold"
+		]
 	},
 	{
 		"index": "dragon-slayer",
 		"url": "/api/2024/magic-items/dragon-slayer",
 		"image" : "/api/images/magic-items/dragon-slayer.png",
 		"name": "Dragon Slayer",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"The weapon deals an extra 3d6 damage of the weapon's type if the target is a Dragon."
+		]
 	},
 	{
 		"index": "dust-of-disappearance",
 		"url": "/api/2024/magic-items/dust-of-disappearance",
 		"image" : "/api/images/magic-items/dust-of-disappearance.png",
 		"name": "Dust of Disappearance",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
+
+		"desc": [
+			"Wondrous Item",
+			"This powder resembles fine sand. There is enough of it for one use. When you take a Utilize action to throw the dust into the air, you and each creature and object within a 10-foot Emanation originating from you have the Invisible condition for 2d4 minutes. The duration is the same for all subjects, and the dust is consumed when its magic takes effect. Immediately after an affected creature makes an attack roll, deals damage, or casts a spell, the Invisible condition ends for that creature."
+		]
 	},
 	{
 		"index": "dust-of-dryness",
 		"url": "/api/2024/magic-items/dust-of-dryness",
 		"image" : "/api/images/magic-items/dust-of-dryness.png",
 		"name": "Dust of Dryness",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.\nAs a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
+
+		"desc": [
+			"Wondrous Item",
+			"This small packet contains 1d6 + 4 pinches of dust. As a Utilize action, you can sprinkle a pinch of the dust over water, turning up to a 15-foot Cube of water into one marble-sized pellet, which floatsor rests near where the dust was sprinkled. The pellet's weight is negligible. A creature can take a Utilize action to smash the pellet against a hardsurface, causing the pellet to shatter and release the water the dust absorbed. Doing so destroys the pellet and ends its magic.",
+			"As a Utilize action, you can sprinkle a pinch of the dust on an Elemental within 5 feet of yourself that is composed mostly of water (such as a Water Elemental). Such a creature exposed to a pinch of the dust makes a DC 13 Constitution saving throw, taking 10d6 Necrotic damage on a failed save or half as much damage on a successful one."
+		]
 	},
 	{
 		"index": "dust-of-sneezing-and-choking",
 		"url": "/api/2024/magic-items/dust-of-sneezing-and-choking",
 		"image" : "/api/images/magic-items/dust-of-sneezing-and-choking.png",
 		"name": "Dust of Sneezing and Choking",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.\nAs a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.\nOn a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
+
+		"desc": [
+			"Wondrous Item",
+			"Found in a small container, this powder resembles Dust of Disappearance, and Identify reveals it to be such. There is enough of it for one use.",
+			"As a Utilize action, you can throw the dust into the air, forcing yourself and every creature in a 30-footEmanation originating from you to make a DC 15 Constitution saving throw. Constructs, Elementals, Oozes, Plants, and Undead succeed on the save automatically.",
+			"On a failed save, a creature begins sneezing uncontrollably; it has the Incapacitated condition and is suffocating. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success. The effect also ends on any creature targeted by a Lesser Restoration spell."
+		]
 	},
 	{
 		"index": "dwarven-plate",
 		"url": "/api/2024/magic-items/dwarven-plate",
 		"image" : "/api/images/magic-items/dwarven-plate.png",
 		"name": "Dwarven Plate",
-		"type": "Armor (Half Plate Armor or Plate Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
+
+		"desc": [
+			"Armor (Half Plate Armor or Plate Armor)",
+			"While wearing this armor, you gain a +2 bonus to Armor Class. In addition, if an effect moves you against your will along the ground, you can take a Reaction to reduce the distance you are moved by up to 10 feet."
+		]
 	},
 	{
 		"index": "dwarven-thrower",
 		"url": "/api/2024/magic-items/dwarven-thrower",
 		"image" : "/api/images/magic-items/dwarven-thrower.png",
 		"name": "Dwarven Thrower",
-		"type": "Weapon (Warhammer)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"limited-to": "Dwarf or a Creature Attuned to a Belt of Dwarvenkind",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
+
+		"desc": [
+			"Weapon (Warhammer)",
+			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. It has the Thrown property with a normal range of 20 feet and a long range of 60 feet. When you hit with a ranged attack using this weapon, it deals an extra 1d8 Force damage, or an extra 2d8 Force damage if the target isa Giant. Immediately after hitting or missing, theweapon flies back to your hand."
+		]
 	},
 	{
 		"index": "efficient-quiver",
 		"url": "/api/2024/magic-items/efficient-quiver",
 		"image" : "/api/images/magic-items/efficient-quiver.png",
 		"name": "Efficient Quiver",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.\nYou can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
+
+		"desc": [
+			"Wondrous Item",
+			"Each of the quiver's three compartments connects to an extradimensional space that allows the quiver to hold numerous items while never weighing more than 2 pounds. The shortest compartment can hold up to 60 Arrows, Bolts, or similar objects. The midsize compartment holds up to 18 Javelins or similar objects. The longest compartment holds up to 6 long objects, such as bows, Quarterstaffs, or Spears.",
+			"You can draw any item the quiver contains as if doing so from a regular quiver or scabbard."
+		]
 	},
 	{
 		"index": "efreeti-bottle",
 		"url": "/api/2024/magic-items/efreeti-bottle",
 		"image" : "/api/images/magic-items/efreeti-bottle.png",
 		"name": "Efreeti Bottle",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
+
+		"desc": [
+			"Wondrous Item",
+			"When you take a Magic action to remove the stopper of this painted brass bottle, a cloud of thick smoke flows out of it. At the end of your turn, the smoke disappears with a flash of harmless fire, and an Efreeti appears in an unoccupied space within 30 feet of you.The first time the bottle is opened, the GM rolls onthe following table to determine what happens.1d10  Effect2-9  The efreeti understands your languages and obeys your commands for 1 hour, after which it returns to the bottle, and a new stopper contains it. The stopper can't be removed for 24 hours. The next two times the bottle is opened, the same effect occurs. If the bottle is opened a fourth time, the efreeti escapes and disappears, and the bottle loses its magic."
+		]
 	},
 	{
 		"index": "elemental-gem",
 		"url": "/api/2024/magic-items/elemental-gem",
 		"image" : "/api/images/magic-items/elemental-gem.png",
 		"name": "Elemental Gem",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
+
+		"desc": [
+			"Wondrous Item",
+			"This gem contains a mote of elemental energy. When you take a Utilize action to break the gem, an elemental is summoned (see \"Monsters\" for its stat block), and the gem ceases to be magical. The elemental appears in an unoccupied space as close to the broken gem as possible, understands your languages, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The type of gem determines the elemental, as shown in the following table. Gem Summoned Elemental Emerald Water Elemental Red corundum Fire Elemental Yellow diamond Earth Elemental"
+		]
 	},
 	{
 		"index": "elven-chain",
 		"url": "/api/2024/magic-items/elven-chain",
 		"image" : "/api/images/magic-items/elven-chain.png",
 		"name": "Elven Chain",
-		"type": "Armor (Chain Mail or Chain Shirt)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
+
+		"desc": [
+			"Armor (Chain Mail or Chain Shirt)",
+			"You gain a +1 bonus to Armor Class while you wear this armor. You are considered trained with this armor even if you lack training with Medium or Heavy armor."
+		]
 	},
 	{
 		"index": "eversmoking-bottle",
 		"url": "/api/2024/magic-items/eversmoking-bottle",
 		"image" : "/api/images/magic-items/eversmoking-bottle.png",
 		"name": "Eversmoking Bottle",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.\nEach minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.\nClosing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
+
+		"desc": [
+			"Wondrous Item",
+			"As a Magic action, you can open or close this bottle. Opening the bottle causes thick smoke to billow out, forming a cloud that fills a 60-foot Emanationoriginating from the bottle. The area within the smoke is Heavily Obscured.",
+			"Each minute the bottle remains open, the size of the Emanation increases by 10 feet until it reaches its maximum size of 120 feet.",
+			"Closing the bottle causes the cloud to become fixed in place until it disperses after 10 minutes. A strong wind (such as that created by the Gust of Wind spell) disperses the cloud after 1 minute."
+		]
 	},
 	{
 		"index": "eyes-of-charming",
 		"url": "/api/2024/magic-items/eyes-of-charming",
 		"image" : "/api/images/magic-items/eyes-of-charming.png",
 		"name": "Eyes of Charming",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 or more charges to cast Charm Person (save DC13). For 1 charge, you cast the level 1 version of the spell. You increase the spell's level by one for each additional charge you expend. The lenses regain all expended charges daily at dawn."
+		]
 	},
 	{
 		"index": "eyes-of-minute-seeing",
 		"url": "/api/2024/magic-items/eyes-of-minute-seeing",
 		"image" : "/api/images/magic-items/eyes-of-minute-seeing.png",
 		"name": "Eyes of Minute Seeing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
+
+		"desc": [
+			"Wondrous Item",
+			"These crystal lenses fit over the eyes. While wearing them, your vision improves significantly out to a range of 1 foot, granting you Darkvision within that range and Advantage on Intelligence (Investigation) checks made to examine something within that range."
+		]
 	},
 	{
 		"index": "eyes-of-the-eagle",
 		"url": "/api/2024/magic-items/eyes-of-the-eagle",
 		"image" : "/api/images/magic-items/eyes-of-the-eagle.png",
 		"name": "Eyes of the Eagle",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
+
+		"desc": [
+			"Wondrous Item",
+			"These crystal lenses fit over the eyes. While wearing them, you have Advantage on Wisdom (Perception) checks that rely on sight. In conditions of clear visibility, you can make out details of even extremely distant creatures and objects as small as 2 feet across."
+		]
 	},
 	{
 		"index": "feather-token",
 		"url": "/api/2024/magic-items/feather-token",
 		"image" : "/api/images/magic-items/feather-token.png",
 		"name": "Feather Token",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.\nAnchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.\nBird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.\nFan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.\nSwan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.\nTree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.\nWhip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.\nAs a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
+
+		"desc": [
+			"Wondrous Item",
+			"This object looks like a feather. Different types of feather tokens exist, each with a different single-use effect. The GM chooses the kind of token or determines it randomly by rolling on the Feather Tokens table. The type of token determines its rarity.",
+			"Anchor (Uncommon). You can take a Magic action to touch the token to a boat or ship. For the next24 hours, the vessel can't be moved by any means. Touching the token to the vessel again ends the effect. When the effect ends, the token disappears.",
+			"Bird (Rare). You can take a Magic action to toss the token 5 feet into the air. The token disappears and an enormous, multicolored bird takes its place. The bird has the statistics of a Roc, but it can't attack. It obeys your simple commands and can carry up to 500 pounds while flying at its maximum speed (16 miles per hour for a maximum of 144 miles per day, with a 1-hour rest for every 3 hours of flying) or 1,000 pounds at half that speed. The bird disappears after flying its maximum distance for a day or if it drops to 0 Hit Points. You can dismiss the bird as a Magic action.",
+			"Fan (Uncommon). If you are on a boat or ship, you can take a Magic action to toss the token up to 10 feet in the air. The token disappears, and a giant flapping fan takes its place. The fan floats and cre-ates a strong wind. This wind can fill the sails of one ship, increasing its speed by 5 miles per hour for 8 hours. You can dismiss the fan as a Magic action.",
+			"Swan Boat (Rare). You can take a Magic action to touch the token to a body of water at least 60 feet in diameter. The token disappears, and a 50-footlong, 20-foot-wide boat shaped like a swan takes its place. The boat is self-propelled and moves across water at a speed of 6 miles per hour. You can takea Magic action while on the boat to command it to move or to turn up to 90 degrees. The boat remains for 24 hours and then disappears. You can dismiss the boat as a Magic action.",
+			"Tree (Uncommon). You must be outdoors to use this token. You can take a Magic action to touch it to an unoccupied space on the ground. The token disappears, and in its place a nonmagical oak tree springs into existence. The tree is 60 feet tall and has a 5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius.",
+			"Whip (Rare). You can take a Magic action to throw the token to a point within 10 feet of yourself. The token disappears, and a floating whip takes its place. You can then take a Bonus Action to make a melee spell attack against a creature within 10 feet of the whip, with an attack bonus of +9. On a hit, the target takes 1d6 + 5 Force damage.",
+			"As a Bonus Action, you can direct the whip to fly up to 20 feet and repeat the attack against a creature within 10 feet of the whip. The whip dis-appears after 1 hour, when you take a Magic action to dismiss it, or when you die or have the Incapacitated condition.Feather Tokens1d100TokenRarity01-20AnchorUncommon21-35BirdRare36-50FanUncommon51-65Swan boatRare66-90TreeUncommon91-00WhipRare"
+		]
 	},
 	{
 		"index": "figurine-of-wondrous-power",
 		"url": "/api/2024/magic-items/figurine-of-wondrous-power",
 		"image" : "/api/images/magic-items/figurine-of-wondrous-power.png",
 		"name": "Figurine of Wondrous Power",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.\nThe creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.\nThe creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.\nBronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.\nEbony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)\nGolden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.\nIvory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.\nMarble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.\nObsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.\nThe figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.\nOnyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.\nSerpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.\nSilver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
+
+		"desc": [
+			"Wondrous Item",
+			"A Figurine of Wondrous Power is a statuette small enough to fit in a pocket. If you take a Magic action to throw the figurine to a point on the ground within 60 feet of yourself, the figurine becomes a living creature specified in the figurine's description below. If the space where the creature wouldappear is occupied by other creatures or objects, or if there isn't enough space for the creature, the figurine doesn't become a creature.",
+			"The creature is Friendly to you and your allies. It understands your languages, obeys your com-mands, and takes its turn immediately after you on your Initiative count. If you issue no commands, the creature defends itself but takes no other actions.",
+			"The creature exists for a duration specific to each figurine. At the end of the duration, the creature reverts to its figurine form. It reverts to a figurine early if its creature form drops to 0 Hit Points or if you take a Magic action while touching the creature to make it revert to figurine form. When the creature becomes a figurine again, its property can'tbe used again until a certain amount of time haspassed, as specified in the figurine's description.",
+			"Bronze Griffon (Rare). This bronze statuette is of a griffon rampant. It can become a Griffon for up to 6 hours. Once it has been used, it can't be used again until 5 days have passed.",
+			"Ebony Fly (Rare). This ebony statuette, carved in the likeness of a horsefly, can become a Giant Fly (see the accompanying stat block) for up to 12 hours and can be ridden as a mount. Once it has been used, it can't be used again until 2 days have passed.Large Beast, UnalignedAC 11  Initiative +1 (11)HP 19 (3d10 + 3)Speed 30 ft., Fly 60 ft.MOD SAVE  MOD SAVE  MOD SAVEStr14+2+2Dex 13+1+1Con 13+1+1Int2-4-4WIS 10+0+0Cha 3-4-4Senses Darkvision 60 ft., Passive Perception 10Languages NoneCR 0 (XP 0; PB +2)",
+			"Golden Lions (Rare). These gold statuettes of lions are always created in pairs. You can use one figurine or both simultaneously. Each can become a Lion for up to 1 hour. Once a lion has been used, it can't be used again until 7 days have passed.",
+			"Ivory Goats (Rare). These ivory statuettes of goats are always created in sets of three. Each goat looks unique and functions differently from the others. Their properties are as follows:Goat of Terror. This figurine can become a Giant Goat for up to 3 hours. The goat can't attack, but you can (harmlessly) remove its horns and use them as weapons. One horn becomes a +1 Lance, and the other becomes a +2 Longsword. Removing a horn requires a Magic action, and the weapons disappear and the horns return when the goat reverts to figurine form. While you ride the goat,any Hostile creature that starts its turn within a 30-foot Emanation originating from the goatmust succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute, until you are no longer riding the goat, or until the goat reverts to figurine form. The Frightened creature repeats the save at the end of each of its turns, ending the effect on itself on a success. Once it succeeds on the save, a creature is immune to this effect for the next 24 hours. Once the figurine has been used, it can't be used again until 15 days have passed.Goat of Traveling. This figurine can become a Large goat with the same statistics as a Riding Horse. It has 24 charges, and each hour or portion thereof it spends in goat form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all expended charges.Goat of Travail. This figurine can become a Giant Goat for up to 3 hours. Once it has been used, it can't be used again until 30 days have passed.",
+			"Marble Elephant (Rare). This marble statuette resembles a trumpeting elephant. It can become an Elephant for up to 24 hours. Once it has been used, it can't be used again until 7 days have passed.",
+			"Obsidian Steed (Very Rare). This polished obsidian horse can become a Nightmare for up to 24 hours. The nightmare fights only to defend itself. Once it has been used, it can't be used again until 5 days have passed.",
+			"The figurine has a 10 percent chance each time you use it to ignore your orders, including a command to revert to figurine form. If you mount the nightmare while it is ignoring your orders, you and the nightmare are instantly transported to a random location on the plane of Hades, where the nightmare reverts to figurine form.",
+			"Onyx Dog (Rare). This onyx statuette of a dog can become a Mastiff for up to 6 hours. The mastiff has an Intelligence of 8 and can speak Common. It also has Blindsight with a range of 60 feet. Once it has been used, it can't be used again until 7 days have passed.",
+			"Serpentine Owl (Rare). This serpentine statuette of an owl can become a Giant Owl for up to 8 hours. The owl can communicate telepathically with you at any range if you and it are on the same plane of existence. Once it has been used, it can't be used again until 2 days have passed.",
+			"Silver Raven (Uncommon). This silver statuette of a raven can become a Raven for up to 12 hours. Once it has been used, it can't be used again until 2 days have passed. While in raven form, the figurine grants you the ability to cast Animal Messenger on it."
+		]
 	},
 	{
 		"index": "flame-tongue",
 		"url": "/api/2024/magic-items/flame-tongue",
 		"image" : "/api/images/magic-items/flame-tongue.png",
 		"name": "Flame Tongue",
-		"type": "Weapon (Any Melee Weapon)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
+
+		"desc": [
+			"Weapon (Any Melee Weapon)",
+			"While holding this magic weapon, you can take a Bonus Action and use a command word to cause flames to engulf the damage-dealing part of the weapon. These flames shed Bright Light in a 40foot radius and Dim Light for an additional 40 feet. While the weapon is ablaze, it deals an extra 2d6 Fire damage on a hit. The flames last until you take a Bonus Action to issue the command again or until you drop, stow, or sheathe the weapon."
+		]
 	},
 	{
 		"index": "folding-boat",
 		"url": "/api/2024/magic-items/folding-boat",
 		"image" : "/api/images/magic-items/folding-boat.png",
 		"name": "Folding Boat",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.\nStatistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
+
+		"desc": [
+			"Wondrous Item",
+			"This object appears as a wooden box that measures 12 inches long, 6 inches wide, and 6 inches deep.It weighs 4 pounds and floats. It can be opened to store items inside. This item also has three command words, each requiring a Magic action to use:First Command Word. The box unfolds into a Rowboat.Second Command Word. The box unfolds into a Keelboat.Third Command Word. The Folding Boat folds back into a box if no creatures are aboard. Any objects in the vessel that can't fit inside the box remain outside the box as it folds. Any objects in the vessel that can fit inside the box do so.When the box becomes a vessel, its weight becomes that of a normal vessel its size, and anything that was stored in the box remains in the boat.",
+			"Statistics for the Rowboat and Keelboat appear in \"Equipment.\" If either vessel is reduced to 0 Hit Points, the Folding Boat is destroyed."
+		]
 	},
 	{
 		"index": "frost-brand",
 		"url": "/api/2024/magic-items/frost-brand",
 		"image" : "/api/images/magic-items/frost-brand.png",
 		"name": "Frost Brand",
-		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.\nIn freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.\nWhen you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+			"When you hit with an attack roll using this magic weapon, the target takes an extra 1d6 Cold damage. In addition, while you hold the weapon, you have Resistance to Fire damage.",
+			"In freezing temperatures, the weapon sheds Bright Light in a 10-foot radius and Dim Light for an additional 10 feet.",
+			"When you draw this weapon, you can extinguish all nonmagical flames within 30 feet of yourself. Once used, this property can't be used again for1 hour."
+		]
 	},
 	{
 		"index": "gauntlets-of-ogre-power",
 		"url": "/api/2024/magic-items/gauntlets-of-ogre-power",
 		"image" : "/api/images/magic-items/gauntlets-of-ogre-power.png",
 		"name": "Gauntlets of Ogre Power",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
+
+		"desc": [
+			"Wondrous Item",
+			"Your Strength is 19 while you wear these gauntlets. They have no effect on you if your Strength is 19 or higher without them."
+		]
 	},
 	{
 		"index": "gem-of-brightness",
 		"url": "/api/2024/magic-items/gem-of-brightness",
 		"image" : "/api/images/magic-items/gem-of-brightness.png",
 		"name": "Gem of Brightness",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
+
+		"desc": [
+			"Wondrous Item",
+			"This prism has 50 charges. While you are holding it, you can take a Magic action and use one of three command words to cause one of the following effects:First Command Word. The gem sheds Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. This effect doesn't expend a charge. It lasts until you take a Bonus Action to repeat the command word or until you use another function of the gem.Second Command Word. You expend 1 charge and cause the gem to fire a brilliant beam of light at one creature you can see within 60 feet of yourself. The creature must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. The creature repeats the save at the end of each of its turns, ending the effect on itself on a success.Third Command Word. You expend 5 charges and cause the gem to flare with intense light in a 30foot Cone. Each creature in the Cone makes a saving throw as if struck by the beam created with the second command word.When all of the gem's charges are expended, the gem becomes a nonmagical jewel worth 50 GP."
+		]
 	},
 	{
 		"index": "gem-of-seeing",
 		"url": "/api/2024/magic-items/gem-of-seeing",
 		"image" : "/api/images/magic-items/gem-of-seeing.png",
 		"name": "Gem of Seeing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.\nThe gem regains 1d3 expended charges daily at dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"This gem has 3 charges. As a Magic action, you can expend 1 charge. For the next 10 minutes, you have Truesight out to 120 feet when you peer through the gem.",
+			"The gem regains 1d3 expended charges daily at dawn."
+		]
 	},
 	{
 		"index": "giant-slayer",
 		"url": "/api/2024/magic-items/giant-slayer",
 		"image" : "/api/images/magic-items/giant-slayer.png",
 		"name": "Giant Slayer",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nWhen you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"When you hit a Giant with this weapon, the Giant takes an extra 2d6 damage of the weapon's type and must succeed on a DC 15 Strength saving throw or have the Prone condition."
+		]
 	},
 	{
 		"index": "glamoured-studded-leather",
 		"url": "/api/2024/magic-items/glamoured-studded-leather",
 		"image" : "/api/images/magic-items/glamoured-studded-leather.png",
 		"name": "Glamoured Studded Leather",
-		"type": "Armor (Studded Leather Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
+
+		"desc": [
+			"Armor (Studded Leather Armor)",
+			"While wearing this armor, you gain a +1 bonus to Armor Class. You can also take a Bonus Action tocause the armor to assume the appearance of a normal set of clothing or some other kind of armor. You decide what it looks like-including color, style, and accessories-but the armor retains its normal bulk and weight. The illusory appearance lasts until you use this property again or doff the armor."
+		]
 	},
 	{
 		"index": "gloves-of-missile-snaring",
 		"url": "/api/2024/magic-items/gloves-of-missile-snaring",
 		"image" : "/api/images/magic-items/gloves-of-missile-snaring.png",
 		"name": "Gloves of Missile Snaring",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
+
+		"desc": [
+			"Wondrous Item",
+			"If you're hit by an attack roll made with a Ranged or Thrown weapon while wearing these gloves, you can take a Reaction to reduce the damage by 1d10plus your Dexterity modifier if you have a free hand. If you reduce the damage to 0, you can catch the ammunition or weapon if it is small enough for you to hold in that hand."
+		]
 	},
 	{
 		"index": "gloves-of-swimming-and-climbing",
 		"url": "/api/2024/magic-items/gloves-of-swimming-and-climbing",
 		"image" : "/api/images/magic-items/gloves-of-swimming-and-climbing.png",
 		"name": "Gloves of Swimming and Climbing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing these gloves, you have a Climb Speed and a Swim Speed equal to your Speed, and you gain a +5 bonus to Strength (Athletics) checks made to climb or swim."
+		]
 	},
 	{
 		"index": "goggles-of-night",
 		"url": "/api/2024/magic-items/goggles-of-night",
 		"image" : "/api/images/magic-items/goggles-of-night.png",
 		"name": "Goggles of Night",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing these dark lenses, you have Darkvision out to 60 feet. If you already have Darkvision, wearing the goggles increases its range by 60 feet."
+		]
 	},
 	{
 		"index": "hammer-of-thunderbolts",
 		"url": "/api/2024/magic-items/hammer-of-thunderbolts",
 		"image" : "/api/images/magic-items/hammer-of-thunderbolts.png",
 		"name": "Hammer of Thunderbolts",
-		"type": "Weapon (Maul or Warhammer)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.\nThe weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.\nGiant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
+
+		"desc": [
+			"Weapon (Maul or Warhammer)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"The weapon has 5 charges. You can expend 1 charge and make a ranged attack with the weapon, hurling it as if it had the Thrown property with a normal range of 20 feet and a long range of 60 feet. If the attack hits, the weapon unleashes a thunderclap audible out to 300 feet. The target and every creature within 30 feet of it other than you must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn. Immediately after hitting or missing, the weapon flies back to your hand. The weapon regains 1d4 + 1 expended charges daily at dawn.",
+			"Giant's Bane. While you are attuned to the weapon and wearing either a Belt of Giant Strength or Gauntlets of Ogre Power to which you are also attuned, you gain the following benefits:Giants' Bane. When you roll a 20 on the d20 for an attack roll made with this weapon against a Giant, the creature must succeed on a DC 17 Constitution saving throw or die.Might of Giants. The Strength score bestowed by your Belt of Giant Strength or Gauntlets of Ogre Power increases by 4, to a maximum of 30."
+		]
 	},
 	{
 		"index": "handy-haversack",
 		"url": "/api/2024/magic-items/handy-haversack",
 		"image" : "/api/images/magic-items/handy-haversack.png",
 		"name": "Handy Haversack",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.\nRetrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.\nIf any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.\nEach pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.\nPlacing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+
+		"desc": [
+			"Wondrous Item",
+			"This backpack has a central pouch and two side pouches, each of which is an extradimensional space. Each side pouch can hold up to 200 pounds of material, not exceeding a volume of 25 cubic feet. The central pouch can hold up to 500 pounds of material, not exceeding a volume of 64 cubic feet. Thehaversack always weighs 5 pounds, regardless of its contents.",
+			"Retrieving an item from the haversack requires a Utilize action or a Bonus Action (your choice). When you reach into the haversack for a specific item, the item is always magically on top.",
+			"If any of its pouches is overloaded, pierced, or torn, the haversack ruptures and is destroyed. If the haversack is destroyed, its contents are lost forever, although an Artifact always turns up again somewhere. If the haversack is turned inside out, its contents spill forth unharmed, and the haversack must be put right before it can be used again.",
+			"Each pouch of the haversack holds enough air for 10 minutes of breathing, divided by the number of breathing creatures inside.",
+			"Placing the haversack inside an extradimensional space created by a Bag of Holding, Portable Hole,or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+		]
 	},
 	{
 		"index": "hat-of-disguise",
 		"url": "/api/2024/magic-items/hat-of-disguise",
 		"image" : "/api/images/magic-items/hat-of-disguise.png",
 		"name": "Hat of Disguise",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this hat, you can cast the Disguise Self spell. The spell ends if the hat is removed."
+		]
 	},
 	{
 		"index": "headband-of-intellect",
 		"url": "/api/2024/magic-items/headband-of-intellect",
 		"image" : "/api/images/magic-items/headband-of-intellect.png",
 		"name": "Headband of Intellect",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
+
+		"desc": [
+			"Wondrous Item",
+			"Your Intelligence is 19 while you wear this headband. It has no effect on you if your Intelligence is 19 or higher without it."
+		]
 	},
 	{
 		"index": "helm-of-brilliance",
 		"url": "/api/2024/magic-items/helm-of-brilliance",
 		"image" : "/api/images/magic-items/helm-of-brilliance.png",
 		"name": "Helm of Brilliance",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.\nDiamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.\nFire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.\nRuby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.\nSpells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.\nTaking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
+
+		"desc": [
+			"Wondrous Item",
+			"This helm is set with 1d10 diamonds, 2d10 rubies, 3d10 fire opals, and 4d10 opals. Any gem pried from the helm crumbles to dust. When all the gems are removed or destroyed, the helm loses its magic.You gain the following benefits while wearing thehelm.",
+			"Diamond Light. As long as it has at least one diamond, the helm emits a 30-foot Emanation. When at least one Undead is within that area, the Emanation is filled with Dim Light. Any Undead that starts its turn in that area takes 1d6 Radiant damage.",
+			"Fire Opal Flames. As long as the helm has at least one fire opal, you can take a Magic action to cause one weapon you are holding to burst into flames.The flames emit Bright Light in a 10-foot radius and Dim Light for an additional 10 feet. The flames are harmless to you and the weapon. When you hit with an attack using the blazing weapon, the target takes an extra 1d6 Fire damage. The flames last until you take a Bonus Action to extinguish them or until you drop or stow the weapon.",
+			"Ruby Resistance. As long as the helm has at least one ruby, you have Resistance to Fire damage.",
+			"Spells. You can cast one of the following spells (save DC 18), using one of the helm's gems of the specified type as a component: Daylight (opal), Fireball (fire opal), Prismatic Spray (diamond), or Wall of Fire (ruby). The gem is destroyed when the spell is cast and disappears from the helm.",
+			"Taking Fire Damage. Roll 1d20 if you are wearing the helm and take Fire damage as a result of failing a saving throw against a spell. On a roll of 1, the helm emits beams of light from its remaining gems and is then destroyed. Each creature within a 60foot Emanation originating from you must succeed on a DC 17 Dexterity saving throw or be struck by a beam, taking Radiant damage equal to the number of gems in the helm."
+		]
 	},
 	{
 		"index": "helm-of-comprehending-languages",
 		"url": "/api/2024/magic-items/helm-of-comprehending-languages",
 		"image" : "/api/images/magic-items/helm-of-comprehending-languages.png",
 		"name": "Helm of Comprehending Languages",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this helm, you can cast Comprehend Languages from it."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this helm, you can cast Comprehend Languages from it."
+		]
 	},
 	{
 		"index": "helm-of-telepathy",
 		"url": "/api/2024/magic-items/helm-of-telepathy",
 		"image" : "/api/images/magic-items/helm-of-telepathy.png",
 		"name": "Helm of Telepathy",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this helm, you have telepathy with a range of 30 feet, and you can cast Detect Thoughts or Suggestion (save DC 13) from the helm. Once either spell is cast from the helm, that spell can't be cast from it again until the next dawn."
+		]
 	},
 	{
 		"index": "helm-of-teleportation",
 		"url": "/api/2024/magic-items/helm-of-teleportation",
 		"image" : "/api/images/magic-items/helm-of-teleportation.png",
 		"name": "Helm of Teleportation",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"This helm has 3 charges. While wearing it, you can expend 1 charge to cast Teleport from it. The helm regains 1d3 expended charges daily at dawn."
+		]
 	},
 	{
 		"index": "holy-avenger",
 		"url": "/api/2024/magic-items/holy-avenger",
 		"image" : "/api/images/magic-items/holy-avenger.png",
 		"name": "Holy Avenger",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"limited-to": "Paladin",
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. When you hit a Fiend or an Undead with it, that creature takes an extra 2d10 Radiant damage.While you hold the drawn weapon, it creates a10-foot Emanation originating from you. You and all creatures Friendly to you in the Emanation have Advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the Paladin class, the size of the Emanation increases to 30 feet."
+		]
 	},
 	{
 		"index": "horn-of-blasting",
 		"url": "/api/2024/magic-items/horn-of-blasting",
 		"image" : "/api/images/magic-items/horn-of-blasting.png",
 		"name": "Horn of Blasting",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.\nEach use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
+
+		"desc": [
+			"Wondrous Item",
+			"You can take a Magic action to blow the horn, which emits a thunderous blast in a 30-foot Cone that is audible out to 600 feet. Each creature in the Cone makes a DC 15 Constitution saving throw. On a failed save, a creature takes 5d8 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only. Glass or crystal objects in the Cone that aren't being worn or carried take 10d8 Thunder damage.",
+			"Each use of the horn's magic has a 20 percent chance of causing the horn to explode. The explosion deals 10d6 Force damage to the user and destroys the horn."
+		]
 	},
 	{
 		"index": "horn-of-valhalla",
 		"url": "/api/2024/magic-items/horn-of-valhalla",
 		"image" : "/api/images/magic-items/horn-of-valhalla.png",
 		"name": "Horn of Valhalla",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare (Silver or Brass), Very Rare (Bronze), or Legendary (Iron)"
 		},
-		"description": "You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.\nFour types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.\nIf you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+
+		"desc": [
+			"Wondrous Item",
+			"You can take a Magic action to blow this horn. In response, warrior spirits from the plane of Ysgard appear in unoccupied spaces within 60 feet of you. Each spirit uses the Berserker stat block and returns to Ysgard after 1 hour or when it drops to 0 Hit Points. The spirits look like living, breathing warriors, and they have Immunity to the Charmed and Frightened conditions. Once you use the horn, it can't be used again until 7 days have passed.",
+			"Four types of Horn of Valhalla are known to exist, each made of a different metal. The horn's type determines how many spirits it summons, as well as the requirement for its use. The GM chooses the horn's type or determines it randomly by rolling on the following table.",
+			"If you blow the horn without meeting its requirement, the summoned spirits attack you. If you meet the requirement, they are Friendly to you and your allies and follow your commands.1d100Horn TypeSpiritsRequirement01-40Silver2None41-75Brass3Proficiency with allSimple weapons76-90Bronze4Training with all Medium armor91-00Iron5Proficiency with allMartial weapons"
+		]
 	},
 	{
 		"index": "horseshoes-of-a-zephyr",
 		"url": "/api/2024/magic-items/horseshoes-of-a-zephyr",
 		"image" : "/api/images/magic-items/horseshoes-of-a-zephyr.png",
 		"name": "Horseshoes of a Zephyr",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
+
+		"desc": [
+			"Wondrous Item",
+			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
+			"While all four shoes are affixed to the hooves of a horse or similar creature, they allow the creature to move normally while floating 4 inches above a surface. This effect means the creature can cross or stand above nonsolid or unstable surfaces, such as water or lava. The creature leaves no tracks and ignores Difficult Terrain. In addition, the creature can travel for up to 12 hours a day without gaining Exhaustion levels from extended travel."
+		]
 	},
 	{
 		"index": "horseshoes-of-speed",
 		"url": "/api/2024/magic-items/horseshoes-of-speed",
 		"image" : "/api/images/magic-items/horseshoes-of-speed.png",
 		"name": "Horseshoes of Speed",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.\nWhile all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
+
+		"desc": [
+			"Wondrous Item",
+			"These horseshoes come in a set of four. As a Magic action, you can touch one of the horseshoes to the hoof of a horse or similar creature, whereupon the horseshoe affixes itself to the hoof. Removing a horseshoe also takes a Magic action.",
+			"While all four horseshoes are attached to the same creature, its Speed is increased by 30 feet."
+		]
 	},
 	{
 		"index": "immovable-rod",
 		"url": "/api/2024/magic-items/immovable-rod",
 		"image" : "/api/images/magic-items/immovable-rod.png",
 		"name": "Immovable Rod",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
+
+		"desc": [
+			"Rod",
+			"This iron rod has a button on one end. You can take a Utilize action to press the button, which causes the rod to become magically fixed in place. Until you or another creature takes a Utilize action to push the button again, the rod doesn't move, even if it defies gravity. The rod can hold up to 8,000 pounds of weight. More weight causes the rod to deactivate and fall. A creature can take a Utilize action to make a DC 30 Strength (Athletics) check, moving the fixed rod up to 10 feet on a successful check."
+		]
 	},
 	{
 		"index": "instant-fortress",
 		"url": "/api/2024/magic-items/instant-fortress",
 		"image" : "/api/images/magic-items/instant-fortress.png",
 		"name": "Instant Fortress",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.\nThe tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.\nMagic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
+
+		"desc": [
+			"Wondrous Item",
+			"As a Magic action, you can place this 1-inch adamantine statuette on the ground and, using a command word, cause it to grow rapidly into asquare adamantine tower. Repeating the commandword causes the tower to revert to statuette form, which works only if the tower is empty. Each creature in the area where the tower appears is pushed to an unoccupied space outside but next to the tower. Objects in the area that aren't being worn or carried are also pushed clear of the tower.",
+			"The tower is 20 feet on a side and 30 feet high, with arrow slits on all sides and a battlement atop it. Its interior is divided into two floors, with a ladder, staircase, or ramp (your choice) connecting them. This ladder, staircase, or ramp ends at a trapdoor leading to the roof. When created, the tower has a single door at ground level on the side facing you. The door opens only at your command, which you can issue as a Bonus Action. It is immune to the Knock spell and similar magic.",
+			"Magic prevents the tower from being tipped over. The roof, the door, and the walls each have AC 20; HP 100; Immunity to Bludgeoning, Piercing, and Slashing damage except that which is dealt by siege equipment; and Resistance to all other damage. Shrinking the tower back down to statuette form doesn't repair damage to the tower. Only a Wish spell can repair the tower (this use of the spell counts as replicating a spell of level 8 or lower). Each casting of Wish causes the tower to regain all its Hit Points."
+		]
 	},
 	{
 		"index": "ioun-stone",
 		"url": "/api/2024/magic-items/ioun-stone",
 		"image" : "/api/images/magic-items/ioun-stone.png",
 		"name": "Ioun Stone",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.\nWhen you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.\nEach Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.\nAs a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.\nThe type of stone determines its rarity and effects.\nAbsorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nAgility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.\nAwareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.\nFortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.\nGreater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.\nInsight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.\nIntellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.\nLeadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.\nMastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.\nProtection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.\nRegeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.\nReserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.\nStrength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.\nSustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
+
+		"desc": [
+			"Wondrous Item",
+			"Roughly marble sized, Ioun Stones are named after Ioun, a god of knowledge and prophecy revered on some worlds. Many types of Ioun Stones exist, each type a distinct combination of shape and color.",
+			"When you take a Magic action to toss an Ioun Stone into the air, the stone orbits your head at a distance of 1d3 feet, conferring its benefit to you while doing so. You can have up to three Ioun Stones orbiting your head at the same time.",
+			"Each Ioun Stone orbiting your head is considered to be an object you are wearing. The orbiting stone avoids contact with other creatures and objects, adjusting its orbit to avoid collisions and thwarting all attempts by other creatures to attack or snatch it.",
+			"As a Utilize action, you can seize and stow any number of Ioun Stones orbiting your head. If your Attunement to an Ioun Stone ends while it's orbiting your head, the stone falls as though you had dropped it.",
+			"The type of stone determines its rarity and effects.",
+			"Absorption (Very Rare). While this pale lavender ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 4 or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.",
+			"Agility (Very Rare). Your Dexterity increases by 2, to a maximum of 20, while this deep-red sphere orbits your head.",
+			"Awareness (Rare). While this dark-blue rhomboid orbits your head, you have Advantage on Initiative rolls and Wisdom (Perception) checks.",
+			"Fortitude (Very Rare). Your Constitution increases by 2, to a maximum of 20, while this pink rhomboid orbits your head.",
+			"Greater Absorption (Legendary). While this marbled lavender and green ellipsoid orbits your head, you can take a Reaction to cancel a spell of level 8or lower cast by a creature you can see. A canceled spell has no effect, and any resources used to cast it are wasted. Once the stone has canceled 20 levels of spells, it burns out, turns dull gray, and loses its magic.",
+			"Insight (Very Rare). Your Wisdom increases by 2, to a maximum of 20, while this incandescent blue sphere orbits your head.",
+			"Intellect (Very Rare). Your Intelligence increases by 2, to a maximum of 20, while this marbled scarlet and blue sphere orbits your head.",
+			"Leadership (Very Rare). Your Charisma increases by 2, to a maximum of 20, while this marbled pink and green sphere orbits your head.",
+			"Mastery (Legendary). Your Proficiency Bonus increases by 1 while this pale green prism orbits your head.",
+			"Protection (Rare). You gain a +1 bonus to Armor Class while this dusty-rose prism orbits your head.",
+			"Regeneration (Legendary). You regain 15 Hit Points at the end of each hour this pearly white spindle orbits your head if you have at least 1 Hit Point.",
+			"Reserve (Rare). This vibrant purple prism stores spells cast into it, holding them until you use them. The stone can store up to 4 levels of spells at a time. When found, it contains 1d4 levels of stored spells chosen by the GM.",
+			"Any creature can cast a spell of level 1 through 4 into the stone by touching it as the spell is cast. The spell has no effect, other than to be stored in the stone. If the stone can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.",
+			"While this stone orbits your head, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast fromthe stone is no longer stored in it, freeing up space.",
+			"Strength (Very Rare). Your Strength increases by 2, to a maximum of 20, while this pale blue rhomboid orbits your head.",
+			"Sustenance (Rare). You don't need to eat or drink while this clear spindle orbits your head."
+		]
 	},
 	{
 		"index": "iron-bands",
 		"url": "/api/2024/magic-items/iron-bands",
 		"image" : "/api/images/magic-items/iron-bands.png",
 		"name": "Iron Bands",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.\nMake a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.\nA creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.\nOnce the bands are used, they can't be used again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"This rusty iron sphere measures 3 inches in diameter and weighs 1 pound. You can take a Magic action to throw the sphere at a Huge or smaller creature you can see within 60 feet of yourself. As the sphere moves through the air, it opens into a tangle of metal bands.",
+			"Make a ranged attack roll with an attack bonus equal to your Dexterity modifier plus your Proficiency Bonus. On a hit, the target has the Restrained condition until you take a Bonus Action to issue a command that releases it. Doing so or missing with the attack causes the bands to contract and become a sphere once more.",
+			"A creature that can touch the bands, including the one Restrained, can take an action to make a DC 20 Strength (Athletics) check to break the iron bands. On a successful check, the item is destroyed, and the Restrained creature is freed. On a failed check, any further attempts made by that creature automatically fail until 24 hours have elapsed.",
+			"Once the bands are used, they can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "iron-flask",
 		"url": "/api/2024/magic-items/iron-flask",
 		"image" : "/api/images/magic-items/iron-flask.png",
 		"name": "Iron Flask",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.\nYou can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.\nAn Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
+
+		"desc": [
+			"Wondrous Item",
+			"While holding this brass-stoppered iron flask, you can take a Magic action to target a creature that you can see within 60 feet of yourself. If the flask is empty and the target is native to a plane of existence other than the one you're on, the target must succeed on a DC 17 Wisdom saving throw or be trapped in the flask. If the target has been trapped by the flask before, it has Advantage on the save. Once trapped, a creature remains in the flask until released. The flask can hold only one creature at atime. A creature trapped in the flask doesn't age anddoesn't need to breathe, eat, or drink.",
+			"You can take a Magic action to remove the flask's stopper and release the creature in the flask. The creature then obeys your commands for 1 hour, understanding those commands even if it doesn't know the language in which the commands are given. If you issue no commands or give the creature a command that is likely to result in its death or imprisonment, it defends itself but otherwise takes no actions. At the end of the duration, the creature acts in accordance with its normal disposition and alignment.",
+			"An Identify spell reveals if the flask contains a creature, but the only way to determine the type of creature is to open the flask. A newly discovered Iron Flask might already contain a creature chosen by the GM."
+		]
 	},
 	{
 		"index": "javelin-of-lightning",
 		"url": "/api/2024/magic-items/javelin-of-lightning",
 		"image" : "/api/images/magic-items/javelin-of-lightning.png",
 		"name": "Javelin of Lightning",
-		"type": "Weapon (Javelin)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.\nLightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
+
+		"desc": [
+			"Weapon (Javelin)",
+			"Each time you make an attack roll with this magic weapon and hit, you can have it deal Lightning damage instead of Piercing damage.",
+			"Lightning Bolt. When you throw this weapon at a target no farther than 120 feet from you, you can forgo making a ranged attack roll and instead turn the weapon into a bolt of lightning. This bolt forms a 5-foot-wide Line between you and the target. The target and each other creature in the Line (exclud-ing you) makes a DC 13 Dexterity saving throw, tak-ing 4d6 Lightning damage on a failed save or half as much damage on a successful one. Immediately after dealing this damage, the weapon reappears in your hand. This property can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "lantern-of-revealing",
 		"url": "/api/2024/magic-items/lantern-of-revealing",
 		"image" : "/api/images/magic-items/lantern-of-revealing.png",
 		"name": "Lantern of Revealing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
+
+		"desc": [
+			"Wondrous Item",
+			"While lit, this hooded lantern burns for 6 hours on 1 pint of oil, shedding Bright Light in a 30-foot radius and Dim Light for an additional 30 feet. Invisible creatures and objects are visible as long as they are in the lantern's Bright Light. You can take a Utilize action to lower the hood, reducing the lantern's light to Dim Light in a 5-foot radius."
+		]
 	},
 	{
 		"index": "luck-blade",
 		"url": "/api/2024/magic-items/luck-blade",
 		"image" : "/api/images/magic-items/luck-blade.png",
 		"name": "Luck Blade",
-		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.\nLuck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.\nWish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, Sickle, or Shortsword)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. While the weapon is on your person, you also gain a +1 bonus to saving throws.",
+			"Luck. If the weapon is on your person, you can call on its luck (no action required) to reroll one failed D20 Test if you don't have the Incapacitated condition. You must use the second roll. Once used, this property can't be used again until the next dawn.",
+			"Wish. The weapon has 1d3 charges. While holding it, you can expend 1 charge and cast Wish from it.Once used, this property can't be used again until the next dawn. The weapon loses this property if it has no charges."
+		]
 	},
 	{
 		"index": "mace-of-disruption",
 		"url": "/api/2024/magic-items/mace-of-disruption",
 		"image" : "/api/images/magic-items/mace-of-disruption.png",
 		"name": "Mace of Disruption",
-		"type": "Weapon (Mace)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.\nLight. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
+
+		"desc": [
+			"Weapon (Mace)",
+			"When you hit a Fiend or an Undead with this magic weapon, that creature takes an extra 2d6 Radiant damage. If the target has 25 Hit Points or fewer after taking this damage, it must succeed on a DC 15 Wisdom saving throw or be destroyed. On a successful save, the creature has the Frightened condition until the end of your next turn.",
+			"Light. While you hold this weapon, it sheds Bright Light in a 20-foot radius and Dim Light for an additional 20 feet."
+		]
 	},
 	{
 		"index": "mace-of-smiting",
 		"url": "/api/2024/magic-items/mace-of-smiting",
 		"image" : "/api/images/magic-items/mace-of-smiting.png",
 		"name": "Mace of Smiting",
-		"type": "Weapon (Mace)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.\nWhen you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
+
+		"desc": [
+			"Weapon (Mace)",
+			"You gain a +1 bonus to attack rolls and damage rolls made with this magic weapon. The bonus increases to +3 when you use the weapon to attack a Construct.",
+			"When you roll a 20 on an attack roll made with this weapon, the target takes an extra 7 Bludgeoning damage, or 14 Bludgeoning damage if it's a Construct. If a Construct has 25 Hit Points or fewer after taking this damage, it is destroyed."
+		]
 	},
 	{
 		"index": "mace-of-terror",
 		"url": "/api/2024/magic-items/mace-of-terror",
 		"image" : "/api/images/magic-items/mace-of-terror.png",
 		"name": "Mace of Terror",
-		"type": "Weapon (Mace)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
+
+		"desc": [
+			"Weapon (Mace)",
+			"This magic weapon has 3 charges and regains 1d3 expended charges daily at dawn. While holding the weapon, you can take a Magic action and expend1 charge to release a wave of terror from it. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. While Frightened in this way, a creature must spend its turns trying to move as far away from you as it can, andit can't make Opportunity Attacks. For its action, it can use only the Dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can take the Dodge action. At the end of each of its turns, a creature repeats the save, ending the effect on itself on a success."
+		]
 	},
 	{
 		"index": "mantle-of-spell-resistance",
 		"url": "/api/2024/magic-items/mantle-of-spell-resistance",
 		"image" : "/api/images/magic-items/mantle-of-spell-resistance.png",
 		"name": "Mantle of Spell Resistance",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You have Advantage on saving throws against spells while you wear this cloak."
+
+		"desc": [
+			"Wondrous Item",
+			"You have Advantage on saving throws against spells while you wear this cloak."
+		]
 	},
 	{
 		"index": "manual-of-bodily-health",
 		"url": "/api/2024/magic-items/manual-of-bodily-health",
 		"image" : "/api/images/magic-items/manual-of-bodily-health.png",
 		"name": "Manual of Bodily Health",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book contains health and nutrition tips, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Constitution increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+		]
 	},
 	{
 		"index": "manual-of-gainful-exercise",
 		"url": "/api/2024/magic-items/manual-of-gainful-exercise",
 		"image" : "/api/images/magic-items/manual-of-gainful-exercise.png",
 		"name": "Manual of Gainful Exercise",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book describes fitness exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Strengthincreases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+		]
 	},
 	{
 		"index": "manual-of-golems",
 		"url": "/api/2024/magic-items/manual-of-golems",
 		"image" : "/api/images/magic-items/manual-of-golems.png",
 		"name": "Manual of Golems",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.\nTo create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.\nOnce you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
+
+		"desc": [
+			"Wondrous Item",
+			"This tome contains information and incantations necessary to make a particular type of golem. The GM chooses the type or determines it randomly by rolling on the accompanying table. To decipher and use the manual, you must be a spellcaster with at least two level 5 spell slots. A creature that can't use a Manual of Golems and attempts to read it takes 6d6 Psychic damage.",
+			"To create a golem, you must spend the time shown on the table, working without interruption with the manual at hand and resting no more than 8 hours per day. You must also pay the specified cost to purchase supplies.",
+			"Once you finish creating the golem, the book is consumed in eldritch flames. The golem becomes animate when the ashes of the manual are sprinkled on it. See \"Monsters\" for the golem's stat block. The golem is under your control, and it understands and obeys your commands. 1d20 Golem Time Cost 1-5 Clay Golem 30 days 65,000 GP 6-17 Flesh Golem 60 days 50,000 GP 18 Iron Golem 120 days 100,000 GP 19-20 Stone Golem 90 days 80,000 GP"
+		]
 	},
 	{
 		"index": "manual-of-quickness-of-action",
 		"url": "/api/2024/magic-items/manual-of-quickness-of-action",
 		"image" : "/api/images/magic-items/manual-of-quickness-of-action.png",
 		"name": "Manual of Quickness of Action",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book contains coordination and balance exercises, and its words are charged with magic.If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Dexterity increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+		]
 	},
 	{
 		"index": "marvelous-pigments",
 		"url": "/api/2024/magic-items/marvelous-pigments",
 		"image" : "/api/images/magic-items/marvelous-pigments.png",
 		"name": "Marvelous Pigments",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).\nUsing the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.\nWhen the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.\nNo object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.\nIf you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
+
+		"desc": [
+			"Wondrous Item",
+			"This fine wooden box contains 1d4 pots of pigmentand a brush (weighing 1 pound in total).",
+			"Using the brush and expending 1 pot of pigment, you can paint any number of three-dimensional objects and terrain features (such as walls, doors, trees, flowers, weapons, webs, and pits), provided these elements are all confined to a 20-foot Cube. The effort takes 10 minutes (regardless of the number of elements you create), during which time you must remain in the Cube, and requires Concentration. If your Concentration is broken or you leave the Cube before the work is done, all the painted elements vanish, and the pot of pigment is wasted.",
+			"When the work is done, all the painted objects and terrain features become real. Thus, painting a door on a wall creates an actual door, which can be opened to whatever is beyond. Painting a pit creates a real pit, the entire depth of which must lie within the 20-foot Cube.",
+			"No object created by a pot of pigment can have a value greater than 25 GP, and the total value of all objects created by a pot of pigment can't exceed 500 GP. If you paint objects of greater value (such as a large pile of gold), they look authentic, but close inspection reveals they're made from paste, cookies, or some other worthless material.",
+			"If you paint a form of energy such as fire or lightning, the energy dissipates as soon as you complete the painting, doing no harm."
+		]
 	},
 	{
 		"index": "medallion-of-thoughts",
 		"url": "/api/2024/magic-items/medallion-of-thoughts",
 		"image" : "/api/images/magic-items/medallion-of-thoughts.png",
 		"name": "Medallion of Thoughts",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"The medallion has 5 charges. While wearing it, you can expend 1 charge to cast Detect Thoughts (save DC 13) from it. The medallion regains 1d4 expended charges daily at dawn."
+		]
 	},
 	{
 		"index": "mirror-of-life-trapping",
 		"url": "/api/2024/magic-items/mirror-of-life-trapping",
 		"image" : "/api/images/magic-items/mirror-of-life-trapping.png",
 		"name": "Mirror of Life Trapping",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.\nIf the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.\nAny creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.\nAn extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.\nIf the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.\nWhile within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.\nIn a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.\nPlacing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+
+		"desc": [
+			"Wondrous Item",
+			"When this 4-foot-tall, 2-foot-wide mirror is viewed indirectly, its surface shows faint images of creatures. The mirror weighs 50 pounds, and it has AC 11, HP 10, Immunity to Poison and Psychic damage, and Vulnerability to Bludgeoning damage. It shatters and is destroyed when reduced to 0 Hit Points.",
+			"If the mirror is hanging on a vertical surface and you are within 5 feet of it, you can take a Magic action and use a command word to activate it. It remains activated until you take a Magic action and repeat the command word to deactivate it.",
+			"Any creature other than you that sees its reflection in the activated mirror while within 30 feet of the mirror must succeed on a DC 15 Charisma saving throw or be trapped, along with anything itis wearing or carrying, in one of the mirror's twelve extradimensional cells. A creature that knows the mirror's nature makes the save with Advantage, and Constructs succeed on the save automatically.",
+			"An extradimensional cell is an infinite expanse filled with thick fog that reduces visibility to 10 feet. Creatures trapped in the mirror's cells don't age, and they don't need to eat, drink, or sleep. A creature trapped within a cell can escape using magic that permits planar travel. Otherwise, the creature is confined to the cell until freed.",
+			"If the mirror traps a creature but its twelve extradimensional cells are already occupied, the mirror frees one trapped creature at random to accommodate the new prisoner. A freed creature appears in an unoccupied space within sight of the mirrorbut facing away from it. If the mirror is shattered, all creatures it contains are freed and appear in unoccupied spaces near it.",
+			"While within 5 feet of the mirror, you can take a Magic action to name one creature trapped in it or call out a particular cell by number. The creature named or contained in the named cell appears as an image on the mirror's surface. You and the creature can then communicate.",
+			"In a similar way, you can take a Magic action and use a second command word to free one creature trapped in the mirror. The freed creature appears, along with its possessions, in the unoccupied space nearest to the mirror and facing away from it.",
+			"Placing the mirror inside an extradimensional space created by a Bag of Holding, Portable Hole, or similar item instantly destroys both items andopens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it to a random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+		]
 	},
 	{
 		"index": "mithral-armor",
 		"url": "/api/2024/magic-items/mithral-armor",
 		"image" : "/api/images/magic-items/mithral-armor.png",
 		"name": "Mithral Armor",
-		"type": "Armor (Any Medium or Heavy, Except Hide Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
+
+		"desc": [
+			"Armor (Any Medium or Heavy, Except Hide Armor)",
+			"Mithral is a light, flexible metal. Armor made of this substance can be worn under normal clothes. If the armor normally imposes Disadvantage on Dexterity (Stealth) checks or has a Strength requirement, the mithral version of the armor doesn't."
+		]
 	},
 	{
 		"index": "mysterious-deck",
 		"url": "/api/2024/magic-items/mysterious-deck",
 		"image" : "/api/images/magic-items/mysterious-deck.png",
 		"name": "Mysterious Deck",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.\nBefore you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.\nOnce a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.\nEuryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.\nBalance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.\nComet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.\nDonjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.\nFates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.\nFlames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.\nFool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.\nGem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.\nJester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.\nKey. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.\nKnight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.\nPuzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.\nRogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.\nRuin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.\nSage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.\nSkull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.\nStar. Increase one of your ability scores by 2, to a maximum of 24.\nSun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.\nTalons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.\nThrone. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.\nVoid. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
+
+		"desc": [
+			"Wondrous Item",
+			"Usually found in a box or pouch, this deck contains a number of cards made of ivory or vellum. Most (75 percent) of these decks have thirteen cards, but some have twenty-two. Use the appropriate column of the Mysterious Deck table when randomly determining cards drawn from the deck.",
+			"Before you draw a card, you must declare how many cards you intend to draw and then draw them randomly. Any cards drawn in excess of this number have no effect. Otherwise, as soon as you draw a card from the deck, its magic takes effect. You must draw each card no more than 1 hour after the previous draw. If you fail to draw the chosen number, the remaining number of cards fly from the deck on their own and take effect all at once.",
+			"Once a card is drawn, it disappears. Unless the card is the Fool or Jester, the card reappears in the deck, making it possible to draw the same card twice. (Once the Fool or Jester has left the deck, reroll on the table if that card comes up again.)Mysterious Deck1d100(13-Card Deck)1d100(22-Card Deck)Cardcan reveal the location of your prison. You draw no more cards.",
+			"Euryale. The card's medusa-like visage curses you. You take a -2 penalty to saving throws while cursed in this way. Only a god or the magic of the-  06-10  Comet01-08  15-18  Euryale09-16  24-27  Flames-  32-36  Gem25-32  42-46  Key41-48  52-56  Moon49-56  61-64  Rogue-  69-73  Sage73-80  78-82  Star-  88-91  Talons97-00  97-00  VoidEach card's effect is described below.",
+			"Balance. You can increase one of your ability scores by 2, to a maximum of 22, provided you also decrease another one of your ability scores by 2.You can't decrease an ability that has a score of 5 or lower. Alternatively, you can choose not to adjust your ability scores, in which case this card has no effect.",
+			"Comet. The next time you enter combat against one or more Hostile creatures, you can select one of them as your foe when you roll Initiative. If you reduce your foe to 0 Hit Points during that combat, you have Advantage on Death Saving Throws for 1 year. If someone else reduces your chosen foe to 0Hit Points or you don't choose a foe, this card has no effect.",
+			"Donjon. You disappear and become entombed in a state of suspended animation in an extradimensional sphere. Everything you're wearing and carrying disappears with you except for Artifacts,which stay behind in the space you occupied when you disappeared. You remain imprisoned until you are found and removed from the sphere. You can't be located by any Divination magic, but a Wish spellFates card can end this curse.",
+			"Fates. Reality's fabric unravels and spins anew, allowing you to avoid or erase one event as if it never happened. You can use the card's magic as soonas you draw the card or at any other time before you die.",
+			"Flames. A powerful devil becomes your enemy. The devil seeks your ruin and torments you, savoring your suffering before attempting to slay you.This enmity lasts until either you or the devil dies.",
+			"Fool. You have Disadvantage on D20 Tests for the next 72 hours. Draw another card; this draw doesn't count as one of your declared draws.",
+			"Gem. Twenty-five pieces of jewelry worth 2,000 GP each or fifty gems worth 1,000 GP each appear at your feet.",
+			"Jester. You have Advantage on D20 Tests for the next 72 hours, or you can draw two additional cards beyond your declared draws.",
+			"Key. A Rare or rarer magic weapon with which you are proficient appears on your person. The GM chooses the weapon.",
+			"Knight. You gain the service of a Knight, who magically appears in an unoccupied space you choose within 30 feet of yourself. The knight has the same alignment as you and serves you loyally until death, believing the two of you have been drawn together by fate. Work with your GM to create a name and backstory for this NPC. The GM can use a different stat block to represent the knight, as desired.Moon. You gain the ability to cast Wish 1d3 times.",
+			"Puzzle. Permanently reduce your Intelligence or Wisdom by 1d4 + 1 (to a minimum score of 1). You can draw one additional card beyond your declared draws.",
+			"Rogue. An NPC of the GM's choice becomes Hostile toward you. You don't know the identity of this NPC until they or someone else reveals it. Nothing less than a Wish spell or divine intervention can end the NPC's hostility toward you.",
+			"Ruin. All forms of wealth that you carry or own, other than magic items, are lost to you. Portable property vanishes. Businesses, buildings, and land you own are lost in a way that alters reality the least. Any documentation that proves you should own something lost to this card also disappears.",
+			"Sage. At any time you choose within one year of drawing this card, you can ask a question in meditation and mentally receive a truthful answer to that question.",
+			"Skull. An Avatar of Death (see the accompanying stat block) appears in an unoccupied space as closeto you as possible. The avatar targets only you with its attacks, appearing as a ghostly skeleton clad in a tattered black robe and carrying a spectral scythe. The avatar disappears when it drops to 0 Hit Points or you die. If an ally of yours deals damage to the avatar, that ally summons another Avatar of Death. The new avatar appears in an unoccupied space as close to that ally as possible and targets only that ally with its attacks. You and your allies can each summon only one avatar as a consequence of this draw. A creature slain by an avatar can't be restored to life.",
+			"Star. Increase one of your ability scores by 2, to a maximum of 24.",
+			"Sun. A magic item (chosen by the GM) appears on your person. In addition, you gain 10 Temporary Hit Points daily at dawn until you die.",
+			"Talons. Every magic item you wear or carry disintegrates. Artifacts in your possession vanish instead.",
+			"Throne. You gain proficiency and Expertise in your choice of History, Insight, Intimidation, or Persuasion. In addition, you gain rightful ownership of a small keep somewhere in the world. However, the keep is currently home to one or more monsters, which must be cleared out before you can claim the keep as yours.",
+			"Void. Your soul is drawn from your body and contained in an object in a place of the GM's choice. One or more powerful beings guard the place. While your soul is trapped in this way, your body is inert, ceases aging, and requires no food, air, or water. A Wish spell can't return your soul to your body, but the spell reveals the location of the object that holds your soul. You draw no more cards.Medium Undead, Neutral evilAC 20  Initiative +3 (13) HP Half the HP maximum of its summoner Speed 60 ft., Fly 60 ft. (hover)MOD SAVE  MOD SAVE  MOD SAVEStr 16+3+3Dex 16+3+3Con 16+3+3Int  16+3+3WIS 16+3+3Cha 16+3+3Immunities Necrotic, Poison; Charmed, Exhaustion,Frightened, Paralyzed, Petrified, Poisoned, UnconsciousSenses Truesight 60 ft., Passive Perception 13 Languages All languages known to its summoner CR None (XP 0; PB equals its summoner's)Traits  Incorporeal Movement. The avatar can move through other creatures and objects as if they were Difficult Terrain. It takes 5 (1d10) Force damage if it ends its turn inside an object.Actions  Multiattack. The avatar makes a number of Reaping Scythe attacks equal to half the summoner's Proficiency Bonus (rounded up).Reaping Scythe. Melee Attack Roll: Automatic hit, reach 5 ft. Hit: 7 (1d8 + 3) Slashing damage plus 4 (1d8) Necrotic damage."
+		]
 	},
 	{
 		"index": "necklace-of-adaptation",
 		"url": "/api/2024/magic-items/necklace-of-adaptation",
 		"image" : "/api/images/magic-items/necklace-of-adaptation.png",
 		"name": "Necklace of Adaptation",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this necklace, you can breathe normally in any environment, and you have Advantage on saving throws made to avoid or end the Poisoned condition."
+		]
 	},
 	{
 		"index": "necklace-of-fireballs",
 		"url": "/api/2024/magic-items/necklace-of-fireballs",
 		"image" : "/api/images/magic-items/necklace-of-fireballs.png",
 		"name": "Necklace of Fireballs",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).\nYou can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
+
+		"desc": [
+			"Wondrous Item",
+			"This necklace has 1d6 + 3 beads hanging from it. You can take a Magic action to detach a bead and throw it up to 60 feet away. When it reaches the end of its trajectory, the bead detonates as a level 3 Fireball (save DC 15).",
+			"You can hurl multiple beads, or even the whole necklace, at one time. When you do so, increase the damage of the Fireball by 1d6 for each bead after the first (maximum 12d6)."
+		]
 	},
 	{
 		"index": "necklace-of-prayer-beads",
 		"url": "/api/2024/magic-items/necklace-of-prayer-beads",
 		"image" : "/api/images/magic-items/necklace-of-prayer-beads.png",
 		"name": "Necklace of Prayer Beads",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"limited-to": "Cleric, Druid, or Paladin",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.\nSix types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"This necklace has 1d4 + 2 magic beads made from aquamarine, black pearl, or topaz. It also has many nonmagical beads made from stones such as amber, bloodstone, citrine, coral, jade, pearl, or quartz. If a magic bead is removed from the necklace, that bead loses its magic.",
+			"Six types of magic beads exist. The GM decides the type of each bead on the necklace or determines it randomly by rolling on the table below. A necklace can have more than one bead of the same type. To use one, you must be wearing the necklace. Each bead contains a spell that you can cast from it as a Bonus Action (using your spell save DC if a save is necessary). Once a magic bead's spell is cast, that bead can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "nine-lives-stealer",
 		"url": "/api/2024/magic-items/nine-lives-stealer",
 		"image" : "/api/images/magic-items/nine-lives-stealer.png",
 		"name": "Nine Lives Stealer",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.\nLife Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon.",
+			"Life Stealing. The weapon has 1d8 + 1 charges. When you attack a creature that has fewer than 100 Hit Points with this weapon and roll a 20 on the d20 for the attack roll, the creature must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body. Constructs and Undead succeed on the save automatically. The weapon loses 1 charge if the creature is slain. When the weapon has no charges remaining, it loses this property."
+		]
 	},
 	{
 		"index": "oathbow",
 		"url": "/api/2024/magic-items/oathbow",
 		"image" : "/api/images/magic-items/oathbow.png",
 		"name": "Oathbow",
-		"type": "Weapon (Longbow or Shortbow)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.\nWhen you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.\nWhile your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
+
+		"desc": [
+			"Weapon (Longbow or Shortbow)",
+			"When you nock an arrow on this bow, it whispers in Elvish, \"Swift defeat to my enemies.\" When you use this weapon to make a ranged attack, you can utter or sign the following command words: \"Swift death to you who have wronged me.\" The target of your attack becomes your sworn enemy until it dies or until dawn 7 days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.",
+			"When you make a ranged attack roll with this weapon against your sworn enemy, you have Advantage on the roll. In addition, your target gains no benefit from Half Cover or Three-Quarters Cover, and you suffer no Disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 Piercing damage.",
+			"While your sworn enemy lives, you have Disadvantage on attack rolls with all other weapons."
+		]
 	},
 	{
 		"index": "oil-of-etherealness",
 		"url": "/api/2024/magic-items/oil-of-etherealness",
 		"image" : "/api/images/magic-items/oil-of-etherealness.png",
 		"name": "Oil of Etherealness",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.\nBeads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
+
+		"desc": [
+			"Potion",
+			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Etherealness spell for 1 hour.",
+			"Beads of this cloudy, gray oil form on the outside of its container and quickly evaporate."
+		]
 	},
 	{
 		"index": "oil-of-sharpness",
 		"url": "/api/2024/magic-items/oil-of-sharpness",
 		"image" : "/api/images/magic-items/oil-of-sharpness.png",
 		"name": "Oil of Sharpness",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.\nThis clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
+
+		"desc": [
+			"Potion",
+			"One vial of this oil can coat one Melee weapon or twenty pieces of ammunition, but only ammunition and Melee weapons that are nonmagical and deal Slashing or Piercing damage are affected. Applying the oil takes 1 minute, after which the oil magicallyseeps into whatever it coats, turning the coated weapon into a +3 Weapon or the coated ammunition into +3 Ammunition.",
+			"This clear, gelatinous oil sparkles with tiny, ultrathin silver shards."
+		]
 	},
 	{
 		"index": "oil-of-slipperiness",
 		"url": "/api/2024/magic-items/oil-of-slipperiness",
 		"image" : "/api/images/magic-items/oil-of-slipperiness.png",
 		"name": "Oil of Slipperiness",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.\nAlternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
+
+		"desc": [
+			"Potion",
+			"One vial of this oil can cover one Medium or smaller creature, along with the equipment it's wearing and carrying (one additional vial is required for each size category above Medium). Applying the oil takes 10 minutes. The affected creature then gains the effect of the Freedom of Movement spell for 8 hours.",
+			"Alternatively, the oil can be poured on the ground as a Magic action, where it covers a 10-foot square, duplicating the effect of the Grease spell in that area for 8 hours.This sticky, black unguent is thick and heavy, butit flows quickly when poured."
+		]
 	},
 	{
 		"index": "pearl-of-power",
 		"url": "/api/2024/magic-items/pearl-of-power",
 		"image" : "/api/images/magic-items/pearl-of-power.png",
 		"name": "Pearl of Power",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While this pearl is on your person, you can take a Magic action to regain one expended spell slot of level 3 or lower. Once you use the pearl, it can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "periapt-of-health",
 		"url": "/api/2024/magic-items/periapt-of-health",
 		"image" : "/api/images/magic-items/periapt-of-health.png",
 		"name": "Periapt of Health",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.\nIn addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this pendant, you can take a Magic action to regain 2d4 + 2 Hit Points. Once used, this property can't be used again until the next dawn.",
+			"In addition, you have Advantage on saving throws to avoid or end the Poisoned condition while you wear this pendant."
+		]
 	},
 	{
 		"index": "periapt-of-proof-against-poison",
 		"url": "/api/2024/magic-items/periapt-of-proof-against-poison",
 		"image" : "/api/images/magic-items/periapt-of-proof-against-poison.png",
 		"name": "Periapt of Proof against Poison",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
+
+		"desc": [
+			"Wondrous Item",
+			"This delicate silver chain has a brilliant-cut black gem pendant. While you wear it, you have Immunity to the Poisoned condition and Poison damage."
+		]
 	},
 	{
 		"index": "periapt-of-wound-closure",
 		"url": "/api/2024/magic-items/periapt-of-wound-closure",
 		"image" : "/api/images/magic-items/periapt-of-wound-closure.png",
 		"name": "Periapt of Wound Closure",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this pendant, you gain the followingbenefits.\nLife Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.\nNatural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this pendant, you gain the followingbenefits.",
+			"Life Preservation. Whenever you make a Death Saving Throw, you can change a roll of 9 or lower to a 10, turning a failed save into a successful one.",
+			"Natural Healing Boost. Whenever you roll a Hit Point Die to regain Hit Points, double the number of Hit Points it restores."
+		]
 	},
 	{
 		"index": "philter-of-love",
 		"url": "/api/2024/magic-items/philter-of-love",
 		"image" : "/api/images/magic-items/philter-of-love.png",
 		"name": "Philter of Love",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.\nThis rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
+
+		"desc": [
+			"Potion",
+			"The next time you see a creature within 10 minutes after drinking this philter, you are charmed by that creature and have the Charmed condition for 1 hour.",
+			"This rose-hued, effervescent liquid contains one easy-to-miss bubble shaped like a heart."
+		]
 	},
 	{
 		"index": "pipes-of-haunting",
 		"url": "/api/2024/magic-items/pipes-of-haunting",
 		"image" : "/api/images/magic-items/pipes-of-haunting.png",
 		"name": "Pipes of Haunting",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
+
+		"desc": [
+			"Wondrous Item",
+			"These pipes have 3 charges and regain 1d3 expended charges daily at dawn. You can take a Magic action to play them and expend 1 charge to create an eerie, spellbinding tune. Each creature of your choice within 30 feet of you must succeed on a DC 15 Wisdom saving throw or have the Frightened condition for 1 minute. A creature that fails the save repeats it at the end of each of its turns, ending the effect on itself on a success. A creature that succeeds on its save is immune to the effect of these pipes for 24 hours."
+		]
 	},
 	{
 		"index": "pipes-of-the-sewers",
 		"url": "/api/2024/magic-items/pipes-of-the-sewers",
 		"image" : "/api/images/magic-items/pipes-of-the-sewers.png",
 		"name": "Pipes of the Sewers",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.\nThe pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.\nWhenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
+
+		"desc": [
+			"Wondrous Item",
+			"While these pipes are on your person, ordinary rats and giant rats are Indifferent toward you and won't attack you unless you threaten or harm them.",
+			"The pipes have 3 charges and regain 1d3 expended charges daily at dawn. If you play the pipes as a Magic action, you can take a Bonus Action to expend 1 to 3 charges, calling forth one Swarmof Rats with each expended charge if enough rats are within half a mile of you to be called in this fashion (as determined by the GM). If there aren't enough rats to form a swarm, the charge is wasted. Called swarms move toward the music by the shortest available route but aren't under your control otherwise.",
+			"Whenever a Swarm of Rats that isn't under another creature's control comes within 30 feet of you while you are playing the pipes, the swarm makesa DC 15 Wisdom saving throw. On a successful save, the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours. On a failed save, the swarm is swayed by the pipes' music and becomes Friendly to you and your allies for as long as you continue to play the pipes each round as a Magic action. A Friendly swarm obeys your commands. If you issue no commands to a Friendly swarm, it defends itself but otherwise takes no actions. If a Friendly swarm starts its turn more than 30 feet away from you, your control over that swarm ends, and the swarm behaves as it normally would and can't be swayed by the pipes' music for the next 24 hours."
+		]
 	},
 	{
 		"index": "plate-armor-of-etherealness",
 		"url": "/api/2024/magic-items/plate-armor-of-etherealness",
 		"image" : "/api/images/magic-items/plate-armor-of-etherealness.png",
 		"name": "Plate Armor of Etherealness",
-		"type": "Armor (Half Plate Armor or Plate Armor)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
+
+		"desc": [
+			"Armor (Half Plate Armor or Plate Armor)",
+			"While you're wearing this armor, you can take a Magic action and use a command word to gain the effect of the Etherealness spell. The spell ends immediately if you remove the armor or take a Magic action to repeat the command word. This property of the armor can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "portable-hole",
 		"url": "/api/2024/magic-items/portable-hole",
 		"image" : "/api/images/magic-items/portable-hole.png",
 		"name": "Portable Hole",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.\nYou can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.\nIf the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.\nPlacing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+
+		"desc": [
+			"Wondrous Item",
+			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
+			"You can take a Magic action to unfold a Portable Hole and place it on or against a solid surface, whereupon the Portable Hole creates an extradimensional hole 10 feet deep. The cylindrical space within the hole exists on a different plane of existence, so it can't be used to create open passages. Any creature inside an open Portable Hole can exit the hole by climbing out of it.",
+			"You can take a Magic action to close a Portable Hole by taking hold of the edges of the cloth and folding it up. Folding the cloth closes the hole, and any creatures or objects within remain in the extradimensional space. No matter what's in it, the hole weighs next to nothing.",
+			"If the hole is folded up, a creature within the hole's extradimensional space can take an action to make a DC 10 Strength (Athletics) check. On a successful check, the creature forces its way out and appears within 5 feet of the Portable Hole. A closed Portable Hole holds enough air for 1 hour of breathing, divided by the number of breathing creatures inside.",
+			"Placing a Portable Hole inside an extradimensional space created by a Bag of Holding, Handy Haversack, or similar item instantly destroys both items and opens a gate to the Astral Plane. The gate originates where the one item was placed inside the other. Any creature within 10 feet of the gate and not behind Total Cover is sucked through it and deposited ina random location on the Astral Plane. The gate then closes. The gate is one-way only and can't be reopened."
+		]
 	},
 	{
 		"index": "potion-of-animal-friendship",
 		"url": "/api/2024/magic-items/potion-of-animal-friendship",
 		"image" : "/api/images/magic-items/potion-of-animal-friendship.png",
 		"name": "Potion of Animal Friendship",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you can cast the level3 version of the Animal Friendship spell (save DC 13). Agitating this potion's muddy liquid brings little bits into view: a fish scale, a hummingbird feather, acat claw, or a squirrel hair."
+		]
 	},
 	{
 		"index": "potion-of-clairvoyance",
 		"url": "/api/2024/magic-items/potion-of-clairvoyance",
 		"image" : "/api/images/magic-items/potion-of-clairvoyance.png",
 		"name": "Potion of Clairvoyance",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).\nAn eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain the effect of the Clairvoyance spell (no Concentration required).",
+			"An eyeball bobs in this potion's yellowish liquid but vanishes when the potion is opened."
+		]
 	},
 	{
 		"index": "potion-of-climbing",
 		"url": "/api/2024/magic-items/potion-of-climbing",
 		"image" : "/api/images/magic-items/potion-of-climbing.png",
 		"name": "Potion of Climbing",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Common"
 		},
-		"description": "When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.\nThis potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain a Climb Speed equal to your Speed for 1 hour. During this time, you have Advantage on Strength (Athletics) checks to climb.",
+			"This potion is separated into brown, silver, and gray layers resembling bands of stone. Shaking the bottle fails to mix the colors."
+		]
 	},
 	{
 		"index": "potion-of-diminution",
 		"url": "/api/2024/magic-items/potion-of-diminution",
 		"image" : "/api/images/magic-items/potion-of-diminution.png",
 		"name": "Potion of Diminution",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).\nThe red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain the \"reduce\" effect of the Enlarge/Reduce spell for 1d4 hours (no Concentration required).",
+			"The red in the potion's liquid continuously contracts to a tiny bead and then expands to color the clear liquid around it. Shaking the bottle fails to interrupt this process."
+		]
 	},
 	{
 		"index": "potion-of-flying",
 		"url": "/api/2024/magic-items/potion-of-flying",
 		"image" : "/api/images/magic-items/potion-of-flying.png",
 		"name": "Potion of Flying",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain a Fly Speed equal to your Speed for 1 hour and can hover. If you're in the air when the potion wears off, you fall unless you have some other means of staying aloft.This potion's clear liquid floats at the top of itsPotionStr.RarityPotion of Giant Strength (hill)21UncommonPotion of Giant Strength (frost or stone)23RarePotion of Giant Strength (fire)25RarePotion of Giant Strength (cloud)27Very RarePotion of Giant Strength (storm)29Legendary"
+		]
 	},
 	{
 		"index": "potion-of-growth",
 		"url": "/api/2024/magic-items/potion-of-growth",
 		"image" : "/api/images/magic-items/potion-of-growth.png",
 		"name": "Potion of Growth",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).\nThe red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain the \"enlarge\" effect of the Enlarge/Reduce spell for 10 minutes (no Concentration required).",
+			"The red in the potion's liquid continuously expands from a tiny bead to color the clear liquid around it and then contracts. Shaking the bottle fails to interrupt this process."
+		]
 	},
 	{
 		"index": "potions-of-healing",
 		"url": "/api/2024/magic-items/potions-of-healing",
 		"image" : "/api/images/magic-items/potions-of-healing.png",
 		"name": "Potions of Healing",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.\nWhatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
+
+		"desc": [
+			"Potion",
+			"You regain Hit Points when you drink this potion. The number of Hit Points depends on the potion's rarity, as shown in the table below.",
+			"Whatever its potency, the potion's red liquid glimmers when agitated.PotionHP RegainedRarityPotion of Healing2d4 + 2CommonPotion of Healing(greater)4d4 + 4UncommonPotion of Healing(superior)8d4 + 8Rarecontainer and has cloudy white impurities drifting in it."
+		]
 	},
 	{
 		"index": "potion-of-gaseous-form",
 		"url": "/api/2024/magic-items/potion-of-gaseous-form",
 		"image" : "/api/images/magic-items/potion-of-gaseous-form.png",
 		"name": "Potion of Gaseous Form",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "Potion of Healing    (supreme)"
+
+		"desc": [
+			"Potion",
+			"Potion of Healing    (supreme)"
+		]
 	},
 	{
 		"index": "potion-of-heroism",
 		"url": "/api/2024/magic-items/potion-of-heroism",
 		"image" : "/api/images/magic-items/potion-of-heroism.png",
 		"name": "Potion of Heroism",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.\nThis potion's container seems to hold fog that moves and pours like water."
+
+		"desc": [
+			"Potion",
+			"    10d4 + 20  Very Rare      When you drink this potion, you gain the effect of the Gaseous Form spell for 1 hour (no Concentration required) or until you end the effect as a Bonus Action.",
+			"This potion's container seems to hold fog that moves and pours like water."
+		]
 	},
 	{
 		"index": "potion-of-giant-strength",
 		"url": "/api/2024/magic-items/potion-of-giant-strength",
 		"image" : "/api/images/magic-items/potion-of-giant-strength.png",
 		"name": "Potion of Giant Strength",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.\nThis potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).\nThis potion's blue liquid bubbles and steams as if boiling."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, your Strength score changes for 1 hour. The type of giant determines the score (see the table below). The potion has no effect on you if your Strength is equal to or greater than that score.",
+			"This potion's transparent liquid has floating in it a sliver of light resembling a giant's fingernail.When you drink this potion, you gain 10 Temporary Hit Points that last for 1 hour. For the same duration, you are under the effect of the Bless spell (no Concentration required).",
+			"This potion's blue liquid bubbles and steams as if boiling."
+		]
 	},
 	{
 		"index": "potion-of-invisibility",
 		"url": "/api/2024/magic-items/potion-of-invisibility",
 		"image" : "/api/images/magic-items/potion-of-invisibility.png",
 		"name": "Potion of Invisibility",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
+
+		"desc": [
+			"Potion",
+			"This potion's container looks empty but feels as though it holds liquid. When you drink the potion, you have the Invisible condition for 1 hour. The effect ends early if you make an attack roll, deal damage, or cast a spell."
+		]
 	},
 	{
 		"index": "potion-of-mind-reading",
 		"url": "/api/2024/magic-items/potion-of-mind-reading",
 		"image" : "/api/images/magic-items/potion-of-mind-reading.png",
 		"name": "Potion of Mind Reading",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain the effect of the Detect Thoughts spell (save DC 13) for 10 minutes (no Concentration required).This potion's dense, purple liquid has an ovoidcloud of pink floating in it."
+		]
 	},
 	{
 		"index": "potion-of-poison",
 		"url": "/api/2024/magic-items/potion-of-poison",
 		"image" : "/api/images/magic-items/potion-of-poison.png",
 		"name": "Potion of Poison",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.\nIf you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
+
+		"desc": [
+			"Potion",
+			"This concoction looks, smells, and tastes like a Potion of Healing or another beneficial potion. However, it is actually poison masked by illusion magic. Identify reveals its true nature.",
+			"If you drink this potion, you take 4d6 Poison damage and must succeed on a DC 13 Constitution saving throw or have the Poisoned condition for 1 hour."
+		]
 	},
 	{
 		"index": "potion-of-resistance",
 		"url": "/api/2024/magic-items/potion-of-resistance",
 		"image" : "/api/images/magic-items/potion-of-resistance.png",
 		"name": "Potion of Resistance",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you have Resistance to one type of damage for 1 hour. The GM chooses the type or determines it randomly by rolling on the following table.1d10  Damage Type  1d10  Damage Type1 Acid  6  Necrotic2 Cold  7  Poison3 Fire  8  Psychic4 Force  9  Radiant5 Lightning  10  Thunder"
+		]
 	},
 	{
 		"index": "potion-of-speed",
 		"url": "/api/2024/magic-items/potion-of-speed",
 		"image" : "/api/images/magic-items/potion-of-speed.png",
 		"name": "Potion of Speed",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
+
+		"desc": [
+			"Potion",
+			"When you drink this potion, you gain the effect of the Haste spell for 1 minute (no Concentration required) without suffering the wave of lethargy that typically occurs when the effect ends.This potion's yellow fluid is streaked with blackand swirls on its own."
+		]
 	},
 	{
 		"index": "potion-of-water-breathing",
 		"url": "/api/2024/magic-items/potion-of-water-breathing",
 		"image" : "/api/images/magic-items/potion-of-water-breathing.png",
 		"name": "Potion of Water Breathing",
-		"type": "Potion",
+		"equipment_category": {
+			"index": "potions",
+			"name": "Potions",
+			"url": "/api/2024/equipment-categories/potions"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "You can breathe underwater for 24 hours after drinking this potion.\nThis potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
+
+		"desc": [
+			"Potion",
+			"You can breathe underwater for 24 hours after drinking this potion.",
+			"This potion's cloudy green fluid smells of the sea and has a jellyfish-like bubble floating in it."
+		]
 	},
 	{
 		"index": "ring-of-animal-influence",
 		"url": "/api/2024/magic-items/ring-of-animal-influence",
 		"image" : "/api/images/magic-items/ring-of-animal-influence.png",
 		"name": "Ring of Animal Influence",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
+
+		"desc": [
+			"Ring",
+			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. While wearing the ring, you can expend 1 charge to cast one of the following spells (save DC 13) from it:• Animal Friendship• Fear (affects Beasts only)• Speak with Animals"
+		]
 	},
 	{
 		"index": "ring-of-djinni-summoning",
 		"url": "/api/2024/magic-items/ring-of-djinni-summoning",
 		"image" : "/api/images/magic-items/ring-of-djinni-summoning.png",
 		"name": "Ring of Djinni Summoning",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.\nWhile summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.\nAfter the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.\nRings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can take a Magic action to summon a particular Djinni from the Elemental Plane of Air. The djinni appears in an unoccupied space you choose within 120 feet of yourself. It remains as long as you maintain Concentration, to a maximum of 1 hour, or until it drops to 0 Hit Points.",
+			"While summoned, the djinni is Friendly to you and your allies, and it obeys your commands. If you fail to command it, the djinni defends itself against attackers but takes no other actions.",
+			"After the djinni departs, it can't be summoned again for 24 hours, and the ring becomes nonmagical if the djinni dies.",
+			"Rings of Djinni Summoning are often created by the djinn they summon and given to mortals as gifts of friendship or tokens of esteem."
+		]
 	},
 	{
 		"index": "ring-of-elemental-command",
 		"url": "/api/2024/magic-items/ring-of-elemental-command",
 		"image" : "/api/images/magic-items/ring-of-elemental-command.png",
 		"name": "Ring of Elemental Command",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.\nEvery Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.\nElemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.\nSpellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
+
+		"desc": [
+			"Ring",
+			"Each Ring of Elemental Command is linked to one of the four Elemental Planes. The GM chooses or randomly determines the linked plane. For example, a Ring of Elemental Command (air) is linked to the Elemental Plane of Air.",
+			"Every Ring of Elemental Command has the following two properties:Elemental Bane. While wearing the ring, you have Advantage on attack rolls against Elementals and they have Disadvantage on attack rolls against you.Elemental Compulsion. While wearing the ring, you can take a Magic action to try to compel an Elemental you see within 60 feet of yourself. The Elemental makes a DC 18 Wisdom saving throw. On a failed save, the Elemental has the Charmed condition until the start your next turn, and you determine what it does with its move and action on its next turn.",
+			"Elemental Focus. While wearing the ring, you benefit from additional properties corresponding to the ring's linked Elemental Plane:Air. You know Auran, you have Resistance to Lightning damage, and you have a Fly Speed equal to your Speed and can hover.Earth. You know Terran, and you have Resistance to Acid damage. Terrain composed of rubble, rocks, or dirt isn't Difficult Terrain for you. In addition, you can move through solid earth or rock as if those areas were Difficult Terrain without disturbing the matter through which you pass. Ifyou end your turn in solid earth or rock, you are shunted out to the nearest unoccupied space you last occupied.Fire. You know Ignan, and you have Immunity to Fire damage.Water. You know Aquan, you gain a Swim Speed of 60 feet, and you can breathe underwater.",
+			"Spellcasting. The ring has 5 charges and regains 1d4 + 1 expended charges daily at dawn. While wearing the ring, you can cast a spell from it. Choose the spell from the list of available spells based on the Elemental Plane the ring is linked to, as shown in the following table. The table indicates how many charges you must expend to cast the spell, which has a save DC of 18.Plane  Spells (Charges)Earth  Earthquake (5 charges), Stone Shape (2 charges), Stoneskin (3 charges), Wall of Stone (3 charges)Water  Create or Destroy Water (1 charge), Ice Storm (2 charges), Tsunami (5 charges), Wall of Ice (3 charges), Water Walk (2 charges)"
+		]
 	},
 	{
 		"index": "ring-of-evasion",
 		"url": "/api/2024/magic-items/ring-of-evasion",
 		"image" : "/api/images/magic-items/ring-of-evasion.png",
 		"name": "Ring of Evasion",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
+
+		"desc": [
+			"Ring",
+			"This ring has 3 charges, and it regains 1d3 expended charges daily at dawn. When you fail a Dexterity saving throw while wearing the ring, you can take a Reaction to expend 1 charge to succeed on that save instead."
+		]
 	},
 	{
 		"index": "ring-of-feather-falling",
 		"url": "/api/2024/magic-items/ring-of-feather-falling",
 		"image" : "/api/images/magic-items/ring-of-feather-falling.png",
 		"name": "Ring of Feather Falling",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
+
+		"desc": [
+			"Ring",
+			"When you fall while wearing this ring, you descend 60 feet per round and take no damage from falling."
+		]
 	},
 	{
 		"index": "ring-of-free-action",
 		"url": "/api/2024/magic-items/ring-of-free-action",
 		"image" : "/api/images/magic-items/ring-of-free-action.png",
 		"name": "Ring of Free Action",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
+
+		"desc": [
+			"Ring",
+			"While you wear this ring, Difficult Terrain doesn't cost you extra movement. In addition, magic can neither reduce any of your Speeds nor cause you to have the Paralyzed or Restrained condition."
+		]
 	},
 	{
 		"index": "ring-of-invisibility",
 		"url": "/api/2024/magic-items/ring-of-invisibility",
 		"image" : "/api/images/magic-items/ring-of-invisibility.png",
 		"name": "Ring of Invisibility",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can take a Magic action to give yourself the Invisible condition. You remain Invisible until the ring is removed or until you take a Bonus Action to become visible again."
+		]
 	},
 	{
 		"index": "ring-of-jumping",
 		"url": "/api/2024/magic-items/ring-of-jumping",
 		"image" : "/api/images/magic-items/ring-of-jumping.png",
 		"name": "Ring of Jumping",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can cast Jump from it, but can target only yourself when you do so."
+		]
 	},
 	{
 		"index": "ring-of-mind-shielding",
 		"url": "/api/2024/magic-items/ring-of-mind-shielding",
 		"image" : "/api/images/magic-items/ring-of-mind-shielding.png",
 		"name": "Ring of Mind Shielding",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.\nYou can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.\nIf you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you are immune to magic that allows other creatures to read your thoughts, determine whether you are lying, know your alignment, or know your creature type. Creatures can telepathically communicate with you only if you allow it.",
+			"You can take a Magic action to cause the ring to become imperceptible until you take another Magic action to make it perceptible, until you remove the ring, or until you die.",
+			"If you die while wearing the ring, your soul enters it, unless it already houses a soul. You can remain in the ring or depart for the afterlife. As long as your soul is in the ring, you can telepathically communicate with any creature wearing it. A wearer can't prevent this telepathic communication."
+		]
 	},
 	{
 		"index": "ring-of-protection",
 		"url": "/api/2024/magic-items/ring-of-protection",
 		"image" : "/api/images/magic-items/ring-of-protection.png",
 		"name": "Ring of Protection",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
+
+		"desc": [
+			"Ring",
+			"You gain a +1 bonus to Armor Class and saving throws while wearing this ring."
+		]
 	},
 	{
 		"index": "ring-of-regeneration",
 		"url": "/api/2024/magic-items/ring-of-regeneration",
 		"image" : "/api/images/magic-items/ring-of-regeneration.png",
 		"name": "Ring of Regeneration",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you regain 1d6 Hit Points every 10 minutes if you have at least 1 Hit Point. If you lose a body part, the ring causes the missing part to regrow and return to full functionality after 1d6 + 1 days if you have at least 1 Hit Point the whole time."
+		]
 	},
 	{
 		"index": "ring-of-resistance",
 		"url": "/api/2024/magic-items/ring-of-resistance",
 		"image" : "/api/images/magic-items/ring-of-resistance.png",
 		"name": "Ring of Resistance",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
+
+		"desc": [
+			"Ring",
+			"You have Resistance to one damage type while wearing this ring. The gemstone in the ring indicates the type, which the GM chooses or determines randomly by rolling on the following table."
+		]
 	},
 	{
 		"index": "ring-of-shooting-stars",
 		"url": "/api/2024/magic-items/ring-of-shooting-stars",
 		"image" : "/api/images/magic-items/ring-of-shooting-stars.png",
 		"name": "Ring of Shooting Stars",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You can cast Dancing Lights or Light from the ring.\nThe ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.\nFaerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.\nLightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.\nEach sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.\nAs a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4\nShooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
+
+		"desc": [
+			"Ring",
+			"You can cast Dancing Lights or Light from the ring.",
+			"The ring has 6 charges and regains 1d6 expended charges daily at dawn. You can expend its charges to use the properties below.",
+			"Faerie Fire. You can expend 1 charge to cast Faerie Fire from the ring.",
+			"Lightning Spheres. You can expend 2 charges as a Magic action to create up to four 3-foot-diameter spheres of lightning.",
+			"Each sphere appears in an unoccupied space you can see within 120 feet of yourself. The spheres last as long as you maintain Concentration, up to 1 minute. Each sphere sheds Dim Light in a 30-foot radius.",
+			"As a Bonus Action, you can move each sphere up to 30 feet, but no farther than 120 feet away from yourself. The first time the sphere comes within 5 feet of a creature other than you that isn't behind Total Cover, the sphere discharges lightning at that creature and disappears. That creature makes a DC 15 Dexterity saving throw. On a failed save, thecreature takes Lightning damage based on the number of spheres you created, as shown in the following table. On a successful save, the creature takes half as much damage.Number of SpheresLightning DamageNumber of SpheresLightning Damage14d1232d625d442d4",
+			"Shooting Stars. You can expend 1 to 3 charges as a Magic action. For every charge you expend, you launch a glowing mote of light from the ring at a point you can see within 60 feet of yourself. Each creature in a 15-foot Cube originating from that point is showered in sparks and makes a DC 15 Dexterity saving throw, taking 5d4 Radiant damage on a failed save or half as much damage on a successful one."
+		]
 	},
 	{
 		"index": "ring-of-spell-storing",
 		"url": "/api/2024/magic-items/ring-of-spell-storing",
 		"image" : "/api/images/magic-items/ring-of-spell-storing.png",
 		"name": "Ring of Spell Storing",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.\nAny creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.\nWhile wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
+
+		"desc": [
+			"Ring",
+			"This ring stores spells cast into it, holding them until the attuned wearer uses them. The ring can store up to 5 levels worth of spells at a time. When found, it contains 1d6 1 levels of stored spells chosen by the GM.",
+			"Any creature can cast a spell of level 1 through 5 into the ring by touching the ring as the spell is cast. The spell has no effect other than to be stored in the ring. If the ring can't hold the spell, the spell is expended without effect. The level of the slot used to cast the spell determines how much space it uses.",
+			"While wearing this ring, you can cast any spell stored in it. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster but is otherwise treated as if you cast the spell. The spell cast from the ring is no longer stored in it, freeing up space."
+		]
 	},
 	{
 		"index": "ring-of-spell-turning",
 		"url": "/api/2024/magic-items/ring-of-spell-turning",
 		"image" : "/api/images/magic-items/ring-of-spell-turning.png",
 		"name": "Ring of Spell Turning",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you have Advantage on saving throws against spells. If you succeed on the save for a spell of level 7 or lower, the spell has no effect on you. If that spell targeted only you and didn't create an area of effect, you can take a Reaction to deflect the spell back at the spell's caster; the caster must make a saving throw against the spell using their own spell save DC."
+		]
 	},
 	{
 		"index": "ring-of-swimming",
 		"url": "/api/2024/magic-items/ring-of-swimming",
 		"image" : "/api/images/magic-items/ring-of-swimming.png",
 		"name": "Ring of Swimming",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "You have a Swim Speed of 40 feet while wearing this ring."
+
+		"desc": [
+			"Ring",
+			"You have a Swim Speed of 40 feet while wearing this ring."
+		]
 	},
 	{
 		"index": "ring-of-telekinesis",
 		"url": "/api/2024/magic-items/ring-of-telekinesis",
 		"image" : "/api/images/magic-items/ring-of-telekinesis.png",
 		"name": "Ring of Telekinesis",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While wearing this ring, you can cast Telekinesisfrom it."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can cast Telekinesisfrom it."
+		]
 	},
 	{
 		"index": "ring-of-the-ram",
 		"url": "/api/2024/magic-items/ring-of-the-ram",
 		"image" : "/api/images/magic-items/ring-of-the-ram.png",
 		"name": "Ring of the Ram",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.\nAlternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
+
+		"desc": [
+			"Ring",
+			"This ring has 3 charges and regains 1d3 expended charges daily at dawn. While wearing the ring, you can take a Magic action to expend 1 to 3 charges to make a ranged spell attack against one creature you can see within 60 feet of yourself. The ring produces a spectral ram's head and makes its attack roll with a +7 bonus. On a hit, for each charge you spend, the target takes 2d10 Force damage and is pushed 5 feet away from you.",
+			"Alternatively, you can expend 1 to 3 of the ring's charges as a Magic action to try to break a nonmagical object you can see within 60 feet of yourself that isn't being worn or carried. The ring makesa Strength check with a +5 bonus for each charge you spend."
+		]
 	},
 	{
 		"index": "ring-of-three-wishes",
 		"url": "/api/2024/magic-items/ring-of-three-wishes",
 		"image" : "/api/images/magic-items/ring-of-three-wishes.png",
 		"name": "Ring of Three Wishes",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can expend 1 of its 3 charges to cast Wish from it. The ring becomes nonmagical when you use the last charge."
+		]
 	},
 	{
 		"index": "ring-of-warmth",
 		"url": "/api/2024/magic-items/ring-of-warmth",
 		"image" : "/api/images/magic-items/ring-of-warmth.png",
 		"name": "Ring of Warmth",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.\nIn addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
+
+		"desc": [
+			"Ring",
+			"If you take Cold damage while wearing this ring, the ring reduces the damage you take by 2d8.",
+			"In addition, while wearing this ring, you and everything you wear and carry are unharmed by temperatures of 0 degrees Fahrenheit or lower."
+		]
 	},
 	{
 		"index": "ring-of-water-walking",
 		"url": "/api/2024/magic-items/ring-of-water-walking",
 		"image" : "/api/images/magic-items/ring-of-water-walking.png",
 		"name": "Ring of Water Walking",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While wearing this ring, you cast Water Walk from it, targeting only yourself."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you cast Water Walk from it, targeting only yourself."
+		]
 	},
 	{
 		"index": "ring-of-x-ray-vision",
 		"url": "/api/2024/magic-items/ring-of-x-ray-vision",
 		"image" : "/api/images/magic-items/ring-of-x-ray-vision.png",
 		"name": "Ring of X-ray Vision",
-		"type": "Ring",
+		"equipment_category": {
+			"index": "rings",
+			"name": "Rings",
+			"url": "/api/2024/equipment-categories/rings"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.\nWhenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
+
+		"desc": [
+			"Ring",
+			"While wearing this ring, you can take a Magic action to gain X-ray vision with a range of 30 feet for 1 minute. To you, solid objects within that radius appear transparent and don't prevent light from passing through them. The vision can penetrate 1foot of stone, 1 inch of common metal, or up to 3 feet of wood or dirt. Thicker substances or a thin sheet of lead block the vision.",
+			"Whenever you use the ring again before taking a Long Rest, you must succeed on a DC 15 Constitution saving throw or gain 1 Exhaustion level."
+		]
 	},
 	{
 		"index": "robe-of-eyes",
 		"url": "/api/2024/magic-items/robe-of-eyes",
 		"image" : "/api/images/magic-items/robe-of-eyes.png",
 		"name": "Robe of Eyes",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.\nDrawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
+
+		"desc": [
+			"Wondrous Item",
+			"This robe is adorned with eyelike patterns. Whileyou wear the robe, you gain the following benefits:All-Around Vision. The robe gives you Advantage on Wisdom (Perception) checks that rely on sight.Special Senses. You have Darkvision and Truesight, both with a range of 120 feet.",
+			"Drawbacks. A Light spell cast on the robe or a Daylight spell cast within 5 feet of the robe gives you the Blinded condition for 1 minute. At the end of each of your turns, you make a Constitution saving throw (DC 11 for Light or DC 15 for Daylight), ending the condition on yourself on a success."
+		]
 	},
 	{
 		"index": "robe-of-scintillating-colors",
 		"url": "/api/2024/magic-items/robe-of-scintillating-colors",
 		"image" : "/api/images/magic-items/robe-of-scintillating-colors.png",
 		"name": "Robe of Scintillating Colors",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
+
+		"desc": [
+			"Wondrous Item",
+			"This robe has 3 charges, and it regains 1d3 expended charges daily at dawn. While you wear it, you can take a Magic action and expend 1 charge to cause the garment to display a shifting pattern of dazzling hues until the end of your next turn. During this time, the robe sheds Bright Light in a 30-foot radius and Dim Light for an additional 30feet, and creatures that can see you have Disadvantage on attack rolls against you. Any creature in the Bright Light that can see you when the robe's power is activated must succeed on a DC 15 Wisdom saving throw or have the Stunned condition until the effect ends."
+		]
 	},
 	{
 		"index": "robe-of-stars",
 		"url": "/api/2024/magic-items/robe-of-stars",
 		"image" : "/api/images/magic-items/robe-of-stars.png",
 		"name": "Robe of Stars",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.\nSix stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.\nWhile you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
+
+		"desc": [
+			"Wondrous Item",
+			"This black or dark-blue robe is embroidered with small white or silver stars. You gain a +1 bonus to saving throws while you wear it.",
+			"Six stars, located on the robe's upper-front portion, are particularly large. While wearing this robe, you can take a Magic action to remove one of the stars and expend it to cast the level 5 version of Magic Missile. Daily at dusk, 1d6 removed stars reappear on the robe.",
+			"While you wear the robe, you can take a Magic action to enter the Astral Plane along with everything you are wearing and carrying. You remain there until you take a Magic action to return to the plane you were on. You reappear in the last space you occupied or, if that space is occupied, the nearest unoccupied space."
+		]
 	},
 	{
 		"index": "robe-of-the-archmagi",
 		"url": "/api/2024/magic-items/robe-of-the-archmagi",
 		"image" : "/api/images/magic-items/robe-of-the-archmagi.png",
 		"name": "Robe of the Archmagi",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This elegant garment is made from exquisite cloth and adorned with runes.\nYou gain these benefits while wearing the robe.\nArmor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.\nMagic Resistance. You have Advantage on saving throws against spells and other magical effects.\nWar Mage. Your spell save DC and spell attack bonus each increase by 2."
+
+		"desc": [
+			"Wondrous Item",
+			"This elegant garment is made from exquisite cloth and adorned with runes.",
+			"You gain these benefits while wearing the robe.",
+			"Armor. If you aren't wearing armor, your base Armor Class is 15 plus your Dexterity modifier.",
+			"Magic Resistance. You have Advantage on saving throws against spells and other magical effects.",
+			"War Mage. Your spell save DC and spell attack bonus each increase by 2."
+		]
 	},
 	{
 		"index": "robe-of-useful-items",
 		"url": "/api/2024/magic-items/robe-of-useful-items",
 		"image" : "/api/images/magic-items/robe-of-useful-items.png",
 		"name": "Robe of Useful Items",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
+
+		"desc": [
+			"Wondrous Item",
+			"This robe has cloth patches of various shapes and colors covering it. While wearing the robe, you can take a Magic action to detach one of the patches, causing it to become the object or creature it represents. Once the last patch is removed, the robe becomes an ordinary garment.The robe has two of each of the following patches:• Bullseye Lantern (filled and lit)• Dagger• Mirror• Pole• Rope (coiled)• SackIn addition, the robe has 4d4 other patches. The GM chooses the patches or determines them randomly by rolling on the following table.1d100  Patch 01-08 Bag of 100 GP   09-15 Silver coffer (1 foot long, 6 inches wide anddeep) worth 500 GP23-30  10 gems worth 100 GP each 31-44 Wooden ladder (24 feet long)   45-51 Riding Horse with a Riding Saddle60-68  4 Potions of Healing 69-75 Rowboat (12 feet long)   76-83 Spell Scroll containing one spell of level 1, 2, or3 (your choice) 84-90  2 Mastiffs  91-96 Window (2 feet by 4 feet, up to 2 feet deep), which you can place on a vertical surface you can reach 97-00  Portable Ram"
+		]
 	},
 	{
 		"index": "rod-of-absorption",
 		"url": "/api/2024/magic-items/rod-of-absorption",
 		"image" : "/api/images/magic-items/rod-of-absorption.png",
 		"name": "Rod of Absorption",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.\nWhen you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.\nIf you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.\nA newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
+
+		"desc": [
+			"Rod",
+			"While holding this rod, you can take a Reaction to absorb a spell that is targeting only you and doesn't create an area of effect. The absorbed spell's effect is canceled, and the spell's energy-not the spell itself-is stored in the rod. The energy has the same level as the spell when it was cast. A canceled spell dissipates with no effect, and any resources usedto cast it are wasted. The rod can absorb and store up to 50 levels of energy over the course of its existence. Once the rod absorbs 50 levels of energy, it can't absorb more. If you are targeted by a spellthat the rod can't store, the rod has no effect on that spell.",
+			"When you become attuned to the rod, you know how many levels of energy the rod has absorbed over the course of its existence and how many levels of spell energy it currently has stored.",
+			"If you are a spellcaster holding the rod, you can convert energy stored in it into spell slots to cast spells you have prepared or know. You can create spell slots only of a level equal to or lower than your own spell slots, up to a maximum of level 5. You use the stored levels in place of your slots but otherwise cast the spell as normal. For example, you can use 3 levels stored in the rod as a level 3 spell slot.",
+			"A newly found rod typically has 1d10 levels of spell energy stored in it. A rod that can no longer absorb spell energy and has no energy remaining becomes nonmagical."
+		]
 	},
 	{
 		"index": "rod-of-alertness",
 		"url": "/api/2024/magic-items/rod-of-alertness",
 		"image" : "/api/images/magic-items/rod-of-alertness.png",
 		"name": "Rod of Alertness",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This rod has the following properties.\nAlertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.\nSpells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility\nProtective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.\nThe rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
+
+		"desc": [
+			"Rod",
+			"This rod has the following properties.",
+			"Alertness. While holding the rod, you have Advantage on Wisdom (Perception) checks and on Initiative rolls.",
+			"Spells. While holding the rod, you can cast the following spells from it:• Detect Evil and Good• Detect Magic• Detect Poison and Disease• See Invisibility",
+			"Protective Aura. As a Magic action, you can plant the haft end of the rod in the ground, whereupon the rod's head sheds Bright Light in a 60-foot radius and Dim Light for an additional 60 feet. While in that Bright Light, you and your allies gain a +1 bonus to Armor Class and saving throws and can sense the location of any Invisible creature that is also in the Bright Light.",
+			"The rod's head stops glowing and the effect ends after 10 minutes or when a creature takes a Magic action to pull the rod from the ground. Once used, this property can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "rod-of-lordly-might",
 		"url": "/api/2024/magic-items/rod-of-lordly-might",
 		"image" : "/api/images/magic-items/rod-of-lordly-might.png",
 		"name": "Rod of Lordly Might",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.\nButtons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.\nDrain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.\nParalyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.\nTerrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
+
+		"desc": [
+			"Rod",
+			"This rod has a flanged head, and it functions as a magic Mace that grants a +3 bonus to attack rolls and damage rolls made with it. The rod has properties associated with six different buttons that are set in a row along the haft. It has three other properties as well, detailed below.",
+			"Buttons. You can press one of the following buttons as a Bonus Action; a button's effect lasts until you push a different button or until you push the same button again, which causes the rod to revert to its normal form:Button 1. A fiery blade sprouts from the end opposite the rod's flanged head. The flames shed Bright Light in a 40-foot radius and Dim Light for an additional 40 feet, and the blade functions as a magic Longsword or Shortsword (your choice) that deals an extra 2d6 Fire damage on a hit.Button 2. The rod's flanged head folds down and two crescent-shaped blades spring out, transforming the rod into a magic Battleaxe that grants a +3 bonus to attack rolls and damage rolls made with it.Button 3. The rod's flanged head folds down, a spear point springs from the rod's tip, and the rod's handle lengthens into a 6-foot haft, transforming the rod into a magic Spear that grants a+3 bonus to attack rolls and damage rolls made with it.Button 4. The rod transforms into a climbing pole up to 50 feet long (you specify the length), though the rod's buttons remain within your reach. In surfaces as hard as granite, a spike at the bottom and three hooks at the top anchor the pole.Horizontal bars 3 inches long fold out from the sides, 1 foot apart, forming a ladder. The pole can bear up to 4,000 pounds. More weight or lack of solid anchoring causes the rod to revert to its normal form.Button 5. The rod transforms into a handheld battering ram and grants its user a +10 bonus to Strength (Athletics) checks made to break through doors, barricades, and other barriers.Button 6. The rod assumes or remains in its normal form and indicates magnetic north. (Nothing happens if this function of the rod is used in a location that has no magnetic north.) The rod also gives you knowledge of your approximate depth beneath the ground or your height above it.",
+			"Drain Life. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target takes an extra 4d6 Necrotic damage, and you regain a number of Hit Points equal to half that Necrotic damage. Once used, this property can't be used again until the next dawn.",
+			"Paralyze. When you hit a creature with a melee attack using the rod, you can force the target to make a DC 17 Constitution saving throw. On a failed save, the target has the Paralyzed condition for 1 minute. The target repeats the save at the end of each of its turns, ending the effect on a success.Once used, this property can't be used again until the next dawn.",
+			"Terrify. While holding the rod, you can take a Magic action to force each creature you can see within 30 feet of yourself to make a DC 17 Wisdom saving throw. On a failed save, a target has the Frightened condition for 1 minute. A Frightened target repeats the save at the end of each of its turns, ending the effect on itself on a success. Once used, this property can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "rod-of-rulership",
 		"url": "/api/2024/magic-items/rod-of-rulership",
 		"image" : "/api/images/magic-items/rod-of-rulership.png",
 		"name": "Rod of Rulership",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
+
+		"desc": [
+			"Rod",
+			"You can take a Magic action to present the rod and command obedience from each creature of your choice that you can see within 120 feet of yourself.Each target must succeed on a DC 15 Wisdom saving throw or have the Charmed condition for 8 hours. While Charmed in this way, the creature regards you as its trusted leader. If harmed by you or your allies or commanded to do something contrary to its nature, a target ceases to be Charmed in this way. Once used, this property can't be used again until the next dawn."
+		]
 	},
 	{
 		"index": "rod-of-security",
 		"url": "/api/2024/magic-items/rod-of-security",
 		"image" : "/api/images/magic-items/rod-of-security.png",
 		"name": "Rod of Security",
-		"type": "Rod",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.\nFor each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).\nWhen the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
+
+		"desc": [
+			"Rod",
+			"While holding this rod, you can take a Magic action to activate it. The rod then instantly transports you and up to 199 other willing creatures you can see to a demiplane. You choose the form the demiplanetakes. It could be a tranquil garden, a cheery tavern, an immense palace, a tropical island, a fantastic carnival, or whatever else you can imagine. Regardless of its nature, the demiplane contains enough water and food to sustain its visitors, and the demiplane's environment can't harm its occupants. Everything else that can be interacted with there can existonly there. For example, a flower picked from a garden there disappears if it is taken outside the demiplane.",
+			"For each hour spent in the demiplane, a visitor regains Hit Points as if it had spent 1 Hit Point Die. Also, creatures don't age while there, although time passes normally. Visitors can remain there for up to 200 days divided by the number of creatures present (round down).",
+			"When the time runs out or you take a Magic action to end the effect, all visitors reappear in the location they occupied when you activated the rod or an unoccupied space nearest that location. Once used, this property can't be used again until 10 days have passed."
+		]
 	},
 	{
 		"index": "rope-of-climbing",
 		"url": "/api/2024/magic-items/rope-of-climbing",
 		"image" : "/api/images/magic-items/rope-of-climbing.png",
 		"name": "Rope of Climbing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.\nIf you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+
+		"desc": [
+			"Wondrous Item",
+			"This 60-foot length of rope can hold up to 3,000 pounds. While holding one end of the rope, you can take a Magic action to command the other end of the rope to animate and move toward a destination you choose, up to the rope's length away from you. That end moves 10 feet on your turn when you first command it and 10 feet at the start of each of your subsequent turns until reaching its destination or until you tell it to stop. You can also tell the rope to fasten itself securely to an object or to unfasten itself, to knot or unknot itself, or to coil itself for carrying.",
+			"If you tell the rope to knot, large knots appear at 1-foot intervals along the rope. While knotted, therope shortens to a 50-foot length and grants Advantage on ability checks made to climb using the rope. The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+		]
 	},
 	{
 		"index": "rope-of-entanglement",
 		"url": "/api/2024/magic-items/rope-of-entanglement",
 		"image" : "/api/images/magic-items/rope-of-entanglement.png",
 		"name": "Rope of Entanglement",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).\nA target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.\nThe rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+
+		"desc": [
+			"Wondrous Item",
+			"This rope is 30 feet long. While holding one end of the rope, you can take a Magic action to command the other end to dart forward and entangle one creature you can see within 20 feet of yourself. The target must succeed on a DC 15 Dexterity saving throw or have the Restrained condition. You can release the target by letting go of your end of the rope (causing the rope to coil up in the target's space)or by using a Bonus Action to repeat the command (causing the rope to coil up in your hand).",
+			"A target Restrained by the rope can take an action to make its choice of a DC 15 Strength (Athletics) or Dexterity (Acrobatics) check. On a successful check, the target is no longer Restrained by the rope. If you're still holding onto the rope when a target escapes from it, you can take a Reaction to command the rope to coil up in your hand; otherwise, the rope coils up in the target's space.",
+			"The rope has AC 20, HP 20, and Immunity to Poison and Psychic damage. It regains 1 Hit Point every 5 minutes as long as it has at least 1 Hit Point. If the rope drops to 0 Hit Points, it is destroyed."
+		]
 	},
 	{
 		"index": "scarab-of-protection",
 		"url": "/api/2024/magic-items/scarab-of-protection",
 		"image" : "/api/images/magic-items/scarab-of-protection.png",
 		"name": "Scarab of Protection",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.\nPreservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.\nSpell Resistance. You have Advantage on saving throws against spells."
+
+		"desc": [
+			"Wondrous Item",
+			"This beetle-shaped medallion provides three bene-fits while it is on your person.Defense. You gain a +1 bonus to Armor Class.",
+			"Preservation. The scarab has 12 charges. If you fail a saving throw against a Necromancy spell or a harmful effect originating from an Undead, youcan take a Reaction to expend 1 charge and turn the failed save into a successful one. The scarab crumbles into powder and is destroyed when its last charge is expended.",
+			"Spell Resistance. You have Advantage on saving throws against spells."
+		]
 	},
 	{
 		"index": "scimitar-of-speed",
 		"url": "/api/2024/magic-items/scimitar-of-speed",
 		"image" : "/api/images/magic-items/scimitar-of-speed.png",
 		"name": "Scimitar of Speed",
-		"type": "Weapon (Scimitar)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
+
+		"desc": [
+			"Weapon (Scimitar)",
+			"You gain a +2 bonus to attack rolls and damage rolls made with this magic weapon. In addition, you can make one attack with it as a Bonus Action on each of your turns."
+		]
 	},
 	{
 		"index": "shield",
 		"url": "/api/2024/magic-items/shield",
 		"image" : "/api/images/magic-items/shield.png",
 		"name": "Shield",
-		"type": "Armor (Shield)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"description": "While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
+
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have a bonus to Armor Class determined by the Shield's rarity, in addition to the Shield's normal bonus to AC."
+		]
 	},
 	{
 		"index": "shield-of-missile-attraction",
 		"url": "/api/2024/magic-items/shield-of-missile-attraction",
 		"image" : "/api/images/magic-items/shield-of-missile-attraction.png",
 		"name": "Shield of Missile Attraction",
-		"type": "Armor (Shield)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.\nCurse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
+
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have Resistance to damage from attacks made with Ranged weapons.",
+			"Curse. This Shield is cursed. Attuning to it curses you until you are targeted by a Remove Curse spell or similar magic. Removing the Shield fails toend the curse on you. Whenever an attack with a Ranged weapon targets a creature within 10 feet of you, the curse causes you to become the target instead."
+		]
 	},
 	{
 		"index": "slippers-of-spider-climbing",
 		"url": "/api/2024/magic-items/slippers-of-spider-climbing",
 		"image" : "/api/images/magic-items/slippers-of-spider-climbing.png",
 		"name": "Slippers of Spider Climbing",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
+
+		"desc": [
+			"Wondrous Item",
+			"While you wear these light shoes, you can move up, down, and across vertical surfaces and along ceilings, while leaving your hands free. You have aClimb Speed equal to your Speed. However, the slippers don't allow you to move this way on a slippery surface, such as one covered by ice or oil."
+		]
 	},
 	{
 		"index": "sovereign-glue",
 		"url": "/api/2024/magic-items/sovereign-glue",
 		"image" : "/api/images/magic-items/sovereign-glue.png",
 		"name": "Sovereign Glue",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.\nOne ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
+
+		"desc": [
+			"Wondrous Item",
+			"This viscous, milky-white substance can form a permanent adhesive bond between any two objects. It must be stored in a jar or flask that has been coated inside with Oil of Slipperiness. When found, a container contains 1d6 + 1 ounces.",
+			"One ounce of the glue can cover a 1-foot square surface. Applying an ounce of Sovereign Glue takes a Utilize action, and the applied glue takes 1 minuteto set. Once it has done so, the bond it creates can be broken only by the application of Universal Solvent or Oil of Etherealness, or with a Wish spell."
+		]
 	},
 	{
 		"index": "spellguard-shield",
 		"url": "/api/2024/magic-items/spellguard-shield",
 		"image" : "/api/images/magic-items/spellguard-shield.png",
 		"name": "Spellguard Shield",
-		"type": "Armor (Shield)",
+		"equipment_category": {
+			"index": "armor",
+			"name": "Armor",
+			"url": "/api/2024/equipment-categories/armor"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
+
+		"desc": [
+			"Armor (Shield)",
+			"While holding this Shield, you have Advantage on saving throws against spells and other magical effects, and spell attack rolls have Disadvantage against you."
+		]
 	},
 	{
 		"index": "spell-scroll",
 		"url": "/api/2024/magic-items/spell-scroll",
 		"image" : "/api/images/magic-items/spell-scroll.png",
 		"name": "Spell Scroll",
-		"type": "Scroll",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rarity Varies"
 		},
-		"description": "A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.\nIf the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.\nThe level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11\nCopying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
+
+		"desc": [
+			"Scroll",
+			"A Spell Scroll bears the words of a single spell, written in a mystical cipher. If the spell is on your spell list, you can read the scroll and cast its spell without Material components. Otherwise, the scroll is unintelligible. Casting the spell by reading the scroll requires the spell's normal casting time. Once the spell is cast, the scroll crumbles to dust. If the casting is interrupted, the scroll isn't lost.",
+			"If the spell is on your spell list but of a higher level than you can normally cast, you make an ability check using your spellcasting ability to determine whether you cast the spell. The DC equals 10 plusthe spell's level. On a failed check, the spell disappears from the scroll with no other effect.",
+			"The level of the spell on the scroll determines the spell's saving throw DC and attack bonus, as well as the scroll's rarity, as shown in the following table.Spell Level Rarity  Save DC  Attack Bonus1  Common  13  +53  Uncommon  15  +75  Rare  17  +97  Very Rare  18  +109  Legendary  19  +11",
+			"Copying a Scroll into a Spellbook. A Wizard spell on a Spell Scroll can be copied into a spellbook.When a spell is copied in this way, the copier must succeed on an Intelligence (Arcana) check with a DC equal to 10 plus the spell's level. On a successful check, the spell is copied. Whether the check succeeds or fails, the Spell Scroll is destroyed."
+		]
 	},
 	{
 		"index": "sphere-of-annihilation",
 		"url": "/api/2024/magic-items/sphere-of-annihilation",
 		"image" : "/api/images/magic-items/sphere-of-annihilation.png",
 		"name": "Sphere of Annihilation",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.\nThe sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.\nControlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.\nWhile in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.\nSphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
+
+		"desc": [
+			"Wondrous Item",
+			"This 2-foot-diameter black sphere is a hole in the multiverse, hovering in space and stabilized by a magical field surrounding it.",
+			"The sphere obliterates all matter it passes through and all matter that passes through it. Artifacts are the exception. Unless an Artifact is susceptible to damage from a Sphere of Annihilation, it passes through the sphere unscathed. Anything else that touches the sphere but isn't wholly engulfed and obliterated by it takes 8d10 Force damage.",
+			"Controlling the Sphere. A Sphere of Annihilation is stationary until someone takes control of it. If you are within 60 feet of a sphere, you can take a Magic action to make a DC 25 Intelligence (Arcana) check. On a successful check, you control the sphere until the start of your next turn, and if it was under another creature's control, that creature loses control of the sphere. On a failed check, the sphere moves 10 feet toward you in a straight line.",
+			"While in control of the sphere, you can take a Bonus Action to cause it to move in one directionobliterated, leaving its possessions behind but no other physical remains.",
+			"Sphere Interactions. If the sphere comes into contact with a planar portal (such as that created by the Gate spell) or an extradimensional space (such as that within a Portable Hole), the GM determines randomly what happens using the following table.1d100  Result 01-50 The sphere is destroyed.   51-85 The sphere moves through the portal or intothe extradimensional space."
+		]
 	},
 	{
 		"index": "staff-of-charming",
 		"url": "/api/2024/magic-items/staff-of-charming",
 		"image" : "/api/images/magic-items/staff-of-charming.png",
 		"name": "Staff of Charming",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.\nRegaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
+
+		"desc": [
+			"Staff",
+			"This staff has 10 charges. While holding the staff, you can use any of its properties:Cast Spell. You can expend 1 of the staff's charges to cast Charm Person, Command, or Comprehend Languages from it using your spell save DC.Reflect Enchantment. If you succeed on a saving throw against an Enchantment spell that targets only you, you can take a Reaction to expend 1 charge from the staff and turn the spell back on its caster as if you had cast the spell.Resist Enchantment. If you fail a saving throw against an Enchantment spell that targets only you, you can turn your failed save into a successful one. You can't use this property of the staff again until the next dawn.",
+			"Regaining Charges. The staff regains 1d8 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles to dust and is destroyed."
+		]
 	},
 	{
 		"index": "staff-of-fire",
 		"url": "/api/2024/magic-items/staff-of-fire",
 		"image" : "/api/images/magic-items/staff-of-fire.png",
 		"name": "Staff of Fire",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You have Resistance to Fire damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
+
+		"desc": [
+			"Staff",
+			"You have Resistance to Fire damage while you hold this staff.",
+			"Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.of your choice, up to a number of feet equal to5 times your Intelligence modifier (minimum 5SpellChargeCost  SpellChargeCostfeet). Any creature whose space the sphere enters must succeed on a DC 19 Dexterity saving throw or be touched by it, taking 8d10 Force damage. A creature reduced to 0 Hit Points by this damage is Burning Hands  1    Wall of Fire  4  Fireball  3",
+			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff crumbles intospell save DC. The table indicates how many charges you must expend to cast the spell.Chargecinders and is destroyed."
+		]
 	},
 	{
 		"index": "staff-of-frost",
 		"url": "/api/2024/magic-items/staff-of-frost",
 		"image" : "/api/images/magic-items/staff-of-frost.png",
 		"name": "Staff of Frost",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "You have Resistance to Cold damage while you hold this staff.\nSpells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
+
+		"desc": [
+			"Staff",
+			"You have Resistance to Cold damage while you hold this staff.",
+			"Spells. The staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Fireball (level 5 version)  5Hold Monster  5Lightning Bolt (level 5 version)  5Ray of Enfeeblement  1SpellChargeCost  SpellCharge Cost Regaining Charges. The staff regains 2d8 + 4 expended charges daily at dawn. If you expend theFog Cloud  1  Wall of Ice  4",
+			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff turns to water and is destroyed."
+		]
 	},
 	{
 		"index": "staff-of-healing",
 		"url": "/api/2024/magic-items/staff-of-healing",
 		"image" : "/api/images/magic-items/staff-of-healing.png",
 		"name": "Staff of Healing",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Bard, Cleric, or Druid",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
+
+		"desc": [
+			"Staff",
+			"This staff has 10 charges. While holding the staff, you can cast one of the spells on the following table from it, using your spellcasting ability modifier. The table indicates how many charges you must expend to cast the spell.Spell  Charge CostLesser Restoration  2",
+			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff vanishes in a flash of light, lost forever."
+		]
 	},
 	{
 		"index": "staff-of-power",
 		"url": "/api/2024/magic-items/staff-of-power",
 		"image" : "/api/images/magic-items/staff-of-power.png",
 		"name": "Staff of Power",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+
+		"desc": [
+			"Staff",
+			"This staff has 20 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you gain a +2 bonus to Armor Class, saving throws, and spell attack rolls.",
+			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using yourlast charge, roll 1d20. On a 1, the staff retains its +2 bonus to attack rolls and damage rolls but loses all other properties. On a 20, the staff regains 1d8 + 2 charges.",
+			"Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 4 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+		]
 	},
 	{
 		"index": "staff-of-striking",
 		"url": "/api/2024/magic-items/staff-of-striking",
 		"image" : "/api/images/magic-items/staff-of-striking.png",
 		"name": "Staff of Striking",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.\nThe staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
+
+		"desc": [
+			"Staff",
+			"This staff can be wielded as a magic Quarterstaff that grants a +3 bonus to attack rolls and damage rolls made with it.",
+			"The staff has 10 charges. When you hit with a melee attack using it, you can expend up to 3charges. For each charge you expend, the target takes an extra 1d6 Force damage.",
+			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff becomes a nonmagical Quarterstaff."
+		]
 	},
 	{
 		"index": "staff-of-swarming-insects",
 		"url": "/api/2024/magic-items/staff-of-swarming-insects",
 		"image" : "/api/images/magic-items/staff-of-swarming-insects.png",
 		"name": "Staff of Swarming Insects",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This staff has 10 charges.\nInsect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5\nRegaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
+
+		"desc": [
+			"Staff",
+			"This staff has 10 charges.",
+			"Insect Cloud. While holding the staff, you can take a Magic action and expend 1 charge to cause a swarm of harmless flying insects to fill a 30-footEmanation originating from you. The insects remain for 10 minutes, making the area Heavily Obscured for creatures other than you. A strong wind (like that created by Gust of Wind) disperses theSpellCharge Costswarm and ends the effect.",
+			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC and spell attack modifier. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostLightning Bolt (level 7 version)  7Passwall  5Protection from Evil and Good  0Wall of Fire  4Insect Plague  5",
+			"Regaining Charges. The staff regains 1d6 + 4 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, a swarm of insects consumes and destroys the staff, then disperses."
+		]
 	},
 	{
 		"index": "staff-of-the-magi",
 		"url": "/api/2024/magic-items/staff-of-the-magi",
 		"image" : "/api/images/magic-items/staff-of-the-magi.png",
 		"name": "Staff of the Magi",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Sorcerer, Warlock, or Wizard",
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.\nSpell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge\nRegaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.\nRetributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+
+		"desc": [
+			"Staff",
+			"This staff has 50 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While you hold it, you gain a +2 bonus to spell attack rolls.",
+			"Spell Absorption. While holding the staff, you have Advantage on saving throws against spells. In addition, you can take a Reaction when another creature casts a spell that targets only you. If you do, the staff absorbs the magic of the spell, cancel-ing its effect and gaining a number of charges equal to the absorbed spell's level. However, if doing so brings the staff's total number of charges above 50, the staff explodes as if you activated its Retributive Strike (see below).",
+			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.Charge",
+			"Regaining Charges. The staff regains 4d6 + 2 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 20, the staff regains 1d12 + 1 charges.",
+			"Retributive Strike. You can take a Magic action to break the staff over your knee or against a solid surface. The staff is destroyed and releases its magic in an explosion that fills a 30-foot Emanation originating from itself. You have a 50 percent chance to instantly travel to a random plane of existence, avoiding the explosion. If you fail to avoid the effect, you take Force damage equal to 16 times the numberof charges in the staff. Each other creature in the area makes a DC 17 Dexterity saving throw. On a failed save, a creature takes Force damage equal to 6 times the number of charges in the staff. On a successful save, a creature takes half as much damage."
+		]
 	},
 	{
 		"index": "staff-of-the-python",
 		"url": "/api/2024/magic-items/staff-of-the-python",
 		"image" : "/api/images/magic-items/staff-of-the-python.png",
 		"name": "Staff of the Python",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.\nOn your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.\nAs a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
+
+		"desc": [
+			"Staff",
+			"As a Magic action, you can throw this staff so that it lands in an unoccupied space within 10 feet of you, causing the staff to become a Giant Constrictor Snake in that space. The snake is under your control and shares your Initiative count, taking its turn immediately after yours.",
+			"On your turn, you can mentally command the snake (no action required) if it is within 60 feet of you and you don't have the Incapacitated condition. You decide what action the snake takes and where it moves during its turn, or you can issue it a general command, such as to attack your enemies or guard a location. Absent commands from you, the snake defends itself.",
+			"As a Bonus Action, you can command the snake to revert to staff form in its current space, and you can't use the staff's property again for 1 hour. If the snake is reduced to 0 Hit Points, it dies and reverts to its staff form; the staff then shatters and is destroyed. If the snake reverts to staff form before losing all its Hit Points, it regains all of them."
+		]
 	},
 	{
 		"index": "staff-of-the-woodlands",
 		"url": "/api/2024/magic-items/staff-of-the-woodlands",
 		"image" : "/api/images/magic-items/staff-of-the-woodlands.png",
 		"name": "Staff of the Woodlands",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"limited-to": "Druid",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.\nSpells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6\nTree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.\nRegaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
+
+		"desc": [
+			"Staff",
+			"This staff has 6 charges and can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. While holding it, you have a +2 bonus to spell attack rolls.",
+			"Spells. While holding the staff, you can cast one of the spells on the following table from it, using your spell save DC. The table indicates how many charges you must expend to cast the spell.SpellChargeCostAnimal Friendship1Awaken5Barkskin2Locate Animals or Plants2Pass without Trace2Speak with Animals1Speak with Plants3Wall of Thorns6",
+			"Tree Form. You can take a Magic action to plant one end of the staff in earth in an unoccupied space and expend 1 charge to transform the staff intoa healthy tree. The tree is 60 feet tall and has a5-foot-diameter trunk, and its branches at the top spread out in a 20-foot radius. The tree appears ordinary but radiates a faint aura of Transmutation magic that can be discerned with the Detect Magic spell. While touching the tree and using a Magic action, you return the staff to its normal form. Any creature in the tree falls when the tree reverts toa staff.",
+			"Regaining Charges. The staff regains 1d6 expended charges daily at dawn. If you expend the last charge, roll 1d20. On a 1, the staff loses its properties and becomes a nonmagical Quarterstaff."
+		]
 	},
 	{
 		"index": "staff-of-thunder-and-lightning",
 		"url": "/api/2024/magic-items/staff-of-thunder-and-lightning",
 		"image" : "/api/images/magic-items/staff-of-thunder-and-lightning.png",
 		"name": "Staff of Thunder and Lightning",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.\nLightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).\nThunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.\nThunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.\nLightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.\nThunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
+
+		"desc": [
+			"Staff",
+			"This staff can be wielded as a magic Quarterstaff that grants a +2 bonus to attack rolls and damage rolls made with it. It also has the following additional properties. Once one of these properties is used, it can't be used again until the next dawn.",
+			"Lightning. When you hit with a melee attack using the staff, you can cause the target to take an extra 2d6 Lightning damage (no action required).",
+			"Thunder. When you hit with a melee attack using the staff, you can cause the staff to emit a crack of thunder audible out to 300 feet (no action required). The target you hit must succeed on a DC 17 Constitution saving throw or have the Stunned condition until the end of your next turn.",
+			"Thunder and Lightning. Immediately after you hit with a melee attack using the staff, you can take a Bonus Action to use the Lightning and Thunder properties (see above) at the same time. Doing so doesn't expend the daily use of those properties, only the use of this one.",
+			"Lightning Strike. You can take a Magic action to cause a bolt of lightning to leap from the staff's tip in a Line that is 5 feet wide and 120 feet long. Each creature in that Line makes a DC 17 Dexterity saving throw, taking 9d6 Lightning damage on a failed save or half as much damage on a successful one.",
+			"Thunderclap. You can take a Magic action to cause the staff to produce a thunderclap audible out to 600 feet. Every creature within a 60-foot Emanation originating from you makes a DC 17 Constitution saving throw. On a failed save, a creature takes 2d6 Thunder damage and has the Deafened condition for 1 minute. On a successful save, a creature takes half as much damage only."
+		]
 	},
 	{
 		"index": "staff-of-withering",
 		"url": "/api/2024/magic-items/staff-of-withering",
 		"image" : "/api/images/magic-items/staff-of-withering.png",
 		"name": "Staff of Withering",
-		"type": "Staff",
+		"equipment_category": {
+			"index": "staffs",
+			"name": "Staffs",
+			"url": "/api/2024/equipment-categories/staffs"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This staff has 3 charges and regains 1d3 expended charges daily at dawn.\nThe staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
+
+		"desc": [
+			"Staff",
+			"This staff has 3 charges and regains 1d3 expended charges daily at dawn.",
+			"The staff can be wielded as a magic Quarterstaff. On a hit, it deals damage as a normal Quarterstaff, and you can expend 1 charge to deal an extra 2d10 Necrotic damage to the target and force it to make a DC 15 Constitution saving throw. On a failed save, the target has Disadvantage for 1 hour on any ability check or saving throw that uses Strength or Constitution."
+		]
 	},
 	{
 		"index": "stone-of-controlling-earth-elementals",
 		"url": "/api/2024/magic-items/stone-of-controlling-earth-elementals",
 		"image" : "/api/images/magic-items/stone-of-controlling-earth-elementals.png",
 		"name": "Stone of Controlling Earth Elementals",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
+
+		"desc": [
+			"Wondrous Item",
+			"While touching this 5-pound stone to the ground, you can take a Magic action to summon an Earth Elemental. The elemental appears in an unoccupied space you choose within 30 feet of yourself, obeys your commands, and takes its turn immediately after you on your Initiative count. The elemental disappears after 1 hour, when it dies, or when you dismiss it as a Bonus Action. The stone can't be used this way again until the next dawn."
+		]
 	},
 	{
 		"index": "stone-of-good-luck-(luckstone)",
 		"url": "/api/2024/magic-items/stone-of-good-luck-(luckstone)",
 		"image" : "/api/images/magic-items/stone-of-good-luck-(luckstone).png",
 		"name": "Stone of Good Luck (Luckstone)",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
+
+		"desc": [
+			"Wondrous Item",
+			"While this polished agate is on your person, you gain a +1 bonus to ability checks and saving throws."
+		]
 	},
 	{
 		"index": "sun-blade",
 		"url": "/api/2024/magic-items/sun-blade",
 		"image" : "/api/images/magic-items/sun-blade.png",
 		"name": "Sun Blade",
-		"type": "Weapon (Longsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This item appears to be a sword hilt.\nBlade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.\nYou gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.\nSunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
+
+		"desc": [
+			"Weapon (Longsword)",
+			"This item appears to be a sword hilt.",
+			"Blade of Radiance. While grasping the hilt, you can take a Bonus Action to cause a blade of pure radiance to spring into existence or make theblade disappear. While the blade exists, this magic weapon functions as a Longsword with the Finesse property. If you are proficient with Longswords or Shortswords, you are proficient with the Sun Blade.",
+			"You gain a +2 bonus to attack rolls and damage rolls made with this weapon, which deals Radiant damage instead of Slashing damage. When you hit an Undead with it, that target takes an extra 1d8 Radiant damage.",
+			"Sunlight. The sword's luminous blade emits Bright Light in a 15-foot radius and Dim Light for an additional 15 feet. The light is sunlight. While the blade persists, you can take a Magic action to expand or reduce its radius of Bright Light and Dim Light by 5 feet each, to a maximum of 30 feet each or a minimum of 10 feet each."
+		]
 	},
 	{
 		"index": "sword-of-life-stealing",
 		"url": "/api/2024/magic-items/sword-of-life-stealing",
 		"image" : "/api/images/magic-items/sword-of-life-stealing.png",
 		"name": "Sword of Life Stealing",
-		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+			"When you attack a creature with this magic weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 15 Necrotic damage if it isn'ta Construct or an Undead, and you gain Temporary Hit Points equal to the amount of Necrotic damage taken."
+		]
 	},
 	{
 		"index": "sword-of-sharpness",
 		"url": "/api/2024/magic-items/sword-of-sharpness",
 		"image" : "/api/images/magic-items/sword-of-sharpness.png",
 		"name": "Sword of Sharpness",
-		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.\nWhen you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+			"When you attack an object with this magic weapon and hit, maximize your weapon damage dice against the target.",
+			"When you attack a creature with this weapon and roll a 20 on the d20 for the attack roll, that target takes an extra 14 Slashing damage and gains1 Exhaustion level."
+		]
 	},
 	{
 		"index": "sword-of-wounding",
 		"url": "/api/2024/magic-items/sword-of-wounding",
 		"image" : "/api/images/magic-items/sword-of-wounding.png",
 		"name": "Sword of Wounding",
-		"type": "Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, Rapier, Scimitar, or Shortsword)",
+			"When you hit a creature with an attack using this magic weapon, the target takes an extra 2d6 Necrotic damage and must succeed on a DC 15Constitution saving throw or be unable to regain Hit Points for 1 hour. The target repeats the save at the end of each of its turns, ending the effect on itself on a success."
+		]
 	},
 	{
 		"index": "talisman-of-pure-good",
 		"url": "/api/2024/magic-items/talisman-of-pure-good",
 		"image" : "/api/images/magic-items/talisman-of-pure-good.png",
 		"name": "Talisman of Pure Good",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"limited-to": "Cleric or Paladin",
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nPure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
+
+		"desc": [
+			"Wondrous Item",
+			"This talisman is a mighty symbol of goodness. A Fiend or an Undead that touches the talisman takes 8d6 Radiant damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
+			"Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.",
+			"Pure Rebuke. The talisman has 7 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Fiend or an Undead, it has Disadvantage on the save. On a failed save, the target falls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman disperses into motes of golden light and is destroyed."
+		]
 	},
 	{
 		"index": "talisman-of-the-sphere",
 		"url": "/api/2024/magic-items/talisman-of-the-sphere",
 		"image" : "/api/images/magic-items/talisman-of-the-sphere.png",
 		"name": "Talisman of the Sphere",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
+
+		"desc": [
+			"Wondrous Item",
+			"While holding or wearing this talisman, you have Advantage on any Intelligence (Arcana) check you make to control a Sphere of Annihilation. In addition, when you start your turn in control of a Sphere of Annihilation, you can take a Magic action to move it 10 feet plus a number of additional feet equal to 10 times your Intelligence modifier. This movement doesn't have to be in a straight line."
+		]
 	},
 	{
 		"index": "talisman-of-ultimate-evil",
 		"url": "/api/2024/magic-items/talisman-of-ultimate-evil",
 		"image" : "/api/images/magic-items/talisman-of-ultimate-evil.png",
 		"name": "Talisman of Ultimate Evil",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.\nHoly Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.\nUltimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
+
+		"desc": [
+			"Wondrous Item",
+			"This item symbolizes unrepentant evil. A creature that isn't a Fiend or an Undead that touches the talisman takes 8d6 Necrotic damage and takes the damage again each time it ends its turn holding or carrying the talisman.",
+			"Holy Symbol. You can use the talisman as a Holy Symbol. You gain a +2 bonus to spell attack rolls while you wear or hold it.",
+			"Ultimate End. The talisman has 6 charges. While wearing or holding the talisman, you can take a Magic action to expend 1 charge and target one creature you can see on the ground within 120 feet of yourself. A flaming fissure opens under the target, and the target makes a DC 20 Dexterity saving throw. If the target is a Celestial, it has Disadvantage on the save. On a failed save, the targetfalls into the fissure and is destroyed, leaving no remains. On a successful save, the target isn't cast into the fissure but takes 4d6 Psychic damage from the ordeal. In either case, the fissure then closes, leaving no trace of its existence. When you expend the last charge, the talisman dissolves into foul-smelling slime and is destroyed."
+		]
 	},
 	{
 		"index": "tome-of-clear-thought",
 		"url": "/api/2024/magic-items/tome-of-clear-thought",
 		"image" : "/api/images/magic-items/tome-of-clear-thought.png",
 		"name": "Tome of Clear Thought",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book contains memory and logic exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Intelligence increases by 2, to a maximum of30. The manual then loses its magic but regains it in a century."
+		]
 	},
 	{
 		"index": "tome-of-leadership-and-influence",
 		"url": "/api/2024/magic-items/tome-of-leadership-and-influence",
 		"image" : "/api/images/magic-items/tome-of-leadership-and-influence.png",
 		"name": "Tome of Leadership and Influence",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book contains guidelines for influencing and charming others, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Charisma increases by 2, to a maximum of 30. The manual then loses its magic but regains it in a century."
+		]
 	},
 	{
 		"index": "tome-of-understanding",
 		"url": "/api/2024/magic-items/tome-of-understanding",
 		"image" : "/api/images/magic-items/tome-of-understanding.png",
 		"name": "Tome of Understanding",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
+
+		"desc": [
+			"Wondrous Item",
+			"This book contains intuition and insight exercises, and its words are charged with magic. If you spend 48 hours over a period of 6 days or fewer studying the book's contents and practicing its guidelines, your Wisdom increases by 2, to a maximum of 30.The manual then loses its magic, but regains it in a century."
+		]
 	},
 	{
 		"index": "trident-of-fish-command",
 		"url": "/api/2024/magic-items/trident-of-fish-command",
 		"image" : "/api/images/magic-items/trident-of-fish-command.png",
 		"name": "Trident of Fish Command",
-		"type": "Weapon (Trident)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
+
+		"desc": [
+			"Weapon (Trident)",
+			"This magic weapon has 3 charges, and it regains 1d3 expended charges daily at dawn. While you carry it, you can expend 1 charge to cast Dominate Beast (save DC 15) from it on a Beast that has a Swim Speed."
+		]
 	},
 	{
 		"index": "universal-solvent",
 		"url": "/api/2024/magic-items/universal-solvent",
 		"image" : "/api/images/magic-items/universal-solvent.png",
 		"name": "Universal Solvent",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.\nYou can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
+
+		"desc": [
+			"Wondrous Item",
+			"This tube holds milky liquid with a strong alcohol smell. When found, a tube contains 1d6 + 1 ounces.",
+			"You can take a Utilize action to pour 1 or more ounces of solvent from the tube onto a surface within reach. Each ounce instantly dissolves up to 1 square foot of adhesive it touches, including Sovereign Glue."
+		]
 	},
 	{
 		"index": "vicious-weapon",
 		"url": "/api/2024/magic-items/vicious-weapon",
 		"image" : "/api/images/magic-items/vicious-weapon.png",
 		"name": "Vicious Weapon",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"This magic weapon deals an extra 2d6 damage to any creature it hits. This extra damage is of the same type as the weapon's normal damage."
+		]
 	},
 	{
 		"index": "vorpal-sword",
 		"url": "/api/2024/magic-items/vorpal-sword",
 		"image" : "/api/images/magic-items/vorpal-sword.png",
 		"name": "Vorpal Sword",
-		"type": "Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.\nWhen you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
+
+		"desc": [
+			"Weapon (Glaive, Greatsword, Longsword, or Scimitar)",
+			"You gain a +3 bonus to attack rolls and damage rolls made with this magic weapon. In addition, the weapon ignores Resistance to Slashing damage.",
+			"When you use this weapon to attack a creature that has at least one head and roll a 20 on the d20 for the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it has Immunity to Slashing damage, if it doesn't have or need a head, or if the GM decides that thecreature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra 30 Slashing damage from the hit. If the creature has Legendary Resistance, it can expend one daily use of that trait to avoid losing its head, taking the extra damage instead."
+		]
 	},
 	{
 		"index": "wand-of-binding",
 		"url": "/api/2024/magic-items/wand-of-binding",
 		"image" : "/api/images/magic-items/wand-of-binding.png",
 		"name": "Wand of Binding",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges.",
+			"Spells. While holding the wand, you can cast one of the spells (save DC 17) on the following table from it. The table indicates how many charges you must expend to cast the spell.Spell  ChargeCostHold Person  2",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-enemy-detection",
 		"url": "/api/2024/magic-items/wand-of-enemy-detection",
 		"image" : "/api/images/magic-items/wand-of-enemy-detection.png",
 		"name": "Wand of Enemy Detection",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge. For 1 minute, you know the direction of the nearest creature Hostile to you within 60 feet, but not its distance from you. The wand can sense the presence of Hostile creatures that are Invisible, ethereal, disguised, or hidden, as well as those in plain sight. The effect ends if you stop holding the wand.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-fear",
 		"url": "/api/2024/magic-items/wand-of-fear",
 		"image" : "/api/images/magic-items/wand-of-fear.png",
 		"name": "Wand of Fear",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges.\nSpells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges.",
+			"Spells. While holding the wand, you can cast one of the spells (save DC 15) on the following table from it. The table indicates how many charges you must expend to cast the spell.Charge"
+		]
 	},
 	{
 		"index": "wand-of-fireballs",
 		"url": "/api/2024/magic-items/wand-of-fireballs",
 		"image" : "/api/images/magic-items/wand-of-fireballs.png",
 		"name": "Wand of Fireballs",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Fireball (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-lightning-bolts",
 		"url": "/api/2024/magic-items/wand-of-lightning-bolts",
 		"image" : "/api/images/magic-items/wand-of-lightning-bolts.png",
 		"name": "Wand of Lightning Bolts",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Lightning Bolt (save DC 15) from it. For 1 charge, you cast the level 3 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-magic-detection",
 		"url": "/api/2024/magic-items/wand-of-magic-detection",
 		"image" : "/api/images/magic-items/wand-of-magic-detection.png",
 		"name": "Wand of Magic Detection",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
+
+		"desc": [
+			"Wand",
+			"This wand has 3 charges. While holding it, you can expend 1 charge to cast Detect Magic from it. The wand regains 1d3 expended charges daily at dawn."
+		]
 	},
 	{
 		"index": "wand-of-magic-missiles",
 		"url": "/api/2024/magic-items/wand-of-magic-missiles",
 		"image" : "/api/images/magic-items/wand-of-magic-missiles.png",
 		"name": "Wand of Magic Missiles",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can expend no more than 3 charges to cast Magic Missile from it. For 1 charge, you cast the level 1 version of the spell. You can increase the spell's level by 1 for each additional charge you expend.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expend the wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-paralysis",
 		"url": "/api/2024/magic-items/wand-of-paralysis",
 		"image" : "/api/images/magic-items/wand-of-paralysis.png",
 		"name": "Wand of Paralysis",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge to cause a thin blue ray to streak from the tip toward a creature you can see within 60 feet of yourself. The target must succeed on a DC 15 Constitution savingthrow or have the Paralyzed condition for 1 minute. At the end of each of the target's turns, it repeats the save, ending the effect on itself on a success.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-polymorph",
 		"url": "/api/2024/magic-items/wand-of-polymorph",
 		"image" : "/api/images/magic-items/wand-of-polymorph.png",
 		"name": "Wand of Polymorph",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Very Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Polymorph (save DC 15) from it.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-secrets",
 		"url": "/api/2024/magic-items/wand-of-secrets",
 		"image" : "/api/images/magic-items/wand-of-secrets.png",
 		"name": "Wand of Secrets",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
+
+		"desc": [
+			"Wand",
+			"This wand has 3 charges and regains 1d3 expended charges daily at dawn. While holding it, you can take a Magic action to expend 1 charge, and if a secret door or trap is within 60 feet of you, the wand pulses and points at the one nearest to you."
+		]
 	},
 	{
 		"index": "wand-of-the-war-mage",
 		"url": "/api/2024/magic-items/wand-of-the-war-mage",
 		"image" : "/api/images/magic-items/wand-of-the-war-mage.png",
 		"name": "Wand of the War Mage",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"description": "While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
+
+		"desc": [
+			"Wand",
+			"While holding this wand, you gain a bonus to spell attack rolls determined by the wand's rarity. In addition, you ignore Half Cover when making a spell attack roll."
+		]
 	},
 	{
 		"index": "wand-of-web",
 		"url": "/api/2024/magic-items/wand-of-web",
 		"image" : "/api/images/magic-items/wand-of-web.png",
 		"name": "Wand of Web",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"limited-to": "Spellcaster",
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can expend 1 charge to cast Web (save DC 13) from it.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into ashes and is destroyed."
+		]
 	},
 	{
 		"index": "wand-of-wonder",
 		"url": "/api/2024/magic-items/wand-of-wonder",
 		"image" : "/api/images/magic-items/wand-of-wonder.png",
 		"name": "Wand of Wonder",
-		"type": "Wand",
+		"equipment_category": {
+			"index": "wands",
+			"name": "Wands",
+			"url": "/api/2024/equipment-categories/wands"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.\nRegaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
+
+		"desc": [
+			"Wand",
+			"This wand has 7 charges. While holding it, you can take a Magic action to expend 1 charge while choosing a point within 120 feet of yourself. Thatlocation becomes the point of origin of a spell or other magical effect determined by rolling on the Wand of Wonder Effects table. Spells cast from the wand have a save DC of 15. If a spell's maximum range is normally less than 120 feet, it becomes 120 feet when cast from the wand. If an effect has multiple possible subjects, the GM determines randomly which among them are affected.",
+			"Regaining Charges. The wand regains 1d6 + 1 expended charges daily at dawn. If you expendthe wand's last charge, roll 1d20. On a 1, the wand crumbles into dust and is destroyed.Wand of Wonder Effects1d100  Effect61-64 Grass covers a 60-foot-radius circle of ground, with the center of that circle as close to the chosen point of origin as possible. Grass that's already there grows to ten times its normal size and remains overgrown for 1 minute.21-25 Nothing happens at the chosen point of origin. Instead, you have the Stunned condition until the start of your next turn, believing something awesome just happened.69-72 Nothing happens at the chosen point of origin. Instead, you shrink as if you had cast Enlarge/ Reduce on yourself and remain in that state for 1 minute.31-35  Nothing happens at the chosen point of origin. Instead, you take 1d6 Psychic damage.41-45  A cloud of 600 oversized butterflies fills a 60-foot-high, 30-foot-radius Cylinder centered on the chosen point of origin. The butterflies remain for 10 minutes, during which time the area of effect is Heavily Obscured.78-82 Nothing happens at the chosen point of origin. Instead, a burst of colorful, shimmering light extends from you in a 30-foot Emanation. Each creature in the area must succeed on a DC 15 Constitution saving throw or have the Blinded condition for 1 minute. A creature repeats the save at the end of each of its turns, ending the effect on itself on a success.51-55 The creature closest to the chosen point of origin is enlarged as if you had cast Enlarge/ Reduce on it. If the target isn't you and can't be affected by that spell, you become the target instead.88-92  Nothing happens at the chosen point of origin. Instead, a stream of 1d4 × 10 gems, each worth 1 GP, shoots from the wand's tip in a Line 30 feet long and 5 feet wide toward the chosen point of origin. Each gem deals 1 Bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the Line.98-00 The creature closest to the chosen point of origin makes a DC 15 Constitution saving throw. On a failed save, the creature has the Restrained condition and begins to turn to stone. While Restrained in this way, the creature repeats the save at the end of its next turn. On a successful save, the effect ends. On a failed save, the creature has the Petrified condition instead of the Restrained condition. The petrification lasts until the creature is freed by the Greater Restoration spell or similar magic."
+		]
 	},
 	{
 		"index": "weapon",
 		"url": "/api/2024/magic-items/weapon",
 		"image" : "/api/images/magic-items/weapon.png",
 		"name": "Weapon",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon (+1), Rare (+2), or Very Rare (+3)"
 		},
-		"description": "You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"You have a bonus to attack rolls and damage rolls made with this magic weapon. The bonus is determined by the weapon's rarity."
+		]
 	},
 	{
 		"index": "weapon-of-warning",
 		"url": "/api/2024/magic-items/weapon-of-warning",
 		"image" : "/api/images/magic-items/weapon-of-warning.png",
 		"name": "Weapon of Warning",
-		"type": "Weapon (Any Simple or Martial)",
+		"equipment_category": {
+			"index": "weapons",
+			"name": "Weapons",
+			"url": "/api/2024/equipment-categories/weapons"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.\nAlarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.\nSupernatural Readiness. Each subject has Advantage on its Initiative rolls."
+
+		"desc": [
+			"Weapon (Any Simple or Martial)",
+			"As long as this weapon is within your reach and you are attuned to it, you and allies within 30 feet of you gain the following benefits.",
+			"Alarm. The weapon magically awakens each subject who is sleeping naturally when combat begins. This benefit doesn't wake a subject from magically induced sleep.",
+			"Supernatural Readiness. Each subject has Advantage on its Initiative rolls."
+		]
 	},
 	{
 		"index": "well-of-many-worlds",
 		"url": "/api/2024/magic-items/well-of-many-worlds",
 		"image" : "/api/images/magic-items/well-of-many-worlds.png",
 		"name": "Well of Many Worlds",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Legendary"
 		},
-		"description": "This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.\nYou can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.\nOnce the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
+
+		"desc": [
+			"Wondrous Item",
+			"This fine black cloth, soft as silk, is folded up to the dimensions of a handkerchief. It unfolds into a circular sheet 6 feet in diameter.",
+			"You can take a Magic action to unfold the Well of Many Worlds and place it on a solid surface, whereupon it forms a two-way, 6-foot-diameter, circular portal to another world or plane of existence. Each time the item opens a portal, the GM decides where it leads. The portal remains open until a creature within 5 feet of it takes a Magic action to close itby taking hold of the edges of the cloth and folding it up.",
+			"Once the Well of Many Worlds has opened a portal, it can't do so again for 1d8 hours."
+		]
 	},
 	{
 		"index": "wind-fan",
 		"url": "/api/2024/magic-items/wind-fan",
 		"image" : "/api/images/magic-items/wind-fan.png",
 		"name": "Wind Fan",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": false,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
+
+		"desc": [
+			"Wondrous Item",
+			"While holding this fan, you can cast Gust of Wind (save DC 13) from it. Each subsequent time the fan is used before the next dawn, it has a cumulative 20 percent chance of not working; if the fan fails to work, it tears into useless, nonmagical tatters."
+		]
 	},
 	{
 		"index": "winged-boots",
 		"url": "/api/2024/magic-items/winged-boots",
 		"image" : "/api/images/magic-items/winged-boots.png",
 		"name": "Winged Boots",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Uncommon"
 		},
-		"description": "These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
+
+		"desc": [
+			"Wondrous Item",
+			"These boots have 4 charges and regain 1d4 expended charges daily at dawn. While wearing the boots, you can take a Magic action to expend 1 charge, gaining a Fly Speed of 30 feet for 1 hour. If you are flying when the duration expires, you descend at a rate of 30 feet per round until you land."
+		]
 	},
 	{
 		"index": "wings-of-flying",
 		"url": "/api/2024/magic-items/wings-of-flying",
 		"image" : "/api/images/magic-items/wings-of-flying.png",
 		"name": "Wings of Flying",
-		"type": "Wondrous Item",
+		"equipment_category": {
+			"index": "wondrous-items",
+			"name": "Wondrous Items",
+			"url": "/api/2024/equipment-categories/wondrous-items"
+		},
 		"attunement": true,
 		"rarity" : {
 			"name": "Rare"
 		},
-		"description": "While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
+
+		"desc": [
+			"Wondrous Item",
+			"While wearing this cloak, you can take a Magic action to turn the cloak into a pair of wings on your back. The wings lasts for 1 hour or until you end the effect early as a Magic action. The wings give you a Fly Speed of 60 feet. If you are aloft when the wings disappear, you fall. When the wings disappear, you can't use them again for 1d12 hours."
+		]
 	}
 ]

--- a/src/2024/5e-SRD-Magic-Items.json
+++ b/src/2024/5e-SRD-Magic-Items.json
@@ -34,17 +34,17 @@
 			{  
 				"index": "ammunition-1",  
 				"name": "Ammunition, +1",  
-				"url": "/api/2014/magic-items/ammunition-1"  
+				"url": "/api/2024/magic-items/ammunition-1"  
 			},  
 			{  
 				"index": "ammunition-2",  
 				"name": "Ammunition, +2",  
-				"url": "/api/2014/magic-items/ammunition-2"  
+				"url": "/api/2024/magic-items/ammunition-2"  
 			},  
 			{  
 				"index": "ammunition-3",  
 				"name": "Ammunition, +3",  
-				"url": "/api/2014/magic-items/ammunition-3"  
+				"url": "/api/2024/magic-items/ammunition-3"  
 			}  
 		],
 		"variant": false,
@@ -61,7 +61,7 @@
 		"index": "ammunition-1",
 		"url": "/api/2024/magic-items/ammunition-1",
 		"image" : "/api/images/magic-items/ammunition.png",
-		"name": "Ammunition +1",
+		"name": "Ammunition, +1",
 		"equipment_category": {
 			"index": "weapons",
 			"name": "Weapons",
@@ -83,7 +83,7 @@
 		"index": "ammunition-2",
 		"url": "/api/2024/magic-items/ammunition-2",
 		"image" : "/api/images/magic-items/ammunition.png",
-		"name": "Ammunition +2",
+		"name": "Ammunition, +2",
 		"equipment_category": {
 			"index": "weapons",
 			"name": "Weapons",
@@ -105,7 +105,7 @@
 		"index": "ammunition-3",
 		"url": "/api/2024/magic-items/ammunition-3",
 		"image" : "/api/images/magic-items/ammunition.png",
-		"name": "Ammunition +3",
+		"name": "Ammunition, +3",
 		"equipment_category": {
 			"index": "weapons",
 			"name": "Weapons",

--- a/src/2024/tests/5e-SRD-Magic-Items.test.js
+++ b/src/2024/tests/5e-SRD-Magic-Items.test.js
@@ -1,0 +1,24 @@
+import test from "./test-function.js";
+import MagicItems from "../5e-SRD-Magic-Items.json" with { type: "json" }
+
+// Mandatory Properties
+const mandatory = {
+	"name"               : "string",
+	"index"              : "string",
+	"url"                : "string",
+	"image"              : "string",
+	"equipment_category" : "object",
+	"variant"            : "boolean",
+	"variants"           : "array",
+	"attunement"         : "boolean",
+	"rarity"             : "object",
+	"desc"               : "string"
+};
+// Optional Properties
+const optional = {
+	"limited-to"         : "string"
+}
+
+
+// Tests
+test(MagicItems, mandatory, optional);

--- a/src/2024/tests/test-function.js
+++ b/src/2024/tests/test-function.js
@@ -1,0 +1,43 @@
+import { describe, expect } from "vitest";
+
+
+// Function to get property type (including Array)
+const getType = (item)=>{
+	let result = typeof item;
+	if(result == 'object' && Array.isArray(item)) result = 'array';
+	return result;
+}
+
+export default function(items, mandatory, optional){
+	return describe('2024 magic items test', () => {
+		it('only permitted properties exist on all objects', () => {
+			const foundProperties = new Set (items.map((item)=>{
+				return Object.keys(item);
+			}).flat());
+
+			const permittedProperties = new Set([ Object.keys(mandatory), Object.keys(optional) ].flat());
+
+			expect(foundProperties).toEqual(permittedProperties);
+		});
+
+		it('mandatory properties are of correct types and exist on all objects', () => {
+			const testItems = items.every((item)=>{
+				return Object.keys(mandatory).every((key)=>{
+					return mandatory[key] === getType(item[key]);
+				})
+			})
+
+			expect(testItems).toBe(true);
+		});
+
+		it('only mandatory or optional properties are of correct types on all objects', () => {
+			const testItems = items.every((item)=>{
+				return Object.keys(item).every((key)=>{
+					return mandatory[key] === getType(item[key]) || optional[key] === getType(item[key]);
+				})
+			})
+
+			expect(testItems).toBe(true);
+		});
+	});
+}


### PR DESCRIPTION
## What does this do?

This PR adds the 5E2024 (or 5.5E) magic items. This is an initial pass, so some items may be missing, incomplete, or poorly formatted.

## How was it tested?

Local testing using `npm test` and `npm db:refresh`.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

I made this a while ago, in the midst of the _Live, Laugh, Love_ craze. <img width="786" height="566" alt="Live_Laugh_Roll_Initiative" src="https://github.com/user-attachments/assets/4a61a692-43e2-41fb-968d-4b548f5da623" />

