### PR TITLE
ci(deploy): Update all changes since last release.

### DIFF
--- a/.github/workflows/manual-db-refresh.yml
+++ b/.github/workflows/manual-db-refresh.yml
@@ -4,7 +4,17 @@ name: Manual Database Refresh
 # from the JSON files in the repository. Use with caution.
 
 on:
-  workflow_dispatch: # Allows manual triggering from the Actions tab
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Which DB version to refresh'
+        required: false
+        type: choice
+        default: 'all'
+        options:
+          - 'all'
+          - '2014'
+          - '2024'
 
 jobs:
   refresh-database:
@@ -27,4 +37,5 @@ jobs:
       - name: Run Database Refresh Script
         run: npm run db:refresh
         env:
-          MONGODB_URI: ${{ secrets.MONGODB_URI }} # Inject DB URI from secrets
+          MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          DB_VERSION: ${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,17 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.tag.outputs.tag }}
-          fetch-depth: 2
+          fetch-depth: 0
+      - name: Find Previous Release Tag
+        id: prev-tag
+        run: |
+          PREV_TAG=$(git describe --abbrev=0 --tags HEAD^ 2>/dev/null || echo "")
+          if [ -z "$PREV_TAG" ]; then
+            echo "No previous tag found, will fall back to HEAD~1 comparison"
+          else
+            echo "Previous release tag: $PREV_TAG"
+          fi
+          echo "prev_tag=$PREV_TAG" >> $GITHUB_OUTPUT
       - name: Set up Node.js 22.x
         uses: actions/setup-node@v6
         with:
@@ -43,6 +53,7 @@ jobs:
       - name: Run Database Update Script
         env:
           MONGODB_URI: ${{ secrets.MONGODB_URI }}
+          GIT_FROM_REF: ${{ steps.prev-tag.outputs.prev_tag }}
         run: npm run db:update
 
   container-release:

--- a/scripts/dbRefresh.ts
+++ b/scripts/dbRefresh.ts
@@ -314,21 +314,32 @@ async function uploadTranslationsFromFolder(
 }
 
 async function main() {
+  const version = process.env.DB_VERSION;
+  if (version && version !== 'all' && version !== '2014' && version !== '2024') {
+    console.error(`Invalid DB_VERSION: '${version}'. Must be 'all', '2014', or '2024'.`);
+    process.exit(1);
+  }
+  const runAll = !version || version === 'all';
+
   const client = new MongoClient(mongodbUri);
   try {
     await client.connect();
     console.log('Connected successfully to MongoDB server');
     const db = client.db();
 
-    console.log('\nUploading 2014 tables...');
-    await uploadTablesFromFolder(db, 'src/2014/en', '2014-');
-    console.log('\nLoading 2014 translations...');
-    await uploadTranslationsFromFolder(db, 'src/2014', '2014-');
+    if (runAll || version === '2014') {
+      console.log('\nUploading 2014 tables...');
+      await uploadTablesFromFolder(db, 'src/2014/en', '2014-');
+      console.log('\nLoading 2014 translations...');
+      await uploadTranslationsFromFolder(db, 'src/2014', '2014-');
+    }
 
-    console.log('\nUploading 2024 tables...');
-    await uploadTablesFromFolder(db, 'src/2024/en', '2024-');
-    console.log('\nLoading 2024 translations...');
-    await uploadTranslationsFromFolder(db, 'src/2024', '2024-');
+    if (runAll || version === '2024') {
+      console.log('\nUploading 2024 tables...');
+      await uploadTablesFromFolder(db, 'src/2024/en', '2024-');
+      console.log('\nLoading 2024 translations...');
+      await uploadTranslationsFromFolder(db, 'src/2024', '2024-');
+    }
 
     console.log('\nDatabase refresh completed successfully.');
   } catch (error) {

--- a/scripts/update/gitUtils.ts
+++ b/scripts/update/gitUtils.ts
@@ -49,23 +49,27 @@ function parseLsFilesOutput(output: string): ChangedFile[] {
 
 /**
  * Gets the list of changed JSON files with their status within the src/ directory
- * comparing the current HEAD to the previous commit (HEAD~1).
- * Includes fallback logic for initial commits or shallow clones.
+ * comparing the current HEAD to a base ref. The base ref is read from the
+ * GIT_FROM_REF environment variable (e.g. a previous release tag); falls back
+ * to HEAD~1 when not set. Includes fallback logic for initial commits or
+ * shallow clones when using the default HEAD~1 ref.
  * @returns An array of ChangedFile objects.
  */
 export function getChangedJsonFilesWithStatus(): ChangedFile[] {
-  console.log('Checking for changed JSON files with status in the last commit...');
+  const fromRef = process.env.GIT_FROM_REF || 'HEAD~1';
+  const isDefaultRef = fromRef === 'HEAD~1';
+  console.log(`Checking for changed JSON files with status since ${fromRef}...`);
   let diffOutput: string = '';
   let isFallback = false;
 
-  // 1. Try comparing HEAD vs the previous commit
+  // 1. Try comparing fromRef vs HEAD
   try {
-    diffOutput = execSync('git diff --name-status -M HEAD~1 HEAD -- src/**/*.json', {
+    diffOutput = execSync(`git diff --name-status -M ${fromRef} HEAD -- src/**/*.json`, {
       encoding: 'utf8',
     });
   } catch (error) {
-    // Check if the error is due to missing history (e.g., first commit)
-    if (hasStderr(error) && error.stderr.includes('unknown revision or path not in the working tree')) {
+    // Fallback for missing HEAD~1 history only applies to the default ref
+    if (isDefaultRef && hasStderr(error) && error.stderr.includes('unknown revision or path not in the working tree')) {
       console.warn(
         'Could not find previous commit (HEAD~1). Checking working tree status against index...'
       );
@@ -82,8 +86,7 @@ export function getChangedJsonFilesWithStatus(): ChangedFile[] {
         );
       }
     } else {
-      // Re-throw other errors
-      console.error('Error diffing HEAD~1..HEAD:', error);
+      console.error(`Error diffing ${fromRef}..HEAD:`, error);
       throw new Error(
         `Failed to get changed files from git: ${error instanceof Error ? error.message : String(error)}`
       );
@@ -115,14 +118,15 @@ export function getChangedJsonFilesWithStatus(): ChangedFile[] {
 }
 
 /**
- * Fetches JSON content string of a file from the previous commit (HEAD~1).
- * Uses spawn to stream output, avoiding buffer limits.
+ * Fetches JSON content string of a file from the base ref (GIT_FROM_REF env var,
+ * or HEAD~1 by default). Uses spawn to stream output, avoiding buffer limits.
  * @param gitPath The path used in the git command (could be old path for renames).
  * @returns A promise resolving to the raw string content, or an empty string on error.
  */
 export async function getOldFileContent(gitPath: string): Promise<string> {
+  const fromRef = process.env.GIT_FROM_REF || 'HEAD~1';
   return new Promise((resolve, reject) => {
-    const gitShow = spawn('git', ['show', `HEAD~1:${gitPath}`]);
+    const gitShow = spawn('git', ['show', `${fromRef}:${gitPath}`]);
     let oldFileContent = '';
     let errorOutput = '';
 
@@ -136,7 +140,7 @@ export async function getOldFileContent(gitPath: string): Promise<string> {
 
     gitShow.on('error', (err: Error) => {
       // Handle errors spawning the process itself
-      console.error(`Error spawning git show for HEAD~1:${gitPath}:`, err);
+      console.error(`Error spawning git show for ${fromRef}:${gitPath}:`, err);
       resolve(''); // Resolve with empty string on spawn error
     });
 
@@ -146,10 +150,10 @@ export async function getOldFileContent(gitPath: string): Promise<string> {
       } else {
         // Handle errors reported by git show (like file not found)
         if (errorOutput.includes('exists on disk, but not in')) {
-          console.warn(`Previous version not found in git history (HEAD~1:${gitPath}).`);
+          console.warn(`Previous version not found in git history (${fromRef}:${gitPath}).`);
         } else {
           console.error(
-            `Error running git show for HEAD~1:${gitPath} (code ${code}): ${errorOutput}`
+            `Error running git show for ${fromRef}:${gitPath} (code ${code}): ${errorOutput}`
           );
         }
         resolve(''); // Resolve with empty string if git show fails


### PR DESCRIPTION
## What does this do?

* `manual-db-refresh` now accepts a version input (all / 2014 / 2024). When a specific version is selected, only that version's tables and translations are refreshed. Defaults to all for existing behavior.

* `db:update` now diffs against the previous release tag instead of just the last commit. Previously, the Deploy Changes job was a no-op on release because the Release Please merge commit contains no JSON data changes. The workflow now fetches full git history (`fetch-depth: 0`), resolves the previous release tag via `git describe --abbrev=0 --tags HEAD^`, and passes it as `GIT_FROM_REF` to the update script. `gitUtils.ts` uses this env var as the base ref for both the changed-file diff and old-content lookups, falling back to `HEAD~1` when unset (local dev) or when no previous tag exists (first release).

## Here's a fun image for your troubles

<img width="500" height="680" alt="image" src="https://github.com/user-attachments/assets/4aff6aec-29d1-4ddf-872d-f705199ba2c8" />

