### PR TITLE
fix(2024): Add class property to subclass schema

### DIFF
--- a/src/2024/schemas/5e-SRD-Subclasses.ts
+++ b/src/2024/schemas/5e-SRD-Subclasses.ts
@@ -11,7 +11,7 @@ export const SubclassSchema = z.object({
   index: z.string(),
   url: z.string(),
   name: z.string(),
-  class: z.object(APIReferenceSchema),
+  class: APIReferenceSchema,
   summary: z.string(),
   description: z.string(),
   features: z.array(SubclassFeatureSchema),

--- a/src/2024/schemas/5e-SRD-Subclasses.ts
+++ b/src/2024/schemas/5e-SRD-Subclasses.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { APIReferenceSchema } from '../../schemas/common';
 
 const SubclassFeatureSchema = z.object({
   name: z.string(),
@@ -10,6 +11,7 @@ export const SubclassSchema = z.object({
   index: z.string(),
   url: z.string(),
   name: z.string(),
+  class: z.object(APIReferenceSchema),
   summary: z.string(),
   description: z.string(),
   features: z.array(SubclassFeatureSchema),


### PR DESCRIPTION
## What does this do?

Adds the class property to the subclass schema to match what now exists.

## Here's a fun image for your troubles

<img width="1400" height="700" alt="image" src="https://github.com/user-attachments/assets/3e91a196-86ef-4036-9e19-7e7a5f6f6973" />

