### PR TITLE
fix(all): Shift everything to strict schemas and make sure they still pass

### DIFF
--- a/src/2014/schemas/5e-SRD-Ability-Scores.ts
+++ b/src/2014/schemas/5e-SRD-Ability-Scores.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const AbilityScoreSchema = z.object({
+export const AbilityScoreSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   full_name: z.string(),

--- a/src/2014/schemas/5e-SRD-Alignments.ts
+++ b/src/2014/schemas/5e-SRD-Alignments.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const AlignmentSchema = z.object({
+export const AlignmentSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   abbreviation: z.string(),

--- a/src/2014/schemas/5e-SRD-Backgrounds.ts
+++ b/src/2014/schemas/5e-SRD-Backgrounds.ts
@@ -1,17 +1,17 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const BackgroundFeatureSchema = z.object({
+const BackgroundFeatureSchema = z.strictObject({
   name: z.string(),
   desc: z.array(z.string()),
 });
 
-const StartingEquipmentSchema = z.object({
+const StartingEquipmentSchema = z.strictObject({
   equipment: APIReferenceSchema,
   quantity: z.number(),
 });
 
-export const BackgroundSchema = z.object({
+export const BackgroundSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   starting_proficiencies: z.array(APIReferenceSchema),

--- a/src/2014/schemas/5e-SRD-Classes.ts
+++ b/src/2014/schemas/5e-SRD-Classes.ts
@@ -1,35 +1,35 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const SpellcastingInfoSchema = z.object({
+const SpellcastingInfoSchema = z.strictObject({
   name: z.string(),
   desc: z.array(z.string()),
 });
 
-const SpellcastingSchema = z.object({
+const SpellcastingSchema = z.strictObject({
   level: z.number(),
   spellcasting_ability: APIReferenceSchema,
   info: z.array(SpellcastingInfoSchema),
 });
 
-const StartingEquipmentSchema = z.object({
+const StartingEquipmentSchema = z.strictObject({
   equipment: APIReferenceSchema,
   quantity: z.number(),
 });
 
-const MultiClassingPrereqSchema = z.object({
+const MultiClassingPrereqSchema = z.strictObject({
   ability_score: APIReferenceSchema.optional(),
   minimum_score: z.number(),
 });
 
-const MultiClassingSchema = z.object({
+const MultiClassingSchema = z.strictObject({
   prerequisites: z.array(MultiClassingPrereqSchema).optional(),
   prerequisite_options: ChoiceSchema.optional(),
   proficiencies: z.array(APIReferenceSchema).optional(),
   proficiency_choices: z.array(ChoiceSchema).optional(),
 });
 
-export const ClassSchema = z.object({
+export const ClassSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   hit_die: z.number(),

--- a/src/2014/schemas/5e-SRD-Conditions.ts
+++ b/src/2014/schemas/5e-SRD-Conditions.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const ConditionSchema = z.object({
+export const ConditionSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2014/schemas/5e-SRD-Damage-Types.ts
+++ b/src/2014/schemas/5e-SRD-Damage-Types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const DamageTypeSchema = z.object({
+export const DamageTypeSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2014/schemas/5e-SRD-Equipment-Categories.ts
+++ b/src/2014/schemas/5e-SRD-Equipment-Categories.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const EquipmentCategorySchema = z.object({
+export const EquipmentCategorySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   equipment: z.array(APIReferenceSchema),

--- a/src/2014/schemas/5e-SRD-Equipment.ts
+++ b/src/2014/schemas/5e-SRD-Equipment.ts
@@ -1,38 +1,38 @@
 import { z } from 'zod';
 import { APIReferenceSchema, DamageSchema } from '../../schemas/common';
 
-const CostSchema = z.object({
+const CostSchema = z.strictObject({
   quantity: z.number(),
   unit: z.string(),
 });
 
-const ArmorClassSchema = z.object({
+const ArmorClassSchema = z.strictObject({
   base: z.number(),
   dex_bonus: z.boolean(),
   max_bonus: z.number().optional(),
 });
 
-const ContentSchema = z.object({
+const ContentSchema = z.strictObject({
   item: APIReferenceSchema,
   quantity: z.number(),
 });
 
-const RangeSchema = z.object({
+const RangeSchema = z.strictObject({
   normal: z.number(),
   long: z.number().optional(),
 });
 
-const ThrowRangeSchema = z.object({
+const ThrowRangeSchema = z.strictObject({
   normal: z.number(),
   long: z.number(),
 });
 
-const SpeedSchema = z.object({
+const SpeedSchema = z.strictObject({
   quantity: z.number(),
   unit: z.string(),
 });
 
-export const EquipmentSchema = z.object({
+export const EquipmentSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   equipment_category: APIReferenceSchema,

--- a/src/2014/schemas/5e-SRD-Feats.ts
+++ b/src/2014/schemas/5e-SRD-Feats.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const PrerequisiteSchema = z.object({
+const PrerequisiteSchema = z.strictObject({
   ability_score: APIReferenceSchema.optional(),
   minimum_score: z.number(),
 });
 
-export const FeatSchema = z.object({
+export const FeatSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   prerequisites: z.array(PrerequisiteSchema).optional(),

--- a/src/2014/schemas/5e-SRD-Features.ts
+++ b/src/2014/schemas/5e-SRD-Features.ts
@@ -16,7 +16,7 @@ const FeaturePrerequisiteSchema = z.strictObject({
   spell: z.string().optional(),
 });
 
-export const FeatureSchema = z.object({
+export const FeatureSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   level: z.number(),

--- a/src/2014/schemas/5e-SRD-Languages.ts
+++ b/src/2014/schemas/5e-SRD-Languages.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const LanguageSchema = z.object({
+export const LanguageSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   type: z.string(),

--- a/src/2014/schemas/5e-SRD-Levels.ts
+++ b/src/2014/schemas/5e-SRD-Levels.ts
@@ -1,16 +1,16 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const ClassSpecificSchema = z.object({
+const ClassSpecificSchema = z.strictObject({
   action_surges: z.number().optional(),
   arcane_recovery_levels: z.number().optional(),
   aura_range: z.number().optional(),
   bardic_inspiration_die: z.number().optional(),
   brutal_critical_dice: z.number().optional(),
   channel_divinity_charges: z.number().optional(),
-  creating_spell_slots: z.array(
-    z.object({ sorcery_point_cost: z.number(), spell_slot_level: z.number() })
-  ).optional(),
+  creating_spell_slots: z
+    .array(z.strictObject({ sorcery_point_cost: z.number(), spell_slot_level: z.number() }))
+    .optional(),
   destroy_undead_cr: z.number().optional(),
   extra_attacks: z.number().optional(),
   favored_enemies: z.number().optional(),
@@ -21,7 +21,7 @@ const ClassSpecificSchema = z.object({
   magical_secrets_max_5: z.number().optional(),
   magical_secrets_max_7: z.number().optional(),
   magical_secrets_max_9: z.number().optional(),
-  martial_arts: z.object({ dice_count: z.number(), dice_value: z.number() }).optional(),
+  martial_arts: z.strictObject({ dice_count: z.number(), dice_value: z.number() }).optional(),
   metamagic_known: z.number().optional(),
   mystic_arcanum_level_6: z.number().optional(),
   mystic_arcanum_level_7: z.number().optional(),
@@ -29,7 +29,7 @@ const ClassSpecificSchema = z.object({
   mystic_arcanum_level_9: z.number().optional(),
   rage_count: z.number().optional(),
   rage_damage_bonus: z.number().optional(),
-  sneak_attack: z.object({ dice_count: z.number(), dice_value: z.number() }).optional(),
+  sneak_attack: z.strictObject({ dice_count: z.number(), dice_value: z.number() }).optional(),
   song_of_rest_die: z.number().optional(),
   sorcery_points: z.number().optional(),
   unarmored_movement: z.number().optional(),
@@ -38,7 +38,7 @@ const ClassSpecificSchema = z.object({
   wild_shape_swim: z.boolean().optional(),
 });
 
-const LevelSpellcastingSchema = z.object({
+const LevelSpellcastingSchema = z.strictObject({
   cantrips_known: z.number().optional(),
   spell_slots_level_1: z.number(),
   spell_slots_level_2: z.number(),
@@ -52,12 +52,12 @@ const LevelSpellcastingSchema = z.object({
   spells_known: z.number().optional(),
 });
 
-const SubclassSpecificSchema = z.object({
+const SubclassSpecificSchema = z.strictObject({
   additional_magical_secrets_max_lvl: z.number().optional(),
   aura_range: z.number().optional(),
 });
 
-export const LevelSchema = z.object({
+export const LevelSchema = z.strictObject({
   index: z.string(),
   level: z.number(),
   ability_score_bonuses: z.number().optional(),

--- a/src/2014/schemas/5e-SRD-Magic-Items.ts
+++ b/src/2014/schemas/5e-SRD-Magic-Items.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const RaritySchema = z.object({
+const RaritySchema = z.strictObject({
   name: z.string(),
 });
 
-export const MagicItemSchema = z.object({
+export const MagicItemSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   equipment_category: APIReferenceSchema,

--- a/src/2014/schemas/5e-SRD-Magic-Schools.ts
+++ b/src/2014/schemas/5e-SRD-Magic-Schools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const MagicSchoolSchema = z.object({
+export const MagicSchoolSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.string().optional(),

--- a/src/2014/schemas/5e-SRD-Monsters.ts
+++ b/src/2014/schemas/5e-SRD-Monsters.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
-import { APIReferenceSchema, ChoiceSchema, DamageSchema, DifficultyClassSchema } from '../../schemas/common';
+import {
+  APIReferenceSchema,
+  ChoiceSchema,
+  DamageSchema,
+  DifficultyClassSchema,
+} from '../../schemas/common';
 
-const MonsterSpeedSchema = z.object({
+const MonsterSpeedSchema = z.strictObject({
   walk: z.string().optional(),
   burrow: z.string().optional(),
   climb: z.string().optional(),
@@ -10,7 +15,7 @@ const MonsterSpeedSchema = z.object({
   hover: z.boolean().optional(),
 });
 
-const SenseSchema = z.object({
+const SenseSchema = z.strictObject({
   passive_perception: z.number(),
   blindsight: z.string().optional(),
   darkvision: z.string().optional(),
@@ -18,7 +23,7 @@ const SenseSchema = z.object({
   truesight: z.string().optional(),
 });
 
-const MonsterProficiencySchema = z.object({
+const MonsterProficiencySchema = z.strictObject({
   value: z.number(),
   proficiency: APIReferenceSchema,
 });
@@ -32,10 +37,12 @@ const MonsterArmorClassSchema = z.strictObject({
   desc: z.string().optional(),
 });
 
-const ActionUsageSchema = z.object({
+const ActionUsageSchema = z.strictObject({
   type: z.string(),
   dice: z.string().optional(),
   min_value: z.number().optional(),
+  times: z.number().optional(),
+  rest_types: z.array(z.string()).optional(),
 });
 
 const MonsterActionItemSchema = z.strictObject({
@@ -64,7 +71,7 @@ const MonsterActionSchema = z.strictObject({
   damage: z.array(z.union([DamageSchema, ChoiceSchema])).optional(),
 });
 
-const LegendaryActionSchema = z.object({
+const LegendaryActionSchema = z.strictObject({
   name: z.string(),
   desc: z.string(),
   attack_bonus: z.number().optional(),
@@ -72,13 +79,13 @@ const LegendaryActionSchema = z.object({
   dc: DifficultyClassSchema.optional(),
 });
 
-const ReactionSchema = z.object({
+const ReactionSchema = z.strictObject({
   name: z.string(),
   desc: z.string(),
   dc: DifficultyClassSchema.optional(),
 });
 
-const SpecialAbilityUsageSchema = z.object({
+const SpecialAbilityUsageSchema = z.strictObject({
   type: z.string(),
   times: z.number().optional(),
   rest_types: z.array(z.string()).optional(),
@@ -118,9 +125,10 @@ const SpecialAbilitySchema = z.strictObject({
   spellcasting: SpellcastingSchema.optional(),
 });
 
-export const MonsterSchema = z.object({
+export const MonsterSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
+  desc: z.string().optional(),
   size: z.string(),
   type: z.string(),
   subtype: z.string().optional(),

--- a/src/2014/schemas/5e-SRD-Proficiencies.ts
+++ b/src/2014/schemas/5e-SRD-Proficiencies.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const ProficiencySchema = z.object({
+export const ProficiencySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   type: z.string(),

--- a/src/2014/schemas/5e-SRD-Races.ts
+++ b/src/2014/schemas/5e-SRD-Races.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const AbilityBonusSchema = z.object({
+const AbilityBonusSchema = z.strictObject({
   ability_score: APIReferenceSchema,
   bonus: z.number(),
 });
 
-export const RaceSchema = z.object({
+export const RaceSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   speed: z.number(),

--- a/src/2014/schemas/5e-SRD-Rule-Sections.ts
+++ b/src/2014/schemas/5e-SRD-Rule-Sections.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const RuleSectionSchema = z.object({
+export const RuleSectionSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.string(),

--- a/src/2014/schemas/5e-SRD-Rules.ts
+++ b/src/2014/schemas/5e-SRD-Rules.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const RuleSchema = z.object({
+export const RuleSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.string(),

--- a/src/2014/schemas/5e-SRD-Skills.ts
+++ b/src/2014/schemas/5e-SRD-Skills.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const SkillSchema = z.object({
+export const SkillSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2014/schemas/5e-SRD-Spells.ts
+++ b/src/2014/schemas/5e-SRD-Spells.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
 import { APIReferenceSchema, AreaOfEffectSchema } from '../../schemas/common';
 
-const SpellDamageSchema = z.object({
+const SpellDamageSchema = z.strictObject({
   damage_type: APIReferenceSchema.optional(),
   damage_at_slot_level: z.record(z.string(), z.string()).optional(),
   damage_at_character_level: z.record(z.string(), z.string()).optional(),
 });
 
-const SpellDCSchema = z.object({
+const SpellDCSchema = z.strictObject({
   dc_type: APIReferenceSchema,
   dc_success: z.string(),
   desc: z.string().optional(),
 });
 
-export const SpellSchema = z.object({
+export const SpellSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2014/schemas/5e-SRD-Subclasses.ts
+++ b/src/2014/schemas/5e-SRD-Subclasses.ts
@@ -1,19 +1,19 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const SubclassSpellPrerequisiteSchema = z.object({
+const SubclassSpellPrerequisiteSchema = z.strictObject({
   index: z.string(),
   type: z.string(),
   name: z.string(),
   url: z.string(),
 });
 
-const SubclassSpellSchema = z.object({
+const SubclassSpellSchema = z.strictObject({
   prerequisites: z.array(SubclassSpellPrerequisiteSchema),
   spell: APIReferenceSchema,
 });
 
-export const SubclassSchema = z.object({
+export const SubclassSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   class: APIReferenceSchema,

--- a/src/2014/schemas/5e-SRD-Subraces.ts
+++ b/src/2014/schemas/5e-SRD-Subraces.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const AbilityBonusSchema = z.object({
+const AbilityBonusSchema = z.strictObject({
   ability_score: APIReferenceSchema,
   bonus: z.number(),
 });
 
-export const SubraceSchema = z.object({
+export const SubraceSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   race: APIReferenceSchema,

--- a/src/2014/schemas/5e-SRD-Traits.ts
+++ b/src/2014/schemas/5e-SRD-Traits.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { APIReferenceSchema, AreaOfEffectSchema, ChoiceSchema, DifficultyClassSchema } from '../../schemas/common';
+import {
+  APIReferenceSchema,
+  AreaOfEffectSchema,
+  ChoiceSchema,
+  DifficultyClassSchema,
+} from '../../schemas/common';
 
 const BreathWeaponUsageSchema = z.strictObject({
   type: z.string(),
@@ -27,7 +32,7 @@ const TraitSpecificSchema = z.strictObject({
   subtrait_options: ChoiceSchema.optional(),
 });
 
-export const TraitSchema = z.object({
+export const TraitSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2014/schemas/5e-SRD-Weapon-Properties.ts
+++ b/src/2014/schemas/5e-SRD-Weapon-Properties.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const WeaponPropertySchema = z.object({
+export const WeaponPropertySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   desc: z.array(z.string()),

--- a/src/2024/en/5e-SRD-Equipment.json
+++ b/src/2024/en/5e-SRD-Equipment.json
@@ -5700,53 +5700,78 @@
         "url": "/api/2024/equipment-categories/equipment-packs"
       }
     ],
-    "container": [
+    "contents": [
       {
-        "index": "backpack",
-        "name": "Backpack",
-        "url": "/api/2024/equipment/backpack"
+        "item": {
+          "index": "backpack",
+          "name": "Backpack",
+          "url": "/api/2024/equipment/backpack"
+        },
+        "quantity": 1
       },
       {
-        "index": "blanket",
-        "name": "Blanket",
-        "url": "/api/2024/equipment/blanket"
+        "item": {
+          "index": "blanket",
+          "name": "Blanket",
+          "url": "/api/2024/equipment/blanket"
+        },
+        "quantity": 1
       },
       {
-        "index": "book",
-        "name": "Book",
-        "url": "/api/2024/equipment/book"
+        "item": {
+          "index": "book",
+          "name": "Book",
+          "url": "/api/2024/equipment/book"
+        },
+        "quantity": 1
       },
       {
-        "index": "ink",
-        "name": "Ink",
-        "url": "/api/2024/equipment/ink"
+        "item": {
+          "index": "ink",
+          "name": "Ink",
+          "url": "/api/2024/equipment/ink"
+        },
+        "quantity": 1
       },
       {
-        "index": "ink-pen",
-        "name": "Ink Pen",
-        "url": "/api/2024/equipment/ink-pen"
+        "item": {
+          "index": "ink-pen",
+          "name": "Ink Pen",
+          "url": "/api/2024/equipment/ink-pen"
+        },
+        "quantity": 1
       },
       {
-        "index": "lamp",
-        "name": "Lamp",
-        "url": "/api/2024/equipment/lamp"
+        "item": {
+          "index": "lamp",
+          "name": "Lamp",
+          "url": "/api/2024/equipment/lamp"
+        },
+        "quantity": 1
       },
       {
-        "index": "oil",
-        "name": "Oil",
-        "url": "/api/2024/equipment/oil",
+        "item": {
+          "index": "oil",
+          "name": "Oil",
+          "url": "/api/2024/equipment/oil"
+        },
         "quantity": 10
       },
       {
-        "index": "parchment",
-        "name": "Parchment",
-        "url": "/api/2024/equipment/parchment",
+        "item": {
+          "index": "parchment",
+          "name": "Parchment",
+          "url": "/api/2024/equipment/parchment"
+        },
         "quantity": 10
       },
       {
-        "index": "tinderbox",
-        "name": "Tinderbox",
-        "url": "/api/2024/equipment/tinderbox"
+        "item": {
+          "index": "tinderbox",
+          "name": "Tinderbox",
+          "url": "/api/2024/equipment/tinderbox"
+        },
+        "quantity": 1
       }
     ],
     "cost": {
@@ -6491,9 +6516,7 @@
       "unit": "gp"
     },
     "weight": 3,
-    "desc": [
-      "Essential for wizards, a spellbook is a leather-bound tome with 100 blank vellum pages suitable for recording spells."
-    ],
+    "description": "Essential for wizards, a spellbook is a leather-bound tome with 100 blank vellum pages suitable for recording spells.",
     "url": "/api/2024/equipment/spellbook"
   },
   {

--- a/src/2024/en/5e-SRD-Monsters.json
+++ b/src/2024/en/5e-SRD-Monsters.json
@@ -99,7 +99,7 @@
       },
       {
         "name": "Mucous Cloud",
-        "desc": "While underwater, the aboleth is surrounded by mucus. Constitution Saving Throw: DC 14,each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth’s turn. Failure: The target is cursed. Until the curse ends, the target’s skin becomes slimy, the target can breathe air and water, and it can’t regain Hit Points unless it is underwater. \nWhile the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed.",
+        "desc": "While underwater, the aboleth is surrounded by mucus. Constitution Saving Throw: DC 14,each creature in a 5-foot Emanation originating from the aboleth at the end of the aboleth's turn. Failure: The target is cursed. Until the curse ends, the target's skin becomes slimy, the target can breathe air and water, and it can't regain Hit Points unless it is underwater. \nWhile the cursed creature is outside a body of water, the creature takes 6 (1d12) Acid damage at the end of every 10 minutes unless moisture is applied to its skin before those minutes have passed.",
         "dc": {
           "dc_type": {
             "index": "con",
@@ -112,7 +112,7 @@
       },
       {
         "name": "Probing Telepathy",
-        "desc": "If a creature the aboleth can see communicates telepathically with the aboleth, the aboleth learns the creature’s greatest desires."
+        "desc": "If a creature the aboleth can see communicates telepathically with the aboleth, the aboleth learns the creature's greatest desires."
       }
     ],
     "actions": [
@@ -175,7 +175,7 @@
       },
       {
         "name": "Consume Memories.",
-        "desc": " Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grappled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target’s memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
+        "desc": " Intelligence Saving Throw: DC 16, one creature within 30 feet that is Charmed or Grappled by the aboleth. Failure: 10 (3d6) Psychic damage. Success: Half damage. Failure or Success: The aboleth gains the target's memories if the target is a Humanoid and is reduced to 0 Hit Points by this action.",
         "dc": {
           "dc_type": {
             "index": "int",
@@ -458,7 +458,7 @@
     "legendary_actions": [
       {
         "name": "Cloud of Insects",
-        "desc": "Dexterity Saving Throw: DC 17, one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can’t take this action again until the start of its next turn.",
+        "desc": "Dexterity Saving Throw: DC 17, one creature the dragon can see within 120 feet. Failure: 22 (4d10) Poison damage, and the target has Disadvantage on saving throws to maintain Concentration until the end of its next turn. Failure or Success: The dragon can't take this action again until the start of its next turn.",
         "dc": {
           "dc_type": {
             "index": "dex",
@@ -481,7 +481,7 @@
       },
       {
         "name": "Frightful Presence",
-        "desc": "The dragon uses Spellcasting to cast Fear. The dragon can’t take this action again until the start of its next turn."
+        "desc": "The dragon uses Spellcasting to cast Fear. The dragon can't take this action again until the start of its next turn."
       },
       {
         "name": "Pounce",
@@ -737,11 +737,11 @@
     "legendary_actions": [
       {
         "name": "Cloaked Flight",
-        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can’t take this action again until the start of its next turn."
+        "desc": "The dragon uses Spellcasting to cast Invisibility on itself, and it can fly up to half its Fly Speed. The dragon can't take this action again until the start of its next turn."
       },
       {
         "name": "Sonic Boom",
-        "desc": "The dragon uses Spellcasting to cast Shatter. The dragon can’t take this action again until the start of its next turn."
+        "desc": "The dragon uses Spellcasting to cast Shatter. The dragon can't take this action again until the start of its next turn."
       },
       {
         "name": "Tail Swipe",

--- a/src/2024/schemas/5e-SRD-Ability-Scores.ts
+++ b/src/2024/schemas/5e-SRD-Ability-Scores.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const AbilityScoreSchema = z.object({
+export const AbilityScoreSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   full_name: z.string(),

--- a/src/2024/schemas/5e-SRD-Alignments.ts
+++ b/src/2024/schemas/5e-SRD-Alignments.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const AlignmentSchema = z.object({
+export const AlignmentSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   abbreviation: z.string(),

--- a/src/2024/schemas/5e-SRD-Backgrounds.ts
+++ b/src/2024/schemas/5e-SRD-Backgrounds.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const BackgroundFeatReferenceSchema = z.object({
+const BackgroundFeatReferenceSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),
   note: z.string().optional(),
 });
 
-export const BackgroundSchema = z.object({
+export const BackgroundSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   ability_scores: z.array(APIReferenceSchema),

--- a/src/2024/schemas/5e-SRD-Conditions.ts
+++ b/src/2024/schemas/5e-SRD-Conditions.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const ConditionSchema = z.object({
+export const ConditionSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Damage-Types.ts
+++ b/src/2024/schemas/5e-SRD-Damage-Types.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const DamageTypeSchema = z.object({
+export const DamageTypeSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Equipment-Categories.ts
+++ b/src/2024/schemas/5e-SRD-Equipment-Categories.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const EquipmentCategorySchema = z.object({
+export const EquipmentCategorySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   equipment: z.array(APIReferenceSchema),

--- a/src/2024/schemas/5e-SRD-Equipment.ts
+++ b/src/2024/schemas/5e-SRD-Equipment.ts
@@ -1,38 +1,38 @@
 import { z } from 'zod';
 import { APIReferenceSchema, DamageSchema, DifficultyClassSchema } from '../../schemas/common';
 
-const CostSchema = z.object({
+const CostSchema = z.strictObject({
   quantity: z.number(),
   unit: z.string(),
 });
 
-const ArmorClassSchema = z.object({
+const ArmorClassSchema = z.strictObject({
   base: z.number(),
   dex_bonus: z.boolean(),
   max_bonus: z.number().optional(),
 });
 
-const RangeSchema = z.object({
+const RangeSchema = z.strictObject({
   normal: z.number(),
   long: z.number().optional(),
 });
 
-const ThrowRangeSchema = z.object({
+const ThrowRangeSchema = z.strictObject({
   normal: z.number(),
   long: z.number(),
 });
 
-const ContentSchema = z.object({
+const ContentSchema = z.strictObject({
   item: APIReferenceSchema,
   quantity: z.number(),
 });
 
-const UtilizeSchema = z.object({
+const UtilizeSchema = z.strictObject({
   name: z.string(),
   dc: DifficultyClassSchema,
 });
 
-export const EquipmentSchema = z.object({
+export const EquipmentSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   equipment_categories: z.array(APIReferenceSchema),
@@ -53,6 +53,7 @@ export const EquipmentSchema = z.object({
   notes: z.array(z.string()).optional(),
   properties: z.array(APIReferenceSchema).optional(),
   quantity: z.number().optional(),
+  storage: APIReferenceSchema.optional(),
   range: RangeSchema.optional(),
   stealth_disadvantage: z.boolean().optional(),
   str_minimum: z.number().optional(),

--- a/src/2024/schemas/5e-SRD-Feats.ts
+++ b/src/2024/schemas/5e-SRD-Feats.ts
@@ -1,12 +1,12 @@
 import { z } from 'zod';
 import { ChoiceSchema } from '../../schemas/common';
 
-const FeatPrerequisitesSchema = z.object({
+const FeatPrerequisitesSchema = z.strictObject({
   minimum_level: z.number().optional(),
   feature_named: z.string().optional(),
 });
 
-export const FeatSchema = z.object({
+export const FeatSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Languages.ts
+++ b/src/2024/schemas/5e-SRD-Languages.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const LanguageSchema = z.object({
+export const LanguageSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   is_rare: z.boolean(),

--- a/src/2024/schemas/5e-SRD-Magic-Items.ts
+++ b/src/2024/schemas/5e-SRD-Magic-Items.ts
@@ -1,11 +1,11 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const RaritySchema = z.object({
+const RaritySchema = z.strictObject({
   name: z.string(),
 });
 
-export const MagicItemSchema = z.object({
+export const MagicItemSchema = z.strictObject({
   name: z.string(),
   index: z.string(),
   url: z.string(),

--- a/src/2024/schemas/5e-SRD-Magic-Schools.ts
+++ b/src/2024/schemas/5e-SRD-Magic-Schools.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const MagicSchoolSchema = z.object({
+export const MagicSchoolSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Monsters.ts
+++ b/src/2024/schemas/5e-SRD-Monsters.ts
@@ -1,7 +1,12 @@
 import { z } from 'zod';
-import { APIReferenceSchema, ChoiceSchema, DamageSchema, DifficultyClassSchema } from '../../schemas/common';
+import {
+  APIReferenceSchema,
+  ChoiceSchema,
+  DamageSchema,
+  DifficultyClassSchema,
+} from '../../schemas/common';
 
-const MonsterSpeedSchema = z.object({
+const MonsterSpeedSchema = z.strictObject({
   walk: z.string().optional(),
   burrow: z.string().optional(),
   climb: z.string().optional(),
@@ -10,7 +15,7 @@ const MonsterSpeedSchema = z.object({
   hover: z.boolean().optional(),
 });
 
-const SenseSchema = z.object({
+const SenseSchema = z.strictObject({
   passive_perception: z.number(),
   blindsight: z.string().optional(),
   darkvision: z.string().optional(),
@@ -18,7 +23,7 @@ const SenseSchema = z.object({
   truesight: z.string().optional(),
 });
 
-const MonsterProficiencySchema = z.object({
+const MonsterProficiencySchema = z.strictObject({
   value: z.number(),
   proficiency: APIReferenceSchema,
 });
@@ -32,7 +37,7 @@ const MonsterArmorClassSchema = z.strictObject({
   desc: z.string().optional(),
 });
 
-const SpecialAbilityUsageSchema = z.object({
+const SpecialAbilityUsageSchema = z.strictObject({
   type: z.string(),
   times: z.number().optional(),
   times_in_lair: z.number().optional(),
@@ -64,10 +69,11 @@ const SpellcastingSchema = z.strictObject({
   slots: z.record(z.string(), z.number()).optional(),
 });
 
-const ActionUsageSchema = z.object({
+const ActionUsageSchema = z.strictObject({
   type: z.string(),
   dice: z.string().optional(),
   min_value: z.number().optional(),
+  times: z.number().optional(),
 });
 
 const MonsterActionItemSchema = z.strictObject({
@@ -97,7 +103,7 @@ const MonsterActionSchema = z.strictObject({
   spellcasting: SpellcastingSchema.optional(),
 });
 
-const LegendaryActionSchema = z.object({
+const LegendaryActionSchema = z.strictObject({
   name: z.string(),
   desc: z.string(),
   attack_bonus: z.number().optional(),
@@ -105,7 +111,7 @@ const LegendaryActionSchema = z.object({
   dc: DifficultyClassSchema.optional(),
 });
 
-const ReactionSchema = z.object({
+const ReactionSchema = z.strictObject({
   name: z.string(),
   desc: z.string(),
   dc: DifficultyClassSchema.optional(),
@@ -121,7 +127,7 @@ const SpecialAbilitySchema = z.strictObject({
   spellcasting: SpellcastingSchema.optional(),
 });
 
-export const MonsterSchema = z.object({
+export const MonsterSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   size: z.string(),

--- a/src/2024/schemas/5e-SRD-Proficiencies.ts
+++ b/src/2024/schemas/5e-SRD-Proficiencies.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const ProficiencySchema = z.object({
+export const ProficiencySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   type: z.string(),

--- a/src/2024/schemas/5e-SRD-Skills.ts
+++ b/src/2024/schemas/5e-SRD-Skills.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-export const SkillSchema = z.object({
+export const SkillSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Species.ts
+++ b/src/2024/schemas/5e-SRD-Species.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-export const SpeciesSchema = z.object({
+export const SpeciesSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),

--- a/src/2024/schemas/5e-SRD-Subclasses.ts
+++ b/src/2024/schemas/5e-SRD-Subclasses.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const SubclassFeatureSchema = z.object({
+const SubclassFeatureSchema = z.strictObject({
   name: z.string(),
   level: z.number(),
   description: z.string(),
 });
 
-export const SubclassSchema = z.object({
+export const SubclassSchema = z.strictObject({
   index: z.string(),
   url: z.string(),
   name: z.string(),

--- a/src/2024/schemas/5e-SRD-Subspecies.ts
+++ b/src/2024/schemas/5e-SRD-Subspecies.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 import { APIReferenceSchema } from '../../schemas/common';
 
-const SubspeciesTraitSchema = z.object({
+const SubspeciesTraitSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),
   level: z.number(),
 });
 
-export const SubspeciesSchema = z.object({
+export const SubspeciesSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),

--- a/src/2024/schemas/5e-SRD-Traits.ts
+++ b/src/2024/schemas/5e-SRD-Traits.ts
@@ -1,13 +1,13 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
-const SpellTraitSchema = z.object({
+const SpellTraitSchema = z.strictObject({
   spell: APIReferenceSchema,
   uses: z.string().optional(),
   recovery: z.string().optional(),
 });
 
-export const TraitSchema = z.object({
+export const TraitSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),

--- a/src/2024/schemas/5e-SRD-Weapon-Mastery-Properties.ts
+++ b/src/2024/schemas/5e-SRD-Weapon-Mastery-Properties.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const WeaponMasteryPropertySchema = z.object({
+export const WeaponMasteryPropertySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/2024/schemas/5e-SRD-Weapon-Properties.ts
+++ b/src/2024/schemas/5e-SRD-Weapon-Properties.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const WeaponPropertySchema = z.object({
+export const WeaponPropertySchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   description: z.string(),

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,30 +1,31 @@
 import { z } from 'zod';
 
-export const APIReferenceSchema = z.object({
+export const APIReferenceSchema = z.strictObject({
   index: z.string(),
   name: z.string(),
   url: z.string(),
   note: z.string().optional(),
 });
 
-export const DamageSchema = z.object({
-  damage_type: APIReferenceSchema,
-  damage_dice: z.string(),
-});
-
-export const DifficultyClassSchema = z.object({
+export const DifficultyClassSchema = z.strictObject({
   dc_type: APIReferenceSchema,
   dc_value: z.number().optional(),
   success_type: z.enum(['none', 'half', 'other']),
 });
 
-export const AreaOfEffectSchema = z.object({
+export const DamageSchema = z.strictObject({
+  damage_type: APIReferenceSchema,
+  damage_dice: z.string(),
+  dc: DifficultyClassSchema.optional(),
+});
+
+export const AreaOfEffectSchema = z.strictObject({
   size: z.number(),
   type: z.enum(['sphere', 'cube', 'cylinder', 'line', 'cone']),
 });
 
 export const ChoiceSchema: z.ZodType<any> = z.lazy(() =>
-  z.object({
+  z.strictObject({
     desc: z.string().optional(),
     choose: z.number(),
     type: z.string().optional(),
@@ -37,29 +38,68 @@ const OptionSchema: z.ZodType<any> = z.lazy(() =>
     z.strictObject({ option_type: z.literal('reference'), item: APIReferenceSchema }),
     z.strictObject({ option_type: z.literal('choice'), choice: ChoiceSchema }),
     z.strictObject({ option_type: z.literal('string'), string: z.string() }),
-    z.strictObject({ option_type: z.literal('ability_bonus'), ability_score: APIReferenceSchema, bonus: z.number() }),
-    z.strictObject({ option_type: z.literal('action'), action_name: z.string(), count: z.number(), type: z.string(), desc: z.string().optional() }),
-    z.strictObject({ option_type: z.literal('breath'), name: z.string(), dc: DifficultyClassSchema, damage: z.array(DamageSchema).optional() }),
-    z.strictObject({ option_type: z.literal('counted_reference'), count: z.number(), of: APIReferenceSchema, prerequisites: z.array(z.strictObject({ type: z.string(), proficiency: APIReferenceSchema.optional() })).optional() }),
-    z.strictObject({ option_type: z.literal('damage'), damage_dice: z.string(), damage_type: APIReferenceSchema, notes: z.string().optional() }),
-    z.strictObject({ option_type: z.literal('ideal'), alignments: z.array(APIReferenceSchema), desc: z.string() }),
+    z.strictObject({
+      option_type: z.literal('ability_bonus'),
+      ability_score: APIReferenceSchema,
+      bonus: z.number(),
+    }),
+    z.strictObject({
+      option_type: z.literal('action'),
+      action_name: z.string(),
+      count: z.number(),
+      type: z.string(),
+      desc: z.string().optional(),
+    }),
+    z.strictObject({
+      option_type: z.literal('breath'),
+      name: z.string(),
+      dc: DifficultyClassSchema,
+      damage: z.array(DamageSchema).optional(),
+    }),
+    z.strictObject({
+      option_type: z.literal('counted_reference'),
+      count: z.number(),
+      of: APIReferenceSchema,
+      prerequisites: z
+        .array(z.strictObject({ type: z.string(), proficiency: APIReferenceSchema.optional() }))
+        .optional(),
+    }),
+    z.strictObject({
+      option_type: z.literal('damage'),
+      damage_dice: z.string(),
+      damage_type: APIReferenceSchema,
+      notes: z.string().optional(),
+    }),
+    z.strictObject({
+      option_type: z.literal('ideal'),
+      alignments: z.array(APIReferenceSchema),
+      desc: z.string(),
+    }),
     z.strictObject({ option_type: z.literal('money'), count: z.number(), unit: z.string() }),
-    z.strictObject({ option_type: z.literal('multiple'), items: z.array(OptionSchema), desc: z.string().optional() }),
-    z.strictObject({ option_type: z.literal('score_prerequisite'), ability_score: APIReferenceSchema, minimum_score: z.number() }),
+    z.strictObject({
+      option_type: z.literal('multiple'),
+      items: z.array(OptionSchema),
+      desc: z.string().optional(),
+    }),
+    z.strictObject({
+      option_type: z.literal('score_prerequisite'),
+      ability_score: APIReferenceSchema,
+      minimum_score: z.number(),
+    }),
     z.strictObject({ option_type: z.literal('size'), size: z.string() }),
   ])
 );
 
 const OptionSetSchema = z.union([
-  z.object({
+  z.strictObject({
     option_set_type: z.literal('equipment_category'),
     equipment_category: APIReferenceSchema,
   }),
-  z.object({
+  z.strictObject({
     option_set_type: z.literal('resource_list'),
     resource_list_url: z.string(),
   }),
-  z.object({
+  z.strictObject({
     option_set_type: z.literal('options_array'),
     options: z.array(z.union([OptionSchema, z.string()])),
   }),


### PR DESCRIPTION
## What does this do?

### Schema: Strict validation across the board
The biggest change (touching all 46 schema files) is converting `z.object()` to `z.strictObject()` everywhere. This means unknown keys now fail validation rather than being silently ignored — making schemas much safer as a contract for the data.

`src/schemas/common.ts` — several fixes bundled in:

* DifficultyClassSchema moved before DamageSchema so the reference works
* DamageSchema gains an optional dc: DifficultyClassSchema field — needed for monsters like the Assassin where individual damage entries (e.g. poison) carry their own saving throw separate from the action-level DC
* All option/choice schemas (ChoiceSchema, OptionSchema, OptionSetSchema) converted to strict and reformatted for readability

### Data: 2024 Equipment JSON fixes

`src/2024/en/5e-SRD-Equipment.json` — two data corrections:

* Scholar's Pack: container key replaced with contents, and items reshaped to the standard { item: { index, name, url }, quantity } format (items without an explicit quantity default to 1)
* Spellbook: desc array replaced with a scalar description string, matching the correct field name

### Data: 2024 Monsters JSON cosmetic fixes

`src/2024/en/5e-SRD-Monsters.json` — whitespace/newline-only changes in description strings (smart quotes normalized, trailing newline added to file) with no content changes.

## Here's a fun image for your troubles

<img width="600" height="591" alt="image" src="https://github.com/user-attachments/assets/050fa61d-59d6-4df9-b5de-480d4ef5062d" />
