### PR TITLE
fix(2024): Clean up existing nyi urls

### DIFF
--- a/src/2024/en/5e-SRD-Subclasses.json
+++ b/src/2024/en/5e-SRD-Subclasses.json
@@ -5,7 +5,7 @@
 		"name": "Path of the Berserker",
 		"class": {
 			"index": "barbarian",
-			"nyi": "/api/2024/classes/barbarian",
+			"url": "/api/2024/classes/barbarian",
 			"name": "Barbarian"
 		},
 		"summary": "Channel Rage into Violent Fury",
@@ -39,7 +39,7 @@
 		"name": "College of Lore",
 		"class": {
 			"index": "bard",
-			"nyi": "/api/2024/classes/bard",
+			"url": "/api/2024/classes/bard",
 			"name": "Bard"
 		},
 		"summary": "Plumb the Depths of Magical Knowledge",
@@ -73,7 +73,7 @@
 		"name": "Life Domain",
 		"class": {
 			"index": "cleric",
-			"nyi": "/api/2024/classes/cleric",
+			"url": "/api/2024/classes/cleric",
 			"name": "Cleric"
 		},
 		"summary": "Soothe the Hurts of the World",
@@ -112,7 +112,7 @@
 		"name": "Circle of the Land",
 		"class": {
 			"index": "druid",
-			"nyi": "/api/2024/classes/druid",
+			"url": "/api/2024/classes/druid",
 			"name": "Druid"
 		},
 		"summary": "Celebrate Connection to the Natural World",
@@ -151,7 +151,7 @@
 		"name": "Champion",
 		"class": {
 			"index": "fighter",
-			"nyi": "/api/2024/classes/fighter",
+			"url": "/api/2024/classes/fighter",
 			"name": "Fighter"
 		},
 		"summary": "Pursue Physical Excellence in Combat",
@@ -195,7 +195,7 @@
 		"name": "Warrior of the Open Hand",
 		"class": {
 			"index": "monk",
-			"nyi": "/api/2024/classes/monk",
+			"url": "/api/2024/classes/monk",
 			"name": "Monk"
 		},
 		"summary": "Master Unarmed Combat Techniques",
@@ -229,7 +229,7 @@
 		"name": "Oath of Devotion",
 		"class": {
 			"index": "paladin",
-			"nyi": "/api/2024/classes/paladin",
+			"url": "/api/2024/classes/paladin",
 			"name": "Paladin"
 		},
 		"summary": "Uphold the Ideals of Justice and Order",
@@ -268,7 +268,7 @@
 		"name": "Hunter",
 		"class": {
 			"index": "ranger",
-			"nyi": "/api/2024/classes/ranger",
+			"url": "/api/2024/classes/ranger",
 			"name": "Ranger"
 		},
 		"summary": "Protect Nature and People from Destruction",
@@ -307,7 +307,7 @@
 		"name": "Thief",
 		"class": {
 			"index": "rogue",
-			"nyi": "/api/2024/classes/rogue",
+			"url": "/api/2024/classes/rogue",
 			"name": "Rogue"
 		},
 		"summary": "Hunt for Treasure as a Classic Adventurer",
@@ -346,7 +346,7 @@
 		"name": "Draconic Sorcery",
 		"class": {
 			"index": "sorcerer",
-			"nyi": "/api/2024/classes/sorcerer",
+			"url": "/api/2024/classes/sorcerer",
 			"name": "Sorcerer"
 		},
 		"summary": "Breathe the Magic of Dragons",
@@ -385,7 +385,7 @@
 		"name": "Fiend Patron",
 		"class": {
 			"index": "warlock",
-			"nyi": "/api/2024/classes/warlock",
+			"url": "/api/2024/classes/warlock",
 			"name": "Warlock"
 		},
 		"summary": "Make a Deal with the Lower Planes",
@@ -424,7 +424,7 @@
 		"name": "Evoker",
 		"class": {
 			"index": "wizard",
-			"nyi": "/api/2024/classes/wizard",
+			"url": "/api/2024/classes/wizard",
 			"name": "Wizard"
 		},
 		"summary": "Create Explosive Elemental Effects",

--- a/src/2024/en/5e-SRD-Traits.json
+++ b/src/2024/en/5e-SRD-Traits.json
@@ -566,7 +566,11 @@
     "description": "You always have the Speak with Animals spell prepared. You can cast it without a spell slot a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. You can also use any spell slots you have to cast the spell.",
     "spells": [
       {
-        "nyi": "Speak with Animals",
+        "spell": {
+          "index": "speak-with-animals",
+          "name": "Speak with Animals",
+          "url": "/api/2024/spells/speak-with-animals-nyi"
+        },
         "uses": "Proficiency Bonus",
         "recovery": "Long Rest"
       }
@@ -593,7 +597,11 @@
     "description": "You know the Prestidigitation cantrip. In addition, you can spend 10 minutes casting Prestidigitation to create a Tiny clockwork device (AC 5, 1 HP), such as a toy, fire starter, or music box. When you create the device, you determine its function by choosing one effect from Prestidigitation; the device produces that effect whenever you or another creature takes a Bonus Action to activate it with a touch. If the chosen effect has options within it, you choose one of those options for the device when you create it. For example, if you choose the spell’s ignite-extinguish effect, you determine whether the device ignites or extinguishes fire; the device doesn’t do both. You can have three such devices in existence at a time, and each falls apart 8 hours after its creation or when you dismantle it with a touch as a Utilize action.",
     "spells": [
       {
-        "nyi": "Prestidigitation"
+        "spell": {
+          "index": "prestidigitation",
+          "name": "Prestidigitation",
+          "url": "/api/2024/spells/prestidigitation-nyi"
+        }
       }
     ],
     "species" : [
@@ -631,7 +639,11 @@
     "description": "You know the Prestidigitation cantrip. Whenever you finish a Long Rest, you can replace that cantrip with a different cantrip from the Wizard spell list.",
     "spells": [
       {
-        "nyi": "Prestidigitation"
+        "spell": {
+          "index": "prestidigitation",
+          "name": "Prestidigitation",
+          "url": "/api/2024/spells/prestidigitation-nyi"
+        }
       }
     ],
     "species": [
@@ -776,7 +788,11 @@
     "description": "You know the spell Chill Touch.",
     "spells": [
       {
-        "nyi": "Chill Touch"
+        "spell": {
+          "index": "chill-touch",
+          "name": "Chill Touch",
+          "url": "/api/2024/spells/chill-touch-nyi"
+        }
       }
     ],
     "species": [
@@ -801,7 +817,11 @@
     "description": "You know the spell Dancing Lights.",
     "spells": [
       {
-        "nyi": "Dancing Lights"
+        "spell": {
+          "index": "dancing-lights",
+          "name": "Dancing Lights",
+          "url": "/api/2024/spells/dancing-lights-nyi"
+        }
       }
     ],
     "species": [
@@ -826,7 +846,11 @@
     "description": "You know the spell Darkness.",
     "spells": [
       {
-        "nyi": "Darkness"
+        "spell": {
+          "index": "darkness",
+          "name": "Darkness",
+          "url": "/api/2024/spells/darkness-nyi"
+        }
       }
     ],
     "species": [
@@ -861,7 +885,11 @@
     "description": "You know the spell Detect Magic.",
     "spells": [
       {
-        "nyi": "Detect Magic"
+        "spell": {
+          "index": "detect-magic",
+          "name": "Detect Magic",
+          "url": "/api/2024/spells/detect-magic-nyi"
+        }
       }
     ],
     "species": [
@@ -886,7 +914,11 @@
     "description": "You know the spell Faerie Fire.",
     "spells": [
       {
-        "nyi": "Faerie Fire"
+        "spell": {
+          "index": "faerie-fire",
+          "name": "Faerie Fire",
+          "url": "/api/2024/spells/faerie-fire-nyi"
+        }
       }
     ],
     "species": [
@@ -911,7 +943,11 @@
     "description": "You know the spell False Life.",
     "spells": [
       {
-        "nyi": "False Life"
+        "spell": {
+          "index": "false-life",
+          "name": "False Life",
+          "url": "/api/2024/spells/false-life-nyi"
+        }
       }
     ],
     "species": [
@@ -936,7 +972,11 @@
     "description": "You know the spell Fire Bolt.",
     "spells": [
       {
-        "nyi": "Fire Bolt"
+        "spell": {
+          "index": "fire-bolt",
+          "name": "Fire Bolt",
+          "url": "/api/2024/spells/fire-bolt-nyi"
+        }
       }
     ],
     "species": [
@@ -961,7 +1001,11 @@
     "description": "You know the spell Hellish Rebuke.",
     "spells": [
       {
-        "nyi": "Hellish Rebuke"
+        "spell": {
+          "index": "hellish-rebuke",
+          "name": "Hellish Rebuke",
+          "url": "/api/2024/spells/hellish-rebuke-nyi"
+        }
       }
     ],
     "species": [
@@ -986,7 +1030,11 @@
     "description": "You know the spell Hold Person.",
     "spells": [
       {
-        "nyi": "Hold Person"
+        "spell": {
+          "index": "hold-person",
+          "name": "Hold Person",
+          "url": "/api/2024/spells/hold-person-nyi"
+        }
       }
     ],
     "species": [
@@ -1011,7 +1059,11 @@
     "description": "You learn the spell Longstrider.",
     "spells": [
       {
-        "nyi": "Longstrider"
+        "spell": {
+          "index": "longstrider",
+          "name": "Longstrider",
+          "url": "/api/2024/spells/longstrider-nyi"
+        }
       }
     ],
     "species": [
@@ -1036,7 +1088,11 @@
     "description": "You know the cantrip Mending.",
     "spells": [
       {
-        "nyi": "Mending"
+        "spell": {
+          "index": "mending",
+          "name": "Mending",
+          "url": "/api/2024/spells/mending-nyi"
+        }
       }
     ],
     "species": [
@@ -1061,7 +1117,11 @@
     "description": "You know the spell Minor Illusion.",
     "spells": [
       {
-        "nyi": "Minor Illusion"
+        "spell": {
+          "index": "minor-illusion",
+          "name": "Minor Illusion",
+          "url": "/api/2024/spells/minor-illusion-nyi"
+        }
       }
     ],
     "species": [
@@ -1086,7 +1146,11 @@
     "description": "You know the spell Misty Step.",
     "spells": [
       {
-        "nyi": "Misty Step"
+        "spell": {
+          "index": "misty-step",
+          "name": "Misty Step",
+          "url": "/api/2024/spells/misty-step-nyi"
+        }
       }
     ],
     "species": [
@@ -1111,7 +1175,11 @@
     "description": "You learn the spell Pass without Trace.",
     "spells": [
       {
-        "nyi": "Pass without Trace"
+        "spell": {
+          "index": "pass-without-trace",
+          "name": "Pass without Trace",
+          "url": "/api/2024/spells/pass-without-trace-nyi"
+        }
       }
     ],
     "species": [
@@ -1136,7 +1204,11 @@
     "description": "You know the spell Poison Spray.",
     "spells": [
       {
-        "nyi": "Poison Spray"
+        "spell": {
+          "index": "poison-spray",
+          "name": "Poison Spray",
+          "url": "/api/2024/spells/poison-spray-nyi"
+        }
       }
     ],
     "species": [
@@ -1161,7 +1233,11 @@
     "description": "You know the spell Ray of Enfeeblement.",
     "spells": [
       {
-        "nyi": "Ray of Enfeeblement"
+        "spell": {
+          "index": "ray-of-enfeeblement",
+          "name": "Ray of Enfeeblement",
+          "url": "/api/2024/spells/ray-of-enfeeblement-nyi"
+        }
       }
     ],
     "species": [
@@ -1186,7 +1262,11 @@
     "description": "You know the spell Ray of Sickness.",
     "spells": [
       {
-        "nyi": "Ray of Sickness"
+        "spell": {
+          "index": "ray-of-sickness",
+          "name": "Ray of Sickness",
+          "url": "/api/2024/spells/ray-of-sickness-nyi"
+        }
       }
     ],
     "species": [

--- a/src/2024/schemas/5e-SRD-Traits.ts
+++ b/src/2024/schemas/5e-SRD-Traits.ts
@@ -1,12 +1,19 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
+const SpellTraitSchema = z.object({
+  spell: APIReferenceSchema,
+  uses: z.string(),
+  recovery: z.string(),
+});
+
 export const TraitSchema = z.object({
   index: z.string(),
   name: z.string(),
   url: z.string(),
   description: z.string(),
   species: z.array(APIReferenceSchema),
+  spells: z.array(SpellTraitSchema).optional(),
   subspecies: z.array(APIReferenceSchema).optional(),
   proficiency_choices: ChoiceSchema.optional(),
   speed: z.number().optional(),

--- a/src/2024/schemas/5e-SRD-Traits.ts
+++ b/src/2024/schemas/5e-SRD-Traits.ts
@@ -3,8 +3,8 @@ import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
 const SpellTraitSchema = z.object({
   spell: APIReferenceSchema,
-  uses: z.string(),
-  recovery: z.string(),
+  uses: z.string().optional(),
+  recovery: z.string().optional(),
 });
 
 export const TraitSchema = z.object({


### PR DESCRIPTION
## What does this do?

Cleans up any NYI urls to either link to existing data or postfix `-nyi` to the url to pass existing tests.