### PR TITLE
fix(5e-SRD-Monsters.json): regular range format

### DIFF
--- a/src/2014/en/5e-SRD-Monsters.json
+++ b/src/2014/en/5e-SRD-Monsters.json
@@ -5645,7 +5645,7 @@
       },
       {
         "name": "Breath Weapons",
-        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 90- foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+        "desc": "The dragon uses one of the following breath weapons.\nCold Breath. The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 24 Constitution saving throw, taking 67 (15d8) cold damage on a failed save, or half as much damage on a successful one.\nParalyzing Breath. The dragon exhales paralyzing gas in a 90-foot cone. Each creature in that area must succeed on a DC 24 Constitution saving throw or be paralyzed for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",
@@ -7841,7 +7841,7 @@
       },
       {
         "name": "Light Crossbow",
-        "desc": "Ranged Weapon Attack: +3 to hit, range 80 ft./320 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
+        "desc": "Ranged Weapon Attack: +3 to hit, range 80/320 ft., one target. Hit: 5 (1d8 + 1) piercing damage.",
         "attack_bonus": 3,
         "damage": [
           {
@@ -33420,7 +33420,7 @@
       },
       {
         "name": "Spear",
-        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20 ft./60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
+        "desc": "Melee or Ranged Weapon Attack: +7 to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 11 (2d6 + 4) piercing damage, or 13 (2d8 + 4) piercing damage if used with two hands to make a melee attack, plus 3 (1d6) fire damage.",
         "attack_bonus": 7,
         "damage": [
           {


### PR DESCRIPTION
Bandit and salamander have the only two attacks not following the common range format.
Erroneous whitespace on one of the dragon's attacks.

## What does this do?

\<It's not clear if I don't update this text with relevant info\>

## How was it tested?

\<It's not clear if I don't update this text with relevant info\>

## Is there a Github issue this is resolving?

\<It's not clear if I don't update this text with relevant info\>

## Did you update the docs in the API? Please link an associated PR if applicable.

\<It's not clear if I don't update this text with relevant info\>

## Here's a fun image for your troubles

\<Add a fun image here\>
