### PR TITLE
fix(2024): Change field names for primary ability in classes and convert to choice schema

### DIFF
--- a/src/2024/en/5e-SRD-Classes.json
+++ b/src/2024/en/5e-SRD-Classes.json
@@ -4,7 +4,7 @@
         "name": "Barbarian",
         "primary_ability": {
             "desc": "Strength",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "str",
                     "name": "STR",
@@ -215,7 +215,7 @@
         "name": "Bard",
         "primary_ability": {
             "desc": "Charisma",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "cha",
                     "name": "CHA",
@@ -889,7 +889,7 @@
         "name": "Cleric",
         "primary_ability": {
             "desc": "Wisdom",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "wis",
                     "name": "WIS",
@@ -1161,7 +1161,7 @@
         "name": "Druid",
         "primary_ability": {
             "desc": "Wisdom",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "wis",
                     "name": "WIS",
@@ -1461,18 +1461,31 @@
         "name": "Fighter",
         "primary_ability": {
             "desc": "Strength or Dexterity",
-            "any_of": [
-                {
-                    "index": "str",
-                    "name": "STR",
-                    "url": "/api/2024/ability-scores/str"
-                },
-                {
-                    "index": "dex",
-                    "name": "DEX",
-                    "url": "/api/2024/ability-scores/dex"
+            "ability_score_options": {
+                "choose": 1,
+                "type": "ability_scores",
+                "from": {
+                    "option_set_type": "options_array",
+                    "options": [
+                        {
+                            "option_type": "reference",
+                            "item": {
+                                "index": "str",
+                                "name": "STR",
+                                "url": "/api/2024/ability-scores/str"
+                            }
+                        },
+                        {
+                            "option_type": "reference",
+                            "item": {
+                                "index": "dex",
+                                "name": "DEX",
+                                "url": "/api/2024/ability-scores/dex"
+                            }
+                        }
+                    ]
                 }
-            ]
+            }
         },
         "hit_die": 10,
         "proficiency_choices": [
@@ -1806,7 +1819,7 @@
         "name": "Monk",
         "primary_ability": {
             "desc": "Dexterity and Wisdom",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "dex",
                     "name": "DEX",
@@ -2327,7 +2340,7 @@
         "name": "Paladin",
         "primary_ability": {
             "desc": "Strength and Charisma",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "str",
                     "name": "STR",
@@ -2626,7 +2639,7 @@
         "name": "Ranger",
         "primary_ability": {
             "desc": "Dexterity and Wisdom",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "dex",
                     "name": "DEX",
@@ -3039,7 +3052,7 @@
         "name": "Rogue",
         "primary_ability": {
             "desc": "Dexterity",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "dex",
                     "name": "DEX",
@@ -3454,7 +3467,7 @@
         "name": "Sorcerer",
         "primary_ability": {
             "desc": "Charisma",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "cha",
                     "name": "CHA",
@@ -3693,7 +3706,7 @@
         "name": "Warlock",
         "primary_ability": {
             "desc": "Charisma",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "cha",
                     "name": "CHA",
@@ -3970,7 +3983,7 @@
         "name": "Wizard",
         "primary_ability": {
             "desc": "Intelligence",
-            "all_of": [
+            "ability_scores": [
                 {
                     "index": "int",
                     "name": "INT",

--- a/src/2024/schemas/5e-SRD-Classes.ts
+++ b/src/2024/schemas/5e-SRD-Classes.ts
@@ -1,36 +1,36 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const SpellcastingInfoSchema = z.object({
+const SpellcastingInfoSchema = z.strictObject({
   name: z.string(),
   desc: z.array(z.string()),
 });
 
-const SpellcastingSchema = z.object({
+const SpellcastingSchema = z.strictObject({
   level: z.number(),
   spellcasting_ability: APIReferenceSchema,
   info: z.array(SpellcastingInfoSchema),
 });
 
-const MultiClassingPrereqSchema = z.object({
+const MultiClassingPrereqSchema = z.strictObject({
   ability_score: APIReferenceSchema.optional(),
   minimum_score: z.number(),
 });
 
-const MultiClassingSchema = z.object({
+const MultiClassingSchema = z.strictObject({
   prerequisites: z.array(MultiClassingPrereqSchema).optional(),
   prerequisite_options: ChoiceSchema.optional(),
   proficiencies: z.array(APIReferenceSchema).optional(),
   proficiency_choices: z.array(ChoiceSchema).optional(),
 });
 
-const PrimaryAbilitySchema = z.object({
+const PrimaryAbilitySchema = z.strictObject({
   desc: z.string(),
-  all_of: z.array(APIReferenceSchema).optional(),
-  any_of: ChoiceSchema.optional()
+  ability_scores: z.array(APIReferenceSchema).optional(),
+  ability_score_options: ChoiceSchema.optional(),
 });
 
-export const ClassSchema = z.object({
+export const ClassSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   primary_ability: PrimaryAbilitySchema,

--- a/src/2024/tests/schemas.test.ts
+++ b/src/2024/tests/schemas.test.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import AbilityScores from '../en/5e-SRD-Ability-Scores.json' with { type: 'json' };
 import Alignments from '../en/5e-SRD-Alignments.json' with { type: 'json' };
 import Backgrounds from '../en/5e-SRD-Backgrounds.json' with { type: 'json' };
+import Classes from '../en/5e-SRD-Classes.json' with { type: 'json' };
 import Conditions from '../en/5e-SRD-Conditions.json' with { type: 'json' };
 import DamageTypes from '../en/5e-SRD-Damage-Types.json' with { type: 'json' };
 import EquipmentCategories from '../en/5e-SRD-Equipment-Categories.json' with { type: 'json' };
@@ -25,6 +26,7 @@ import WeaponProperties from '../en/5e-SRD-Weapon-Properties.json' with { type: 
 import { AbilityScoreSchema } from '../schemas/5e-SRD-Ability-Scores';
 import { AlignmentSchema } from '../schemas/5e-SRD-Alignments';
 import { BackgroundSchema } from '../schemas/5e-SRD-Backgrounds';
+import { ClassSchema } from '../schemas/5e-SRD-Classes';
 import { ConditionSchema } from '../schemas/5e-SRD-Conditions';
 import { DamageTypeSchema } from '../schemas/5e-SRD-Damage-Types';
 import { EquipmentCategorySchema } from '../schemas/5e-SRD-Equipment-Categories';
@@ -43,7 +45,6 @@ import { TraitSchema } from '../schemas/5e-SRD-Traits';
 import { WeaponMasteryPropertySchema } from '../schemas/5e-SRD-Weapon-Mastery-Properties';
 import { WeaponPropertySchema } from '../schemas/5e-SRD-Weapon-Properties';
 
-
 function testAll(data: unknown[], schema: z.ZodTypeAny) {
   for (const item of data as { index?: string; name?: string }[]) {
     const result = schema.safeParse(item);
@@ -55,6 +56,7 @@ describe('2024 schemas', () => {
   it('ability scores', () => testAll(AbilityScores, AbilityScoreSchema));
   it('alignments', () => testAll(Alignments, AlignmentSchema));
   it('backgrounds', () => testAll(Backgrounds, BackgroundSchema));
+  it('classes', () => testAll(Classes, ClassSchema));
   it('conditions', () => testAll(Conditions, ConditionSchema));
   it('damage types', () => testAll(DamageTypes, DamageTypeSchema));
   it('equipment categories', () => testAll(EquipmentCategories, EquipmentCategorySchema));
@@ -70,6 +72,7 @@ describe('2024 schemas', () => {
   it('subclasses', () => testAll(Subclasses, SubclassSchema));
   it('subspecies', () => testAll(Subspecies, SubspeciesSchema));
   it('traits', () => testAll(Traits, TraitSchema));
-  it('weapon mastery properties', () => testAll(WeaponMasteryProperties, WeaponMasteryPropertySchema));
+  it('weapon mastery properties', () =>
+    testAll(WeaponMasteryProperties, WeaponMasteryPropertySchema));
   it('weapon properties', () => testAll(WeaponProperties, WeaponPropertySchema));
 });


### PR DESCRIPTION
## What does this do?

* Swaps a few fields on classes:
  * `all_of` -> `ability_scores`
  * `any_of` -> `ability_score_options`
* `ability_score_options` now uses the `Choice` schema
* Class schema now uses `strictObject`

## Here's a fun image for your troubles

<img width="686" height="386" alt="image" src="https://github.com/user-attachments/assets/62626e0f-d456-411e-9afd-0c19197554d9" />
