### PR TITLE
feat(2024): Add Dev bypass to tests ('-nyi')

### DIFF
--- a/src/2024/tests/tables.test.ts
+++ b/src/2024/tests/tables.test.ts
@@ -33,9 +33,9 @@ describe('api references', () => {
     forEachFileEntry((filename, entry) => {
       if (entry.url === undefined) return;
 
-      if (entry.index === undefined) {
-        errors.push(`${filename}: Entry with URL '${entry.url}' should have an index.`);
-      }
+      indexAndUrlChecks(filename, entry)?.forEach((error: string) => {
+        errors.push(error);
+      });
 
       resources[entry.url as string] = { index: entry.index, name: entry.name };
     });
@@ -43,6 +43,18 @@ describe('api references', () => {
     forEachFileEntry((filename, topLevelEntry) => {
       recurseIntoObject(topLevelEntry, (subEntry) => {
         if (!Object.prototype.hasOwnProperty.call(subEntry, 'url')) return;
+
+        indexAndUrlChecks(filename, subEntry)?.forEach((error: string) => {
+          errors.push(error);
+        });
+
+        // Do not return errors if flagged as NYI
+        if((subEntry.url as string).slice(-4) === '-nyi') {
+          errors.forEach((error: string)=>{
+            console.warn(error);
+          })
+          return;
+        }
 
         if (resources[subEntry.url as string] === undefined) {
           errors.push(`${filename}: URL '${subEntry.url}' not found.`);
@@ -85,3 +97,47 @@ const recurseIntoObject = (object: Entry, callback: (subEntry: Entry) => void) =
     }
   }
 };
+
+const indexAndUrlChecks = (filename: string, entry: Entry) => {
+  const errors: string[] = [];
+
+  if (entry.index === undefined) {
+    errors.push(`${filename}: Entry with URL '${entry.url}' should have an index.`);
+  }
+
+  // Check Index for whitespace
+  if((entry.index as string).indexOf(' ') != -1){
+    errors.push(`${filename}: Index '${entry.index as string}' contains whitespace`);
+  }
+
+  // Check Index for illegal characters
+  if((entry.index as string).match(/[^-a-z0-9()]/)){
+    errors.push(`${filename}: Index '${entry.index as string}' contains illegal characters`);
+  }
+
+  // Check URL for whitespace
+  if((entry.url as string).indexOf(' ') != -1){
+    errors.push(`${filename}: URL '${entry.url as string}' contains whitespace`);
+  }
+
+  // Check URL for illegal characters
+  if((entry.url as string).match(/[^-/a-z0-9()]/)){
+    errors.push(`${filename}: URL '${entry.url as string}' contains illegal characters`);
+  }
+
+  // Check URL starts correctly
+  if(!(entry.url as string).startsWith('/api/2024')){
+    errors.push(`${filename}: URL '${entry.url as string}' is malformed`);
+  }
+
+  // Check Index matches URL
+  if((entry.url as string).slice(-4) == '-nyi'){
+    console.warn(`${filename}: URL '${entry.url}' is marked as Not Yet Implemented.`)
+  } else {
+    if((entry.index as string) != (entry.url as string).slice(0 - (entry.index as string).length)){
+      errors.push(`${filename}: Index '${entry.index as string}' does not match URL ${entry.url as string}`);
+    }
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## What does this do?

This PR modifies the testing process. It standardizes the URL and Index tests, and adds a bypass when the URL ends in '-nyi'.

## How was it tested?

Locally and repeatedly.

## Is there a Github issue this is resolving?

No

## Did you update the docs in the API? Please link an associated PR if applicable.

No

## Here's a fun image for your troubles

I have recently started running *Curse of Strahd* for my D&D5E players. However, my pre-game reading included the original *I6 Ravenloft* module (from D&D 1.0), and *Expedition to Castle Ravenloft* from D&D 3.5.

<img width="355" height="633" alt="image" src="https://github.com/user-attachments/assets/96c72c07-0fec-4c24-b8ba-a2c8da612e91" />

My brain is, quite literally, full of vampires at the moment.