### PR TITLE
feat(language): add some french translations

### DIFF
--- a/src/2014/fr-FR/5e-SRD-Ability-Scores.json
+++ b/src/2014/fr-FR/5e-SRD-Ability-Scores.json
@@ -1,0 +1,163 @@
+[
+  {
+    "index": "str",
+    "name": "FOR",
+    "full_name": "Force",
+    "desc": [
+      "La Force détermine la puissance physique, l’entrainement sportif et la mesure dans laquelle vous pouvez exercer une force physique brute.",
+      "Un jet de Force peut modéliser toute tentative de soulever, pousser, tirer ou casser quelque chose, de faire passer votre corps à travers un espace, ou bien d’appliquer la force brute à une situation. La compétence Athlétisme reflète une aptitude à certains types de jets de Force."
+    ],
+    "skills": [
+      {
+        "name": "Athlétisme",
+        "index": "athletics",
+        "url": "/api/2014/skills/athletics"
+      }
+    ],
+    "url": "/api/2014/ability-scores/str"
+  },
+  {
+    "index": "dex",
+    "name": "DEX",
+    "full_name": "Dextérité",
+    "desc": [
+      "La Dextérité détermine l’agilité, les réflexes et l’équilibre.",
+      "Un jet de Dextérité peut modéliser toute tentative de se déplacer rapidement ou tranquillement, ou pour éviter de tomber dans un piège. Les compétences Acrobaties, Escamotage et Discrétion reflètent une aptitude à certains types de jets de Dextérité."
+    ],
+    "skills": [
+      {
+        "name": "Acrobaties",
+        "index": "acrobatics",
+        "url": "/api/2014/skills/acrobatics"
+      },
+      {
+        "name": "Escamotage",
+        "index": "sleight-of-hand",
+        "url": "/api/2014/skills/sleight-of-hand"
+      },
+      {
+        "name": "Discrétion",
+        "index": "stealth",
+        "url": "/api/2014/skills/stealth"
+      }
+    ],
+    "url": "/api/2014/ability-scores/dex"
+  },
+  {
+    "index": "con",
+    "name": "CON",
+    "full_name": "Constitution",
+    "desc": [
+      "La Constitution détermine la santé, l’endurance et la force vitale.",
+      "Les jets de Constitution sont rares, et aucune compétence n’applique à un jet de Constitution, car l’endurance que cette caractéristique représente est généralement passive et n’implique pas un effort particulier de la part d’un personnage ou monstre. Un jet de Constitution peut toutefois modéliser votre tentative d’aller au-delà de vos limites normales."
+    ],
+    "skills": [],
+    "url": "/api/2014/ability-scores/con"
+  },
+  {
+    "index": "int",
+    "name": "INT",
+    "full_name": "Intelligence",
+    "desc": [
+      "L’intelligence détermine l’acuité mentale, la précision de la mémoire et la capacité à raisonner.",
+      "Un jet d’Intelligence est nécessaire lorsque vous avez besoin de vous appuyer sur la logique, l’éducation, la mémoire, le raisonnement ou la déduction. Les compétences Arcanes, Histoire, Investigation, Nature, et Religion reflètent une aptitude à certains types de jets d’Intelligence."
+    ],
+    "skills": [
+      {
+        "name": "Arcanes",
+        "index": "arcana",
+        "url": "/api/2014/skills/arcana"
+      },
+      {
+        "name": "Histoire",
+        "index": "history",
+        "url": "/api/2014/skills/history"
+      },
+      {
+        "name": "Investigation",
+        "index": "investigation",
+        "url": "/api/2014/skills/investigation"
+      },
+      {
+        "name": "Nature",
+        "index": "nature",
+        "url": "/api/2014/skills/nature"
+      },
+      {
+        "name": "Religion",
+        "index": "religion",
+        "url": "/api/2014/skills/religion"
+      }
+    ],
+    "url": "/api/2014/ability-scores/int"
+  },
+  {
+    "index": "wis",
+    "name": "SAG",
+    "full_name": "Sagesse",
+    "desc": [
+      "La Sagesse reflète la façon dont vous êtes à l’écoute du monde autour de vous, ainsi que la perspicacité et l’intuition.",
+      "Un jet de Sagesse peut refléter l’effort pour lire le langage du corps, comprendre les sentiments de quelqu’un, noter quelque chose dans l’environnement ou soigner une personne blessée. Les compétences Dressage, Intuition, Médecine, Perception et Survie reflètent une aptitude à certains types de jets de Sagesse."
+    ],
+    "skills": [
+      {
+        "name": "Dressage",
+        "index": "animal-handling",
+        "url": "/api/2014/skills/animal-handling"
+      },
+      {
+        "name": "Intuition",
+        "index": "insight",
+        "url": "/api/2014/skills/insight"
+      },
+      {
+        "name": "Médecine",
+        "index": "medicine",
+        "url": "/api/2014/skills/medicine"
+      },
+      {
+        "name": "Perception",
+        "index": "perception",
+        "url": "/api/2014/skills/perception"
+      },
+      {
+        "name": "Survie",
+        "index": "survival",
+        "url": "/api/2014/skills/survival"
+      }
+    ],
+    "url": "/api/2014/ability-scores/wis"
+  },
+  {
+    "index": "cha",
+    "name": "CHA",
+    "full_name": "Charisme",
+    "desc": [
+      "Le Charisme détermine votre capacité à interagir efficacement avec les autres. Il comprend des facteurs comme la confiance et l’éloquence, et peut représenter une personnalité charmante ou dominante.",
+      "Un jet de Charisme peut être nécessaire lorsque vous essayez d’influencer ou de divertir les autres, lorsque vous essayez de faire impression ou de dire un mensonge de manière convaincante, ou lorsque vous êtes au milieu d’une situation sociale difficile. Les compétences de Tromperie, Intimidation, Représentation et Persuasion reflètent une aptitude à certains types de jets de Charisme."
+    ],
+    "skills": [
+      {
+        "name": "Tromperie",
+        "index": "deception",
+        "url": "/api/2014/skills/deception"
+      },
+      {
+        "name": "Intimidation",
+        "index": "intimidation",
+        "url": "/api/2014/skills/intimidation"
+      },
+      {
+        "name": "Représentation",
+        "index": "performance",
+        "url": "/api/2014/skills/performance"
+      },
+      {
+        "name": "Persuasion",
+        "index": "persuasion",
+        "url": "/api/2014/skills/persuasion"
+      }
+    ],
+    "url": "/api/2014/ability-scores/cha"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Alignments.json
+++ b/src/2014/fr-FR/5e-SRD-Alignments.json
@@ -1,0 +1,56 @@
+[
+  {
+    "index": "lawful-good",
+    "name": "Loyal Bon",
+    "abbreviation": "LB",
+    "desc": "Loyal bon (LB). On peut compter sur ces créatures pour faire le bien dans le sens où la société l’entend. Les dragons d’or et les paladins sont souvent d’alignement loyal bon."
+  },
+  {
+    "index": "neutral-good",
+    "name": "Neutre Bon",
+    "abbreviation": "NB",
+    "desc": "Neutre bon (NB). Ces personnes font du mieux qu’elles peuvent pour aider les autres, en fonction de leurs besoins toutefois. Beaucoup des créatures célestes sont neutre bon."
+  },
+  {
+    "index": "chaotic-good",
+    "name": "Chaotique Bon",
+    "abbreviation": "CB",
+    "desc": "Chaotique bon (CB). Ces créatures agissent selon leur conscience, et ont peu d’égard pour ce que les autres attendent. Les dragons de cuivre et les licornes sont souvent d’alignement chaotique bon"
+  },
+  {
+    "index": "lawful-neutral",
+    "name": "Loyal Neutre",
+    "abbreviation": "LN",
+    "desc": "Loyal neutre (LN). Ces individus agissent conformément à la loi, aux traditions ou suivants des codes personnels. Les modrons et beaucoup de magiciens et de moines sont d'alignement loyal neutre."
+  },
+  {
+    "index": "neutral",
+    "name": "Neutre",
+    "abbreviation": "N",
+    "desc": "Neutre (N) est l’alignement de ceux qui préfèrent rester à l’écart des questions morales et ne prennent pas parti, faisant ce qui leur semble le mieux à un moment donné. La plupart des druides et des villageois sont neutres."
+  },
+  {
+    "index": "chaotic-neutral",
+    "name": "Chaotique Neutre",
+    "abbreviation": "CN",
+    "desc": "Chaotique neutre (CN). Ces créatures suivent leurs caprices, pensant à leur liberté personnelle avant tout. Beaucoup de roublards et de bardes sont d’alignement chaotique neutre."
+  },
+  {
+    "index": "lawful-evil",
+    "name": "Loyal Mauvais",
+    "abbreviation": "LM",
+    "desc": "Loyal mauvais (LM). Ces créatures font méthodiquement ce qu’elles veulent, dans les limites d’un code de tradition, de la loyauté ou d’un ordre. Les diables et les dragons bleus sont souvent d’alignement loyal mauvais."
+  },
+  {
+    "index": "neutral-evil",
+    "name": "Neutre Mauvais",
+    "abbreviation": "NM",
+    "desc": "Neutre mauvais (NM) est l’alignement de ceux qui font ce qu’ils veulent, sans aucune compassion ni aucun scrupule. Les yugoloths sont généralement d’alignement neutre mauvais."
+  },
+  {
+    "index": "chaotic-evil",
+    "name": "Chaotique Mauvais",
+    "abbreviation": "CM",
+    "desc": "Chaotique mauvais (CM). Ces créatures agissent avec une violence arbitraire, stimulées par la cupidité, la haine ou la soif de sang. Les démons et les dragons rouges sont souvent d’alignement chaotique mauvais."
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Backgrounds.json
+++ b/src/2014/fr-FR/5e-SRD-Backgrounds.json
@@ -1,0 +1,321 @@
+[
+  {
+    "index": "acolyte",
+    "name": "Acolyte",
+    "starting_proficiencies": [
+      {
+        "index": "skill-insight",
+        "name": "Compétence : Intuition",
+        "url": "/api/2014/proficiencies/skill-insight"
+      },
+      {
+        "index": "skill-religion",
+        "name": "Compétence : Religion",
+        "url": "/api/2014/proficiencies/skill-religion"
+      }
+    ],
+    "language_options": {
+      "choose": 2,
+      "type": "languages",
+      "from": { "option_set_type": "resource_list", "resource_list_url": "/api/2014/languages" }
+    },
+    "starting_equipment": [
+      {
+        "equipment": {
+          "index": "clothes-common",
+          "name": "Vêtements commun",
+          "url": "/api/2014/equipment/clothes-common"
+        },
+        "quantity": 1
+      },
+      {
+        "equipment": { "index": "pouch", "name": "Bourse", "url": "/api/2014/equipment/pouch" },
+        "quantity": 1
+      }
+    ],
+    "starting_equipment_options": [
+      {
+        "choose": 1,
+        "type": "equipment",
+        "from": {
+          "option_set_type": "equipment_category",
+          "equipment_category": {
+            "index": "holy-symbols",
+            "name": "Symbole sacré",
+            "url": "/api/2014/equipment-categories/holy-symbols"
+          }
+        }
+      }
+    ],
+    "feature": {
+      "name": "Abri du fidèle",
+      "desc": [
+        "En tant qu’acolyte, vous imposez le respect à ceux qui partagent votre foi, et pouvez mener les cérémonies religieuses de votre divinité. Vous et vos compagnons aventuriers pouvez vous attendre à recevoir des soins gratuits dans un temple, un sanctuaire ou toute autre présence établie de votre foi, bien que vous soyez responsable de fournir toutes les composantes matérielles nécessaires aux sorts. Ceux qui partagent votre religion vous aideront (mais seulement vous) et vous offriront un mode de vie modeste.",
+        "Vous pouvez également avoir des liens avec un temple spécifique dédié à votre divinité ou votre panthéon, et vous y avez une résidence. Cela pourrait être le temple où vous avez servi, si vous êtes resté en bons termes avec lui, ou un temple dans lequel vous avez trouvé une nouvelle maison. Lorsque vous êtes proche de votre temple, vous pouvez faire appel à des religieux pour vous aider, à condition que l’aide que vous demandiez ne soit pas dangereuse et que vous restiez en règle avec votre temple."
+      ]
+    },
+    "personality_traits": {
+      "choose": 2,
+      "type": "personality_traits",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "string",
+            "string": "J’idolâtre un héros particulier de ma foi, et renvoie constamment à ses actes et à son exemple."
+          },
+          {
+            "option_type": "string",
+            "string": "Je peux trouver un terrain d’entente entre les ennemis les plus féroces, ressentir de l’empathie pour eux et toujours travailler vers la paix."
+          },
+          {
+            "option_type": "string",
+            "string": "Je vois des présages dans chaque événement et action. Les dieux essaient de nous parler, nous avons juste besoin d’écouter."
+          },
+          { "option_type": "string", "string": "J’ai toujours une attitude optimiste." },
+          {
+            "option_type": "string",
+            "string": "Je cite (ou paraphrase) des textes sacrés et des proverbes dans presque toutes les situations."
+          },
+          {
+            "option_type": "string",
+            "string": "Je suis tolérant (ou intolérant) vis-à-vis des autres fois et je respecte (ou condamne) l’adoration des autres dieux."
+          },
+          {
+            "option_type": "string",
+            "string": "J’ai apprécié la bonne nourriture, les boissons et la haute société parmi l’élite de mon temple. La vie rude me fait grincer."
+          },
+          {
+            "option_type": "string",
+            "string": "J’ai passé tellement de temps dans mon temple que j’ai peu d’expérience pratique pour traiter avec les gens du monde extérieur."
+          }
+        ]
+      }
+    },
+    "ideals": {
+      "choose": 1,
+      "type": "ideals",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "ideal",
+            "desc": "Tradition. Les anciennes traditions de culte et de sacrifice doivent être préservées et respectées (Loyal).",
+            "alignments": [
+              {
+                "index": "lawful-good",
+                "name": "Loyal Bon",
+                "url": "/api/2014/alignments/lawful-good"
+              },
+              {
+                "index": "lawful-neutral",
+                "name": "Loyal Neutre",
+                "url": "/api/2014/alignments/lawful-neutral"
+              },
+              {
+                "index": "lawful-evil",
+                "name": "Loyal Mauvais",
+                "url": "/api/2014/alignments/lawful-evil"
+              }
+            ]
+          },
+          {
+            "option_type": "ideal",
+            "desc": "Charité. J’essaie toujours d’aider ceux dans le besoin, quel qu’en soit le coût (Bon).",
+            "alignments": [
+              {
+                "index": "lawful-good",
+                "name": "Loyal Bon",
+                "url": "/api/2014/alignments/lawful-good"
+              },
+              {
+                "index": "neutral-good",
+                "name": "Neutre Bon",
+                "url": "/api/2014/alignments/neutral-good"
+              },
+              {
+                "index": "chaotic-good",
+                "name": "Chaotique Bon",
+                "url": "/api/2014/alignments/chaotic-good"
+              }
+            ]
+          },
+          {
+            "option_type": "ideal",
+            "desc": "Progrès. Nous devons aider à mettre en place sur terre les changements que les dieux réalisent constamment (Chaotique).",
+            "alignments": [
+              {
+                "index": "chaotic-good",
+                "name": "Chaotique Bon",
+                "url": "/api/2014/alignments/chaotic-good"
+              },
+              {
+                "index": "chaotic-neutral",
+                "name": "Chaotique Neutre",
+                "url": "/api/2014/alignments/chaotic-neutral"
+              },
+              {
+                "index": "chaotic-evil",
+                "name": "Chaotique Mauvais",
+                "url": "/api/2014/alignments/chaotic-evil"
+              }
+            ]
+          },
+          {
+            "option_type": "ideal",
+            "desc": "Pouvoir. J’espère un jour parvenir au sommet de la hiérarchie religieuse de ma foi (Loyal).",
+            "alignments": [
+              {
+                "index": "lawful-good",
+                "name": "Loyal Bon",
+                "url": "/api/2014/alignments/lawful-good"
+              },
+              {
+                "index": "lawful-neutral",
+                "name": "Loyal Neutre",
+                "url": "/api/2014/alignments/lawful-neutral"
+              },
+              {
+                "index": "lawful-evil",
+                "name": "Loyal Mauvais",
+                "url": "/api/2014/alignments/lawful-evil"
+              }
+            ]
+          },
+          {
+            "option_type": "ideal",
+            "desc": "Foi. J’ai confiance dans le fait que ma divinité guidera mes actions et que si je travaille dur, tout ira bien (Loyal).",
+            "alignments": [
+              {
+                "index": "lawful-good",
+                "name": "Loyal Bon",
+                "url": "/api/2014/alignments/lawful-good"
+              },
+              {
+                "index": "lawful-neutral",
+                "name": "Loyal Neutre",
+                "url": "/api/2014/alignments/lawful-neutral"
+              },
+              {
+                "index": "lawful-evil",
+                "name": "Loyal Mauvais",
+                "url": "/api/2014/alignments/lawful-evil"
+              }
+            ]
+          },
+          {
+            "option_type": "ideal",
+            "desc": "Aspiration. Je cherche à me montrer digne de la faveur de mon dieu en faisant correspondre mes actions avec ses enseignements (tout alignement).",
+            "alignments": [
+              {
+                "index": "lawful-good",
+                "name": "Loyal Bon",
+                "url": "/api/2014/alignments/lawful-good"
+              },
+              {
+                "index": "neutral-good",
+                "name": "Neutre Bon",
+                "url": "/api/2014/alignments/neutral-good"
+              },
+              {
+                "index": "chaotic-good",
+                "name": "Chaotique Bon",
+                "url": "/api/2014/alignments/chaotic-good"
+              },
+              {
+                "index": "lawful-neutral",
+                "name": "Loyal Neutre",
+                "url": "/api/2014/alignments/lawful-neutral"
+              },
+              { "index": "neutral", "name": "Neutre", "url": "/api/2014/alignments/neutral" },
+              {
+                "index": "chaotic-neutral",
+                "name": "Chaotique Neutre",
+                "url": "/api/2014/alignments/chaotic-neutral"
+              },
+              {
+                "index": "lawful-evil",
+                "name": "Loyal Mauvais",
+                "url": "/api/2014/alignments/lawful-evil"
+              },
+              {
+                "index": "neutral-evil",
+                "name": "Neutre Mauvais",
+                "url": "/api/2014/alignments/neutral-evil"
+              },
+              {
+                "index": "chaotic-evil",
+                "name": "Chaotique Mauvais",
+                "url": "/api/2014/alignments/chaotic-evil"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "bonds": {
+      "choose": 1,
+      "type": "bonds",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "string",
+            "string": "Je cherche une ancienne relique de ma foi qui a été perdue il y a longtemps. Je mourrais pour la récupérer."
+          },
+          {
+            "option_type": "string",
+            "string": "Un jour je me vengerai de la hiérarchie corrompue de ce temple qui m’a accusé d’être un hérétique."
+          },
+          {
+            "option_type": "string",
+            "string": "Je dois ma vie au prêtre qui m’a recueilli quand mes parents sont morts."
+          },
+          {
+            "option_type": "string",
+            "string": "Tout ce que je fais est pour les gens ordinaires."
+          },
+          {
+            "option_type": "string",
+            "string": "Je ferais tout pour protéger le temple dans lequel je servais."
+          },
+          {
+            "option_type": "string",
+            "string": "Je cherche à préserver un texte sacré que mes ennemis veulent détruire car ils le considèrent hérétique."
+          }
+        ]
+      }
+    },
+    "flaws": {
+      "choose": 1,
+      "type": "flaws",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "string",
+            "string": "Je juge sévèrement les autres, en partie parce que je suis encore plus sévère envers moi-même."
+          },
+          {
+            "option_type": "string",
+            "string": "J’ai trop confiance en ceux qui exercent le pouvoir au sein de la hiérarchie de mon temple."
+          },
+          {
+            "option_type": "string",
+            "string": "Ma piété me conduit parfois à faire confiance aveuglément à ceux qui professent la foi de mon dieu."
+          },
+          { "option_type": "string", "string": "Je suis inflexible dans ma pensée." },
+          {
+            "option_type": "string",
+            "string": "Je suis méfiant envers les étrangers et m’attends au pire de leur part."
+          },
+          {
+            "option_type": "string",
+            "string": "Une fois que j’ai un but, je deviens obsédé par celui-ci, au détriment du reste de ma vie."
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/backgrounds/acolyte"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Conditions.json
+++ b/src/2014/fr-FR/5e-SRD-Conditions.json
@@ -1,0 +1,154 @@
+[
+  {
+    "index": "blinded",
+    "name": "Aveuglé",
+    "desc": [
+      "- Une créature aveuglée ne voit pas et rate automatiquement tout jet de caractéristique qui nécessite la vue.",
+      "- Les jets d'attaque contre la créature ont un avantage, et les jets d'attaque de la créature ont un désavantage."
+    ],
+    "url": "/api/2014/conditions/blinded"
+  },
+  {
+    "index": "charmed",
+    "name": "Charmé",
+    "desc": [
+      "- Une créature charmée ne peut pas attaquer le charmeur ou le cibler avec des capacités ou des effets magiques nuisibles.",
+      "- Le charmeur a un avantage à ses jets de caractéristique pour interagir socialement avec la créature."
+    ],
+    "url": "/api/2014/conditions/charmed"
+  },
+  {
+    "index": "deafened",
+    "name": "Assourdi",
+    "desc": [
+      "- Une créature assourdie n'entend pas et rate automatiquement tout jet de caractéristique qui nécessite l’ouïe."
+    ],
+    "url": "/api/2014/conditions/deafened"
+  },
+  {
+    "index": "frightened",
+    "name": "Effrayé",
+    "desc": [
+      "- Une créature effrayée a un désavantage aux jets de caractéristique et aux jets d'attaque tant que la source de sa peur est dans sa ligne de vue.",
+      "- La créature ne peut se rapprocher volontairement de la source de sa peur."
+    ],
+    "url": "/api/2014/conditions/frightened"
+  },
+  {
+    "index": "grappled",
+    "name": "Grappled",
+    "desc": [
+      "- La vitesse d'une créature agrippée passe à 0, et elle ne peut bénéficier d'aucun bonus à sa vitesse.",
+      "- L'état prend fin si la créature qui agrippe est neutralisée (voir l'état).",
+      "- L'état se termine également si un effet met la créature agrippée hors de portée de la créature ou de l'effet qui l'agrippe, comme par exemple lorsqu'une créature est projetée par le sort vague tonnante."
+    ],
+    "url": "/api/2014/conditions/grappled"
+  },
+  {
+    "index": "incapacitated",
+    "name": "Neutralisé",
+    "desc": ["- Une créature incapable d'agir ne peut effectuer aucune action ni aucune réaction."],
+    "url": "/api/2014/conditions/incapacitated"
+  },
+  {
+    "index": "invisible",
+    "name": "Invisible",
+    "desc": [
+      "- Une créature invisible ne peut être vue sans l'aide de la magie ou un sens particulier. En ce qui concerne le fait de se cacher, la créature est considérée dans une zone à visibilité nulle. L'emplacement de la créature peut être détecté par un bruit qu'elle fait ou par les traces qu'elle laisse.",
+      "- Les jets d'attaque contre la créature ont un désavantage, et les jets d'attaque de la créature ont un avantage."
+    ],
+    "url": "/api/2014/conditions/invisible"
+  },
+  {
+    "index": "paralyzed",
+    "name": "Paralysé",
+    "desc": [
+      "- Une créature paralysée est incapable d'agir (voir l'état) et ne peut plus bouger ni parler.",
+      "- La créature rate automatiquement ses jets de sauvegarde de Force et de Dextérité.",
+      "- Les jets d'attaque contre la créature ont un avantage.",
+      "- Toute attaque qui touche la créature est un coup critique si l'attaquant est à 1,50 mètre ou moins de la créature."
+    ],
+    "url": "/api/2014/conditions/paralyzed"
+  },
+  {
+    "index": "petrified",
+    "name": "Pétrifié",
+    "desc": [
+      "- Une créature pétrifiée est transformée, ainsi que tout objet non magique qu'elle porte, en une substance inanimée solide (généralement en pierre). Son poids est multiplié par dix et son vieillissement cesse.",
+      "- La créature est neutralisée (voir l'état), ne peut plus bouger ni parler, et n'est plus consciente de ce qui se passe autour d'elle.",
+      "- Les jets d'attaque contre la créature ont un avantage.",
+      "- La créature rate automatiquement ses jets de sauvegarde de Force et de Dextérité.",
+      "- La créature obtient la résistance contre tous les types de dégâts.",
+      "- La créature est immunisée contre le poison et la maladie, mais un poison ou une maladie déjà dans son organisme est seulement suspendu, pas neutralisé."
+    ],
+    "url": "/api/2014/conditions/petrified"
+  },
+  {
+    "index": "poisoned",
+    "name": "Empoisonné",
+    "desc": [
+      "- Une créature empoisonnée a un désavantage aux jets d'attaque et aux jets de caractéristique."
+    ],
+    "url": "/api/2014/conditions/poisoned"
+  },
+  {
+    "index": "prone",
+    "name": "À terre",
+    "desc": [
+      "- La seule option de mouvement possible pour une créature à terre est de ramper, à moins qu'elle ne se relève et mette alors un terme à son état.",
+      "- La créature a un désavantage aux jets d'attaque.",
+      "- Un jet d'attaque contre la créature a un avantage si l'attaquant est à 1,50 mètre ou moins de la créature. Sinon, le jet d'attaque a un désavantage."
+    ],
+    "url": "/api/2014/conditions/prone"
+  },
+  {
+    "index": "restrained",
+    "name": "Entravé",
+    "desc": [
+      "- La vitesse d'une créature entravée passe à 0, et elle ne peut bénéficier d'aucun bonus à sa vitesse.",
+      "- Les jets d'attaque contre la créature ont un avantage, et les jets d'attaque de la créature ont un désavantage.",
+      "- La créature a un désavantage à ses jets de sauvegarde de Dextérité."
+    ],
+    "url": "/api/2014/conditions/restrained"
+  },
+  {
+    "index": "stunned",
+    "name": "Étourdi",
+    "desc": [
+      "- Une créature étourdie est incapable d'agir (voir l'état), ne peut plus bouger et parle de manière hésitante.",
+      "- La créature rate automatiquement ses jets de sauvegarde de Force et de Dextérité.",
+      "- Les jets d'attaque contre la créature ont un avantage."
+    ],
+    "url": "/api/2014/conditions/stunned"
+  },
+  {
+    "index": "unconscious",
+    "name": "Inconscient",
+    "desc": [
+      "- Une créature inconsciente est incapable d'agir (voir l'état), ne peut plus bouger ni parler, et n'est plus consciente de ce qui se passe autour d'elle.",
+      "- La créature lâche ce qu'elle tenait et tombe à terre.",
+      "- La créature rate automatiquement ses jets de sauvegarde de Force et de Dextérité.",
+      "- Les jets d'attaque contre la créature ont un avantage.",
+      "- Toute attaque qui touche la créature est un coup critique si l'attaquant est à 1,50 mètre ou moins de la créature."
+    ],
+    "url": "/api/2014/conditions/unconscious"
+  },
+  {
+    "index": "exhaustion",
+    "name": "Épuisement",
+    "desc": [
+      "Certaines capacités spéciales et dangers naturels, comme la famine et les effets d'une exposition prolongée au froid ou à la chaleur, peuvent conduire à un état spécial appelé l'épuisement. L'épuisement se mesure en six niveaux. Un effet peut donner à une créature un ou plusieurs niveaux d'épuisement, comme mentionné dans la description de l'effet.",
+      "1 - Désavantage aux jets de caractéristique",
+      "2 - Vitesse diminuée de moitié",
+      "3 - Désavantage aux jets d'attaque et de sauvegarde",
+      "4 - Maximum de points de vie diminué de moitié",
+      "5 - Vitesse réduite à 0",
+      "6 - Mort",
+      "Si une créature déjà épuisée subit un autre effet qui cause l'épuisement, son niveau actuel d'épuisement augmente par le nombre mentionné dans l'effet d'épuisement.",
+      "Une créature subit les effets de son niveau d'épuisement plus ceux des niveaux inférieurs. Par exemple, une créature qui souffre d'un épuisement de niveau deux voit sa vitesse diminuée de moitié et a un désavantage aux jets de caractéristique.",
+      "Un effet qui supprime l'épuisement réduit son niveau tel que mentionné dans la description de l'effet, et tous les effets reliés à l'épuisement disparaissent si le niveau d'épuisement d'une créature est réduit à moins de 1.",
+      "Terminer un repos long réduit le niveau d'épuisement d'une créature de 1, à condition que la créature ait aussi mangé et bu. De même, être rappelé à la vie réduit le niveau d'épuisement d'une créature de 1."
+    ],
+    "url": "/api/2014/conditions/exhaustion"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Damage-Types.json
+++ b/src/2014/fr-FR/5e-SRD-Damage-Types.json
@@ -1,0 +1,89 @@
+[
+  {
+    "index": "acid",
+    "name": "Acide",
+    "desc": [
+      "Le jet corrosif du souffle d’un dragon noir et les enzymes dissolvantes sécrétées par une gelée noire infligent des dégâts d’acides."
+    ]
+  },
+  {
+    "index": "bludgeoning",
+    "name": "Contondant",
+    "desc": [
+      "Les attaques de force brute (marteaux, chute, constriction et effets similaires) infligent des dégâts contondants."
+    ]
+  },
+  {
+    "index": "cold",
+    "name": "Froid",
+    "desc": [
+      "La froideur mortelle irradiant de la lance de glace d’un diable et le souffle glacial d’un dragon blanc infligent des dégâts de froid."
+    ]
+  },
+  {
+    "index": "fire",
+    "name": "Feu",
+    "desc": [
+      "Les dragons rouges crachent du feu et de nombreux sorts invoquent des flammes qui infligent des dégâts de feu."
+    ]
+  },
+  {
+    "index": "force",
+    "name": "Force",
+    "desc": [
+      "La Force est l’énergie magique pure concentrée sous une forme offensive. La plupart des effets qui infligent des dégâts de force sont des sorts, incluant projectile magique et arme spirituelle."
+    ]
+  },
+  {
+    "index": "lightning",
+    "name": "Foudre",
+    "desc": ["Le sort éclair et le souffle d’un dragon bleu infligent des dégâts de foudre."]
+  },
+  {
+    "index": "necrotic",
+    "name": "Nécrotique",
+    "desc": [
+      "Les dégâts nécrotiques, infligés par certains morts-vivants et sorts, flétrissent la matière et même l’âme."
+    ]
+  },
+  {
+    "index": "piercing",
+    "name": "Perforant",
+    "desc": [
+      "Les attaques de perforation et d’empalement, incluant les lances et les morsures de monstres, infligent des dégâts perforants."
+    ]
+  },
+  {
+    "index": "poison",
+    "name": "Poison",
+    "desc": [
+      "Les dards venimeux et le gaz toxique du souffle du dragon vert infligent des dégâts de poison."
+    ]
+  },
+  {
+    "index": "psychic",
+    "name": "Psychique",
+    "desc": [
+      "Les capacités mentales comme l’attaque psionique d’un illithid infligent des dégâts psychiques."
+    ]
+  },
+  {
+    "index": "radiant",
+    "name": "Radiant",
+    "desc": [
+      "Les dégâts radiants, infligés le sort colonne de flamme du clerc ou le châtiment angélique d’une arme, brûlent la chair comme le feu et surchargent l’esprit de pouvoir."
+    ]
+  },
+  {
+    "index": "slashing",
+    "name": "Tranchant",
+    "desc": ["Les épées, les haches et les griffes des monstres infligent des dégâts tranchants."]
+  },
+  {
+    "index": "thunder",
+    "name": "Tonnerre",
+    "desc": [
+      "Le son commotionnant d’une explosion sonore, comme l’effet du sort vague tonnante, inflige des dégâts de tonnerre."
+    ]
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Languages.json
+++ b/src/2014/fr-FR/5e-SRD-Languages.json
@@ -1,0 +1,135 @@
+[
+  {
+    "index": "common",
+    "name": "Commun",
+    "type": "Courante",
+    "typical_speakers": ["Humains"],
+    "script": "Commun",
+    "url": "/api/2014/languages/common"
+  },
+  {
+    "index": "dwarvish",
+    "name": "Nain",
+    "desc": "Le nain est une langue aux consonnes dures et aux sons gutturaux, des spécificités qui se retrouvent dans l'accent qu'ont les nains en parlant une autre langue.",
+    "type": "Courante",
+    "typical_speakers": ["Nains"],
+    "script": "Nain",
+    "url": "/api/2014/languages/dwarvish"
+  },
+  {
+    "index": "elvish",
+    "name": "Elfe",
+    "desc": "Le langage des elfes est fluide, avec des intonnations subtiles et une grammaire élaborée. La littérature des elfes est riche et variée et leurs chansons et poèmes sont populaires parmi les autres races. De nombreux bardes apprennent à parler elfe afin de pouvoir ajouter des ballades elfiques à leur répertoire.",
+    "type": "Courante",
+    "typical_speakers": ["Elfes"],
+    "script": "Elfe",
+    "url": "/api/2014/languages/elvish"
+  },
+  {
+    "index": "giant",
+    "name": "Géant",
+    "type": "Courante",
+    "typical_speakers": ["Ogres", "Géants"],
+    "script": "Nain",
+    "url": "/api/2014/languages/giant"
+  },
+  {
+    "index": "gnomish",
+    "name": "Gnome",
+    "desc": "La langue gnome utilise l'alphabet nain. Les gnomes sont renommés pour leurs traités techniques et leurs catalogues de connaissances sur la nature.",
+    "type": "Courante",
+    "typical_speakers": ["Gnomes"],
+    "script": "Nain",
+    "url": "/api/2014/languages/gnomish"
+  },
+  {
+    "index": "goblin",
+    "name": "Gobelin",
+    "type": "Courante",
+    "typical_speakers": ["Gobelinoïdes"],
+    "script": "Nain",
+    "url": "/api/2014/languages/goblin"
+  },
+  {
+    "index": "halfling",
+    "name": "Halfelin",
+    "desc": "Bien que la langue halfeline n'ait rien d'un secret, ils n'aiment pas l'apprendre aux autres. Ils écrivent très peu et n'ont donc pas énormément de livres. Leur tradition orale est pas contre très riche. Presque tous les halfelins parlent le commun, ce qui leur permet de converser avec les gens qui habitent sur les mêmes territoires qu'eux ou dont ils traversent les terres.",
+    "type": "Courante",
+    "typical_speakers": ["Halfelins"],
+    "script": "Commun",
+    "url": "/api/2014/languages/halfling"
+  },
+  {
+    "index": "orc",
+    "name": "Orc",
+    "desc": "La langue orc a une sonorité dure et certains sons évoquent des grincements. Les orcs n'ont pas d'alphabet propre et utilisent donc l'alphabet nain.",
+    "type": "Courante",
+    "typical_speakers": ["Orcs"],
+    "script": "Nain",
+    "url": "/api/2014/languages/orc"
+  },
+  {
+    "index": "abyssal",
+    "name": "Abyssal",
+    "type": "Exotique",
+    "typical_speakers": ["Démons"],
+    "script": "Infernal",
+    "url": "/api/2014/languages/abyssal"
+  },
+  {
+    "index": "celestial",
+    "name": "Céleste",
+    "type": "Exotique",
+    "typical_speakers": ["Célestes"],
+    "script": "Céleste",
+    "url": "/api/2014/languages/celestial"
+  },
+  {
+    "index": "draconic",
+    "name": "Draconique",
+    "desc": "Le draconique est considéré comme une des langues les plus anciennes et est souvent utilisé pour étudier la magie. C'est une langue composée de consonnes dures et de sifflements, qui semble rude à la plupart des autres créatures.",
+    "type": "Exotique",
+    "typical_speakers": ["Dragons", "Sangdragons"],
+    "script": "Draconique",
+    "url": "/api/2014/languages/draconic"
+  },
+  {
+    "index": "deep-speech",
+    "name": "Profond",
+    "type": "Exotique",
+    "typical_speakers": ["Aboleths", "Manteleurs"],
+    "url": "/api/2014/languages/deep-speech"
+  },
+  {
+    "index": "infernal",
+    "name": "Infernal",
+    "type": "Exotique",
+    "typical_speakers": ["Diables"],
+    "script": "Infernal",
+    "url": "/api/2014/languages/infernal"
+  },
+  {
+    "index": "primordial",
+    "name": "Primordial",
+    "type": "Exotique",
+    "typical_speakers": ["Élémentaires"],
+    "script": "Nain",
+    "url": "/api/2014/languages/primordial"
+  },
+  {
+    "index": "sylvan",
+    "name": "Sylvain",
+    "type": "Exotique",
+    "typical_speakers": ["Fées"],
+    "script": "Elfe",
+    "url": "/api/2014/languages/sylvan"
+  },
+  {
+    "index": "undercommon",
+    "name": "Commun des profondeurs",
+    "type": "Exotique",
+    "typical_speakers": ["Marchands de l'Underdark"],
+    "script": "Elfe",
+    "url": "/api/2014/languages/undercommon"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Magic-Schools.json
+++ b/src/2014/fr-FR/5e-SRD-Magic-Schools.json
@@ -1,0 +1,50 @@
+[
+  {
+    "index": "abjuration",
+    "name": "Abjuration",
+    "desc": "Les sorts d’abjuration sont en règle générale des sorts de protection, même si certains d’entre eux ont des utilisations agressives. Ils créent des barrières magiques, annulent des effets nocifs, endommagent les intrus, ou bannissent des créatures sur un autre plan d’existence.",
+    "url": "/api/2014/magic-schools/abjuration"
+  },
+  {
+    "index": "conjuration",
+    "name": "Invocation",
+    "desc": "Les sorts d’invocation touchent au transport d’objets et des créatures d’un endroit à un autre. Certains sorts invoquent des créatures ou des objets aux côtés du lanceur de sorts, alors que d’autres permettent au lanceur de sorts de se téléporter vers un autre lieu. Certaines invocations créent des objets ou des effets à partir de rien.",
+    "url": "/api/2014/magic-schools/conjuration"
+  },
+  {
+    "index": "divination",
+    "name": "Divination",
+    "desc": "Les sorts de divination révèlent des informations, que ce soit sous la forme de secrets oubliés depuis longtemps, d’aperçus du futur, d’emplacements de choses cachées, de vérité derrière les illusions, ou de visions de personnes ou de lieux éloignés.",
+    "url": "/api/2014/magic-schools/divination"
+  },
+  {
+    "index": "enchantment",
+    "name": "Enchantement",
+    "desc": "Les sorts d’enchantement affectent l’esprit des autres, en influençant ou en contrôlant leur comportement. Ces sorts peuvent faire en sorte que les ennemis perçoivent le lanceur de sorts comme un ami, forcer des créatures à prendre une action, ou même contrôler une autre créature comme une marionnette.",
+    "url": "/api/2014/magic-schools/enchantment"
+  },
+  {
+    "index": "evocation",
+    "name": "Évocation",
+    "desc": "Les sorts d’évocation manipulent l’énergie magique jusqu’à produire l’effet désiré. Certaines évoquent des explosions de feu ou de foudre. D’autres canalisent l’énergie positive afin de guérir les blessures.",
+    "url": "/api/2014/magic-schools/evocation"
+  },
+  {
+    "index": "illusion",
+    "name": "Illusion",
+    "desc": "Les sorts d’illusion trompent les sens ou l’esprit des autres. Ils amènent les gens à percevoir des choses qui ne sont pas là, à manquer des choses qui sont là, à entendre des bruits fantômes, ou à se souvenir de choses qui n’ont jamais eu lieu. Certaines illusions créent des images fantômes que les créatures peuvent voir, mais les illusions les plus insidieuses sont les illusions qui implantent directement une image dans l’esprit d’une créature.",
+    "url": "/api/2014/magic-schools/illusion"
+  },
+  {
+    "index": "necromancy",
+    "name": "Nécromancie",
+    "desc": "Les sorts de nécromancie manipulent les énergies de la vie et de la mort. Certains sorts peuvent accorder une réserve supplémentaire de force de vie, drainer l’énergie de la vie d’une autre créature, créer des morts-vivants, ou même ramener les morts à la vie. La création de morts-vivants grâce à l’utilisation de sorts de nécromancie comme animation des morts, n’est pas un acte de nature bonne, et seuls les lanceurs de sorts mauvais utilisent ces sorts fréquemment.",
+    "url": "/api/2014/magic-schools/necromancy"
+  },
+  {
+    "index": "transmutation",
+    "name": "Transmutation",
+    "desc": "Les sorts de transmutation modifient les propriétés d’une créature, d’un objet ou d’un environnement. Ils peuvent transformer un ennemi en une créature inoffensive, améliorer la force d’un allié, faire qu’un objet puisse se déplacer sur commande du lanceur de sorts, ou augmenter les capacités innées de guérison d’une créature afin qu’elle puisse récupérer plus rapidement d’une blessure.",
+    "url": "/api/2014/magic-schools/transmutation"
+  }
+]


### PR DESCRIPTION
## What does this do?

This PR adds French translations for the following collections:

- Ability scores
- Alignments
- Backgrounds (only `acolyte` is available in `en`)
- Conditions
- Damage types
- Languages
- Magic schools

This is a first batch of French translations (I started with the easy ones 😅), more will come later!

## How was it tested?

It was tested with `npm run test`.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles

<img width="474" height="466" alt="gm-diabolical-plan" src="https://github.com/user-attachments/assets/e62922ff-a81d-4b9a-a5a4-46742eb1a91a" />
