### PR TITLE
feat(language): add even more French translations

### DIFF
--- a/src/2014/fr-FR/5e-SRD-Languages.json
+++ b/src/2014/fr-FR/5e-SRD-Languages.json
@@ -89,7 +89,7 @@
     "name": "Draconique",
     "desc": "Le draconique est considéré comme une des langues les plus anciennes et est souvent utilisé pour étudier la magie. C'est une langue composée de consonnes dures et de sifflements, qui semble rude à la plupart des autres créatures.",
     "type": "Exotique",
-    "typical_speakers": ["Dragons", "Sangdragons"],
+    "typical_speakers": ["Dragons", "Drakéides"],
     "script": "Draconique",
     "url": "/api/2014/languages/draconic"
   },

--- a/src/2014/fr-FR/5e-SRD-Races.json
+++ b/src/2014/fr-FR/5e-SRD-Races.json
@@ -386,7 +386,7 @@
   },
   {
     "index": "dragonborn",
-    "name": "Sangdragon",
+    "name": "Drakéide",
     "speed": 30,
     "ability_bonuses": [
       {
@@ -406,7 +406,7 @@
         "bonus": 1
       }
     ],
-    "alignment": "Les sangdragons préfèrent généralement les extrêmes et choisissent consciemment leur camp dans la guerre cosmique qui oppose le bien et le mal, respectivement représentés par Bahamut et Tiamat. La plupart des sangdragons sont Bons, mais ceux qui rejoignent le camp de Tiamat font de terribles adversaires.",
+    "alignment": "Les drakéides tendent vers les extrêmes et choisissent en conscience un camp ou l’autre dans la guerre à l’échelle cosmique qui oppose le bien et le mal. La plupart des drakéides sont bons, mais ceux qui se rangent dans le camp du mal font de redoutables adversaires.",
     "age": "Les jeunes drakéides grandissent rapidement. Ils marchent juste quelques heures après l'éclosion, atteignent la taille et le développement d'un enfant humain de dix ans à l'âge de 3 ans, et sont adultes à 15 ans. Ils vivent environ 80 ans.",
     "size": "Moyenne",
     "size_description": "Les drakéides sont plus grands et plus lourds que les humains, mesurant plus de 1,80 mètre pour un poids moyen de près de 125 kg. Votre taille est Moyenne (M).",

--- a/src/2014/fr-FR/5e-SRD-Rules.json
+++ b/src/2014/fr-FR/5e-SRD-Rules.json
@@ -1,0 +1,215 @@
+[
+  {
+    "name": "Combat",
+    "index": "combat",
+    "desc": "# Combat\n",
+    "subsections": [
+      {
+        "name": "L’ordre du combat",
+        "index": "the-order-of-combat",
+        "url": "/api/2014/rule-sections/the-order-of-combat"
+      },
+      {
+        "name": "Déplacement et position",
+        "index": "movement-and-position",
+        "url": "/api/2014/rule-sections/movement-and-position"
+      },
+      {
+        "name": "Actions au combat",
+        "index": "actions-in-combat",
+        "url": "/api/2014/rule-sections/actions-in-combat"
+      },
+      {
+        "name": "Effectuer une attaque",
+        "index": "making-an-attack",
+        "url": "/api/2014/rule-sections/making-an-attack"
+      },
+      {
+        "name": "Abri",
+        "index": "cover",
+        "url": "/api/2014/rule-sections/cover"
+      },
+      {
+        "name": "Dégâts et soins",
+        "index": "damage-and-healing",
+        "url": "/api/2014/rule-sections/damage-and-healing"
+      },
+      {
+        "name": "Combat monté",
+        "index": "mounted-combat",
+        "url": "/api/2014/rule-sections/mounted-combat"
+      },
+      {
+        "name": "Combat subaquatique",
+        "index": "underwater-combat",
+        "url": "/api/2014/rule-sections/underwater-combat"
+      }
+    ],
+    "url": "/api/2014/rules/combat"
+  },
+  {
+    "name": "Utiliser les valeurs de caractéristique",
+    "index": "using-ability-scores",
+    "desc": "# Utiliser les valeurs de caractéristique\n\nLes capacités physiques et mentales de toute créature sont représentées par six caractéristiques.\n- La **Force** mesure sa puissance physique\n- La **Dextérité** représente son agilité\n- La **Constitution** évalue son endurance\n- L’**Intelligence** correspond à sa capacité de raisonnement et sa mémoire\n- La **Sagesse** représente son intuition et la qualité de ses sens\n- Le **Charisme** mesure sa force de caractère\n\nTel personnage est-il costaud et perspicace ? Brillant et charmant ? Agile et robuste ? Les valeurs de caractéristique définissent ces qualités ; elles constituent les atouts d’une créature, de même que ses faiblesses.\n\nLes trois jets de dés principaux du jeu, à savoir le test de caractéristique, le jet de sauvegarde et le jet d’attaque, dépendent de ces six valeurs. Ces jets se déroulent tous selon ce principe de base : on lance un d20, auquel on ajoute un modificateur de caractéristique tiré de l’une des six valeurs de caractéristique, avant de comparer ce total à un nombre cible.\n\n**Valeurs et modificateurs de caractéristique** Chacune des caractéristiques d’une créature est assortie d’une valeur numérique qui représente son potentiel dans le domaine concerné. Une valeur de caractéristique ne mesure pas seulement des capacités innées, mais englobe aussi l’entraînement de la créature et son savoir-faire concernant toute activité liée à cette caractéristique.\n\nUne valeur de 10 ou 11 représente la moyenne humaine, mais les aventuriers comme les monstres dépassent souvent cette norme dans plusieurs caractéristiques. Une valeur de 18 correspond au maximum possible pour un individu normal. Les aventuriers peuvent atteindre jusqu’à 20, tandis que les monstres et les êtres divins bénéficient parfois de valeurs encore supérieures (jusqu’à 30).\n\nChaque caractéristique est aussi assortie d’un modificateur, tiré de la valeur. Il peut aller de −5 (pour une valeur de 1) à +10 (pour une valeur de 30).\n",
+    "subsections": [
+      {
+        "name": "Valeurs et modificateurs de caractéristique",
+        "index": "ability-scores-and-modifiers",
+        "url": "/api/2014/rule-sections/ability-scores-and-modifiers"
+      },
+      {
+        "name": "Avantage et désavantage",
+        "index": "advantage-and-disadvantage",
+        "url": "/api/2014/rule-sections/advantage-and-disadvantage"
+      },
+      {
+        "name": "Bonus de maîtrise",
+        "index": "proficiency-bonus",
+        "url": "/api/2014/rule-sections/proficiency-bonus"
+      },
+      {
+        "name": "Tests de caractéristique",
+        "index": "ability-checks",
+        "url": "/api/2014/rule-sections/ability-checks"
+      },
+      {
+        "name": "Les caractéristiques, au cas par cas",
+        "index": "using-each-ability",
+        "url": "/api/2014/rule-sections/using-each-ability"
+      },
+      {
+        "name": "Jets de sauvegarde",
+        "index": "saving-throws",
+        "url": "/api/2014/rule-sections/saving-throws"
+      }
+    ],
+    "url": "/api/2014/rules/using-ability-scores"
+  },
+  {
+    "name": "Partir à l’aventure",
+    "index": "adventuring",
+    "desc": "# Partir à l’aventure\n",
+    "subsections": [
+      {
+        "name": "Le passage du temps",
+        "index": "time",
+        "url": "/api/2014/rule-sections/time"
+      },
+      {
+        "name": "Déplacement",
+        "index": "movement",
+        "url": "/api/2014/rule-sections/movement"
+      },
+      {
+        "name": "L'environnement",
+        "index": "the-environment",
+        "url": "/api/2014/rule-sections/the-environment"
+      },
+      {
+        "name": "Pièges",
+        "index": "traps",
+        "url": "/api/2014/rule-sections/traps"
+      },
+      {
+        "name": "Maladies",
+        "index": "diseases",
+        "url": "/api/2014/rule-sections/diseases"
+      },
+      {
+        "name": "Folie",
+        "index": "madness",
+        "url": "/api/2014/rule-sections/madness"
+      },
+      {
+        "name": "Repos",
+        "index": "resting",
+        "url": "/api/2014/rule-sections/resting"
+      },
+      {
+        "name": "Entre les aventures",
+        "index": "between-adventures",
+        "url": "/api/2014/rule-sections/between-adventures"
+      }
+    ],
+    "url": "/api/2014/rules/adventuring"
+  },
+  {
+    "name": "Spellcasting",
+    "index": "spellcasting",
+    "desc": "# Spellcasting\n\nMagic permeates fantasy gaming worlds and often appears in the form of a spell.\n\nThis chapter provides the rules for casting spells. Different character classes have distinctive ways of learning and preparing their spells, and monsters use spells in unique ways. Regardless of its source, a spell follows the rules here.\n",
+    "subsections": [
+      {
+        "name": "What Is a Spell?",
+        "index": "what-is-a-spell",
+        "url": "/api/2014/rule-sections/what-is-a-spell"
+      },
+      {
+        "name": "Casting a Spell",
+        "index": "casting-a-spell",
+        "url": "/api/2014/rule-sections/casting-a-spell"
+      }
+    ],
+    "url": "/api/2014/rules/spellcasting"
+  },
+  {
+    "name": "Équipement",
+    "index": "equipment",
+    "desc": "# Équipement\n\nLes pièces les plus courantes portent le nom des métaux plus ou moins précieux qui les composent. Les trois monnaies les plus répandues sont la pièce d’or (po), la pièce d’argent (pa) et la pièce de cuivre (pc).\n\nAvec une pièce d’or, un personnage peut acheter un sac de couchage, 15 m de corde solide ou une chèvre. Un artisan qualifié (mais pas exceptionnel) peut gagner une pièce d’or par jour. La pièce d’or est globalement l’unité de mesure de la richesse, même si la pièce elle-même n’est pas couramment utilisée. Quand des marchands traitent d’une affaire relative à des biens ou des services d’une valeur équivalant à plusieurs centaines ou milliers de pièces d’or, les transactions n’impliquent le plus souvent pas d’échange en pièces d’or sonnantes et trébuchantes. La pièce d’or est dans les faits une mesure de valeur standard alors que les transactions s’effectuent par le biais de lingots, d’une lettre de change ou de biens précieux.\n\nUne pièce d’or vaut dix pièces d’argent, la pièce de monnaie la plus répandue. Une pièce d’argent permet d’acheter la force de travail d’un ouvrier pour une demi-journée, une flasque d’huile pour lampe ou une nuit de sommeil dans l’auberge d’un quartier pauvre.\n\nUne pièce d’argent vaut dix pièces de cuivre, la monnaie courante chez les ouvriers et les mendiants. Une pièce de cuivre permet d’acheter une bougie, une torche ou un morceau de craie.\n\nDes monnaies plus inhabituelles, faites d’autres métaux précieux, figurent parfois dans les trésors. La pièce d’électrum (pe) et la pièce de platine (pp) sont issues d’empires déchus et de royaumes perdus, si bien qu’elles suscitent parfois la méfiance et le scepticisme lors des transactions. Une pièce d’électrum vaut cinq pièces d’argent et une pièce de platine, dix pièces d’or.\n\nUne pièce standard pesant environ dix grammes, cent pièces font un kilogramme.\n",
+    "subsections": [
+      {
+        "name": "Taux de conversion",
+        "index": "standard-exchange-rates",
+        "url": "/api/2014/rule-sections/standard-exchange-rates"
+      },
+      {
+        "name": "Objets",
+        "index": "objects",
+        "url": "/api/2014/rule-sections/objects"
+      },
+      {
+        "name": "Poisons",
+        "index": "poisons",
+        "url": "/api/2014/rule-sections/poisons"
+      },
+      {
+        "name": "Harmonisation",
+        "index": "attunement",
+        "url": "/api/2014/rule-sections/attunement"
+      },
+      {
+        "name": "Porter et manier des objets magiques",
+        "index": "wearing-and-wielding-items",
+        "url": "/api/2014/rule-sections/wearing-and-wielding-items"
+      },
+      {
+        "name": "Activer un objet magique",
+        "index": "activating-an-item",
+        "url": "/api/2014/rule-sections/activating-an-item"
+      },
+      {
+        "name": "Les objets magiques intelligents",
+        "index": "sentient-magic-items",
+        "url": "/api/2014/rule-sections/sentient-magic-items"
+      }
+    ],
+    "url": "/api/2014/rules/equipment"
+  },
+  {
+    "name": "Annexe",
+    "index": "appendix",
+    "desc": "# Annexe\n",
+    "subsections": [
+      {
+        "name": "Panthéons historiques et mythologiques",
+        "index": "fantasy-historical-pantheons",
+        "url": "/api/2014/rule-sections/fantasy-historical-pantheons"
+      },
+      {
+        "name": "Les plans d’existence",
+        "index": "the-planes-of-existence",
+        "url": "/api/2014/rule-sections/the-planes-of-existence"
+      }
+    ],
+    "url": "/api/2014/rules/appendix"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Spells.json
+++ b/src/2014/fr-FR/5e-SRD-Spells.json
@@ -1,0 +1,15811 @@
+[
+  {
+    "index": "acid-arrow",
+    "name": "Flèche acide",
+    "desc": [
+      "Une flèche verte scintillante jaillit en direction d'une cible à portée et l'asperge d'acide. Effectuez une attaque à distance avec un sort contre la cible. Si l'attaque touche, la cible subit 4d4 dégâts d'acide immédiatement et 2d4 dégâts d'acide à la fin de son prochain tour. En cas d'échec, la flèche asperge la cible avec de l'acide, ne lui infligeant que la moitié des dégâts initiaux et aucun dégât à la fin de son prochain tour."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, les dégâts (initiaux et à retardement) sont augmentés de 1d4 pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une feuille de rhubarbe en poudre et un estomac de vipère.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "acid",
+        "name": "Acide",
+        "url": "/api/2014/damage-types/acid"
+      },
+      "damage_at_slot_level": {
+        "2": "4d4",
+        "3": "5d4",
+        "4": "6d4",
+        "5": "7d4",
+        "6": "8d4",
+        "7": "9d4",
+        "8": "10d4",
+        "9": "11d4"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/acid-arrow"
+  },
+  {
+    "index": "acid-splash",
+    "name": "Aspersion acide",
+    "desc": [
+      "Vous projetez une bulle d’acide. Choisissez une créature à portée, ou deux créatures à portée qui ne sont pas distantes de plus de 1,50 m l’une de l’autre. Chaque cible doit réussir un jet de sauvegarde de Dextérité sous peine de subir 1d6 dégâts d’acide.",
+      "Les dégâts du sort augmentent de 1d6 lorsque vous atteignez le niveau 5 (2d6), le niveau 11 (3d6) et le niveau 17 (4d6)."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "damage": {
+      "damage_type": {
+        "index": "acid",
+        "name": "Acide",
+        "url": "/api/2014/damage-types/acid"
+      },
+      "damage_at_character_level": {
+        "1": "1d6",
+        "5": "2d6",
+        "11": "3d6",
+        "17": "4d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/acid-splash"
+  },
+  {
+    "index": "aid",
+    "name": "Aide",
+    "desc": [
+      "Votre sort emplit vos alliés de robustesse et de résolution. Choisissez jusqu'à trois créatures à portée. Le maximum de points de vie et les points de vie actuels de chaque cible augmentent de 5 pour la durée du sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, les points de vie de chaque cible augmentent de 5 pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "un petit bout de vêtement blanc.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "heal_at_slot_level": {
+      "2": "5",
+      "3": "10",
+      "4": "15",
+      "5": "20",
+      "6": "25",
+      "7": "30",
+      "8": "35",
+      "9": "40"
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/aid"
+  },
+  {
+    "index": "alarm",
+    "name": "Alarme",
+    "desc": [
+      "Vous mettez en place une alarme contre les intrusions indésirables. Choisissez une porte, une fenêtre, ou une zone à portée qui ne dépasse pas un cube de 6 mètres d'arête. Jusqu'à la fin du sort, une alarme vous alerte lorsqu'une créature de taille TP ou supérieure touche ou pénètre la zone surveillée. Lorsque vous lancez ce sort, vous pouvez désigner des créatures qui ne déclencheront pas l'alarme. Vous pouvez également choisir si l'alarme est audible ou juste mentale.",
+      "Une alarme mentale vous alerte avec une sonnerie dans votre esprit à condition que vous soyez à 1,5 km maximum de la zone surveillée. Cette sonnerie vous réveille si vous êtes endormi. Une alarme audible produit le son d'une clochette à main, pendant 10 secondes, pouvant être entendue à 18 mètres."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une petite clochette et un morceau de fil d'argent fin.",
+    "ritual": true,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 1,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/alarm"
+  },
+  {
+    "index": "alter-self",
+    "name": "Modification d'apparence",
+    "desc": [
+      "Vous endossez une nouvelle forme. Lorsque vous lancez ce sort, choisissez l'une des options suivantes, dont les effets s'appliqueront jusqu'à ce que le sort prenne fin. Tant que le sort est actif, vous pouvez mettre un terme à une option, en dépensant une action, pour gagner les bénéfices d'une option différente.",
+      "**Adaptation aquatique.** Vous adaptez votre corps à un environnement aquatique, en vous faisant pousser des branchies et des expansions palmaires entre les doigts. Vous pouvez respirer sous l'eau et obtenez une vitesse de nage égale à votre vitesse de marche.",
+      "**Changement d'apparence.** Vous transformez votre apparence. Vous décidez à quoi vous ressemblez, que ce soit votre taille, votre poids, les traits de votre visage, le son de votre voix, la longueur de vos cheveux, votre pigmentation, et vos signes distinctifs, le cas échéant. Vous pouvez prendre l'apparence d'un membre d'une autre race, sans répercussions sur vos caractéristiques ou autres traits raciaux. Vous ne pouvez pas prendre l'apparence d'une créature d'une catégorie de taille différente de la vôtre, et votre forme de base doit rester la même ; si vous êtes un bipède, vous ne pouvez pas utiliser ce sort pour devenir quadrupède par exemple. À tout moment pendant la durée du sort, vous pouvez utiliser votre action pour modifier de nouveau votre apparence.",
+      "**Armes naturelles.** Vous vous dotez de griffes, crocs, épines, cornes ou d'une autre arme naturelle de votre choix. Votre attaque à mains nues inflige 1d6 dégâts contondants, perforants ou tranchants, suivant ce qui est le plus approprié à l'arme naturelle que vous avez choisie, et vous obtenez la maîtrise de votre attaque à mains nues. Enfin, votre arme naturelle est une arme magique et a un bonus de +1 aux jets d'attaque et de dégâts."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/alter-self"
+  },
+  {
+    "index": "animal-friendship",
+    "name": "Amitié avec les animaux",
+    "desc": [
+      "Ce sort vous permet de persuader une bête que vous ne lui voulez aucun mal. Choisissez une bête que vous pouvez voir dans la portée du sort. Elle doit vous voir et vous entendre. Si l'Intelligence de la bête est de 4 ou plus, le sort échoue. Autrement, la bête doit réussir un jet de sauvegarde de Sagesse ou être charmée pour la durée du sort. Si vous, ou un de vos compagnons, blessez la cible, le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de nourriture.",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "INT",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druidee",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/animal-friendship"
+  },
+  {
+    "index": "animal-messenger",
+    "name": "Messager animal",
+    "desc": [
+      "Grâce à ce sort, vous employez un animal pour livrer un message. Choisissez une bête visible de taille TP, comme un écureuil, un geai bleu ou une chauve-souris. Vous précisez une destination, que vous avez préalablement visitée, et un destinataire qui correspond à une description sommaire, comme \"un homme ou une femme vêtu d'un uniforme de la garde civile\" or \"un nain roux portant un chapeau pointu\"",
+      "Vous énoncez aussi un message de 25 mots ou moins. La bête ciblée se déplace pour la durée du sort vers la destination déterminée, au rythme de 75 km par 24 heures pour un messager ailé ou 37,5 km pour les autres animaux.",
+      "Lorsque le messager arrive, il livre son message à la créature que vous avez décrit en imitant le son de votre voix. Le messager parlera uniquement à la créature correspondant à la description que vous avez fournie. Si le messager ne parvient pas à sa destination avant la fin du sort, le message est perdu et la bête revient à l'endroit où le sort a été incanté."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, la durée du sort augmente de 48 heures pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de nourriture.",
+    "ritual": true,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druidee",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/animal-messenger"
+  },
+  {
+    "index": "animal-shapes",
+    "name": "Métamorphose animale",
+    "desc": [
+      "Votre magie transforme autrui en bête. Choisissez autant de créatures consentantes que vous souhaitez, parmi celles que vous voyez à portée. Vous transformez chaque cible en bête de taille G ou inférieure dont le facteur de puissance ne dépasse pas 4. Lors des tours suivants, vous pouvez consacrer votre action à donner de nouvelles formes aux créatures affectées.",
+      "La transformation persiste jusqu’à la fin du sort pour chaque cible, sauf pour celles qui tombent à 0 point de vie ou meurent. Vous pouvez opter pour une forme différente pour chaque cible. Le profil de jeu de chaque cible est remplacé par celui de la bête choisie, à l’exception de son alignement et de ses valeurs d’Intelligence, Sagesse et Charisme, qui restent les siens. La cible adopte les points de vie de sa nouvelle forme. Quand elle reprend sa forme normale, elle retrouve le nombre de points de vie dont elle disposait avant la transformation. Si elle reprend sa forme parce qu’elle tombe à 0 point de vie, les dégâts excédentaires sont répercutés sur sa forme normale. Tant que ces dégâts excédentaires ne réduisent pas sa forme normale à 0 point de vie, elle ne subit pas l’état inconscient. La créature est limitée dans les actions qu’elle peut entreprendre par la nature de sa nouvelle forme, et elle ne peut ni parler ni lancer de sorts.",
+      "L’équipement porté par la cible se fond dans sa nouvelle forme. La cible ne peut pas activer, utiliser ou manier son équipement ni en bénéficier de quelque manière que ce soit"
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "jusqu'à 24 heures",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druidee",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/animal-shapes"
+  },
+  {
+    "index": "animate-dead",
+    "name": "Animation des morts",
+    "desc": [
+      "Ce sort crée un serviteur mort-vivant. Choisissez un tas d'ossements ou le cadavre d'un humanoïde de taille M ou P dans la portée du sort. Votre sort insuffle un semblant de vie à la cible pour la relever en tant que créature morte-vivante. La cible devient un squelette si vous avez choisi des ossements, ou un zombi si vous avez choisi un cadavre.(le MJ possède les caractéristiques de la créature en question).",
+      "À chacun de vos tours, vous pouvez utiliser une action bonus pour commander mentalement les créatures que vous avez animées avec ce sort si elles sont à 18 mètres ou moins de vous. Si vous contrôlez plusieurs créatures, vous commandez simultanément autant de créatures que vous le souhaitez en donnant le même ordre à chacune d'elles. Vous décidez de l'action prise par la créature et du mouvement qu'elle fait. Vous pouvez aussi émettre une consigne générale, comme monter la garde devant une pièce ou dans un couloir. Si vous ne donnez aucun ordre, la créature ne fait que se défendre contre les créatures qui lui sont hostiles. Une fois qu'un ordre est donné, la créature s'exécute jusqu'à ce que la tâche soit complétée.",
+      "La créature est sous votre contrôle pour une période de 24 heures, à la fin de quoi elle cesse d'obéir à votre commandement. Pour maintenir le contrôle de la créature pour 24 heures supplémentaires, vous devez incanter ce sort sur la créature avant la fin de la période actuelle de 24 heures. L'usage de ce sort réaffirme votre contrôle sur 4 créatures ou moins animées par ce sort, plutôt que d'en animer une nouvelle."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, vous animez ou réaffirmez votre contrôle sur deux créatures mortes-vivantes additionnelles pour chaque niveau d'emplacement au-delà du niveau 3. Chaque créature doit provenir d'un cadavre ou d'un tas d'ossements différent."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte de sang, un morceau de chair et une pincée de poussière d'os.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 3,
+    "school": {
+      "index": "necromancy",
+      "name": "Necromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/animate-dead"
+  },
+  {
+    "index": "animate-objects",
+    "name": "Animation des objets",
+    "desc": [
+      "Les objets prennent vie sous votre contrôle. Choisissez à portée un maximum de dix objets non magiques que personne ne porte. Les cibles de taille M comptent pour deux objets, celles de taille G pour quatre objets et celles de taille TG pour huit objets. Vous ne pouvez pas animer d’objet de taille supérieure à TG. Chaque cible s’anime pour devenir une créature sous votre contrôle jusqu’à la fin du sort, sauf si elle est réduite à 0 point de vie avant cela.",
+      "Par une action bonus, vous pouvez donner des ordres mentaux à toute créature que vous avez créée par ce sort et qui se trouve dans un rayon de 150 m. Vous pouvez ainsi contrôler plusieurs créatures, en les choisissant, à condition de leur intimer le même ordre. Vous décidez quelle action la créature va entreprendre et où elle se déplacera à son tour suivant, ou pouvez vous contenter de donner une instruction générale, comme garder une salle donnée ou un couloir. Si vous ne lui donnez pas d’ordre, le mort-vivant ne fait que se défendre contre les créatures hostiles. Une fois qu’elle a reçu un ordre, la créature s’y soumet jusqu’à ce que la tâche soit accomplie.",
+      "| Taille | PV | CA | Attaque | For | Dex |",
+      "|---|---|---|---|---|---|",
+      "| Très Petite | 20 | 18 | +8 au toucher, dégâts 1d4 + 4 | 4 | 18 |",
+      "| Petite | 25 | 16 | +6 au toucher, dégâts 1d8 + 2 | 6 | 14 |",
+      "| Moyenne | 40 | 13 | +5 au toucher, dégâts 2d6 + 1 | 10 | 12 |",
+      "| Grande | 50 | 10 | +6 au toucher, dégâts 2d10 + 2 | 14 | 10 |",
+      "| Très Grande | 80 | 10 | +8 au toucher, dégâts 2d12 + 4 | 18 | 6 |",
+      "Un objet animé est un artificiel dont la CA, les points de vie, les attaques, la Force et la Dextérité sont déterminés par sa catégorie de taille. Sa Constitution est de 10, son Intelligence et sa Sagesse de 3, et son Charisme de 1. Sa vitesse est de 9 m ; si l’objet est dépourvu de pieds et d’appendices par lesquels se mouvoir, il acquiert en fait une vitesse de vol de 9 m avec la capacité de vol stationnaire. Si l’objet est solidement fixé à la surface d’un objet plus volumineux, comme une chaîne attachée à un mur, sa vitesse est de 0. Il dispose de la vision aveugle sur 9 m et ne voit rien au-delà de ce rayon. Quand un objet animé tombe à 0 point de vie, il retrouve sa forme de départ, tous les dégâts excédentaires étant répercutés sur celle-ci.",
+      "Si vous ordonnez à l’objet d’attaquer, il peut effectuer une seule attaque de corps à corps contre une créature située dans un rayon de 1,50 m de lui. Il s’agit d’une attaque de coup avec un bonus d’attaque et des dégâts contondants déterminés par sa catégorie de taille. Le MJ peut statuer qu’un objet donné, en raison de sa forme, inflige des dégâts perforants ou tranchants."
+    ],
+    "higher_level": [
+      "Si vous lancez ce sort par un emplacement du 6e niveau ou supérieur, vous pouvez animer deux objets supplémentaires par niveau d’emplacement au-delà du 5e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/animate-objects"
+  },
+  {
+    "index": "antilife-shell",
+    "name": "Coquille antivie",
+    "desc": [
+      "Une barrière scintillante émane de vous dans un rayon de 3 mètres et se déplace avec vous, restant centrée autour de vous et bloquant les créatures autres que celles de type mort-vivant ou artificiel. La barrière reste en place pour toute la durée du sort.",
+      "La barrière empêche les créatures affectées de pénétrer ou de traverser la zone. Une créature affectée peut lancer des sorts ou effectuer des attaques avec des armes à distance ou des armes à allonge au travers de la barrière.",
+      "Si vous vous déplacez de sorte qu'une créature affectée est obligée de passer au travers de la barrière, le sort prend fin."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druidee",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/antilife-shell"
+  },
+  {
+    "index": "antimagic-field",
+    "name": "Champ antimagie",
+    "desc": [
+      "Une sphère invisible d'antimagie d'un rayon de 3 mètres vous englobe. Cet espace est dissocié de l'énergie magique qui s'étend dans le multivers. Dans la sphère, aucun sort ne peut être incanté, les créatures convoquées disparaissent et même les objets magiques deviennent ordinaires. Jusqu'à la fin du sort, la sphère reste centrée sur vous lors de vos mouvements.",
+      "Les sorts et les autres effets magiques, sauf ceux générés par un artéfact ou une divinité, sont réprimés à l'intérieur de la sphère et ils ne peuvent plus y pénétrer. Un emplacement utilisé pour incanter un sort réprimé est dépensé. Un effet est nul lorsqu'il est réprimé mais le temps continue de s'écouler pour le décompte de sa durée.",
+      "***Effets ciblés.*** Les sorts et autres effets magiques, tels que projectile magique ou charme-personne, qui ciblent une créature ou un objet dans la sphère n'ont aucun effet sur la cible.",
+      "***Zones de magie.*** La zone d'un autre sort ou d'un effet magique, tel que boule de feu, ne peut s'étendre dans la sphère. Si la sphère se superpose à une zone de magie, la partie commune est réprimée. Par exemple, les flammes créées par un mur de feu sont réprimées à l'intérieur de la sphère, créant ainsi une ouverture dans le mur, si la portion commune est suffisamment grande.",
+      "***Sorts.*** Tout sort ou autre effet magique actif sur une créature ou un objet dans la sphère est réprimé pendant qu'il y est.",
+      "***Objets magiques.*** Les propriétés et les pouvoirs des objets magiques sont réprimés dans la sphère. Par exemple, une épée longue +1 présente dans la sphère fonctionne comme une épée longue ordinaire.",
+      "Les propriétés et les pouvoirs d'une arme magique sont réprimés s'ils sont utilisés contre une cible dans la sphère ou si l'arme est maniée par un attaquant dans la sphère. Si une arme magique ou une pièce de munition quitte entièrement la sphère (par exemple, si vous décochez une flèche magique ou si vous lancez une lance vers une cible en dehors de la sphère), la répression de la magie de l'objet cesse aussitôt qu'il la quitte.",
+      "***Déplacement magique.*** La téléportation et les déplacements planaires ne fonctionnent pas dans la sphère, quelle que soit l'origine ou la destination d'un tel déplacement magique. Un portail vers un autre lieu, un autre monde ou un autre plan d'existence, autant qu'une ouverture vers un espace extradimensionnel comme celui créé par le sort corde enchantée, sont temporairement fermés tant qu'ils sont dans la sphère.",
+      "***Créatures et objets.*** Une créature ou un objet convoqué ou créé par magie disparait temporairement de la sphère. Une telle créature réapparait instantanément lorsque l'espace occupé par la créature n'est plus dans la sphère.",
+      "***Dissipation de la magie.*** Les sorts et les effets magiques tel que dissipation de la magie n'ont aucun effet sur la sphère. De même, les sphères créées par des sorts de champ antimagie ne s'annulent pas l'une l'autre."
+    ],
+    "range": "Personnelle (sphère de 3 mètres de rayon)",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poudre de fer ou quelques copeaux du même métal.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/antimagic-field"
+  },
+  {
+    "index": "antipathy-sympathy",
+    "name": "Aversion/Attirance",
+    "desc": [
+      "Ce sort attire ou repousse les créatures de votre choix. Vous ciblez quelque chose à portée, soit un objet de taille TG ou inférieure, soit une créature, soit une zone dont les dimensions maximales ne dépassent pas celles d'un cube de 60 mètres d'arête. Puis spécifiez une sorte de créature intelligente, comme les dragons rouges, les gobelins ou les vampires.",
+      "Vous conférez à la cible une aura qui va soit attirer, soit repousser les créatures spécifiées pour toute la durée du sort. Choisissez l'effet de l'aura, entre l'attirance et l'aversion.",
+      "***Aversion.*** L'enchantement donne, aux créatures que vous avez désignées, le besoin urgent de quitter la zone et de fuir la cible. Lorsqu'une créature désignée peut voir la cible ou s'approche à 18 mètres ou moins d'elle, la créature doit réussir un jet de sauvegarde de Sagesse ou être effrayée. La créature reste effrayée tant qu'elle peut voir la cible ou qu'elle se trouve à 18 mètres ou moins d'elle. Tant qu'elle est effrayée par la cible, la créature doit utiliser son mouvement pour se déplacer vers l'endroit sûr le plus proche et duquel elle ne pourra pas voir la cible. Si la créature se déplace à plus de 18 mètres de la cible et qu'elle ne peut pas la voir, la créature n'est plus effrayée, mais elle redevient immédiatement effrayée si elle a de nouveau la cible en ligne de mire ou si elle se trouve de nouveau à 18 mètres ou moins de la cible.",
+      "***Attirance.*** L'enchantement donne, aux créatures que vous avez désignées, le besoin urgent de s'approcher de la cible tant qu'elles se trouvent à 18 mètres ou moins d'elle ou qu'elles peuvent la voir. Lorsqu'une créature désignée peut voir la cible ou se trouve à 18 mètres ou moins d'elle, la créature doit réussir un jet de sauvegarde de Sagesse sous peine de devoir utiliser son mouvement, à chaque tour, pour entrer dans la zone ou se déplacer à portée de la cible. Une fois que la créature a agi de la sorte, elle ne peut s'éloigner volontairement de la cible.",
+      "Si la cible inflige des dégâts ou quelque autre tort à une créature affectée, la créature affectée peut effectuer un jet de sauvegarde de Sagesse pour mettre un terme à l'effet, comme décrit ci-dessous.",
+      "***Mettre un terme à l'effet.*** Si une créature affectée termine son tour en étant à plus de 18 mètres de la cible et sans être capable de la voir, la créature effectue un jet de sauvegarde de Sagesse. En cas de réussite, la créature n'est plus affectée par la cible et se rend compte que son sentiment d'aversion ou d'attirance lui avait été magiquement inspiré. De plus, une créature affectée par le sort est autorisée à effectuer un autre de jet de sauvegarde de Sagesse toutes les 24 heures tant que le sort persiste.",
+      "Une créature qui réussit son jet de sauvegarde contre cet effet y est immunisée pour 1 minute, après quoi elle peut de nouveau être affectée."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Soit un morceau d'aluminium trempé dans du vinaigre pour l'effet aversion, soit une goutte de miel pour l'effet attirance",
+    "ritual": false,
+    "duration": "10 jours",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 8,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 200
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druidee",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/antipathy-sympathy"
+  },
+  {
+    "index": "arcane-eye",
+    "name": "Œil du mage",
+    "desc": [
+      "Vous créez un œil magique invisible à portée, qui flotte dans les airs pour toute la durée.",
+      "Vous recevez mentalement des informations visuelles transmises par l’œil, doté de la vision normale et de la vision dans le noir sur un rayon de 9 m. L’œil peut observer dans toutes les directions.",
+      "Au prix d’une action, vous pouvez déplacer l’œil d’un maximum de 9 m dans la direction de votre choix. Il n’y a pas de limite à la distance qui peut vous séparer de l’œil, si ce n’est qu’il ne peut accéder à un autre plan d’existence. Un obstacle solide bloque les déplacements de l’œil mais celui-ci peut se glisser dans un interstice d’une largeur minimale de 2,5 cm."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une touffe de poils de chauve-souris.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/arcane-eye"
+  },
+  {
+    "index": "arcane-hand",
+    "name": "Main de Bigby",
+    "desc": [
+      "Vous créez une main de force luminescente et translucide de taille G dans un espace inoccupé à portée et que vous pouvez voir. La main reste pour la durée du sort, et elle se déplace selon vos ordres, reproduisant les mouvements de votre propre main.",
+      "La main est un objet ayant une CA de 20 et un nombre de points de vie égal à votre maximum de points de vie. Si elle tombe à 0 point de vie, le sort prend fin. Elle a une Force de 26 (+8) et une Dextérité de 10 (+0). La main ne remplit pas l'espace qu'elle occupe.",
+      "Lorsque vous lancez ce sort et par une action bonus aux tours qui suivent, vous pouvez déplacer la main jusqu'à 18 mètres puis lui appliquer l'un des effets suivants.",
+      "***Poing de Bigby.*** La main frappe une créature ou un objet à 1,50 mètre d'elle. Effectuez une attaque au corps à corps avec un sort pour la main en utilisant vos statistiques de jeu. Si l'attaque touche, la cible subit 4d8 dégâts de force.",
+      "***Main de force de Bigby.*** La main tente de pousser une créature située à 1,50 mètre d'elle, dans une direction de votre choix. Effectuez un jet de Force de la main contre un jet de Force (Athlétisme) de la cible. Si la cible est de taille M ou inférieure, vous avez un avantage au jet. Si vous gagnez l'opposition, la main repousse la cible sur une distance en mètre égale à 1,50 x (1 + le modificateur de votre caractéristique d'incantation). La main se déplace avec la cible pour rester à 1,50 mètre d'elle.",
+      "***Main broyeuse de Bigby.*** La main tente d'agripper une créature de taille G ou inférieure se trouvant à 1,50 mètre d'elle. Vous utilisez la Force de la main pour résoudre la tentative. Si la cible est de taille M ou inférieure, vous avez un avantage au jet. Tant que la main agrippe la cible, vous pouvez utiliser une action bonus pour que la main la broie. Lorsque vous faites ainsi, la cible subit un nombre de points de dégâts contondants égal à 2d6 + le modificateur de votre caractéristique d'incantation.",
+      "***Main d'interposition de Bigby.*** La main s'interpose entre vous et une créature de votre choix jusqu'à ce que vous donniez à la main un ordre différent. La main se déplace de sorte à toujours rester entre vous et la cible, vous donnant un abri partiel contre la cible. La cible ne peut pas se déplacer au travers de l'espace occupé par la main si sa valeur de Force est inférieure ou égale à celle de la main. Si la valeur de Force de la cible est supérieure à celle de la main, elle peut se déplacer dans votre direction en traversant l'espace de la main, mais son espace est considéré comme étant un terrain difficile pour la cible."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, les dégâts du Poing de Bigby augmentent de 2d8 et les dégâts de la Main broyeuse de Bigby augmentent de 2d6, et ce pour chaque emplacement de niveau supérieur au 5ème."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une coquille d'œuf et un gant en peau de serpent.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/arcane-hand"
+  },
+  {
+    "index": "arcane-lock",
+    "name": "Verrou magique",
+    "desc": [
+      "Vous touchez un objet fermé comme une porte, une fenêtre, un portail ou un coffre, et celui-ci se retrouve verrouillé pour la durée du sort. Vous et les créatures que vous désignez lors du lancement du sort pouvez ouvrir l'objet normalement. Vous pouvez aussi créer un mot de passe qui, quand il est prononcé à 1,50 mètre ou moins de l'objet, supprime l'effet du sort pendant 1 minute. Autrement, il est impossible d'ouvrir l'objet, sauf s'il est brisé ou si le sort est dissipé ou prend fin. Lancer le sort déblocage supprime verrou magique pendant 10 minutes.",
+      "L'objet affecté par le sort est plus difficile à briser ou forcer ; le DD pour le briser ou tenter de le crocheter augmente de 10."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De la poudre d'or d'une valeur d'au moins de 25 po, que le sort consomme",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/arcane-lock"
+  },
+  {
+    "index": "arcane-sword",
+    "name": "Épée arcanique",
+    "desc": [
+      "Vous créez à portée une silhouette de force en forme d’épée qui flotte en vol stationnaire. Elle persiste pour toute la durée.",
+      "À l’apparition de l’épée, vous effectuez une attaque de sort au corps à corps contre la cible de votre choix dans un rayon de 1,50 m de l’épée. Si l’attaque touche, la cible subit 3d10 dégâts de force. Jusqu’à la fin du sort, vous pouvez par une action bonus à chacun de vos tours déplacer l’épée d’un maximum de 6 m vers un point que vous voyez et réitérer l’attaque, contre la même cible ou une autre."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une épée miniature en platine au pommeau et à la poignée de cuivre et de zinc, d’une valeur de 250 po.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 7,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_slot_level": {
+        "7": "3d10"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/arcane-sword"
+  },
+  {
+    "index": "arcanists-magic-aura",
+    "name": "Aura magique de l’arcaniste",
+    "desc": [
+      "Vous placez une illusion sur une créature ou un objet que vous touchez, de manière à ce que les sorts de divination révèlent de fausses informations à son sujet. La cible doit être une créature consentante ou un objet qui n’est pas porté par une autre créature.",
+      "À l’incantation du sort, choisissez l’un des effets suivants, ou les deux. Les effets persistent pour toute la durée. Si vous lancez ce sort sur une même créature ou un même objet pendant 30 jours consécutifs, en lui appliquant chaque fois le même effet, l’illusion persiste jusqu’à dissipation.",
+      "***Aura factice.*** Vous altérez la manière dont la cible se dévoile au gré de sorts et effets magiques qui perçoivent les auras magiques, tels que détection de la magie. Vous pouvez ainsi faire qu’un objet ordinaire paraisse magique, qu’un objet magique paraisse ordinaire, ou modifier l’aura magique d’un objet pour qu’elle soit associée à l’école de magie de votre choix. Lorsque vous recourez à cet effet sur un objet, vous pouvez décider que l’aura factice soit perçue par toute créature qui le manipule.",
+      "***Masque.*** Vous modifiez la façon dont la cible se présente aux sorts et effets magiques qui détectent le type de créature, tels que la Perception divine du paladin ou le déclencheur du sort symbole. Choisissez un type de créature ; les sorts et effets magiques concernés considèrent la cible comme si elle était du type retenu ou de l’alignement associé."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un petit carré de soie.",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/arcanists-magic-aura"
+  },
+  {
+    "index": "astral-projection",
+    "name": "Projection astrale",
+    "desc": [
+      "Vous et jusqu'à huit créatures consentantes dans la portée du sort projetez vos corps astraux dans le plan Astral (le sort échoue et l'incantation est perdue si vous êtes déjà sur ce plan). Les corps matériels laissés derrière sont inconscients et dans un état d'animation suspendue. Ils ne requièrent ni sustentation ni air et ils ne vieillissent pas.",
+      "Votre corps astral est similaire à votre forme mortelle à presque tous les égards. Vos possessions et vos statistiques de jeu sont ainsi répliquées. La principale différence est l'ajout d'un cordon argenté qui prend son origine entre vos omoplates et qui traine derrière vous, pour disparaitre après 30 cm. Ce cordon est votre attache avec votre corps matériel. Aussi longtemps que l'attache demeure intacte, vous pouvez retourner sur votre plan. Si le cordon est tranché, un incident qui ne survient que si un effet spécifie que c'est le cas, votre âme et votre corps sont séparés, vous tuant sur le coup.",
+      "Votre forme astrale peut se déplacer librement à travers le plan Astral et elle peut emprunter des portails vous menant sur tout autre plan. Si vous entrez sur un nouveau plan ou si vous retournez sur le plan d'où le sort fut incanté, votre corps et vos possessions sont transportés le long du cordon argenté, vous permettant de reprendre votre forme matérielle lors de votre arrivée sur le nouveau plan. Votre forme astrale est une incarnation distincte. Les dégâts ou les effets qu'elle subit n'ont pas d'impact sur votre corps physique et ils ne l'affectent pas lorsque vous y retournez.",
+      "Le sort prend fin pour vous et vos compagnons lorsque vous utilisez une action pour le dissiper. Lorsque le sort se termine, les créatures ciblées retournent à leur corps physique puis elles reprennent conscience.",
+      "Le sort peut aussi se terminer prématurément pour vous ou un de vos compagnons. Une dissipation de la magie réussie sur un corps astral ou physique interrompt le sort pour cette créature. Si le corps d'origine ou sa forme astrale tombe à 0 point de vie, le sort s'interrompt pour cette créature. Si le sort se termine et que le cordon argenté est toujours intact, le cordon ramène la forme astrale de la créature à son corps, ce qui met un terme à l'état d'animation suspendue.",
+      "Si vous êtes retourné à votre corps prématurément, vos compagnons conservent leur forme astrale et ils doivent trouver eux-mêmes le chemin du retour, en tombant à 0 point de vie, habituellement."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Pour chaque créature que vous ciblez avec ce sort, vous devez fournir une jacinthe valant au moins 1 000 po et un lingot d'argent ornementé de gravures valant au moins 100 po, que le sort consomme",
+    "ritual": false,
+    "duration": "Spéciale",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 9,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/astral-projection"
+  },
+  {
+    "index": "augury",
+    "name": "Augure",
+    "desc": [
+      "Que ce soit en jetant des bâtonnets incrustés de gemmes ou des osselets de dragon, en retournant des cartes ornées ou en usant d'autres outils divinatoires, vous recevez un présage de la part d'une entité surnaturelle à propos du résultat des actions que vous planifiez d'entreprendre au cours des 30 prochaines minutes. Le MJ choisit de répondre à l'aide des présages suivants :",
+      "- Fortune : l'action a de bonnes chances d'être bénéfique",
+      "- Péril : l'action aura des répercussions néfastes.",
+      "- Péril et fortune : les deux sont possibles.",
+      "- Rien : dans le cas où l'action ne devrait pas avoir de conséquences favorables ou néfastes.",
+      "Le sort ne considère pas les circonstances qui pourraient changer l'issue de la divination, comme l'incantation additionnelle de sorts ou la perte ou le gain d'un nouveau compagnon.",
+      "Si vous incantez le sort plus d'une fois avant la fin de votre prochain repos long, il y a une probabilité cumulative de 25 % de recevoir une réponse aléatoire, et ce, à chaque incantation après la première. Le MJ fait ce jet en secret."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Jeu de bâtonnets ou d'osselets spécialement inscrits valant au moins 25 po",
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/augury"
+  },
+  {
+    "index": "awaken",
+    "name": "Éveil",
+    "desc": [
+      "Après avoir passé le temps d'incantation à tracer des symboles magiques sur une pierre précieuse, vous touchez une bête ou une plante de taille TG ou inférieure. La cible doit avoir une valeur d'Intelligence inférieure ou égale à 3, ou bien ne pas avoir de valeur d'Intelligence du tout. La cible obtient une valeur d'Intelligence égale à 10. La cible gagne également la capacité de parler une langue que vous connaissez. Si la cible est une plante, elle gagne la capacité de mouvoir ses branches, ses racines, ses sarments, ses lianes, et ainsi de suite, et gagne des sens similaires à ceux des humains. Votre MJ choisit les caractéristiques appropriées à la plante que vous avez éveillée, comme l'arbre éveillé ou l'arbuste éveillé.",
+      "Vous charmez la bête ou la plante éveillée pendant 30 jours ou jusqu'à ce que vous, ou vos compagnons, nuisiez à la cible. Lorsque le charme prend fin, la créature éveillée choisit si elle reste amicale envers vous, en fonction de la manière dont vous l'avez traité lorsqu'elle était charmée."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une agate d'une valeur d'au moins 1 000 po, que le sort consomme",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "8 heures",
+    "level": 5,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/awaken"
+  },
+  {
+    "index": "bane",
+    "name": "Imprécation",
+    "desc": [
+      "Jusqu'à trois créatures de votre choix, que vous pouvez voir et qui sont à portée, doivent effectuer un jet de sauvegarde de Charisme. Quand une cible qui a raté son jet de sauvegarde fait un jet d'attaque ou un autre jet de sauvegarde avant la fin du sort, elle doit lancer un d4 et soustraire le résultat à son jet d'attaque ou de sauvegarde."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "une goutte de sang",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/bane"
+  },
+  {
+    "index": "banishment",
+    "name": "Bannissement",
+    "desc": [
+      "Vous tentez d'envoyer dans un autre plan d'existence une créature à portée que vous pouvez voir.",
+      "La cible doit réussir un jet de sauvegarde de Charisme sous peine d'être bannie.Si la cible est native du plan d'existence sur lequel vous êtes, vous bannissez la cible sur un demi-plan non-dangereux. Tant qu'elle s'y trouve, la cible est incapable d'agir. La cible y reste jusqu'à ce que le sort prenne fin, puis elle réapparaît à l'endroit qu'elle a quitté ou dans l'espace inoccupé le plus proche si cet endroit est occupé.",
+      "Si la cible est native d'un plan d'existence différent de celui sur lequel vous vous trouvez, la cible est bannie dans une petite détonation, retournant dans son plan d'existence. Si ce sort se termine avant qu'une minute ne se soit écoulée, la cible réapparaît dans l'espace qu'elle a quitté ou dans l'espace inoccupé le plus proche si cet endroit est déjà occupé. Sinon, la cible ne revient pas."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 5 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 4."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un objet désagréable pour la cible.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/banishment"
+  },
+  {
+    "index": "barkskin",
+    "name": "Peau d'écorce",
+    "desc": [
+      "Vous touchez une créature consentante. Jusqu'à la fin du sort, la peau de la cible prend une texture rugueuse telle l'écorce d'un arbre et la CA de la cible ne peut être inférieure à 16, peu importe le type d'armure qu'elle porte."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une poignée d'écorce de chêne.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/barkskin"
+  },
+  {
+    "index": "beacon-of-hope",
+    "name": "Lueur d'espoir",
+    "desc": [
+      "Ce sort confère espoir et vitalité. Choisissez des créatures dans la portée du sort. Pour la durée du sort, chaque cible bénéficie d'un avantage à ses jets de sauvegarde de Sagesse et à ses jets de sauvegarde contre la mort. Elle récupère aussi le maximum de points de vie lors d'une guérison."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/beacon-of-hope"
+  },
+  {
+    "index": "bestow-curse",
+    "name": "Malédiction",
+    "desc": [
+      "Vous touchez une créature, elle doit alors réussir un jet de sauvegarde de Sagesse sous peine d'être affligée d'une malédiction pour toute la durée du sort. Lorsque vous lancez ce sort, choisissez la nature de la malédiction parmi les options qui suivent :",
+      "- Choisissez une valeur de caractéristique. Tant qu'elle est maudite, la cible a un désavantage à ses jets de caractéristique et de sauvegarde effectués avec la caractéristique en question.",
+      "- Tant qu'elle est maudite, la cible a un désavantage aux jets d'attaque qu'elle effectue contre vous.",
+      "- Tant qu'elle est maudite, la cible doit effectuer un jet de sauvegarde de Sagesse au début de chacun de ses tours. En cas d'échec, elle gaspille l'action de son tour à ne rien faire.",
+      "- Tant que la cible est maudite, vos attaques et sorts lui infligent 1d8 dégâts nécrotiques supplémentaires.",
+      "Un sort de délivrance des malédictions met fin à cet effet. À la discrétion du MJ, vous pouvez choisir une autre option de malédiction que celles présentées, mais elle ne devrait pas être plus puissante que celles-ci-dessus. Le MJ a le dernier mot concernant l'effet de la malédiction."
+    ],
+    "higher_level": [
+      " Si vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, la durée de concentration maximale monte à 10 minutes. Si vous utilisez un emplacement de sort de niveau 5 ou supérieur, le sort dure 8 heures. Si vous utilisez un emplacement de sort de niveau 7 ou supérieur, le sort dure 24 heures. Si vous utilisez un emplacement de sort de niveau 9, le sort dure jusqu'à ce qu'il soit dissipé. Utiliser un emplacement de sort de niveau 5 ou supérieur permet de s'affranchir de la concentration en ce qui concerne la durée du sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec du JS, la créature devient maudite pour toute la durée du sort."
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/bestow-curse"
+  },
+  {
+    "index": "black-tentacles",
+    "name": "Tentacules noirs",
+    "desc": [
+      "Des tentacules frétillants d’un noir d’ébène surgissent du sol et emplissent un espace de 6 m de côté que vous voyez à portée. Pour toute la durée, ces tentacules transforment le sol de la zone en terrain difficile.",
+      "Lorsqu’une créature entre dans la zone pour la première fois d’un tour ou y commence son tour, elle doit réussir un jet de sauvegarde de Dextérité sous peine de subir 3d6 dégâts contondants et d’être entravée par les tentacules jusqu’à la fin du sort. Une créature qui commence son tour dans la zone alors qu’elle est déjà entravée par les tentacules subit 3d6 dégâts contondants.",
+      "Une créature ainsi entravée peut consacrer son action à effectuer un test de Force ou de Dextérité (à sa convenance) assorti de votre DD de sauvegarde des sorts. En cas de réussite, elle se libère des tentacules."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de tentacule d'une pieuvre ou d'un calmar géant.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Contondant",
+        "url": "/api/2014/damage-types/bludgeoning"
+      },
+      "damage_at_slot_level": {
+        "4": "3d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none",
+      "desc": "Une créature ainsi entravée peut consacrer son action à effectuer un test de Force ou de Dextérité (à sa convenance) assorti de votre DD de sauvegarde des sorts. En cas de réussite, elle se libère des tentacules."
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/black-tentacles"
+  },
+  {
+    "index": "blade-barrier",
+    "name": "Barrière de lames",
+    "desc": [
+      "Vous créez un mur de lames acérées et tourbillonnantes faites d'énergie magique. Le mur apparait dans la portée du sort et il persiste pour sa durée. Vous pouvez modeler un mur rectiligne mesurant jusqu'à 30 mètres de long, 6 mètres de haut et 1,50 mètre d'épaisseur, ou un mur circulaire mesurant jusqu'à 18 mètres de diamètre, 6 mètres de haut et 1,50 mètre d'épaisseur. Le mur confère un abri important (3/4) aux créatures situées derrière, et l'espace occupé par le mur est un terrain difficile.",
+      "Lorsqu'une créature pénètre dans la zone du mur pour la première fois de son tour ou lorsqu'elle débute son tour dans la zone, la créature doit effectuer un jet de sauvegarde de Dextérité, subissant 6d10 dégâts tranchants en cas d'échec, ou la moitié de ces dégâts en cas de réussite."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "slashing",
+        "name": "Tranchant",
+        "url": "/api/2014/damage-types/slashing"
+      },
+      "damage_at_slot_level": {
+        "6": "6d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 100
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/blade-barrier"
+  },
+  {
+    "index": "bless",
+    "name": "Bénédiction",
+    "desc": [
+      "Vous bénissez jusqu'à trois créatures de votre choix, dans la portée du sort. À chaque fois qu'une cible fait un jet d'attaque ou de sauvegarde avant la fin du sort, la cible peut lancer un d4 et ajouter le résultat au jet d'attaque ou de sauvegarde."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une aspersion d'eau bénite.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/bless"
+  },
+  {
+    "index": "blight",
+    "name": "Flétrissement",
+    "desc": [
+      "De l'énergie nécromantique déferle sur une créature de votre choix, que vous pouvez voir et à portée, drainant ses liquides corporels et sa vitalité. La cible doit effectuer un jet de sauvegarde de Constitution, subissant 8d8 dégâts nécrotiques en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Ce sort n'a pas d'effet sur un mort-vivant ou un artificiel.",
+      "Si vous ciblez une créature de type plante ou une plante magique, elle effectue son jet de sauvegarde avec un désavantage, et le sort lui inflige les dégâts maximums.",
+      "Si vous ciblez une plante non magique qui n'est pas non plus une créature, comme un arbre ou un buisson, elle n'effectue pas de jet de sauvegarde ; elle se flétrit simplement et meurt."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 5 ou supérieur, les dégâts sont augmentés de 1d8 pour chaque niveau d'emplacement au-delà du niveau 4."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "4": "8d8",
+        "5": "9d8",
+        "6": "10d8",
+        "7": "11d8",
+        "8": "12d8",
+        "9": "13d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/blight"
+  },
+  {
+    "index": "blindness-deafness",
+    "name": "Cécité/Surdité",
+    "desc": [
+      "Vous pouvez aveugler ou assourdir un ennemi. Choisissez une créature que vous pouvez voir dans la portée du sort. Celle-ci doit réussir un jet de sauvegarde de Constitution sans quoi elle est soit aveuglée, soit assourdie (selon votre choix) pour la durée du sort. À la fin de chacun de ses tours, la cible effectue un jet de sauvegarde de Constitution. En cas de réussite, le sort prend fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/blindness-deafness"
+  },
+  {
+    "index": "blink",
+    "name": "Clignotement",
+    "desc": [
+      "Lancez un d20 à la fin de chacun de vos tours pour toute la durée du sort. Si le résultat du jet est 11 ou plus, vous disparaissez du plan d'existence actuel et apparaissez dans le plan éthéré (le sort échoue mais l'emplacement de sort est dépensé si vous vous trouvez déjà dans le plan éthéré). Au début de votre prochain tour, ou lorsque le sort prend fin si vous êtes dans le plan éthéré, vous retournez dans un espace inoccupé de votre choix que vous pouvez voir et situé à 3 mètres maximum de l'endroit où vous avez disparu. S'il n'y a aucun espace inoccupé de disponible à portée, vous apparaissez dans l'espace inoccupé le plus proche (choisi aléatoirement si plus d'un espace inoccupé remplissant les conditions est disponible). Vous pouvez annuler ce sort par une action.",
+      "Lorsque vous êtes dans le plan éthéré, vous pouvez voir et entendre le plan dont vous êtes originaire, qui apparaît en nuances de gris, mais vous ne pouvez voir à plus de 18 mètres. Vous ne pouvez affecter et être affecté que par d'autres créatures du plan éthéré. Les créatures qui n'y sont pas ne peuvent ni vous percevoir ni interagir avec vous, à moins qu'une capacité le leur permette."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/blink"
+  },
+  {
+    "index": "blur",
+    "name": "Flou",
+    "desc": [
+      "Votre corps devient flou, changeant et ondulant pour tous ceux qui peuvent vous voir. Tant que le sort dure, toutes les créatures ont un désavantage au jet d'attaque dirigé contre vous. Un attaquant est immunisé contre cet effet s'il n'utilise pas la vue, comme avec le combat aveugle, ou s'il peut voir à travers les illusions, comme avec une vision véritable."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/blur"
+  },
+  {
+    "index": "branding-smite",
+    "name": "Châtiment révélateur",
+    "desc": [
+      "La prochaine fois que vous touchez une créature lors d'une attaque avec une arme avant que le sort ne prenne fin, votre arme rayonne d'une lueur astrale au moment de l'impact. L'attaque inflige 2d6 dégâts radiants supplémentaires à la cible, qui devient visible si elle était invisible, et la cible émet une lumière faible dans un rayon de 1,50 mètre et ne peut devenir invisible tant que le sort persiste."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, les dégâts supplémentaires augmentent de 1d6 pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "2": "2d6",
+        "3": "3d6",
+        "4": "4d6",
+        "5": "5d6",
+        "6": "6d6",
+        "7": "7d6",
+        "8": "8d6",
+        "9": "9d6"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/branding-smite"
+  },
+  {
+    "index": "burning-hands",
+    "name": "Mains brûlantes",
+    "desc": [
+      "En tendant vos mains, les pouces en contact et les doigts écartés, un mince rideau de flammes gicle du bout de tous vos doigts tendus. Toute créature se trouvant dans le cône de 4,50 mètres doit effectuer un jet de sauvegarde de Dextérité. La créature subit 3d6 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Le feu embrase tous les objets inflammables qui se trouvent dans la zone d'effet et qui ne sont pas tenus ou portés."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, les dégâts augmentent de 1d6 pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "1": "3d6",
+        "2": "4d6",
+        "3": "5d6",
+        "4": "6d6",
+        "5": "7d6",
+        "6": "8d6",
+        "7": "9d6",
+        "8": "10d6",
+        "9": "11d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cone",
+      "size": 15
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/burning-hands"
+  },
+  {
+    "index": "call-lightning",
+    "name": "Appel de la foudre",
+    "desc": [
+      "Un nuage d'orage prend la forme d'un cylindre de 3 mètres de hauteur et d'un rayon de 18 mètres centré sur un point visible à portée au-dessus de vous. Le sort échoue si vous ne pouvez voir un point en l'air là où le nuage devrait apparaître (par exemple, si vous vous trouvez dans une pièce trop petite pour accueillir le nuage).",
+      "Lorsque vous incantez le sort, choisissez un point visible sous le nuage. Un éclair jaillit du nuage jusqu'au point choisi. Chaque créature à 1,50 mètre ou moins de ce point doit effectuer un jet de sauvegarde de Dextérité, subissant 3d10 dégâts de foudre en cas d'échec, ou la moitié de ces dégâts en cas de réussite. À chacun de vos tours, jusqu'à la fin du sort, vous pouvez utiliser votre action pour appeler la foudre de cette manière, en ciblant le même point ou un nouveau.",
+      "Si vous êtes en extérieur et dans des conditions orageuses lors de l'incantation de ce sort, le sort vous permet de contrôler l'orage plutôt que d'en créer un nouveau. Dans ces conditions, les dégâts du sort augmentent de 1d10."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, les dégâts augmentent de 1d10 pour chaque niveau d'emplacement au-delà du niveau 3."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "damage": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "damage_at_slot_level": {
+        "3": "3d10",
+        "4": "4d10",
+        "5": "5d10",
+        "6": "6d10",
+        "7": "7d10",
+        "8": "8d10",
+        "9": "9d10"
+      }
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 5
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/call-lightning"
+  },
+  {
+    "index": "calm-emotions",
+    "name": "Apaisement des émotions",
+    "desc": [
+      "Vous tentez de supprimer les émotions fortes dans un groupe de personnes. Chaque humanoïde dans une sphère de 6 mètres de rayon centrée sur un point choisi dans la portée du sort doit effectuer un jet de sauvegarde de Charisme. Une créature peut choisir de rater volontairement son jet de sauvegarde. En cas d'échec au jet de sauvegarde, choisissez l'un des deux effets suivants. Vous pouvez supprimer tous les effets qui font qu'une cible est charmée ou effrayée. Lorsque ce sort prend fin, les effets supprimés reviennent, en présumant que leur durée n'a pas expiré entre temps.",
+      "Ou vous pouvez rendre une cible indifférente à des créatures envers qui elle montre des signes d'hostilité. Cette indifférence prend fin lorsque la cible est attaquée ou blessée par un sort ou lorsqu'elle est témoin d'une attaque envers un de ses alliés. Lorsque le sort prend fin, la créature redevient hostile, à moins que le MJ en décide autrement."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/calm-emotions"
+  },
+  {
+    "index": "chain-lightning",
+    "name": "Chaîne d'éclairs",
+    "desc": [
+      "Vous créez un trait électrifié qui s'arque à partir d'une cible de votre choix que vous pouvez voir et à portée. Trois traits s'élancent de la cible pour se diriger vers trois autres cibles. Chacune d'entre elles doit être à 9 mètres ou moins de la première cible. La cible peut être une créature ou un objet et ne peut être ciblée que par un seul des traits.",
+      "Toute cible doit effectuer un jet de sauvegarde de Dextérité, subissant 10d8 dégâts de foudre en cas d'échec, ou la moitié de ces dégâts en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort avec un emplacement de sort de niveau 7 ou supérieur, un trait additionnel s'élance de la première cible vers une autre cible pour chaque niveau d'emplacement au-delà du niveau 6."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Quelques poils ; un morceau d'ambre, de verre ou un bâtonnet de cristal ; et 3 épingles en argent.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "damage_at_slot_level": {
+        "6": "10d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/chain-lightning"
+  },
+  {
+    "index": "charm-person",
+    "name": "Charme-personne",
+    "desc": [
+      "Vous pouvez tenter de charmer un humanoïde que vous pouvez voir à portée. Ce dernier doit effectuer un jet de sauvegarde de Sagesse, avec un avantage à son jet si vous ou vos compagnons le combattez. En cas d'échec, il est charmé jusqu'à la fin de la durée du sort ou jusqu'à ce que vous ou vos compagnons cherchiez à lui nuire. La créature charmée vous considère comme un bon ami. Quand le sort prend fin, la créature sait que vous l'avez charmée."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 1. Les créatures doivent se trouver à 9 mètres maximum les unes des autres lorsque vous les ciblez."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/charm-person"
+  },
+  {
+    "index": "chill-touch",
+    "name": "Contact glacial",
+    "desc": [
+      "Vous créez une main squelettique fantomatique dans l'espace d'une créature à portée. Faites une attaque à distance avec un sort contre la créature pour l'étreindre d'une froideur sépulcrale. Si le coup touche, la cible subit 1d8 dégâts nécrotiques, et elle ne peut récupérer ses points de vie avant le début de votre prochain tour. Jusque-là, la main fantomatique s'accroche à la cible.",
+      "Si vous ciblez un mort-vivant, il aura également un désavantage à ses jets d'attaque contre vous jusqu'à la fin de votre prochain tour.",
+      "Les dégâts de ce sort augmentent de 1d8 lorsque vous atteignez le niveau 5 (2d8), le niveau 11 (3d8) et le niveau 17 (4d8)."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_character_level": {
+        "1": "1d8",
+        "5": "2d8",
+        "11": "3d8",
+        "17": "4d8"
+      }
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/chill-touch"
+  },
+  {
+    "index": "circle-of-death",
+    "name": "Cercle de mort",
+    "desc": [
+      "Une sphère d'énergie négative s'étend dans un rayon de 18 mètres à partir d'un point à portée. Chaque créature présente dans la zone doit effectuer un jet de sauvegarde de Constitution, subissant 8d6 dégâts nécrotiques en cas d'échec, ou la moitié de ces dégâts en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 7 ou supérieur, les dégâts augmentent de 2d6 pour chaque niveau d'emplacement au-delà du niveau 6."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De la poudre provenant d'une perle noire broyée, d'une valeur d'au moins 500 po.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "6": "8d6",
+        "7": "10d6",
+        "8": "12d6",
+        "9": "14d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 60
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/circle-of-death"
+  },
+  {
+    "index": "clairvoyance",
+    "name": "Clairvoyance",
+    "desc": [
+      "Vous créez un détecteur invisible, à portée, dans une zone qui vous est familière (un endroit que vous avez visité ou déjà vu) ou dans une zone évidente qui ne vous est pas familière (comme l'autre côté d'une porte, derrière un angle ou dans un bosquet). Le détecteur reste en place pour la durée du sort, il ne peut pas être attaqué ou être en interaction avec quoi que ce soit.",
+      "Lorsque vous lancez le sort, vous choisissez de voir ou d'entendre. Vous pouvez utiliser le sens choisi au travers du détecteur comme si vous étiez à sa place. En utilisant votre action, vous pouvez alterner entre la vue et l'audition via le détecteur.",
+      "Une créature qui peut voir le détecteur (comme une créature bénéficiant du sort voir l'invisible ou de vision véritable) voit un orbe lumineux et intangible de la taille de votre poing."
+    ],
+    "range": "1,5 km",
+    "components": ["V", "S", "M"],
+    "material": "Un focaliseur d'une valeur d'au moins 100 po, soit une corne pour entendre enchâssée de gemme, soit un œil de verre pour voir.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "10 minutes",
+    "level": 3,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/clairvoyance"
+  },
+  {
+    "index": "clone",
+    "name": "Clone",
+    "desc": [
+      "Ce sort crée le double inerte d'une créature vivante, servant de protection contre la mort. Ce clone se forme à l'intérieur du récipient utilisé par le sort et atteint sa taille maximale et sa maturité au bout de 120 jours ; vous pouvez également choisir d'avoir un clone d'une version plus jeune de la même créature. Ce clone reste inerte et persiste indéfiniment, tant que son contenant n'est pas dérangé.",
+      "À n'importe quel moment, une fois le clone mature, si la créature originale meurt, son âme est transférée dans le clone, à condition que l'âme soit libre et qu'elle soit consentante à son retour à la vie. Le clone est physiquement identique à l'original et a la même personnalité, les mêmes souvenirs, et les mêmes caractéristiques, mais pas l'équipement d'origine. Le corps original de la créature reste où il est, s'il existe encore, il devient inerte et ne peut revenir à la vie tant que son âme est ailleurs."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "un diamant d'une valeur d'au moins 1 000 po et au moins 1 cube de 2,50 cm d'arête de chair de la créature qui doit être clonée, que le sort consomme, et un récipient d'une valeur d'au moins 2 000 po qui a un couvercle scellable et qui est suffisamment grand pour contenir la créature à cloner, comme une grande urne, un coffre, un kyste rempli de boue sur le sol ou un contenant en cristal rempli d'eau salée",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 8,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/clone"
+  },
+  {
+    "index": "cloudkill",
+    "name": "Brume mortelle",
+    "desc": [
+      "Vous créez une sphère de 6 mètres de rayon remplie d'un brouillard toxique verdâtre, centré sur un point dans la portée du sort. Le brouillard contourne les coins. Il persiste pour la durée du sort ou jusqu'à ce qu'un vent fort le disperse, mettant ainsi fin au sort. La visibilité de la zone est nulle.",
+      "Lorsqu'une créature pénètre dans la zone du sort pour la première fois ou lorsqu'elle y débute son tour, cette créature doit effectuer un jet de sauvegarde de Constitution, subissant 5d8 dégâts de poison en cas d'échec, ou la moitié de ces dégâts en cas de réussite. Les créatures sont affectées même si elles retiennent leur souffle ou si elles n'ont pas besoin de respirer.",
+      "Le brouillard s'éloigne de vous au début de votre tour, au rythme de 3 mètres par tour. Il roule sur la surface du sol. La vapeur toxique étant plus lourde que l'air, elle descend dans les creux du relief et elle s'infiltre dans les ouvertures."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, les dégâts augmentent de 1d8 pour chaque niveau d'emplacement au-delà du niveau 5."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "damage": {
+      "damage_type": {
+        "index": "poison",
+        "name": "Poison",
+        "url": "/api/2014/damage-types/poison"
+      },
+      "damage_at_slot_level": {
+        "5": "5d8",
+        "6": "6d8",
+        "7": "7d8",
+        "8": "8d8",
+        "9": "9d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half",
+      "desc": "Les créatures sont affectées même si elles retiennent leur souffle ou si elles n'ont pas besoin de respirer."
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/cloudkill"
+  },
+  {
+    "index": "color-spray",
+    "name": "Couleurs dansantes",
+    "desc": [
+      "Un assortiment éblouissant de faisceaux lumineux et colorés fait éruption de votre main. Lancez 6d10. Cette valeur représente le nombre maximal de points de vie des créatures que vous pouvez affecter avec ce sort. Les créatures dans un cône de 4,50 mètres dont vous êtes l'origine sont affectées selon l'ordre croissant de leurs points de vie (en ignorant les créatures inconscientes et celles qui ne peuvent pas voir).",
+      "En partant de la créature avec le plus petit nombre de points de vie, chaque créature affectée par ce sort est aveuglée jusqu'à la fin de votre prochain tour. Retirez les points de vie de chaque créature avant de passer à la prochaine créature avec le plus petit nombre de points de vie. Les points de vie d'une créature doivent être égaux ou inférieurs au total pour que cette créature soit affectée."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, ajoutez 2d10 au lancer initial pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poudre ou de sable de couleur rouge, jaune et bleu.",
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "cone",
+      "size": 15
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/color-spray"
+  },
+  {
+    "index": "command",
+    "name": "Injonction",
+    "desc": [
+      "Vous donnez un ordre d'un mot à une créature dans la portée du sort et que vous pouvez voir. La cible doit réussir un jet de sauvegarde de Sagesse ou suivre l'ordre lors de son prochain tour. Le sort n'a aucun effet si la cible est un mort-vivant, si elle ne comprend pas la langue, ou si votre ordre est directement nocif pour elle.",
+      "Des injonctions typiques et leurs effets suivent. Vous pouvez émettre un ordre autre que ceux décrits ici. Si vous le faites, le MJ détermine comment la cible se comporte. Si la cible est empêchée de suivre votre ordre, le sort prend fin.",
+      "***Approche.*** La cible se déplace vers vous par le chemin le plus court et le plus direct, terminant son tour si elle arrive à 1,50 mètre ou moins de vous.",
+      "***Lâche.*** La cible lâche tout ce qu'elle tient et termine alors à son tour.",
+      "***Fuis.*** La cible s'éloigne de vous le plus rapidement possible.",
+      "***Tombe.*** La cible tombe au sol et termine alors à son tour.",
+      "***Halte.*** La cible ne bouge plus et n'entreprend aucune action."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous pouvez affecter une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 1. Les créatures que vous ciblez doivent toutes être dans un rayon de 9 mètres."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/command"
+  },
+  {
+    "index": "commune",
+    "name": "Communion",
+    "desc": [
+      "Vous entrez en contact avec votre dieu ou un intermédiaire divin et vous posez jusqu'à trois questions qui peuvent être répondues par oui ou par non. Vous devez poser vos questions avant la fin du sort. Vous recevez une réponse correcte à chaque question.",
+      "Les entités divines ne sont pas nécessairement omniscientes. Vous pouvez donc recevoir une réponse \" incertaine \" si la question concerne un sujet qui est hors du domaine de connaissance de la divinité. Dans le cas où une réponse monosyllabique s'avérerait déroutante ou opposée aux intérêts de la divinité, le MJ peut faire une courte phrase en guise de réponse.",
+      "Si vous incantez le sort plus d'une fois avant la fin de votre prochain repos long, il y a une probabilité cumulative de 25 % de ne recevoir aucune réponse et ce, pour chaque incantation après la première. Le MJ fait ce jet en secret."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "De l'encens et une fiole d'eau bénite ou maudite.",
+    "ritual": true,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/commune"
+  },
+  {
+    "index": "commune-with-nature",
+    "name": "Communion avec la nature",
+    "desc": [
+      "Vous ne faites brièvement qu'un avec la nature et obtenez des informations sur le territoire alentour. À l'extérieur, le sort vous donne la connaissance du terrain à 4,5 km autour de vous. Dans des grottes ou tout autre milieu souterrain, le rayon de connaissance est réduit à 90 mètres. Le sort ne fonctionne pas là où des constructions ont pris la place de la nature, comme dans des donjons ou des villes. Vous obtenez instantanément la connaissance de trois types d'informations sur la zone, parmi celles proposées ci-dessous :",
+      "- terrain et plans d'eau",
+      "- plantes, minéraux, animaux ou peuples courants",
+      "- puissants célestes, fiélons, fées, élémentaires ou morts-vivants",
+      "- influence des autres plans d'existence",
+      "- bâtiments",
+      "Par exemple, vous pourriez déterminer l'emplacement d'un puissant mort-vivant dans la zone, la localisation des principales sources d'eau potables, et situer les villes à proximité."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/commune-with-nature"
+  },
+  {
+    "index": "comprehend-languages",
+    "name": "Compréhension des langues",
+    "desc": [
+      "Pendant la durée du sort, vous comprenez la signification littérale de toute langue parlée que vous pouvez entendre. Vous comprenez également tout langage écrit que vous pouvez voir, mais vous devez toucher la surface sur laquelle les mots sont inscrits. Il faut une minute pour lire une page de texte.",
+      "Ce sort ne décode pas les messages secrets dans un texte ou un glyphe, tel qu'un symbole magique, qui ne fait pas partie du langage écrit."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de suie et de sel.",
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/comprehend-languages"
+  },
+  {
+    "index": "compulsion",
+    "name": "Compulsion",
+    "desc": [
+      "Les créatures de votre choix, à portée, que vous pouvez voir et qui peuvent vous entendre, doivent effectuer un jet de sauvegarde de Sagesse. Une cible réussit automatiquement son jet de sauvegarde si elle ne peut pas être charmée. En cas d'échec, une cible est affectée par ce sort. Jusqu'à la fin du sort, vous pouvez utiliser votre action bonus à chacun de vos tours pour désigner une direction horizontale. Chaque cible affectée doit utiliser tout son mouvement possible pour se déplacer dans cette direction lors de son prochain tour. Elle peut effectuer son action avant d'utiliser son mouvement. Après s'être déplacée de la sorte, elle peut effectuer un autre jet de sauvegarde de Sagesse pour tenter de mettre fin à l'effet.",
+      "Une cible n'est pas contrainte de se déplacer dans une direction si celle-ci est manifestement mortelle, comme un feu ou un gouffre, mais elle provoquera des attaques d'opportunité en se déplaçant dans la direction désignée."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/compulsion"
+  },
+  {
+    "index": "cone-of-cold",
+    "name": "Cône de froid",
+    "desc": [
+      "Un souffle d'air froid est propulsé de vos mains. Chaque créature se trouvant dans les 18 mètres du cône doit effectuer un jet de sauvegarde de Constitution. Une créature subit 8d8 dégâts de froid en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Une créature tuée par le sort devient une statue de glace jusqu'à son dégel."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, les dégâts augmentent de 1d8 pour chaque niveau d'emplacement au-delà du niveau 5."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un petit cône de cristal ou de verre.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "damage": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "damage_at_slot_level": {
+        "5": "8d8",
+        "6": "9d8",
+        "7": "10d8",
+        "8": "11d8",
+        "9": "12d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half",
+      "desc": "Une créature tuée par le sort devient une statue de glace jusqu'à son dégel."
+    },
+    "area_of_effect": {
+      "type": "cone",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/cone-of-cold"
+  },
+  {
+    "index": "confusion",
+    "name": "Confusion",
+    "desc": [
+      "Ce sort assaille et tord les esprits des créatures, générant des illusions et provoquant des actions incontrôlées. Chaque créature dans une sphère de 3 mètres de rayon centrée sur un point choisi dans la portée du sort doit réussir un jet de sauvegarde de Sagesse, sans quoi elle sera affectée par le sort.",
+      "Une cible affectée ne peut réagir et elle doit lancer 1d10 au début de chacun de ses tours pour déterminer son comportement pour ce tour.",
+      "| d10 | Comportement |",
+      "|---|---|",
+      "| 1 | La créature emploie tout son mouvement pour se déplacer de façon aléatoire. Pour déterminer la direction, lancez 1d8 et assignez une direction à chaque face. La créature ne prend pas d'action pour ce tour. |",
+      "| 2-6 | La créature ne se déplace pas et elle ne prend pas d'action pour ce tour. |",
+      "| 7-8 | La créature prend son action pour faire une attaque au corps à corps contre une créature à sa portée, déterminée de façon aléatoire. Si aucune créature n'est à sa portée, la créature ne fait rien pour ce tour. |",
+      "| 9-10 | La créature peut agir et se déplacer normalement. |",
+      "À la fin de chacun de ses tours, une créature affectée peut faire un jet de sauvegarde de Sagesse. En cas de réussite, l'effet du sort prend fin pour cette cible."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 5 ou supérieur, le rayon de la sphère augmente de 1,50 mètre pour chaque niveau d'emplacement au-delà du niveau 4."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Trois coquilles de noix.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/confusion"
+  },
+  {
+    "index": "conjure-animals",
+    "name": "Invocation d'animaux",
+    "desc": [
+      "Vous invoquez les esprits des fées qui prennent la forme de bêtes et apparaissent dans des espaces inoccupés à portée que vous pouvez voir. Choisissez ce qui apparaîtra via l'une des options suivantes :",
+      "- Une bête de FP 2 ou inférieur",
+      "- Deux bêtes de FP 1 ou inférieur",
+      "- Quatre bêtes de FP 1/2 ou inférieur",
+      "- Huit bêtes de FP 1/4 ou inférieur",
+      "Chaque bête est également considérée comme une fée, et elle disparaît lorsqu'elle tombe à 0 point de vie ou lorsque le sort prend fin.",
+      "Les créatures invoquées sont amicales envers vous et vos compagnons. Lancez l'initiative pour le groupe de créatures invoquées ; il a ses propres tours de jeu. Elles obéissent aux ordres verbaux que vous leur donnez (aucune action n'est requise de votre part). Si vous ne leur donnez aucun ordre, elles ne font que se défendre contre les créatures qui leur sont hostiles.",
+      "Le MJ possède les statistiques des créatures."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant certains niveaux d'emplacement de sort, vous choisissez l'option d'invocation ci-dessus, et plus de créatures apparaissent : deux fois plus de créatures invoquées avec un emplacement de sort de niveau 5, trois fois plus avec un emplacement de sort de niveau 7, et quatre fois plus avec un emplacement de sort de niveau 9."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/conjure-animals"
+  },
+  {
+    "index": "conjure-celestial",
+    "name": "Invocation de céleste",
+    "desc": [
+      "Vous invoquez un céleste de FP 4 ou inférieur, qui apparaît dans un espace inoccupé que vous pouvez voir et à portée. Le céleste disparaît lorsqu'il tombe à 0 point de vie ou lorsque le sort prend fin.",
+      "Le céleste a une attitude amicale envers vous et vos compagnons pour la durée du sort. Lancez l'initiative pour le céleste ; il a ses propres tours de jeu. Il obéit aux ordres verbaux que vous lui donnez (aucune action n'est requise de votre part), tant qu'elles ne sont pas en contradiction avec son alignement. Si vous ne lui donnez aucun ordre, le céleste ne fait que se défendre contre les créatures qui lui sont hostiles.",
+      "Le MJ possède les statistiques du céleste."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 9, vous invoquez un céleste de FP 5 ou inférieur."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 minute",
+    "level": 7,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/conjure-celestial"
+  },
+  {
+    "index": "conjure-elemental",
+    "name": "Invocation d'élémentaire",
+    "desc": [
+      "Vous invoquez un serviteur élémentaire. Choisissez une zone cubique de 3 mètres d'arête remplie d'air, de terre, de feu ou d'eau et à portée. Un élémentaire de FP 5 ou inférieur, approprié à la zone, apparaît dans un espace inoccupé dans un rayon de 3 mètres autour de cette zone. Par exemple, un élémentaire du feu surgira d'un bûcher, et un élémentaire de la terre émergera du sol. L'élémentaire disparaît lorsqu'il tombe à 0 point de vie ou lorsque le sort prend fin. L'élémentaire a une attitude amicale envers vous et vos compagnons pour la durée du sort. Lancez l'initiative pour l'élémentaire ; il a ses propres tours de jeu. Il obéit aux ordres verbaux que vous lui donnez (aucune action n'est requise de votre part). Si vous ne lui donnez aucun ordre, l'élémentaire ne fait que se défendre contre les créatures qui lui sont hostiles.",
+      "Si votre concentration est brisée, l'élémentaire ne disparaît pas, mais vous perdez le contrôle de l'élémentaire. Il devient hostile envers vous et vos compagnons, et peut même vous attaquer. Vous ne pouvez pas renvoyer un élémentaire incontrôlé, il disparaîtra 1 heure après son invocation.",
+      "Le MJ possède les statistiques de l'élémentaire."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, le FP de l'élémentaire invoqué augmente de 1 pour chaque niveau d'emplacement au-delà du niveau 5."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De l'encens allumé pour l'air, de l'argile malléable pour la terre, du soufre et du phosphore pour le feu, ou de l'eau et du sable pour l'eau.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 minute",
+    "level": 5,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 10
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/conjure-elemental"
+  },
+  {
+    "index": "conjure-fey",
+    "name": "Invocation de fée",
+    "desc": [
+      "Vous invoquez une créature de type fée de FP 6 ou inférieur, ou un esprit féérique qui prend la forme d'une bête de FP 6 ou inférieur. Elle apparaît dans un espace inoccupé que vous pouvez voir et à portée. La fée disparaît lorsqu'elle tombe à 0 point de vie ou lorsque le sort prend fin.",
+      "La fée a une attitude amicale envers vous et vos compagnons pour la durée du sort. Lancez l'initiative pour la fée ; elle a ses propres tours de jeu. Elle obéit aux ordres verbaux que vous lui donnez (aucune action n'est requise de votre part), tant qu'ils ne sont pas en contradiction avec son alignement. Si vous ne lui donnez aucun ordre, la fée ne fait que se défendre contre les créatures qui lui sont hostiles. Si votre concentration est interrompue, la fée ne disparaît pas. Au lieu de cela, vous perdez le contrôle de la créature, elle devient hostile envers vous et vos compagnons, et peut vous attaquer. Vous ne pouvez pas renvoyer une fée que vous ne contrôlez plus. Elle disparaît 1 heure après que vous l'ayez invoquée.",
+      "Le MJ possède les statistiques de la fée."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 7 ou supérieur, le FP augmente de 1 pour chaque niveau d'emplacement au-delà du niveau 6."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 minute",
+    "level": 6,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/conjure-fey"
+  },
+  {
+    "index": "conjure-minor-elementals",
+    "name": "Invocation d'élémentaires mineurs",
+    "desc": [
+      "Vous invoquez les élémentaires qui apparaissent dans un espace inoccupé à portée, que vous pouvez voir. Vous choisissez l'une des options d'apparition suivantes :",
+      "- Un élémentaire de FP 2 ou inférieur",
+      "- Deux élémentaires de FP 1 ou inférieur",
+      "- Quatre élémentaires de FP 1/2 ou inférieur",
+      "- Huit élémentaires de FP 1/4 ou inférieur",
+      "Un élémentaire invoqué par ce sort disparaît lorsqu'il tombe à 0 point de vie ou lorsque le sort prend fin.",
+      "Les créatures invoquées ont une attitude amicale envers vous et vos compagnons. Lancez l'initiative pour le groupe de créatures invoquées ; il a ses propres tours de jeu. Elles obéissent aux ordres verbaux que vous leur donnez (aucune action n'est requise de votre part). Si vous ne leur donnez aucun ordre, elles ne font que se défendre contre les créatures qui leur sont hostiles.",
+      "Le MJ possède les statistiques des créatures."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant certains niveaux d'emplacements de sorts supérieurs, vous choisissez l'une des options d'invocations ci-dessus, et un nombre plus important de créatures apparaîtra ; deux fois plus avec un emplacement de sort de niveau 6 et trois fois plus avec un emplacement de sort de niveau 8."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 minute",
+    "level": 4,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/conjure-minor-elementals"
+  },
+  {
+    "index": "conjure-woodland-beings",
+    "name": "Invocation d'êtres sylvestres",
+    "desc": [
+      "Vous invoquez des créatures de type fée qui apparaissent dans un espace inoccupé que vous pouvez voir et à portée. Choisissez l'une des options d'invocation suivantes :",
+      "- Une fée de FP 2 ou inférieur,",
+      "- Deux fées de FP 1 ou inférieur",
+      "- Quatre fées de FP 1/2 ou inférieur",
+      "- Huit fées de FP 1/4 ou inférieur",
+      "Une créature invoquée disparaît lorsqu'elle tombe à 0 point de vie ou lorsque le sort se termine.",
+      "Les créatures invoquées ont une attitude amicale envers vous et vos compagnons. Lancez l'initiative pour le groupe de créatures invoquées ; il a ses propres tours de jeu. Elles obéissent aux ordres verbaux que vous leur donnez (aucune action n'est requise de votre part). Si vous ne leur donnez aucun ordre, elles ne font que se défendre contre les créatures qui leur sont hostiles.",
+      "Le MJ possède les statistiques des créatures."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant des niveaux d'emplacements de sorts supérieurs, vous choisissez l'une des options d'invocation ci-dessus, et un nombre plus important de créatures apparaîtra ; deux fois plus avec un emplacement de sort de niveau 6 et trois fois plus avec un emplacement de sort de niveau 8."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une baie sacrée par créature invoquée.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/conjure-woodland-beings"
+  },
+  {
+    "index": "contact-other-plane",
+    "name": "Contact avec les plans",
+    "desc": [
+      "Vous contactez mentalement un demi-dieu, l’esprit d’un sage défunt ou quelque autre entité mystérieuse d’un autre plan. Entrer en contact une telle conscience extraplanaire peut vous surmener, voire vous anéantir mentalement. À l’incantation du sort, effectuez un jet de sauvegarde d’Intelligence DD 15. En cas d’échec, vous subissez 6d6 dégâts psychiques et délirez jusqu’à ce que vous terminiez un repos long. Tant que vous délirez, vous ne pouvez pas entreprendre d’action, ne comprenez pas ce que disent les autres, ne pouvez pas lire et proférez des propos incohérents. Le sort restauration suprême met un terme à cet effet s’il est lancé sur vous.",
+      "En cas de sauvegarde réussie, vous pouvez poser jusqu’à cinq questions à l’entité. Vous devez les poser avant la fin du sort. Le MJ répond à chaque question par un seul mot, comme \"oui\", \" non \", \" peut-être \", \" jamais \", \" inconséquent \" ou \" incertain \" (si l’entité ne connaît pas la réponse). Si une réponse en un mot risque de s’avérer trompeuse, le MJ peut se fendre d’une courte phrase"
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": true,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "int",
+        "name": "INT",
+        "url": "/api/2014/ability-scores/int"
+      },
+      "dc_success": "other",
+      "desc": "En cas d'échec, vous subissez 6d6 dégâts psychiques et devenez dément jusqu'à ce que vous finissiez un repos long."
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/contact-other-plane"
+  },
+  {
+    "index": "contagion",
+    "name": "Contagion",
+    "desc": [
+      "Votre toucher est vecteur de maladie. Effectuez une attaque au corps à corps avec un sort contre une créature à portée. Si le coup touche, la cible est empoisonnée. À la fin de chacun des tours de la cible empoisonnée, celle-ci doit effectuer un jet de sauvegarde de Constitution. Si elle en réussit trois, la cible n'est plus empoisonnée et le sort prend fin. Si elle en échoue trois, la cible n'est plus empoisonnée mais vous choisissez une des maladies indiquées ci-dessous. La cible est alors sujette à cette maladie jusqu'à la fin de la durée du sort.",
+      "Étant donné que le sort reproduit une maladie naturelle chez sa cible, tout effet qui peut normalement guérir une maladie, ou au moins en réduire les effets, s'applique.",
+      "***Mal aveuglant.*** La créature a du mal à réfléchir et ses yeux deviennent blancs laiteux. La créature a un désavantage aux jets de Sagesse et aux jets de sauvegarde de Sagesse. Elle est de plus aveuglée.",
+      "***Fièvre répugnante.*** Une violente fièvre se saisit du corps de la créature. La créature a un désavantage aux jets de Force, aux jets de sauvegarde de Force et aux jets d'attaque basés sur la Force.",
+      "***Pourriture.*** La chair de la créature se dégrade. La créature a un désavantage aux jets de Charisme et est vulnérable à tous les types de dégâts.",
+      "***Bouille-crâne.*** L'esprit de la créature devient fiévreux. La créature a un désavantage aux jets d'Intelligence et aux jets de sauvegarde d'Intelligence. De plus, la créature se comporte comme si elle était sous l'effet d'un sort de confusion lorsqu'elle est en combat.",
+      "***Convulsions.*** La créature est parcourue de tremblements incontrôlés. La créature a un désavantage aux jets de Dextérité, aux jets de sauvegarde de Dextérité et aux jets d'attaque basés sur la Dextérité.",
+      "***Mort poisseuse.*** La créature perd du sang de manière incontrôlable. La créature a un désavantage aux jets de Constitution et aux jets de sauvegarde de Constitution. De plus, chaque fois que la créature subit des dégâts, elle est étourdie jusqu'à la fin de son tour suivant."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "7 jours",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "attack_type": "mélée",
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "other",
+      "desc": "Après avoir réussi trois de ses jets de sauvegarde la cible n'est plus empoisonnée et le sort prend fin."
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/contagion"
+  },
+  {
+    "index": "contingency",
+    "name": "Anticipation",
+    "desc": [
+      "Choisissez un sort du 5e niveau ou inférieur que vous pouvez lancer, dont le temps d’incantation est de 1 action et qui peut vous cibler. Vous lancez le sort concerné, qu’on appellera \" sort anticipé \", dans le cadre de l’incantation d’anticipation, et acquittez les emplacements des deux sorts. Le sort anticipé n’agit toutefois pas aussitôt. Au lieu de cela, il ne prendra effet que si certaines conditions sont réunies. Vous décrivez ces conditions à l’incantation des deux sorts. Exemple : une anticipation lancée en conjonction avec respiration aquatique pourrait stipuler que respiration aquatique prendra effet lorsque vous serez englouti par les eaux ou un liquide comparable.",
+      "Le sort anticipé prend effet aussitôt après que les conditions sont réunies pour la première fois, que vous le vouliez ou non, puis l’anticipation prend fin.",
+      "Le sort anticipé ne prend effet que sur vous, même s’il est susceptible d’avoir d’autres cibles en temps normal. Vous ne pouvez recourir qu’à un sort d’anticipation à la fois. Si vous relancez ce sort, l’anticipation qui vous affectait déjà prend fin. L’anticipation prend également fin si sa composante matérielle n’est plus sur vous."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une statuette à votre effigie, sculptée dans l’ivoire et sertie de gemmes, d’une valeur minimale de 1 500 po.",
+    "ritual": false,
+    "duration": "10 jours",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 6,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/contingency"
+  },
+  {
+    "index": "continual-flame",
+    "name": "Flamme éternelle",
+    "desc": [
+      "Une flamme, d'une luminosité équivalente à celle d'une torche, fait éruption depuis un objet que vous touchez. L'effet ressemble à une flamme régulière, mais il ne produit aucune chaleur et ne nécessite pas d'oxygène. Une flamme éternelle peut être recouverte ou dissimulée, mais elle ne peut pas être étouffée ou éteinte."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De la poussière de rubis valant 50 po, que le sort consomme.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/continual-flame"
+  },
+  {
+    "index": "control-water",
+    "name": "Contrôle de l'eau",
+    "desc": [
+      "Jusqu'à la fin du sort, vous contrôlez toute étendue d'eau libre dans une zone cubique de 30 mètres d'arête de votre choix. Vous pouvez choisir parmi les effets suivants lors de l'incantation du sort. Par une action, durant votre tour, vous pouvez répéter le même effet ou en choisir un nouveau.",
+      "***Crue.*** Vous provoquez l'augmentation de 6 mètres du niveau de toute l'eau présente dans la zone d'effet. Si la zone d'effet comprend une berge, l'eau se déverse sur le sol sec. Si votre zone d'effet se trouve au sein d'une importante étendue d'eau, vous créez plutôt une vague de 6 mètres de haut qui part d'un côté de la zone d'effet et se déplace jusqu'au côté opposé avant de se briser. Tout véhicule de taille TG ou inférieure frappé par la vague a 25 % de risque de chavirer.",
+      "Le niveau de l'eau reste élevé jusqu'à la fin du sort ou jusqu'à ce que vous choisissiez un effet différent. Si cet effet produit une vague, la vague se répète au début de votre tour suivant tant que l'effet de Crue est effectif.",
+      "***Scinder l'eau.*** Vous déplacez l'eau dans la zone de sorte à créer une tranchée. La tranchée s'étend au travers de la zone d'effet du sort, et scinde l'eau en deux, formant un mur de chaque côté. La tranchée reste en place jusqu'à la fin du sort ou jusqu'à ce que vous choisissiez un nouvel effet. L'eau remplit alors lentement la tranchée jusqu'au tour suivant, ramenant l'eau à son niveau normal.",
+      "***Diriger le courant.*** Vous provoquez un courant dans la zone d'effet qui se dirige dans la direction de votre choix, même si l'eau doit pour cela submerger des obstacles, passer au-dessus des murs, ou prendre d'autres directions improbables. L'eau dans la zone d'effet se déplace dans la direction souhaitée, mais une fois en dehors de la zone d'effet, elle retrouve un courant basé sur les caractéristiques du terrain. L'eau continue à se déplacer dans la direction choisie jusqu'à ce que le sort prenne fin ou que vous choisissiez un nouvel effet.",
+      "***Tourbillon.*** Cet effet requiert une étendue d'eau large de 15 mètres et profonde de 7,50 mètres minimum. Vous créez un tourbillon qui se forme au centre de la zone d'effet. Le tourbillon produit un vortex large de 1,50 mètre à son pôle inférieur, large de 15 mètres à son pôle supérieur, et profond de 7,50 mètres. Toute créature ou objet dans l'eau à 7,50 mètres du vortex est attiré de 3 mètres vers lui. Une créature peut nager pour s'éloigner du vortex à condition de réussir un jet de Force (Athlétisme) contre le DD de sauvegarde de votre sort.",
+      "La première fois, à chaque tour, qu'un objet entre dans le vortex, l'objet subit 2d8 dégâts contondants ; ces dégâts sont de nouveau infligés à chaque tour que l'objet passe dans le vortex."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte d'eau et une pincée de sable.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Contondant",
+        "url": "/api/2014/damage-types/bludgeoning"
+      },
+      "damage_at_slot_level": {
+        "4": "2d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "str",
+        "name": "FOR",
+        "url": "/api/2014/ability-scores/str"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 100
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/control-water"
+  },
+  {
+    "index": "control-weather",
+    "name": "Contrôle du climat",
+    "desc": [
+      "Vous prenez le contrôle du climat sur 7,5 km autour de vous pour la durée du sort. Vous devez être à l'extérieur pour lancer ce sort. Vous déplacer à un endroit d'où vous n'avez pas une vue dégagée sur le ciel met fin au sort prématurément.",
+      "Lorsque vous lancez ce sort, vous modifiez les conditions climatiques actuelles, qui sont déterminées par le MJ en fonction du climat et de la saison. Vous pouvez modifier les précipitations, la température et le vent. Cela prend 1d4 x 10 minutes pour que de nouvelles conditions météorologiques prennent effets. Une fois qu'elles sont en place, vous pouvez les modifier à nouveau. Lorsque le sort prend fin, le climat retourne progressivement à la normale.",
+      "Lorsque vous modifiez les conditions climatiques, cherchez l'état climatique actuel dans les tables ci-dessous et modifiez cet état d'un rang, inférieur ou supérieur. Lorsque vous modifiez le vent, vous pouvez en modifier la direction.",
+      "##### Précipitation",
+      "| État | Condition |",
+      "|---|---|",
+      "| 1 | Dégagé |",
+      "| 2 | Nuages légers |",
+      "| 3 | Ciel couvert ou brouillard |",
+      "| 4 | Pluie, neige ou grêle |",
+      "| 5 | Pluie torrentielle, tempête de grêle ou blizzard |",
+      "##### Température",
+      "| État | Condition |",
+      "|---|---|",
+      "| 1 | Fournaise insoutenable |",
+      "| 2 | Chaud |",
+      "| 3 | Doux |",
+      "| 4 | Frais |",
+      "| 5 | Froid |",
+      "| 6 | Froid arctique |",
+      "##### Vent",
+      "| État | Condition |",
+      "|---|---|",
+      "| 1 | Calme |",
+      "| 2 | Vent modéré |",
+      "| 3 | Vent fort |",
+      "| 4 | Vent violent |",
+      "| 5 | Ouragan |"
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "De l'encens qui brûle et des morceaux de terre et de bois mélangés à de l'eau.",
+    "ritual": false,
+    "duration": "Jusqu'à 8 heures",
+    "concentration": true,
+    "casting_time": "10 minutes",
+    "level": 8,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/control-weather"
+  },
+  {
+    "index": "counterspell",
+    "name": "Contresort",
+    "desc": [
+      "Vous tentez d'interrompre une créature au moment où elle incante un sort. Si la créature incante un sort de niveau 3 ou inférieur, son sort échoue et il n'a aucun effet. Si elle incante un sort de niveau 4 ou supérieur, effectuez un jet de caractéristique selon celle qui sert à lancer vos sorts. Le DD est de 10 + le niveau du sort. En cas de réussite, le sort de la créature échoue et il n'a aucun effet."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, le sort interrompu n'a aucun effet si son niveau est inférieur ou égal à celui du niveau de l'emplacement de sort utilisé."
+    ],
+    "range": "18 mètres",
+    "components": ["S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 reaction",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/counterspell"
+  },
+  {
+    "index": "create-food-and-water",
+    "name": "Création de nourriture et d'eau",
+    "desc": [
+      "Vous créez 22,5 kg de nourriture et 120 litres d'eau sur le sol ou dans des contenants, à portée, ce qui est assez pour subvenir aux besoins de quinze humanoïdes ou de cinq montures pour 24 heures. La nourriture est fade mais nourrissante, et se gâte si elle n'est pas mangée au-delà de 24 heures. L'eau est claire et ne croupit pas."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/create-food-and-water"
+  },
+  {
+    "index": "create-undead",
+    "name": "Création de mort-vivant",
+    "desc": [
+      "Vous ne pouvez lancer ce sort que durant la nuit. Choisissez jusqu'à trois cadavres d'humanoïdes de taille M ou P à portée. Chaque cadavre devient une goule sous votre contrôle.",
+      "Par une action bonus, à chacun de vos tours, vous pouvez mentalement donner des ordres à toute créature que vous avez animée avec ce sort, si elle se trouve à 36 mètres ou moins de vous (si vous contrôlez de nombreuses créatures, vous pouvez donner vos ordres à plusieurs d'entre elles, voire à toutes, en même temps, à condition qu'elles reçoivent toutes le même ordre). Vous décidez quelle action la créature va effectuer et où elle va se déplacer au cours de son prochain tour, ou bien vous pouvez lui donner un ordre général, comme garder une chambre ou un couloir. Si vous ne donnez aucun ordre, la créature ne fait que se défendre contre les créatures hostiles. Une fois que vous avez donné votre ordre, la créature continue de le suivre jusqu'à ce que sa tâche soit accomplie.",
+      "La créature est sous votre contrôle pour 24 heures. Passé ce délai, elle cesse d'obéir aux ordres que vous lui avez donnés. Pour conserver votre contrôle sur la créature pour 24 heures supplémentaires, vous devez lancer ce sort sur la créature avant que la première période de 24 heures ne se termine. Cette utilisation de ce sort réaffirme votre contrôle sur trois créatures que vous avez déjà animées, plutôt que d'en animer de nouvelles."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 7, vous pouvez animer ou réaffirmer votre contrôle sur quatre goules. Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 8, vous pouvez animer ou réaffirmer votre contrôle sur cinq goules ou deux blêmes ou deux nécrophages. Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 9, vous pouvez animer ou réaffirmer votre contrôle sur six goules ou trois blêmes ou trois nécrophages ou deux momies."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un pot d'argile rempli de terre prélevée sur une tombe, un pot d'argile rempli d'eau croupie, et une pierre d'onyx noire valant au moins 150 po pour chaque cadavre.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 6,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/create-undead"
+  },
+  {
+    "index": "create-or-destroy-water",
+    "name": "Création ou destruction d'eau",
+    "desc": [
+      "Soit vous créez, soit vous détruisez de l'eau.",
+      "***Création d'eau.*** Vous créez jusqu'à 40 litres d'eau pure dans un contenant ouvert à portée. Vous pouvez sinon choisir de faire tomber l'eau sous forme de pluie dans un cube de 9 mètres d'arête à portée, éteignant ainsi les flammes non protégées de la zone.",
+      "***Destruction d'eau.*** Vous détruisez jusqu'à 40 litres d'eau présente dans un contenant ouvert à portée. Sinon, vous pouvez choisir de supprimer le brouillard dans un cube de 9 mètres d'arête à portée."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous créez ou détruisez 40 litres d'eau supplémentaires, ou augmentez la taille du cube de 1,50 mètre d'arête, pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte d'eau pour la création d'eau ou quelques grains de sable pour la destruction d'eau.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 30
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/create-or-destroy-water"
+  },
+  {
+    "index": "creation",
+    "name": "Création",
+    "desc": [
+      "Vous extirpez de la Gisombre des brumes ténébreuses qui vous serviront de matériau pour créer, à portée, un objet non vivant en matière végétale : du tissu, de la corde, du bois, ou quelque chose de similaire. Vous pouvez également utiliser ce sort pour créer un objet minéral comme de la pierre, du cristal ou du métal. L'objet créé ne doit pas dépasser un cube de 1,50 mètre d'arête, et vous devez déjà avoir vu la forme et les matériaux que vous souhaitez donner à l'objet.",
+      "La durée d'effet du sort dépend du matériau de l'objet. Si l'objet comporte plusieurs matériaux, utilisez la durée la plus courte.",
+      "| Matériau | Durée |",
+      "|---|---|",
+      "| Matière végétale | 1 jour |",
+      "| Pierre ou cristal | 12 heures |",
+      "| Métaux précieux | 1 heure |",
+      "| Gemmes | 10 minutes |",
+      "| Adamantium ou mithral | 1 minute |",
+      "Utiliser un matériau créé à l'aide du sort création en tant que composante matérielle d'un autre sort fait automatiquement échouer cet autre sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, les arêtes du cube augmentent de 1,50 mètre pour chaque niveau d'emplacement au-delà du niveau 5."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit bout de matériau du même type que celui composant l'objet que vous souhaitez créer.",
+    "ritual": false,
+    "duration": "Spéciale",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 5
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/creation"
+  },
+  {
+    "index": "cure-wounds",
+    "name": "Soins",
+    "desc": [
+      "Une créature que vous touchez récupère un nombre de points de vie égal à 1d8 + le modificateur de votre caractéristique d'incantation. Ce sort n'a pas d'effet sur les morts-vivants et les artificiels."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, la quantité de points de vie récupérés est augmentée de 1d8 pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "heal_at_slot_level": {
+      "1": "1d8 + MOD",
+      "2": "2d8 + MOD",
+      "3": "3d8 + MOD",
+      "4": "4d8 + MOD",
+      "5": "5d8 + MOD",
+      "6": "6d8 + MOD",
+      "7": "7d8 + MOD",
+      "8": "8d8 + MOD",
+      "9": "9d8 + MOD"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/cure-wounds"
+  },
+  {
+    "index": "dancing-lights",
+    "name": "Lumières dansantes",
+    "desc": [
+      "Ce sort permet de créer jusqu'à quatre lumières, de la taille de torches, qui peuvent revêtir l'apparence de torches, de lanternes ou d'orbes brillantes qui flottent dans les airs. Il est possible de combiner les quatre lumières en une forme vaguement humanoïde brillante de taille M. Peu importe la forme choisie, chaque lumière produit une lumière faible qui éclaire dans un rayon de 3 mètres.",
+      "Au prix d'une action bonus lors de votre tour, il est possible de déplacer les lumières jusqu'à 18 mètres vers un nouvel emplacement à portée. Une lumière doit se situer à 6 mètres ou moins d'une autre lumière créée par ce sort, et une lumière s'éclipse si elle se trouve au-delà de la portée du sort."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "un peu de phosphore ou d'écorce d'orme blanc, ou bien un ver luisant.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/dancing-lights"
+  },
+  {
+    "index": "darkness",
+    "name": "Ténèbres",
+    "desc": [
+      "Des ténèbres magiques s'étendent d'un point de votre choix dans la portée du sort pour remplir une sphère de 4,50 mètres de rayon pour la durée du sort. Ces ténèbres contournent les coins. Une créature avec la vision dans le noir ne peut percer ces ténèbres et une lumière non magique ne peut y éclairer.",
+      "Si le point choisi est un objet que vous portez ou qui n'est pas porté ou transporté, les ténèbres émanent de l'objet et elles se déplacent avec lui. Recouvrir complètement la source des ténèbres avec un objet opaque, comme un bol ou un casque, bloque les ténèbres.",
+      "Si n'importe quelle portion de ce sort chevauche une portion de lumière créée par un sort de niveau 2 ou moins, le sort de lumière est alors dissipé."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "M"],
+    "material": "Des poils de chauve-souris et une goutte de goudron ou un morceau de charbon.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 15
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/darkness"
+  },
+  {
+    "index": "darkvision",
+    "name": "Vision dans le noir",
+    "desc": [
+      "Vous touchez une créature consentante pour lui conférer la capacité de voir dans le noir. Pour la durée du sort, cette créature obtient la vision dans le noir (portée 18 mètres)."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Soit une pincée de carotte séchée, soit une agate.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/darkvision"
+  },
+  {
+    "index": "daylight",
+    "name": "Lumière du jour",
+    "desc": [
+      "Une sphère de lumière de 18 mètres de rayon jaillit d'un point choisi dans la portée du sort. La sphère est composée de lumière vive et elle émet une lumière faible sur 18 mètres supplémentaires.",
+      "Si vous choisissez un point sur un objet que vous tenez ou sur un objet qui n'est pas porté ou transporté, la lumière émane de cet objet et se déplace avec lui. En recouvrant complètement l'objet affecté avec un objet opaque, comme un bol ou un casque, la lumière est bloquée.",
+      "Si une portion de la zone du sort chevauche une zone de ténèbres créée par un sort de niveau 3 ou moindre, le sort qui génère les ténèbres est dissipé."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/daylight"
+  },
+  {
+    "index": "death-ward",
+    "name": "Protection contre la mort",
+    "desc": [
+      "Vous touchez une créature et vous lui octroyez une mesure de protection contre la mort.",
+      "La première fois que la cible atteint 0 point de vie à cause de dégâts reçus, la cible passe à 1 point de vie et le sort prend fin.",
+      "Si le sort est toujours actif lorsque la cible est victime d'un effet qui la tuerait instantanément sans causer de dégât, cet effet est nul pour la cible, et le sort prend fin."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/death-ward"
+  },
+  {
+    "index": "delayed-blast-fireball",
+    "name": "Boule de feu à retardement",
+    "desc": [
+      "La pointe de votre doigt émet un rayon de lumière jaune qui se concentre sur un point dans la portée du sort et prend la forme d'une bille luisante pour la durée du sort. Lorsque le sort prend fin, soit parce que votre concentration est interrompue, soit parce que vous décidez d'y mettre fin, la bille s'ouvre dans un rugissement grave et laisse éclater des flammes qui contournent les coins. Chaque créature dans une sphère de 6 mètres de rayon centrée sur ce point doit effectuer un jet de sauvegarde de Dextérité, subissant un nombre de dégâts de feu égal à la somme cumulée en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Les dégâts de base sont 12d6. Si à la fin de votre tour la bille n'a pas encore explosé, les dégâts augmentent de 1d6.",
+      "Si la bille luisante est touchée avant la fin du sort, la créature qui la touche doit effectuer un jet de sauvegarde de Dextérité. En cas d'échec, le sort prend fin, déclenchant l'éruption de la bille en flammes. En cas de réussite, la créature peut lancer la bille jusqu'à 12 mètres. Lorsqu'elle atteint une créature ou un objet solide, le sort prend fin et la bille explose.",
+      "Le feu endommage les objets dans la zone et enflamme les objets inflammables qui ne sont pas portés ou transportés."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 8 ou supérieur, les dégâts de base augmentent de 1d6 pour chaque niveau d'emplacement au-delà du niveau 7."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "une toute petite boule de guano de chauve-souris et du souffre",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 7,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "7": "12d6",
+        "8": "13d6",
+        "9": "14d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/delayed-blast-fireball"
+  },
+  {
+    "index": "demiplane",
+    "name": "Demi-plan",
+    "desc": [
+      "Vous créez une porte d'ombres sur une surface plate et solide, que vous pouvez voir et à portée. La porte est suffisamment large pour permettre à des créatures de taille M de l'emprunter sans difficulté. Lorsqu'elle est ouverte, la porte conduit à un demi-plan qui semble être une salle vide de 9 mètres (en longueur, largeur et hauteur), faite de bois ou de pierres. Lorsque le sort se termine, la porte disparaît, et toute créature ou objet encore à l'intérieur du demi-plan y reste piégé, étant donné que la porte disparaît également de l'autre côté.",
+      "Chaque fois que vous lancez ce sort, vous pouvez créer un nouveau demi-plan, ou faire en sorte que la porte d'ombre que vous faites apparaître soit connectée avec un demi-plan que vous avez précédemment créé grâce à ce sort. De plus, si vous connaissez la nature et le contenu d'un demi-plan créé, via ce sort, par une autre créature, vous pouvez plutôt faire en sorte que votre porte d'ombre soit connectée à ce demi-plan."
+    ],
+    "range": "18 mètres",
+    "components": ["S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/demiplane"
+  },
+  {
+    "index": "detect-evil-and-good",
+    "name": "Détection du mal et du bien",
+    "desc": [
+      "Pour la durée du sort, vous savez si une aberration, un céleste, un élémentaire, une fée, un fiélon ou un mort-vivant est présent dans un rayon de 9 mètres autour de vous. Vous pouvez aussi déterminer sa localisation. De la même manière, vous savez si un objet ou un lieu à 9 mètres ou moins de vous a été consacré ou profané.",
+      "Le sort peut outrepasser la plupart des obstacles mais il est bloqué par 30 cm de pierre, 2,50 cm de métal ordinaire, une mince feuille de plomb ou 90 cm de bois ou de terre."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/detect-evil-and-good"
+  },
+  {
+    "index": "detect-magic",
+    "name": "Détection de la magie",
+    "desc": [
+      "Pour la durée du sort, vous percevez la présence de magie à 9 mètres ou moins de vous. Si vous percevez de la magie de cette manière, vous pouvez utiliser votre action pour discerner une faible aura enveloppant une créature ou un objet visible dans la zone qui présente de la magie. Vous déterminez aussi l'école de magie, le cas échéant.",
+      "Le sort peut outrepasser la plupart des obstacles mais il est bloqué par 30 cm de pierre, 2,50 cm de métal ordinaire, une mince feuille de plomb ou 90 cm de bois ou de terre."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/detect-magic"
+  },
+  {
+    "index": "detect-poison-and-disease",
+    "name": "Détection du poison et des maladies",
+    "desc": [
+      "Pour la durée du sort, vous pouvez percevoir la présence et localiser les poisons, les créatures venimeuses, et les maladies dans un rayon de 9 mètres autour de vous. Vous identifiez également le type de poison, de créature venimeuse, ou de maladie.",
+      "Le sort peut outrepasser la plupart des obstacles mais il est bloqué par 30 cm de pierre, 2,50 cm de métal ordinaire, une mince feuille de plomb ou 90 cm de bois ou de terre."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une feuille d'if.",
+    "ritual": true,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/detect-poison-and-disease"
+  },
+  {
+    "index": "detect-thoughts",
+    "name": "Détection des pensées",
+    "desc": [
+      "Pour la durée du sort, vous pouvez lire les pensées de certaines créatures. Lorsque vous incantez le sort et lors de votre action à chaque tour jusqu'à la fin du sort, vous pouvez concentrer votre esprit sur une créature que vous pouvez voir à 9 mètres ou moins de vous. Si la créature choisie possède une Intelligence de 3 ou moins, ou si elle ne parle aucun langage, la créature n'est pas affectée.",
+      "Vous lisez d'abord les pensées superficielles de la créature, ce qui occupe son esprit à cet instant. Lors d'une action, vous pouvez diriger votre attention sur les pensées d'une autre créature ou tenter d'approfondir votre lecture des pensées de la même créature. Si vous approfondissez votre lecture, la cible doit effectuer un jet de sauvegarde de Sagesse. En cas d'échec, vous obtenez l'accès à son raisonnement (le cas échéant), à son état émotif et à une pensée qui préoccupe son esprit sur un spectre plus large tel un souci, un amour ou une haine. En cas de réussite, le sort prend fin. Dans tous les cas, la cible est consciente que son esprit est sous votre regard. À moins que vous ne dirigiez votre attention sur les pensées d'une autre créature, la cible peut utiliser son action à son tour pour faire un jet d'Intelligence contre votre jet d'Intelligence. Si elle gagne l'opposition, le sort prend fin.",
+      "Les questions dirigées verbalement vers la cible orientent le fil de ses pensées. Ce sort est donc particulièrement efficace lors d'un interrogatoire.",
+      "Vous pouvez aussi employer ce sort pour détecter la présence de créatures pensantes qui vous sont invisibles. Lorsque vous lancez ce sort ou lors d'une action pendant la durée du sort, vous pouvez chercher des pensées à 9 mètres ou moins de vous. Le sort peut outrepasser la plupart des obstacles mais il est bloqué par 60 cm de pierre, 5 cm de métal ordinaire, ou une mince feuille de plomb. Vous ne pouvez pas détecter une créature possédant une Intelligence de 3 ou moins ou ne parlant aucun langage.",
+      "Après avoir détecté la présence d'une créature de cette manière, vous pouvez lire ses pensées pour le reste de la durée du sort tel que décrit ci-dessus, même si vous ne pouvez plus la voir, mais à condition qu'elle reste dans la portée du sort."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "A copper coin.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/detect-thoughts"
+  },
+  {
+    "index": "dimension-door",
+    "name": "Porte dimensionnelle",
+    "desc": [
+      "Vous vous téléportez de votre position actuelle vers un autre endroit dans la portée du sort. Vous arrivez exactement à l'endroit désiré. Ce peut être un lieu que vous voyez, que vous visualisez ou que vous pouvez décrire en énonçant une distance et une direction, comme \"60 mètres droit devant\" ou \"vers le haut, à 45 degrés sur 90 mètres\".",
+      "Vous pouvez transporter des objets tant que leurs poids ne dépassent pas votre capacité de chargement. Vous pouvez aussi emmener une créature consentante de votre taille ou plus petite, qui porte de l'équipement jusqu'à sa capacité de chargement. La créature doit être à 1,50 mètre ou moins de vous lorsque vous lancez ce sort.",
+      "Si vous devriez arriver à un endroit déjà occupé par un objet ou une créature, vous et la créature se déplaçant avec vous subissez 4d6 dégâts de force et la téléportation échoue."
+    ],
+    "range": "150 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_slot_level": {
+        "4": "4d6"
+      }
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/dimension-door"
+  },
+  {
+    "index": "disguise-self",
+    "name": "Déguisement",
+    "desc": [
+      "Vous changez d'apparence jusqu'à ce que le sort prenne fin ou que vous utilisiez une action pour le dissiper. Le changement inclut vos vêtements, votre armure, vos armes et les autres objets que vous portez. Vous pouvez paraître 30 cm plus grand ou plus petit, mince, obèse, ou entre les deux. Vous ne pouvez pas modifier votre type morphologique. Vous devez donc prendre une forme qui présente un arrangement similaire des membres. Par ailleurs, l'ampleur de l'illusion ne tient qu'à vous.",
+      "Les modifications apportées par ce sort ne résistent pas à une inspection physique. Par exemple, si vous utilisez ce sort pour ajouter un chapeau à votre accoutrement, les objets passeront à travers le chapeau et si on y touche, on ne sentira pas sa présence ou on tâtera plutôt votre tête et votre chevelure. Si vous utilisez ce sort pour paraître plus mince, la main d'une personne qui veut vous toucher entrera en contact avec votre corps alors que sa main semble libre d'obstruction.",
+      "Pour détecter que vous êtes déguisé, une créature peut utiliser son action pour inspecter votre apparence et elle doit réussir un jet d'Intelligence (Investigation) contre le DD de sauvegarde de votre sort."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/disguise-self"
+  },
+  {
+    "index": "disintegrate",
+    "name": "Désintégration",
+    "desc": [
+      "Un mince faisceau de lumière verte surgit de la pointe de votre doigt vers une cible visible dans la portée du sort. La cible peut être une créature, un objet ou une création de force magique, comme un mur façonné par mur de force.",
+      "Une créature ciblée par ce sort doit réussir un jet de sauvegarde de Dextérité ou subir 10d6 + 40 dégâts de force. La cible est désintégrée si ces dommages la laissent à 0 point de vie.",
+      "Une créature désintégrée et tout ce qu'elle porte et transporte, à l'exception des objets magiques, sont réduits à l'état de poussière. La créature peut être ramenée à la vie uniquement avec les sorts résurrection suprême et souhait.",
+      "Le sort désintègre automatiquement un objet non magique de taille G ou plus petit, ou une création de force magique. Si la cible est un objet ou une création de force de taille TG ou supérieure, le sort désintègre une portion équivalente à un cube de 3 mètres d'arête. Un objet magique n'est pas affecté par ce sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 7 ou supérieur, les dégâts sont augmentés de 3d6 pour chaque niveau d'emplacement au-delà du niveau 6."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De la magnétite et une pincée de poussière.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_slot_level": {
+        "6": "10d6 + 40"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 10
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/disintegrate"
+  },
+  {
+    "index": "dispel-evil-and-good",
+    "name": "Dissipation du mal et du bien",
+    "desc": [
+      "Une énergie chatoyante vous enveloppe et vous protège des fées, des morts-vivants et des créatures originaires d'autres plans que le plan matériel. Pour la durée du sort, les célestes, élémentaires, fées, fiélons et morts-vivants ont un désavantage aux jets d'attaque contre vous.",
+      "Vous pouvez mettre fin prématurément au sort en utilisant l'une ou l'autre des options suivantes.",
+      "***Annulation d'enchantement.*** Par une action, vous touchez une créature à portée qui est charmée, effrayée ou possédée par un céleste, un élémentaire, une fée, un fiélon ou un mort-vivant. La créature que vous touchez cesse immédiatement d'être charmée, effrayé ou possédée par de telles créatures.",
+      "***Renvoi.*** Par une action, effectuez une attaque au corps à corps avec un sort contre un céleste, un élémentaire, une fée, un fiélon ou un mort-vivant à portée. Si votre attaque touche, vous tentez de renvoyer cette créature sur son plan d'origine. La créature doit réussir un jet de sauvegarde de Charisme sous peine d'être envoyée sur son plan natif (si elle ne s'y trouve pas actuellement). S'ils ne sont pas sur leur plan natif, les morts-vivants sont envoyés dans la Gisombre et les fées dans la Féerie."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Eau bénite ou de la poudre de fer et d'argent.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "other",
+      "desc": "La créature doit réussir un jet de sauvegarde de Charisme sous peine d'être envoyée sur son plan natif (si elle ne s'y trouve pas actuellement)"
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/dispel-evil-and-good"
+  },
+  {
+    "index": "dispel-magic",
+    "name": "Dissipation de la magie",
+    "desc": [
+      "Choisissez une créature, un objet ou un effet magique dans la portée du sort. Tous les sorts actifs de niveau 3 ou moins sur la cible prennent fin. Pour chaque sort actif de niveau 4 ou plus sur la cible, effectuez un jet de votre caractéristique d'incantation. Le DD est de 10 + le niveau du sort. Si le jet est réussi, le sort prend fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, les effets d'un sort actif sur la cible prennent automatiquement fin si le niveau du sort est égal ou inférieur au niveau de l'emplacement de sort utilisé."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/dispel-magic"
+  },
+  {
+    "index": "divination",
+    "name": "Divination",
+    "desc": [
+      "Votre magie accompagnée d'une offrande vous met en contact avec votre dieu ou un de ses serviteurs. Vous posez une seule question en vue d'un objectif, d'un événement ou d'une activité spécifique qui pourrait se produire dans les 7 jours. Le MJ donne une réponse véridique. La réponse peut prendre la forme d'une courte phrase, d'un vers cryptique ou d'un présage.",
+      "Le sort ne considère pas les circonstances qui pourraient changer l'issue de la divination, comme l'incantation additionnelle de sorts ou la perte ou le gain d'un nouveau compagnon.",
+      "Si vous incantez le sort plus d'une fois avant la fin de votre prochain repos long, il y a une probabilité cumulative de 25 % de recevoir une réponse aléatoire, et ce, pour chaque incantation après la première. Le MJ fait ce jet en secret."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "De l'encens et une offrande sacrificielle appropriée à votre religion, valant au moins 25 po, que le sort consomme.",
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/divination"
+  },
+  {
+    "index": "divine-favor",
+    "name": "Faveur divine",
+    "desc": [
+      "Votre prière vous donne de la puissance dans un rayonnement divin. Jusqu'à ce que le sort se termine, vos attaques avec une arme infligent 1d4 dégâts radiants supplémentaires lorsqu'elles touchent."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "1": "1d4"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/divine-favor"
+  },
+  {
+    "index": "divine-word",
+    "name": "Parole divine",
+    "desc": [
+      "Vous prononcez une parole divine, emplie de la puissance qui a façonné le monde à l'aube de la création. Choisissez autant de créatures que vous le souhaitez parmi celles que vous voyez, dans la portée du sort. Chaque créature qui vous entend doit réussir un jet de sauvegarde de Charisme ou subir un effet selon la valeur actuelle de ses points de vie:",
+      "- 50 pv ou moins : assourdie pendant 1 minute",
+      "- 40 pv ou moins : assourdie et aveuglée pendant 10 minutes",
+      "- 30 pv ou moins : aveuglée, assourdie et étourdie pendant 1 heure",
+      "- 20 pv ou moins : tuée sur le coup",
+      "Indépendamment de ses points de vie actuels, un céleste, un élémentaire, une fée ou un fiélon qui échoue son jet est retourné à son plan d'origine (s'il n'y est pas déjà) et il ne peut revenir sur votre plan pendant 24 heures, peu importe le moyen, à l'exception du sort souhait."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 7,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec des jets de sauvegarde, la créature doit subir un effet selon la valeur actuelle de ses points de vie:."
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/divine-word"
+  },
+  {
+    "index": "dominate-beast",
+    "name": "Domination d’animal",
+    "desc": [
+      "Vous tentez de subjuguer une bête que vous voyez à portée. Elle doit réussir un jet de sauvegarde de Sagesse sous peine d’être charmée par vous pour toute la durée. Si vous ou des créatures qui vous sont amicales êtes en train de l’affronter, elle est avantagée au JS.",
+      "Tant que la bête est charmée et que vous êtes tous deux sur un même plan d’existence, vous entretenez avec elle un lien télépathique. Vous pouvez profiter de ce lien pour lui donner des instructions à condition d’être vous-même conscient (pas d’action requise), ordres auxquels la créature se soumet de son mieux. Vous pouvez spécifier une conduite simple et générique, comme \" Attaque cette créature \", \" File jusque-là \" ou \" Attrape cet objet \". Si la créature accomplit sa tâche et ne reçoit pas d’autre instruction de votre part, elle se défend et se protège de son mieux.",
+      "Vous pouvez consacrer votre action à prendre le contrôle total et précis de la cible. Jusqu’à la fin de votre tour suivant, la créature n’entreprend que les actions de votre choix et ne fait rien sans votre permission. Pendant cet intervalle, vous pouvez aussi lui faire jouer une réaction, au prix toutefois de votre propre réaction. Chaque fois que la cible subit des dégâts, elle effectue un nouveau jet de sauvegarde de Sagesse contre le sort. En cas de réussite, le sort prend fin"
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 5e niveau, la durée est \" concentration, jusqu’à 10 minutes \". Avec un emplacement de sort du 6e niveau, la durée devient \" concentration, jusqu’à 1 heure \". Avec un emplacement de sort du 7e niveau ou supérieur, la durée passe à \" concentration, jusqu’à 8 heures \"."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/dominate-beast"
+  },
+  {
+    "index": "dominate-monster",
+    "name": "Domination de monstre",
+    "desc": [
+      "Vous tentez de subjuguer une créature à portée que vous pouvez voir. Elle doit réussir un jet de sauvegarde de Sagesse ou être charmée pour la durée du sort. Si vous ou des créatures qui vous sont amies la combattez, elle bénéficie d'un avantage à son jet de sauvegarde.",
+      "Tant que la créature est charmée, vous établissez un contact télépathique avec elle aussi longtemps que vous vous trouvez tous les deux sur le même plan d'existence. Vous pouvez utiliser ce lien télépathique pour donner des ordres à la créature tant que vous êtes conscient (aucune action n'est requise). La créature fait tout ce qui est en son pouvoir pour obéir. Vous pouvez préciser un type d'action à la fois simple et général, comme \" Attaque cette créature \", \" Cours jusque-là \" ou \" Rapporte cet objet \". Si la créature exécute la demande et ne reçoit pas d'autres indications de votre part, elle se défend au mieux de sa capacité.",
+      "Vous pouvez utiliser une action pour obtenir le contrôle total et précis de la cible. Jusqu'à la fin de votre prochain tour, la créature agit seulement selon vos choix et elle ne peut rien faire sans que vous ne l'autorisiez. Pendant cette période, vous pouvez provoquer une réaction de la part de la créature, mais l'usage de cette réaction sera aussi le vôtre.",
+      "Chaque fois que la cible subit des dégâts, elle tente un nouveau jet de sauvegarde de Sagesse. Si elle réussit, le sort prend fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 9, la durée du sort sous concentration augmente jusqu'à 8 heures."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec des jets de sauvegarde, Vous charmez la créature pour la durée du sort."
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/dominate-monster"
+  },
+  {
+    "index": "dominate-person",
+    "name": "Domination de personne",
+    "desc": [
+      "Vous tentez de subjuguer un humanoïde à portée que vous pouvez voir. Celui-ci doit réussir un jet de sauvegarde de Sagesse ou être charmé pour la durée du sort. Si vous ou des créatures qui vous sont amies le combattez, il bénéficie d'un avantage à son jet de sauvegarde. Tant que la cible est charmée, vous établissez un contact télépathique avec elle aussi longtemps que vous vous trouvez tous les deux sur le même plan d'existence. Vous pouvez utiliser ce lien télépathique pour donner des ordres à la créature, tant que vous êtes conscient (aucune action n'est requise). La créature fait tout ce qui est en son pouvoir pour obéir. Vous pouvez préciser un type d'action à la fois simple et général, comme \"Attaque cette créature\", \"Cours jusque-là\" ou \"Rapporte cet objet\". Si la créature exécute la demande et ne reçoit pas d'autres indications de votre part, elle se défend au mieux de sa capacité.",
+      "Vous pouvez utiliser une action pour obtenir le contrôle total et précis de la cible. Jusqu'à la fin de votre prochain tour, la créature agit seulement selon vos choix et elle ne peut rien faire sans que vous ne l'autorisiez. Pendant cette période, vous pouvez provoquer une réaction de la part de la créature, mais l'usage de cette réaction sera aussi le vôtre.",
+      "Chaque fois que la cible subit des dégâts, elle tente un nouveau jet de sauvegarde de Sagesse. Si elle réussit, le sort prend fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6, la durée du sort sous concentration augmente jusqu'à 10 minutes. Avec un emplacement de sort de niveau 7, la durée du sort sous concentration augmente jusqu'à 1 heure. Avec un emplacement de sort de niveau 8 ou supérieur, la durée du sort sous concentration augmente jusqu'à 8 heures."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "other",
+      "desc": "Chaque fois que la cible prend des dommages, elle fait un nouveau jet de sauvegarde de sagesse contre le sort. Si le jet est réussi, le sort est rompu."
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/dominate-person"
+  },
+  {
+    "index": "dream",
+    "name": "Songe",
+    "desc": [
+      "Ce sort façonne les rêves d'une créature. Choisissez comme cible une créature que vous connaissez. La cible doit être située sur le même plan d'existence que vous. Les créatures qui ne dorment pas, comme les elfes, ne peuvent être contactées par ce sort. Vous, ou une cible consentante que vous touchez, entrez dans un état de transe, agissant comme un messager.",
+      "Pendant la transe, le messager est conscient de son environnement, mais il ne peut ni agir, ni bouger.",
+      "Si la cible est endormie, le messager apparait dans les rêves de la cible et peut entretenir une conversation avec la cible aussi longtemps qu'elle reste endormie, dans la durée du sort. Le messager peut aussi façonner l'environnement du rêve en créant des paysages, des objets ou d'autres images. Le messager peut émerger de la transe à sa guise. Ce faisant, le sort se termine prématurément. La cible garde un souvenir précis du rêve à son réveil. Si la cible est éveillée lorsque vous incantez le sort, le messager le sait et il peut soit mettre un terme à la transe (et au sort), soit attendre que la cible s'endorme. Le messager apparait alors dans les rêves de la cible.",
+      "Le messager peut prendre la forme d'un monstre terrifiant aux yeux de la cible. Dans ce cas, le message peut livrer un message d'au plus dix mots et la cible doit réussir un jet de sauvegarde de Sagesse, sans quoi les échos d'une monstruosité fantasmagorique donnent naissance à un cauchemar qui persiste tout au long de la période de sommeil de la cible. Au terme de quoi, elle n'obtient pas les bénéfices de ce repos. De plus, lorsque la cible se réveille, elle subit 3d6 dégâts psychiques.",
+      "Si vous possédez une partie du corps, une mèche de cheveux, un ongle coupé ou une portion semblable du corps de la cible, celle-ci fait son jet de sauvegarde avec un désavantage."
+    ],
+    "range": "Spéciale",
+    "components": ["V", "S", "M"],
+    "material": "Une poignée de sable, un peu d'encre et une plume arrachée d'un oiseau endormi.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "damage": {
+      "damage_type": {
+        "index": "psychic",
+        "name": "Psychique",
+        "url": "/api/2014/damage-types/psychic"
+      },
+      "damage_at_slot_level": {
+        "5": "3d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "On a failed save, echoes of the phantasmal monstrosity spawn a nightmare that lasts the duration of the target's sleep and prevents the target from gaining any benefit from that rest."
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/dream"
+  },
+  {
+    "index": "druidcraft",
+    "name": "Druidisme",
+    "desc": [
+      "En murmurant aux esprits de la nature, vous créez l'un des effets suivants, dans la portée du sort :",
+      "- Vous créez un minuscule et inoffensif effet sensoriel qui permet de prédire les conditions météorologiques pour les 24 prochaines heures, à l'endroit où vous êtes. L'effet pourrait se manifester comme un orbe doré pour indiquer un ciel dégagé, un nuage pour annoncer la pluie, un flocon de neige pour une chute de neige et ainsi de suite. L'effet persiste pour 1 round.",
+      "- Vous provoquez immédiatement la floraison d'une fleur, l'ouverture d'une gousse ou le débourrement d'un bourgeon de feuille.",
+      "- Vous créez un inoffensif effet sensoriel instantané comme une chute de feuilles, une légère brise, le son d'un petit animal ou une subtile odeur de putois. L'effet doit se limiter à un cube de 1,50 mètre d'arête.",
+      "- Vous éteignez ou allumez instantanément une bougie, une torche ou un petit feu de camp."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/druidcraft"
+  },
+  {
+    "index": "earthquake",
+    "name": "Tremblement de terre",
+    "desc": [
+      "Vous générez un bouleversement sismique à un endroit visible sur le sol dans la portée du sort. Pendant la durée, une intense secousse déchire le sol sur un cercle de 30 mètres de rayon centré sur le point indiqué. Les créatures et les structures en contact avec le sol sont secouées.",
+      "Le sol dans la zone devient un terrain difficile. Chaque créature au sol qui se concentre doit réussir un jet de sauvegarde de Constitution, sans quoi sa concentration est brisée.",
+      "Lorsque vous lancez ce sort ainsi qu'à chaque fin de tour passé à vous concentrer, chaque créature au sol doit réussir un jet de sauvegarde de Dextérité ou tomber à terre.",
+      "Ce sort peut avoir des effets supplémentaires selon la nature du terrain dans le secteur, à la discrétion du MJ.",
+      "***Fissures***. Des fissures s'ouvrent dans la zone frappée par le sort au début du tour suivant l'incantation du sort. Un total de 1d6 fissures s'ouvrent à des endroits déterminés par le MJ. Chacune des fissures est profonde de 1d10 x 3 mètres, mesure 3 mètres de large et s'étend d'un point sur la circonférence de la zone jusqu'au point opposé. Une créature située à l'endroit où la fissure s'ouvre doit réussir un jet de sauvegarde de Dextérité, sans quoi elle chute. Une créature qui réussit la sauvegarde se déplace avec le bord de la fissure. Une fissure qui s'ouvre sous une structure cause l'effondrement de la structure (voir plus bas).",
+      "***Structures***. La secousse inflige 50 dégâts contondants à toute structure en contact avec le sol qui se trouve dans la zone lorsque vous incantez le sort ainsi qu'au début de chacun de vos tours jusqu'à ce que le sort prenne fin. Si la structure atteint 0 point de vie, elle s'effondre pour possiblement blesser les créatures proches. Une créature située à la moitié ou moins de la hauteur de la structure doit réaliser un jet de sauvegarde de Dextérité. En cas d'échec, elle subit 5d6 dégâts contondants, tombe à terre et est ensevelie dans les décombres. Un jet de Force (Athlétisme) de DD 20 est requis pour s'en extirper. Le MJ peut ajuster le DD en fonction de la nature des décombres. En cas de réussite, la créature subit la moitié de ces dégâts, ne tombe pas à terre et n'est pas ensevelie."
+    ],
+    "range": "150 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de terre, un fragment de roche et un bloc d'argile",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 100
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/earthquake"
+  },
+  {
+    "index": "eldritch-blast",
+    "name": "Décharge occulte",
+    "desc": [
+      "Un rayon d'énergie crépitante zigzague jusqu'à une créature à portée. Effectuez une attaque à distance avec un sort contre la cible. En cas de réussite, la cible subit 1d10 dégâts de force. Ce sort crée plus d'un rayon lorsque vous montez en niveau : deux rayons au niveau 5, trois rayons au niveau 11, et quatre rayons au niveau 17. Vous pouvez diriger les rayons sur une cible unique et les répartir entre différentes créatures. Effectuez un jet d'attaque séparé pour chaque rayon."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_character_level": {
+        "1": "1d10",
+        "5": "1d10",
+        "11": "1d10",
+        "17": "1d10"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/eldritch-blast"
+  },
+  {
+    "index": "enhance-ability",
+    "name": "Amélioration de caractéristique",
+    "desc": [
+      "Vous touchez une créature et lui accordez une amélioration magique. Choisissez l'un des effets suivants ; la cible gagne cet effet jusqu'à ce que le sort prenne fin.",
+      "***Endurance de l'ours.*** La cible a un avantage à ses jets de Constitution. Elle gagne également 2d6 points de vie temporaires, qui sont perdus lorsque le sort prend fin.",
+      "***Force du taureau.*** La cible a un avantage à ses jets de Force, et sa capacité de charge double.",
+      "***Grâce féline.*** La cible a un avantage à ses jets de Dextérité. De plus, elle ne subit aucun dégât lorsqu'elle chute de 6 mètres ou moins et qu'elle n'est pas incapable d'agir.",
+      "***Splendeur de l'aigle.*** La cible a un avantage à ses jets de Charisme.",
+      "***Ruse du renard.*** La cible a un avantage à ses jets d'Intelligence.",
+      "***Sagesse du hibou.*** La cible a un avantage à ses jets de Sagesse."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, vous pouvez cibler une créature supplémentaire pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Le poil ou la plume d'une bête.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/enhance-ability"
+  },
+  {
+    "index": "enlarge-reduce",
+    "name": "Agrandissement/Rapetissement",
+    "desc": [
+      "Vous agrandissez ou réduisez en taille une créature ou un objet que vous pouvez voir et qui est à portée pour la durée du sort. Choisissez une créature ou un objet qui n'est pas porté ou transporté. Si la cible n'est pas consentante, elle peut effectuer un jet de sauvegarde de Constitution. En cas de réussite, le sort n'a aucun effet.",
+      "Si la cible est une créature, toutes les choses qu'elle porte et transporte changent de taille avec elle. Tout objet lâché par la créature affectée reprend sa taille normale.",
+      "***Agrandissement.*** La cible double dans toutes les dimensions, et son poids est multiplié par huit. Cela augmente sa taille d'une catégorie, de M à G par exemple. S'il n'y a pas assez de place dans la pièce pour que la cible double de taille, la créature ou l'objet atteint la taille maximale possible dans l'espace disponible. Jusqu'à la fin du sort, la cible a aussi un avantage à ses jets de Force et ses jets de sauvegarde de Force. Les armes de la cible grandissent également. Tant que ces armes sont agrandies, les attaques de la cible occasionnent 1d4 dégâts supplémentaires.",
+      "***Rapetissement.*** La taille de la cible est diminuée de moitié dans toutes les dimensions, et son poids est divisé par huit. Cette réduction diminue sa taille d'une catégorie, de M à P par exemple. Jusqu'à la fin du sort, la cible a un désavantage à ses jets de Force et à ses jets de sauvegarde de Force. Les armes de la cible rapetissent aussi. Tant que ces armes sont réduites, les attaques de la cible occasionnent 1d4 dégâts en moins (minimum 1 point de dégâts)."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poudre de fer.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/enlarge-reduce"
+  },
+  {
+    "index": "entangle",
+    "name": "Enchevêtrement",
+    "desc": [
+      "Herbes et lianes germent du sol dans un carré de 6 mètres d'arête ayant son origine sur un point dans la portée du sort. Pour la durée du sort, ces plantes rendent le terrain difficile.",
+      "Une créature prise dans la zone lorsque vous incantez le sort doit réussir un jet de sauvegarde de Force ou être entravée par l'enchevêtrement de plantes jusqu'à la fin du sort. Une créature entravée par les plantes peut utiliser une action pour faire un jet de sauvegarde de Force contre le DD de sauvegarde de votre sort. En cas de réussite, la créature se libère.",
+      "Lorsque le sort prend fin, les plantes invoquées se fanent."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "str",
+        "name": "FOR",
+        "url": "/api/2014/ability-scores/str"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/entangle"
+  },
+  {
+    "index": "enthrall",
+    "name": "Discours captivant",
+    "desc": [
+      "Vous entrelacez des phrases distrayantes, ce qui force les créatures de votre choix, que vous pouvez voir et qui peuvent vous entendre, à effectuer un jet de sauvegarde de Sagesse. Toute créature qui ne peut pas être charmée réussit automatiquement son jet de sauvegarde, et si vous ou vos compagnons combattez une créature, celle-ci a un avantage à son jet de sauvegarde. Si une cible échoue son jet de sauvegarde, elle se voit affligée d'un désavantage à ses jets de Sagesse (Perception) effectués pour repérer une autre créature que vous, et ce jusqu'à ce que le sort prenne fin ou jusqu'à ce qu'elle ne puisse plus vous entendre. Ce sort prend fin si vous êtes incapable d'agir ou ne pouvez plus parler."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/enthrall"
+  },
+  {
+    "index": "etherealness",
+    "name": "Forme éthérée",
+    "desc": [
+      "Vous faites un pas dans la zone périphérique du plan éthéré, dans un secteur qui chevauche votre plan actuel. Vous demeurez dans la Limite éthérée pour la durée du sort ou jusqu'à ce que vous utilisiez une action pour dissiper le sort. Entre temps, vous pouvez vous déplacer dans toutes les directions. Si vous vous déplacez vers le haut ou vers le bas, chaque unité de distance compte double. Vous pouvez voir et entendre le plan d'où vous venez, mais tout vous parait gris et vous ne pouvez rien distinguer au-delà de 18 mètres.",
+      "En étant sur le plan éthéré, vous ne pouvez affecter et être affecté que par des créatures également sur ce plan. Les créatures qui n'y sont pas ne peuvent ni percevoir votre présence ni interagir avec vous, à moins qu'une aptitude spéciale ou magique les rende aptes à le faire. Vous ignorez tout objet ou effet qui n'est pas sur le plan éthéré, vous permettant ainsi de vous déplacer à travers les objets que vous percevez sur le plan d'où vous êtes.",
+      "Lorsque le sort prend fin, vous retournez aussitôt sur votre plan d'origine, à l'endroit que vous occupez à ce moment-là. Si vous occupez le même espace qu'un objet solide ou celui d'une créature, vous êtes immédiatement déplacé vers l'espace libre le plus près que vous pouvez occuper. L'éviction vous fait subir des dégâts de force correspondant à 6 fois la distance parcourue en mètre.",
+      "Ce sort n'a pas d'effet si vous l'incantez alors que vous êtes sur le plan éthéré ou sur un plan qui ne lui est pas limitrophe, comme l'un des Plans Extérieurs."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 8 ou supérieur, vous pouvez cibler jusqu'à trois créatures consentantes (vous y compris) pour chaque niveau d'emplacement au-delà du niveau 7. Les créatures doivent être dans un rayon de 3 mètres autour de vous lorsque vous lancez le sort."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/etherealness"
+  },
+  {
+    "index": "expeditious-retreat",
+    "name": "Repli expéditif",
+    "desc": [
+      "Ce sort vous permet de vous déplacer à une vitesse incroyable. Lorsque vous lancez ce sort, puis par une action bonus à chacun de vos tours jusqu'à la fin du sort, vous pouvez effectuer l'action Foncer."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/expeditious-retreat"
+  },
+  {
+    "index": "eyebite",
+    "name": "Mauvais oeil",
+    "desc": [
+      "Pour la durée du sort, vos yeux prennent un couleur d'encre noire sont imprégnés du pouvoir de la mort. Une créature de votre choix, se trouvant à 18 mètres de vous et que vous pouvez voir, doit réussir un jet de sauvegarde de Sagesse sous peine d'être affectée par l'un des effets suivants (au choix) pour la durée du sort. À chacun de vos tours, jusqu'à ce que le sort prenne fin, vous pouvez utiliser votre action pour cibler une autre créature, vous ne pouvez cependant pas cibler une créature qui a déjà réussi son jet de sauvegarde contre ce sort de mauvais œil.",
+      "***Sommeil.*** La cible tombe inconsciente. Elle se réveille si elle subit des dégâts ou si une autre créature utilise son action pour la ramener du pays des songes en la secouant.",
+      "***Panique.*** Vous effrayez la cible. À chacun de ses tours, la créature effrayée doit prendre l'action Foncer et s'éloigner de vous par le chemin le plus sûr et le plus court, à moins qu'elle n'ait nulle part où aller. Si la cible atteint une zone située à au moins 18 mètres de vous et d'où elle ne peut pas vous voir, l'effet prend fin.",
+      "***Fièvre.*** La cible a un désavantage à ses jets d'attaque et à ses jets de caractéristique. À la fin de chacun de ses tours, elle peut effectuer un nouveau jet de sauvegarde de Sagesse. Si elle le réussit, l'effet prend fin."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec, la cible peut être affectée par l'un des effets suivants, au choix, pendant toute la durée de l'effet : [Endormie. La cible perd connaissance. Elle se réveille si elle subit des dégâts ou si une autre créature utilise son action pour la réveiller en la secouant.] [Panique. La cible a peur de vous. À chacun de ses tours, la créature effrayée doit utiliser l'action Foncer et s'éloigner de vous par le chemin le plus court et le plus sûr, sauf s'il n'y a nulle part où aller. Si la cible se déplace à au moins 18 mètres de vous et qu'elle ne peut plus vous voir, cet effet prend fin.] [Fièvre. La cible a un désavantage aux jets d'attaque et aux tests de caractéristique. À la fin de chacun de ses tours, elle peut effectuer un nouveau jet de sauvegarde de Sagesse. En cas de réussite, l'effet prend fin.]"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/eyebite"
+  },
+  {
+    "index": "fabricate",
+    "name": "Fabrication",
+    "desc": [
+      "Vous convertissez des matériaux bruts en objets confectionnés avec ces matières. Par exemple, vous pouvez fabriquer un pont en bois avec quelques arbres, une corde à partir d'une parcelle de chanvre, et des vêtements avec du lin ou de la laine.",
+      "Choisissez des matériaux bruts que vous pouvez voir et à portée. Vous pouvez fabriquer un objet de taille G ou inférieure (pouvant tenir dans un cube de 3 mètres d'arête, ou dans huit cubes de 1,50 mètre d'arête), à condition que vous utilisiez suffisamment de matière première. Si vous utilisez ce sort en ciblant du métal, de la pierre, ou tout autre substance minérale, l'objet fabriqué est, au maximum, de taille M (pouvant tenir dans un cube de 1,50 mètre d'arête). La qualité des objets créés par ce sort correspond à la qualité des matières premières utilisées.",
+      "Les créatures et les objets magiques ne peuvent pas être créés ou transmutés grâce à ce sort. Vous ne pouvez pas non plus utiliser ce sort pour créer des objets qui nécessitent d'ordinaire un haut niveau d'artisanat, comme des bijoux, des armes, des lunettes, ou des armures, à moins que vous n'ayez la maîtrise du type d'outils d'artisans en rapport avec l'objet que vous comptez fabriquer."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 4,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/fabricate"
+  },
+  {
+    "index": "faerie-fire",
+    "name": "Lueurs féeriques",
+    "desc": [
+      "Tous les objets à l'intérieur d'un cube de 6 mètres d'arête dans la portée du sort se distinguent par un halo bleu, vert ou violet (à votre choix). Toutes les créatures présentes dans la zone lors de l'incantation du sort sont également enveloppées du halo si elles échouent à un jet de sauvegarde de Dextérité. Pour la durée du sort, les objets et les créatures affectées émettent une lumière faible dans un rayon de 3 mètres.",
+      "Les jets d'attaque contre des créatures affectées ou des objets bénéficient d'un avantage si l'attaquant peut les voir. Les créatures affectées ou les objets ne peuvent bénéficier de l'état invisible."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/faerie-fire"
+  },
+  {
+    "index": "faithful-hound",
+    "name": "Chien de garde",
+    "desc": [
+      "Vous invoquez un chien de garde spectral en un espace inoccupé que vous voyez à portée, où il reste pour toute la durée, jusqu’à ce que vous le révoquiez au prix d’une action ou que vous vous éloignez de plus de 30 m de lui.",
+      "Le molosse est invisible pour toutes les créatures autres que vous et ne peut être blessé. Quand une créature de taille S ou supérieure s’approche dans un rayon de 9 m de lui sans prononcer au préalable le mot de passe que vous avez spécifié à l’incantation du sort, le chien se met à aboyer puissamment. Le chien voit les créatures invisibles et perçoit le Plan Éthéré. Il n’est pas sujet aux illusions.",
+      "Au début de chacun de vos tours, le molosse tente de mordre une créature située dans un rayon de 1,50 m  de lui si elle vous est hostile. Le bonus à l’attaque du chien spectral est égal à votre modificateur de caractéristique d’incantation + votre bonus de maîtrise. Si l’attaque touche, elle inflige 4d8 dégâts perforants."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit sifflet en argent, un fragment d’os et de la ficelle.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "piercing",
+        "name": "Perforant",
+        "url": "/api/2014/damage-types/piercing"
+      },
+      "damage_at_slot_level": {
+        "4": "4d8"
+      }
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/faithful-hound"
+  },
+  {
+    "index": "false-life",
+    "name": "Simulacre de vie",
+    "desc": [
+      "Vous vous protégez avec un semblant nécromantique de vie. Vous gagnez 1d4 + 4 points de vie temporaires pour la durée du sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, vous gagnez 5 points de vie temporaires supplémentaires pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "une petite quantité d'alcool ou de spiritueux",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "heal_at_slot_level": {
+      "1": "1d4 + 4",
+      "2": "1d4 + 9",
+      "3": "1d4 + 14",
+      "4": "1d4 + 19",
+      "5": "1d4 + 24",
+      "6": "1d4 + 29",
+      "7": "1d4 + 34",
+      "8": "1d4 + 39",
+      "9": "1d4 + 44"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/false-life"
+  },
+  {
+    "index": "fear",
+    "name": "Terreur",
+    "desc": [
+      "Vous projetez une image fantasmatique des pires terreurs de ceux qui vous font face. Chaque créature prise dans un cône de 9 m doit réussir un jet de sauvegarde de Sagesse sous peine de lâcher ce qu’elle tient et d’être effrayée pour toute la durée.",
+      "Ainsi effrayée, la créature doit à chacun de ses tours entreprendre l’action Foncer et s’éloigner de vous par le chemin le plus sûr, sauf si elle n’a nulle part où aller. Si la créature termine son tour en un lieu où elle ne vous a plus en champ de vision, elle effectue un jet de sauvegarde de Sagesse. En cas de réussite, le sort prend fin en ce qui la concerne."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une plume blanche ou un cœur d'une poule.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec, la créature laisse tomber ce qu'elle tient et devient effrayée pendant toute la durée du sort."
+    },
+    "area_of_effect": {
+      "type": "cone",
+      "size": 30
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/fear"
+  },
+  {
+    "index": "feather-fall",
+    "name": "Feuille morte",
+    "desc": [
+      "Choisissez jusqu'à cinq créatures en chute libre dans la portée du sort. Le taux de descente d'une créature en chute libre est ramené à 18 mètres par round jusqu'à la fin du sort. Si la créature atterrit avant la fin du sort, elle ne subit aucun dégât de chute et elle retombe sur ses pieds. Le sort prend alors fin pour cette créature."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "M"],
+    "material": "Une petite plume ou un peu de duvet.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 reaction",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/feather-fall"
+  },
+  {
+    "index": "feeblemind",
+    "name": "Esprit faible",
+    "desc": [
+      "Vous anéantissez l'esprit d'une créature que vous pouvez voir et à portée, tentant ainsi de briser son intellect et sa personnalité. La cible subit 4d6 dégâts psychiques et doit effectuer un jet de sauvegarde d'Intelligence.",
+      "En cas d'échec, les valeurs de Charisme et d'Intelligence de la créature passent à 1. La créature ne peut plus lancer des sorts, activer un objet magique, comprendre un langage ou communiquer de manière intelligible. La créature peut cependant identifier ses amis, les suivre, et même les protéger.",
+      "À la fin de chaque période de 30 jours qui passe, la créature peut tenter un nouveau jet de sauvegarde contre ce sort. S'il le réussit, le sort prend fin.",
+      "Ce sort peut également être dissipé grâce à un sort de restauration supérieure, guérison ou souhait."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une poignée de sphères en argile, verre, cristal ou minéral",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "damage": {
+      "damage_type": {
+        "index": "psychic",
+        "name": "Psychique",
+        "url": "/api/2014/damage-types/psychic"
+      },
+      "damage_at_slot_level": {
+        "8": "4d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "int",
+        "name": "INT",
+        "url": "/api/2014/ability-scores/int"
+      },
+      "dc_success": "other",
+      "desc": "La cible subit toujours les dégâts. En cas d'échec du jet de sauvegarde, les valeurs de Charisme et d'Intelligence de la créature passent à 1."
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/feeblemind"
+  },
+  {
+    "index": "find-familiar",
+    "name": "Appel de familier",
+    "desc": [
+      "Vous gagnez les services d'un familier, un esprit qui prend la forme d'un animal de votre choix : une araignée, une belette, un chat, une chauve-souris, une chouette, un corbeau, un crabe, un faucon, un hippocampe, une grenouille (crapaud), un lézard, une pieuvre, un rat, un poisson (piranha) ou un serpent venimeux. Apparaissant dans un espace inoccupé à portée, le familier a les statistiques de la forme choisie mais est du type céleste, fée ou fiélon (au choix), au lieu du type bête.",
+      "Votre familier agit de manière indépendante, mais obéit toujours à vos ordres. En combat, il lance sa propre initiative et agit au cours de ses propres tours de jeu. Un familier ne peut pas attaquer, mais il peut utiliser normalement les autres actions.",
+      "Lorsque le familier tombe à 0 point de vie, il disparaît, ne laissant aucune forme physique. Il réapparaît après que vous ayez à nouveau lancé ce sort. Par une action, vous pouvez temporairement renvoyer le familier dans une poche dimensionnelle. Vous pouvez aussi le renvoyer pour toujours. Chaque fois que le familier tombe à 0 point de vie ou disparaît dans la poche dimensionnelle, il laisse dans son espace tout ce qu'il portait.",
+      "Lorsque votre familier se trouve à 30 mètres de vous maximum, vous pouvez communiquer avec lui par télépathie. De plus, par une action, vous pouvez voir au travers des yeux du familier et entendre ce qu'il entend jusqu'au début de votre prochain tour, bénéficiant alors des sens spéciaux de votre familier, s'il en a. Au cours de cette période, vous êtes considéré comme étant sourd et aveugle (en ce qui concerne vos propres sens).",
+      "Au prix d'une action lorsqu'il est temporairement renvoyé, vous pouvez le faire réapparaître dans n'importe quel espace inoccupé dans un rayon de 9 mètres autour de vous.",
+      "Vous ne pouvez pas avoir plus d'un familier à la fois. Si vous lancez ce sort alors que vous possédez déjà un familier, votre familier actuel prend une nouvelle forme. Choisissez cette nouvelle forme parmi celles présentées dans la liste ci-dessus. Votre familier prend alors la forme de la créature choisie.",
+      "Enfin, lorsque vous lancez un sort qui a une portée de contact, votre familier peut lancer le sort comme s'il était celui qui avait réalisé l'incantation. Votre familier doit se situer à 30 mètres de vous maximum, et doit utiliser sa réaction pour lancer le sort au moment où vous l'incantez. Si le sort requiert un jet d'attaque, vous utilisez votre modificateur à l'attaque pour ce jet."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Du charbon de bois, de l'encens, et des herbes pour une valeur de totale minimum de 10 po, le tout étant consumé par le feu dans un chaudron en laiton.",
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 1,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/find-familiar"
+  },
+  {
+    "index": "find-steed",
+    "name": "Appel de destrier",
+    "desc": [
+      "Vous invoquez un esprit qui se matérialise sous la forme d'un destrier loyal, fort et remarquablement intelligent, créant un lien durable avec lui. Apparaissant dans un espace inoccupé à portée, le destrier prend la forme que vous voulez : un cheval de guerre, un poney, un chameau, un élan ou un molosse (votre MJ peut autoriser l'invocation d'autres bêtes en tant que destriers). Le destrier a les statistiques de la forme choisie, mais son type est soit céleste, soit fée, soit fiélon (au choix) à la place de son type normal. De plus, si votre destrier a une Intelligence de 5 ou moins, son Intelligence passe à 6 et il gagne la capacité de comprendre l'une des langues que vous parlez (au choix).",
+      "Votre destrier vous sert de monture, en combat ou non, et le lien qui vous unit vous permet de combattre comme un seul homme. Lorsque vous montez votre destrier et que vous lancez un sort qui vous cible, vous pouvez faire en sorte qu'il cible également votre destrier.",
+      "Lorsque votre destrier tombe à 0 point de vie, il disparaît, ne laissant aucune forme physique. Vous pouvez également choisir de renvoyer votre destrier à tout moment en utilisant votre action. Il disparaît alors. Dans tous les cas, lancer de nouveau ce sort invoque le même destrier avec son maximum de points de vie.",
+      "Tant que votre destrier se trouve à 1,5 km ou moins de vous, vous pouvez communiquer entre vous par télépathie.",
+      "Vous ne pouvez avoir plus d'un destrier lié grâce à ce sort en même temps. Par une action, vous pouvez libérer votre destrier du lien qui vous unit, et ce à n'importe quel moment. Le destrier disparaît alors."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 2,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/find-steed"
+  },
+  {
+    "index": "find-traps",
+    "name": "Détection des pièges",
+    "desc": [
+      "Vous percevez la présence de tout piège à la fois à portée et dans votre champ de vision. Un piège, dans le cadre de ce sort, correspond à tout ce qui peut produire un effet soudain ou imprévu que vous considéreriez comme nuisible ou indésirable, et qui a été conçu en ce sens par son créateur. Dans ces conditions, ce sort peut percevoir la zone affectée par le sort alarme, un glyphe de garde ou une fosse qui s’ouvre mécaniquement, mais il ne révèle pas l’usure d’un plancher, l’instabilité d’un plafond ou un gouffre naturel caché par l’environnement",
+      "Le sort se contente de révéler la présence d’un piège à portée. Vous ne savez pas où se trouve précisément chaque piège, mais avez une notion de la nature du danger qu’il présente."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/find-traps"
+  },
+  {
+    "index": "find-the-path",
+    "name": "Orientation",
+    "desc": [
+      "Ce sort vous permet de trouver le chemin le plus court et direct jusqu’à un lieu spécifique fixe que vous connaissez, sur votre plan d’existence actuel. Si vous mentionnez une destination sur un autre plan d’existence, une destination mobile (comme une forteresse mouvante) ou une destination générique (comme \" l’antre d’un dragon vert \"), le sort échoue.",
+      "Pour toute la durée et tant que vous êtes sur le même plan d’existence que la destination, vous savez quelle distance vous en sépare et dans quelle direction elle se trouve. Tant que vous progressez vers votre destination, chaque fois que vous avez le choix entre plusieurs itinéraires, vous savez automatiquement lequel est le plus court et direct (mais pas forcément le plus sûr)."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Des outils divinatoires d’une valeur de 100 po [os, bâtonnets d’ivoire, cartes, dents ou runes gravées] et un objet issu du lieu que vous recherchez.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 jour",
+    "concentration": true,
+    "casting_time": "1 minute",
+    "level": 6,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/find-the-path"
+  },
+  {
+    "index": "finger-of-death",
+    "name": "Doigt de mort",
+    "desc": [
+      "Vous envoyez de l'énergie négative à travers une créature visible dans la portée du sort, lui causant d'affreuses souffrances. La cible doit effectuer un jet de sauvegarde de Constitution, subissant 7d8 + 30 dégâts nécrotiques en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Un humanoïde tué par ce sort se relève au début de votre prochain tour, comme un zombi que vous commandez en permanence et qui suit vos ordres verbaux au mieux de sa capacité."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "7": "7d8 + 30"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/finger-of-death"
+  },
+  {
+    "index": "fire-bolt",
+    "name": "Trait de feu",
+    "desc": [
+      "Vous lancez un trait de feu sur une créature ou un objet à portée. Faites une attaque à distance avec un sort contre la cible. En cas de réussite, la cible prend 1d10 dégâts de feu. Un objet inflammable touché par ce sort prend feu s'il n'est pas porté.",
+      "Les dégâts du sort augmentent de 1d10 aux niveaux 5 (2d10), 11 (3d10) et 17 (4d10)."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_character_level": {
+        "1": "1d10",
+        "5": "2d10",
+        "11": "3d10",
+        "17": "4d10"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/fire-bolt"
+  },
+  {
+    "index": "fire-shield",
+    "name": "Bouclier de feu",
+    "desc": [
+      "De fines et vaporeuses flammes cernent votre corps pour la durée du sort, irradiant une lumière vive dans un rayon de 3 mètres et une lumière faible à trois mètres supplémentaires. Vous pouvez mettre fin au sort en utilisant une action pour le faire disparaitre.",
+      "Les flammes forment autour de vous un bouclier de chaleur ou de froid, à votre choix. Le bouclier de chaleur vous confère une résistance aux dégâts de froid et celui de froid une résistance aux dégâts de feu.",
+      "De plus, si une créature située à 1,50 mètre ou moins de vous vous touche avec une attaque au corps à corps, des flammes jaillissent du bouclier. L'attaquant subit alors 2d8 dégâts de feu ou de froid, selon le modèle choisi."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de phosphore ou une luciole.",
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "4": "2d8"
+      }
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 5
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/fire-shield"
+  },
+  {
+    "index": "fire-storm",
+    "name": "Tempête de feu",
+    "desc": [
+      "Une tempête formée de rideaux enflammés apparait à l'endroit de votre choix, dans la portée du sort. La zone de la tempête se compose de dix cubes de 3 mètres d'arête, que vous pouvez organiser à votre guise. Chaque cube doit avoir une face adjacente à la face d'un autre cube. Chaque créature dans la zone doit effectuer un jet de sauvegarde de Dextérité, subissant 7d10 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Le feu endommage les objets dans la zone et allume les objets inflammables qui ne sont pas portés ou transportés. Si vous le souhaitez, les végétaux dans la zone ne sont pas touchés par le sort."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "7": "7d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 100
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/fire-storm"
+  },
+  {
+    "index": "fireball",
+    "name": "Boule de feu",
+    "desc": [
+      "Une éclatante traînée lumineuse est émise de la pointe de votre doigt vers un point de votre choix dans la portée du sort, puis s'amplifie dans un rugissement grave jusqu'à éclater en flammes. Chaque créature située dans une sphère de 6 mètres de rayon centrée sur le point doit effectuer un jet de sauvegarde de Dextérité, subissant 8d6 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Le feu contourne les coins. Il enflamme les objets inflammables qui ne sont pas portés ou transportés."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, les dégâts sont augmentés de 1d6 pour chaque niveau d'emplacement au-delà du niveau 3."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une toute petite boule de guano de chauve-souris et du souffre",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "3": "8d6",
+        "4": "9d6",
+        "5": "10d6",
+        "6": "11d6",
+        "7": "12d6",
+        "8": "13d6",
+        "9": "14d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/fireball"
+  },
+  {
+    "index": "flame-blade",
+    "name": "Lame de feu",
+    "desc": [
+      "Vous créez une lame ardente dans votre main libre. La lame est similaire en taille et en forme à un cimeterre, et reste jusqu'à ce que le sort prenne fin. Si vous lâchez la lame, elle disparaît, mais vous pouvez la réinvoquer par une action bonus.",
+      "Vous pouvez utiliser votre action pour effectuer une attaque au corps à corps avec un sort avec la lame ardente. Si le coup touche, la cible subit 3d6 dégâts de feu.",
+      "La lame enflammée émet une lumière vive dans un rayon de 3 mètres et une lumière faible sur 3 mètres supplémentaires."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, les dégâts augmentent de 1d6 tous les 2 niveaux d'emplacement au-dessus du niveau 2."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une feuille de sumac.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "2": "3d6",
+        "4": "4d6",
+        "6": "5d6",
+        "8": "6d6"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/flame-blade"
+  },
+  {
+    "index": "flame-strike",
+    "name": "Colonne de flamme",
+    "desc": [
+      "Une colonne verticale de feu divin dévale des cieux vers un endroit que vous spécifiez dans la portée du sort. Chaque créature située dans un cylindre de 3 mètres de rayon et de 12 mètres de haut centré sur le point spécifié doit effectuer un jet de sauvegarde de Dextérité, subissant 4d6 dégâts de feu et 4d6 dégâts radiants en cas d'échec, ou la moitié de ces dégâts en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 6 ou supérieur, les dégâts de feu ou les dégâts radiants (selon votre choix) sont augmentés de 1d6 pour chaque niveau d'emplacement au-delà du niveau 5."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de soufre.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "5": "4d6 + 4d6",
+        "6": "4d6 + 5d6",
+        "7": "4d6 + 6d6",
+        "8": "4d6 + 7d6",
+        "9": "4d6 + 8d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 40
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/flame-strike"
+  },
+  {
+    "index": "flaming-sphere",
+    "name": "Sphère de feu",
+    "desc": [
+      "Une sphère de feu d'un diamètre de 1,50 mètre apparait dans un espace inoccupé de votre choix dans la portée et pour la durée du sort. Toute créature qui termine son tour à 1,50 mètre ou moins de la sphère doit effectuer un jet de sauvegarde de Dextérité, subissant 2d6 dégâts de feu en cas d'échec, ou la moitié de ces dégâts en cas de réussite.",
+      "Avec une action bonus, vous pouvez déplacer la sphère jusqu'à 9 mètres. Si la sphère entre en collision avec une créature, celle-ci doit faire un jet de sauvegarde contre les dégâts de la sphère et elle arrête son mouvement pour ce tour.",
+      "Lorsque vous déplacez la sphère, vous pouvez la diriger par-dessus des barrières de 1,50 mètre ou moins et la propulser au-dessus d'un gouffre large de 3 mètres ou moins. La sphère enflamme les objets inflammables qui ne sont pas portés ou transportés, et émet une lumière vive dans un rayon de 6 mètres et une lumière faible sur 6 mètres supplémentaires."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 3 ou supérieur, les dégâts sont augmentés de 1d6 pour chaque niveau d'emplacement au-delà du niveau 2."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de suif, une pincée de soufre et de la poussière de poudre de fer.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "2": "2d6",
+        "3": "3d6",
+        "4": "4d6",
+        "5": "5d6",
+        "6": "6d6",
+        "7": "7d6",
+        "8": "8d6",
+        "9": "9d6"
+      }
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/flaming-sphere"
+  },
+  {
+    "index": "flesh-to-stone",
+    "name": "Pétrification",
+    "desc": [
+      "Vous tentez de changer en pierre une créature que vous pouvez voir et à portée. Si le corps de la cible est fait de chair, la créature doit effectuer un jet de sauvegarde de Constitution. Si elle échoue, elle est entravée car sa chair commence à durcir. Si elle réussit, la créature n'est pas affectée.",
+      "Une créature entravée par ce sort doit effectuer un nouveau de jet de sauvegarde de Constitution à la fin de chacun de ses tours. Si elle réussit trois fois son jet de sauvegarde contre ce sort, le sort prend fin. Si elle échoue trois fois son jet de sauvegarde contre ce sort, elle est changée en pierre et soumise à l'état pétrifié pour toute la durée du sort. Les succès ou échecs n'ont pas besoin d'être consécutifs ; conservez une trace du résultat de chaque jet jusqu'à ce que la cible cumule trois échecs ou trois réussites.",
+      "Si la créature est physiquement brisée tandis qu'elle est pétrifiée, elle souffre de difformités similaires lorsqu'elle retourne à son état original.",
+      "Si vous maintenez votre concentration sur ce sort pendant sa durée maximale, la créature est changée en pierre jusqu'à ce que cet effet soit dissipé."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de chaux, de l'eau, et un peu de terre.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none",
+      "desc": "En cas d'échec du jet de sauvegarde, la cible est entravée car sa chair commence à durcir."
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/flesh-to-stone"
+  },
+  {
+    "index": "floating-disk",
+    "name": "Disque flottant",
+    "desc": [
+      "Ce sort crée un plan horizontal et circulaire de force, de 90 cm de diamètre pour 2,5 cm d’épaisseur, qui flotte 90 cm au-dessus du sol en un espace inoccupé de votre choix que vous voyez à portée. Le disque persiste pour toute la durée et supporte 250 kg. Si on y pose un excédent de poids, le sort prend fin et tout ce qui se trouvait sur le disque tombe au sol.",
+      "Le disque est immobile tant que vous restez dans un rayon de 6 m de lui. Si vous vous en écartez de plus de 6 m, le disque vous suit pour rester dans ce rayon. Il peut traverser un terrain difficile, monter ou descendre des marches, une pente ou équivalent, mais ne peut pas franchir une dénivellation abrupte de 3 m ou plus. Le disque ne peut ainsi pas franchir une fosse profonde de 3 m, pas plus qu’il ne pourra en sortir s’il a été créé en son fond.",
+      "Si vous vous déplacez à plus de 30 mètres du disque (par exemple parce qu'il ne peut pas passer au-dessus d'un obstacle pour vous suivre), le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte de mercure.",
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/floating-disk"
+  },
+  {
+    "index": "fly",
+    "name": "Vol",
+    "desc": [
+      "Vous touchez une créature consentante. La cible obtient une vitesse de vol de 18 mètres pour la durée du sort. Lorsque le sort prend fin, la cible tombe si elle est toujours dans les airs, sauf si elle peut empêcher la chute."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 4 ou supérieur, vous pouvez cibler une créature additionnelle pour chaque niveau d'emplacement au-delà du niveau 3."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une plume d'aile d'oiseau.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/fly"
+  },
+  {
+    "index": "fog-cloud",
+    "name": "Nappe de brouillard",
+    "desc": [
+      "Vous créez une sphère de brouillard de 6 mètres de rayon centrée sur un point dans la portée du sort. La sphère s'étend au-delà des coins et la visibilité dans la zone est nulle. Elle persiste pour la durée du sort ou jusqu'à ce qu'un vent de force modérée ou plus (au moins 15 km/h) la dissipe."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort en utilisant un emplacement de sort de niveau 2 ou supérieur, le rayon de la sphère augmente de 6 mètres pour chaque niveau d'emplacement au-delà du niveau 1."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/fog-cloud"
+  },
+  {
+    "index": "forbiddance",
+    "name": "Interdiction",
+    "desc": [
+      "Vous créez une défense contre les déplacements magiques qui protège jusqu'à 4,500 mètres carré d'espace au sol sur une hauteur de 9 mètres au-dessus du sol. Pour la durée du sort, les créatures ne peuvent pas se téléporter dans cette zone en utilisant des portails, comme ceux créés par le sort portail, pour pénétrer la zone. Le sort imperméabilise la zone aux voyages planaires, et pour cela, empêche les créatures d'accéder à la zone en passant par le plan Astral, le plan éthéré, la Féerie et la Gisombre, ou grâce au sort changement de plan.",
+      "De plus, le sort inflige des dégâts aux créatures des types que vous choisissez lorsque vous lancez ce sort. Choisissez un ou plus des types suivants : céleste, élémentaire, fée, fiélon, et mort-vivant. Lorsqu'une créature du type choisi pénètre dans l'aire du sort pour la première fois de son tour, ou y commence son tour, la créature subit 5d10 dégâts radiants ou nécrotiques (choix que vous avez effectué lors de l'incantation du sort).",
+      "Lorsque vous lancez ce sort, vous pouvez désigner un mot de passe. Une créature qui prononce le mot de passe au moment où elle pénètre dans la zone ne subit pas les dégâts du sort.",
+      "La zone affectée par ce sort ne peut pas se superposer à une zone créée par un autre sort d'interdiction. Si vous lancez interdiction chaque jour pendant 30 jours sur la même zone, le sort durera jusqu'à ce qu'il soit dissipé et les composantes matérielles seront consommées lors de la dernière incantation."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Quelques gouttes d'eau bénite, des encens très rares, et de la poudre de rubis pour une valeur minimum de 1 000 po.",
+    "ritual": true,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 6,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 40000
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/forbiddance"
+  },
+  {
+    "index": "forcecage",
+    "name": "Cage de force",
+    "desc": [
+      "Une prison en forme de cube immobile et invisible, composée de force magique, apparaît autour d'une zone que vous choisissez et à portée. La prison peut être une cage ou une boîte solide, selon votre choix.",
+      "Une prison prenant la forme d'une cage peut faire jusqu'à 6 mètres de côté et est constituée de barreaux de 1,25 cm de diamètre et espacés de 1,25 cm également.",
+      "Une prison prenant la forme d'une boîte peut faire jusqu'à 3 mètres de côté, créant une barrière solide qui empêche la matière de passer au travers et bloque les sorts lancés de l'intérieur vers l'extérieur de la zone, et vice versa.",
+      "Lorsque vous lancez ce sort, toute créature qui se trouve complètement dans la zone de la cage est piégée. Les créatures qui ne sont que partiellement dans la zone, ou celles qui sont trop larges pour tenir dans la prison, sont repoussées depuis le centre de la zone jusqu'à ce qu'elles en soient complètement sorties.",
+      "Une créature à l'intérieur de la cage ne peut pas la quitter par des moyens non magiques. Si la créature tente d'utiliser la téléportation ou le voyage planaire pour sortir de la cage, elle doit d'abords effectuer un jet de sauvegarde de Charisme. En cas de réussite, la créature peut utiliser cette magie pour sortir de la cage. En cas d'échec, la créature ne peut sortir de la cage et a dépensé cette utilisation de sort ou d'effet. La cage peut également s'étendre dans le plan éthéré pour bloquer les voyages éthérés.",
+      "Ce sort ne peut pas être dissipé avec le sort dissipation de la magie."
+    ],
+    "range": "30 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De la poussière de rubis valant au moins 1500 po.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/forcecage"
+  },
+  {
+    "index": "foresight",
+    "name": "Prémonition",
+    "desc": [
+      "Vous touchez une créature consentante pour lui octroyer une faculté limitée de voir son futur immédiat. Pour la durée du sort, la cible ne peut être surprise et elle bénéficie d'un avantage aux jets d'attaque, de sauvegarde et de caractéristique. De plus, les jets d'attaque des autres créatures contre la cible ont un désavantage pour la durée du sort.",
+      "Le sort prend immédiatement fin si vous l'incantez à nouveau avant la fin de la durée."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "La plume d'un colibri.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 9,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/foresight"
+  },
+  {
+    "index": "freedom-of-movement",
+    "name": "Liberté de mouvement",
+    "desc": [
+      "Vous touchez une créature consentante. Pour la durée du sort, les mouvements de la cible ne sont pas limités par un terrain difficile. Les sorts et autres effets magiques ne peuvent ni réduire la vitesse de la cible ni la rendre paralysée ou entravée.",
+      "La cible peut aussi dépenser 1,50 mètre de son mouvement pour se dégager d'une contrainte non magique, comme des menottes ou l'étreinte d'une créature. Enfin, l'environnement aquatique n'impose aucune pénalité sur les mouvements et les attaques de la cible."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une lanière de cuir sanglée autour du bras ou un appendice semblable.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/freedom-of-movement"
+  },
+  {
+    "index": "freezing-sphere",
+    "name": "Sphère glacée",
+    "desc": [
+      "Un globe d’énergie glaciale jaillit de vos doigts vers un point que vous choisissez à portée, où elle explose sous forme d’une sphère de 18 m de rayon. Chaque créature prise dans la zone effectue un jet de sauvegarde de Constitution. En cas d’échec, une créature subit 10d6 dégâts de froid. En cas de réussite, elle subit la moitié de ces dégâts.",
+      "Si le globe heurte un volume d’eau ou de liquide essentiellement aqueux (les créatures composées d’eau ne sont pas affectées), il gèle cette masse sur une profondeur de 15 cm et une surface carrée de 9 m de côté. Cette glace persiste pendant 1 minute. Les créatures qui nageaient à la surface de l’eau désormais gelée se retrouvent bloquées dans la glace. Une créature bloquée peut consacrer une action à effectuer un test de Force assorti de votre DD de sauvegarde des sorts pour s’extraire de la glace.",
+      "Vous pouvez si vous le souhaitez vous retenir de projeter le globe une fois l’incantation terminée. Dans ce cas, un petit globe de la taille d’une pierre de fronde, froid au contact, apparaît dans votre main. À tout moment, vous ou une créature à qui vous confiez le globe pouvez le projeter (sur une distance maximale de 12 m) ou vous servir d’une fronde pour le lancer (profitant ainsi de la portée normale de la fronde). Il se brise à l’impact, en produisant les mêmes effets que l’incantation de base du sort. Vous pouvez également poser le globe sans le briser. Au bout de 1 minute, s’il ne s’est toujours pas brisé, le globe explose."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau ou supérieur, les dégâts augmentent de 1d6 par niveau d’emplacement au-delà du 6e."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une petite sphère de cristal.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "damage_at_slot_level": {
+        "6": "10d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/freezing-sphere"
+  },
+  {
+    "index": "gaseous-form",
+    "name": "Forme gazeuse",
+    "desc": [
+      "Vous transformez une créature consentante que vous touchez, ainsi que tout ce qu'elle porte et transporte, en un nuage brumeux pour la durée du sort. Le sort prend fin si la créature atteint 0 point de vie. Une créature immatérielle n'est pas affectée.",
+      "Alors qu'elle est dans cet état, la cible ne peut se déplacer que par le vol, à la vitesse de 3 mètres. La cible peut pénétrer et occuper l'espace d'une autre créature. La cible possède une résistance aux dégâts non magiques, et elle a un avantage à ses jets de sauvegarde de Force, Dextérité et Constitution. La cible peut passer par de petits trous, des ouvertures étroites et même par des fissures. Cependant, elle considère les liquides comme des surfaces dures. La cible ne peut chuter et elle se maintient dans les airs même lorsqu'elle est étourdie ou autrement indisposée.",
+      "Alors qu'elle est dans l'état d'un nuage brumeux, la cible ne peut parler ou manipuler des objets. Les objets qu'elle transportait ou tenait ne peuvent être lâchés ou utilisés de quelconque façon. La cible ne peut attaquer ou lancer des sorts."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de gaze et une volute de fumée.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/gaseous-form"
+  },
+  {
+    "index": "gate",
+    "name": "Portail",
+    "desc": [
+      "Vous invoquez un portail reliant un espace inoccupé que vous voyez à portée à un lieu précis sur un autre plan d’existence. Le portail se présente comme une ouverture circulaire dont le diamètre peut aller de 1,50 m à 6 m. Vous l’orientez dans la direction de votre choix. Le portail persiste pour toute la durée.",
+      "Le portail est doté d’une face avant et d’une face arrière, sur chaque plan où il apparaît. Emprunter le portail n’est possible que si on le franchit par sa face avant. Tout ce qui le franchit ainsi est aussitôt transporté sur l’autre plan, pour apparaître dans l’espace inoccupé le plus proche du portail. Les divinités et autres souverains planaires peuvent empêcher les portails engendrés par ce sort de s’ouvrir en leur présence, voire où que ce soit en leur domaine.",
+      "À l’incantation du sort, vous pouvez prononcer le nom d’une créature donnée (un pseudonyme, un titre ou un surnom ne suffisent pas). Si cette créature se trouve sur un plan autre que celui que vous occupez, le portail s’ouvre dans les environs immédiats de la créature et l’aspire pour la transporter jusqu’à l’espace inoccupé le plus proche du portail, sur votre plan. Vous n’avez nulle emprise particulière sur la créature, qui est libre d’agir à l’appréciation du MJ. Elle peut choisir de partir, de vous attaquer ou de vous aider."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "un diamant d’une valeur minimale de 5 000 po.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/gate"
+  },
+  {
+    "index": "geas",
+    "name": "Geas",
+    "desc": [
+      "Vous intimez un ordre magique à une créature que vous voyez à portée, pour la contraindre à accomplir une tâche ou l’empêcher d’accomplir certains actes que vous statuez. Si la créature vous comprend, elle doit réussir un jet de sauvegarde de Sagesse sous peine d’être charmée par vous pour toute la durée. Tant que la créature est charmée par vous, elle subit 5d10 dégâts psychiques quand elle se conduit directement à l’encontre de vos instructions, mais jamais plus d’une fois par jour. Une créature qui ne peut pas vous comprendre n’est pas affectée par le sort.",
+      "Vous pouvez donner n’importe quel ordre, en dehors d’une tâche dont l’issue serait forcément fatale à la cible. Si l’instruction intimée est suicidaire, le sort prend fin.",
+      "Vous pouvez mettre un terme prématuré au sort au prix d’une action qui le révoque. Les sorts délivrance des malédictions, restauration suprême et souhait y mettent également fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e ou 8e niveau, la durée est de 1 an. Lorsque vous lancez ce sort par un emplacement du 9e niveau, le sort persiste jusqu’à ce que l’un des sorts mentionnés ci-dessus y mette un terme."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "30 jours",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/geas"
+  },
+  {
+    "index": "gentle-repose",
+    "name": "Doux repos",
+    "desc": [
+      "Vous touchez physiquement un cadavre ou autre dépouille. Pour toute la durée, la cible est protégée contre la putréfaction et rien ne peut en faire un mort-vivant.",
+      "Ce sort prolonge également le délai au-delà duquel la cible ne pourra plus être ramenée d’entre les morts, les jours passés sous l’influence de ce sort n’étant pas décomptés dans le cadre de sorts tels que rappel à la vie."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "(une pincée de sel et une pièce de cuivre disposée sur chacun des yeux du cadavre, qui doivent y rester pour toute la durée",
+    "ritual": true,
+    "duration": "10 jours",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/gentle-repose"
+  },
+  {
+    "index": "giant-insect",
+    "name": "Insecte géant",
+    "desc": [
+      "Vous transformez pour toute la durée jusqu’à dix mille-pattes, trois araignées, cinq guêpes ou un scorpion à portée en versions géantes de leur forme naturelle. Un mille-pattes devient donc un mille-pattes géant, une araignée une araignée géante, une guêpe une guêpe géante, et un scorpion un scorpion géant.",
+      "Chaque créature se soumet à vos instructions verbales. Au combat, toutes agissent chaque round à votre tour. Le MJ dispose des profils de ces créatures et gère leurs actions comme leurs déplacements.",
+      "Une créature reste sous forme géante pour toute la durée, sauf si elle tombe à 0 point de vie ou si vous révoquez l’effet sur elle au prix d’une action.",
+      "Le MJ peut éventuellement vous autoriser à choisir d’autres cibles. Si vous transformez par exemple une abeille, sa version géante pourrait reprendre le profil de la guêpe géante."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/giant-insect"
+  },
+  {
+    "index": "glibness",
+    "name": "Bagou",
+    "desc": [
+      "Jusqu’à la fin du sort, chaque fois que vous effectuez un test de Charisme, vous pouvez substituer 15 au nombre que vous obtenez sur le dé. De plus, quoi que vous disiez, toute magie censée vérifier que vous ne mentez pas identifie vos paroles comme sincères."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/glibness"
+  },
+  {
+    "index": "globe-of-invulnerability",
+    "name": "Globe d’invulnérabilité",
+    "desc": [
+      "Une barrière immobile qui chatoie légèrement se matérialise dans un rayon de 3 m autour de vous et y persiste pour toute la durée.",
+      "Tout sort du 5e niveau ou inférieur lancé depuis l’extérieur de la barrière ne peut affecter les créatures et objets qui s’y trouvent, même si le sort est lancé par un emplacement d’un niveau supérieur. Un tel sort peut cibler les créatures et objets situés dans le globe, mais il reste sur eux sans effet. De même, la zone comprise dans la barrière est exclue des zones affectées par de tels sorts."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau ou supérieur, la barrière bloque les sorts d’un niveau de plus par niveau d’emplacement au-delà du 6e."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une perle de verre ou de cristal qui se brise à la fin du sort.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/globe-of-invulnerability"
+  },
+  {
+    "index": "glyph-of-warding",
+    "name": "Glyphe de garde",
+    "desc": [
+      "À l’incantation du sort, vous inscrivez un glyphe nuisible à d’autres créatures, soit sur une surface (comme une table, ou un pan de mur ou de sol), soit à l’intérieur d’un objet que l’on peut fermer (comme un livre, un parchemin ou un coffre au trésor) de manière à dissimuler le symbole. Si vous optez pour une surface, le glyphe peut recouvrir une zone dont le diamètre ne dépasse pas 3 m. Si vous optez pour un objet, celui-ci doit rester à sa place ; si on le déplace de plus de 3 m de l’endroit où vous avez lancé le sort, le glyphe est rompu et le sort prend fin sans avoir été activé.",
+      "Le glyphe est pratiquement invisible ; il faut réussir un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts pour le détecter.",
+      "Vous décidez ce qui le déclenche à l’incantation du sort. Dans le cas des glyphes de surface, les déclencheurs les plus courants sont les suivants : toucher le glyphe, se tenir dessus, retirer un objet qui le recouvre, s’approcher dans un certain rayon ou manipuler l’objet sur lequel il est inscrit. Pour les glyphes inscrits à l’intérieur d’un objet, les déclencheurs habituels sont l’ouverture de l’objet, une proximité spécifiée avec l’objet, la lecture du glyphe ou sa simple vue. Une fois le glyphe déclenché, le sort prend fin.",
+      "Vous pouvez préciser davantage le déclencheur pour que le sort ne s’active que sous certaines conditions ou face à certaines caractéristiques physiques (une taille ou un poids), créatures (la protection pourrait ne s’activer que contre les aberrations ou les drows) ou un alignement donné. Vous pouvez aussi définir les critères de créatures qui ne déclenchent pas le glyphe, comme le fait de prononcer un certain mot de passe.",
+      "Lorsque vous inscrivez le glyphe, choisissez entre glyphe à sort et runes explosives.",
+      "***Runes explosives.*** Quand il se déclenche, le glyphe produit une explosion d’énergies magiques sous forme d’une sphère de 6 m de rayon centrée sur le glyphe. La sphère contourne les angles. Chaque créature prise dans la zone effectue un jet de sauvegarde de Dextérité. Elle subit 5d8 dégâts d’acide, de feu, de foudre, de froid ou de tonnerre (type que vous choisissez en inscrivant le glyphe) en cas d’échec, la moitié en cas de réussite.",
+      "***Glyphe à sort.*** Vous pouvez charger le glyphe d’un sort du 3e niveau ou inférieur lors de l’incantation et de la création du glyphe. Le sort doit cibler une seule créature ou une zone. Le sort ainsi appliqué au glyphe n’a pas d’effet immédiat lorsque vous le lancez. C’est seulement lors du déclenchement du glyphe que le sort chargé se déploie. Si le sort a une cible, celle-ci devient la créature qui a provoqué le déclenchement du glyphe. Si le sort affecte une zone, celle-ci est centrée sur cette créature. Si le sort convoque une créature hostile ou crée un objet nuisible ou un piège, l’élément concerné se matérialise aussi près que possible de l’intrus et l’attaque. Si le sort requiert normalement la concentration, il persiste jusqu’à la fin de la durée maximale."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, les dégâts d’un glyphe de runes explosives augmentent de 1d8 par niveau d’emplacement au-delà du 3e. Si vous créez un glyphe à sort, vous pouvez y stocker un sort dont le niveau ne dépasse pas celui de l’emplacement utilisé pour votre glyphe de garde."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De l’encens et de la poudre de diamant d’une valeur minimale de 200 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/glyph-of-warding"
+  },
+  {
+    "index": "goodberry",
+    "name": "Baies nourricières",
+    "desc": [
+      "Un maximum de dix baies se matérialisent dans votre main, gorgées de magie pour toute la durée. Une créature peut consacrer une action à manger une telle baie. L’ingestion d’une baie fait récupérer 1 point de vie et fournit l’équivalent d’une journée de sustentation pour une créature.",
+      "Les baies perdent leurs propriétés si on ne les consomme pas dans les 24 heures qui suivent l’incantation du sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une branche de gui.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/goodberry"
+  },
+  {
+    "index": "grease",
+    "name": "Grease",
+    "desc": [
+      "Une graisse glissante recouvre le sol sur un carré de 3 m de côté centré en un point à portée, ce qui en fait un terrain difficile pour toute la durée.",
+      "À l’apparition de la graisse, toute créature se tenant debout dans cette zone doit réussir un jet de sauvegarde de Dextérité sous peine de se retrouver à terre. Une créature qui pénètre dans la zone ou qui y termine son tour doit également réussir un jet de sauvegarde de Dextérité sous peine de se retrouver à terre."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de couenne de porc ou de beurre",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 10
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/grease"
+  },
+  {
+    "index": "greater-invisibility",
+    "name": "Invisibilité suprême",
+    "desc": [
+      "Vous ou une créature que vous touchez devenez invisible jusqu’à la fin du sort. Tout ce que la cible porte est également invisible tant qu’elle continue à le porter."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/greater-invisibility"
+  },
+  {
+    "index": "greater-restoration",
+    "name": "Restauration suprême",
+    "desc": [
+      "Vous investissez la créature que vous touchez d’énergie positive pour la débarrasser d’un effet débilitant. Vous pouvez réduire le niveau d’épuisement de la cible d’un cran ou mettre fin à l’un des effets suivants la concernant :",
+      "- Un effet qui inflige l’état charmé ou pétrifié à la cible",
+      "- Une malédiction, y compris l’harmonisation éventuelle de la cible à un objet magique maudit",
+      "- Toute réduction de l’une des valeurs de caractéristique de la cible",
+      "- Un effet qui réduit le maximum de points de vie de la cible"
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "poudre de diamant d’une valeur minimale de 100 po, que le sort détruit",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/greater-restoration"
+  },
+  {
+    "index": "guardian-of-faith",
+    "name": "Gardien de la foi",
+    "desc": [
+      "Un gardien spectral de taille G apparaît pour toute la durée et flotte en un espace inoccupé de votre choix parmi ceux que vous voyez à portée. Le gardien occupe cet espace et reste imperceptible, en dehors de son épée luisante et du bouclier frappé du symbole de votre divinité.",
+      "Toute créature qui vous est hostile, quand elle entre dans un espace situé dans un rayon de 3 m du gardien pour la première fois d’un tour, effectue un jet de sauvegarde de Dextérité. Elle subit 20 dégâts radiants en cas d’échec, la moitié en cas de réussite. Le gardien disparaît après avoir infligé un total de 60 dégâts."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "4": "20"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 10
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/guardian-of-faith"
+  },
+  {
+    "index": "guards-and-wards",
+    "name": "Protections et sceaux",
+    "desc": [
+      "Vous créez une barrière qui protège un espace au sol d’une surface maximale de 225 mètres carrés (une zone carrée de 15 m de côté, cent carrés de 1,50 m de côté ou vingt-cinq carrés de 3 m de côté). La zone protégée peut atteindre 6 m de haut et présente la forme de votre choix. Vous pouvez ainsi protéger plusieurs étages d’une forteresse en répartissant astucieusement la zone, à condition de marcher sur chaque zone contiguë pendant l’incantation du sort.",
+      "À l’incantation du sort, vous pouvez spécifier quels individus ne seront pas affectés par tout ou partie des effets que vous choisissez. Vous pouvez également définir un mot de passe immunisant l’individu qui le prononce contre ces effets.",
+      "Le sort protections et sceaux produit les effets suivants au sein de la zone protégée.",
+      "***Couloirs.*** La brume envahit les couloirs protégés, dans lesquels la visibilité devient nulle. De plus, à chaque intersection ou embranchement qui présente un choix de direction, toute créature autre que vous a 50 % de chances de croire qu’elle a pris une direction autre que celle qu’elle a réellement empruntée, voire radicalement opposée.",
+      "***Escaliers.*** Tous les escaliers de la zone protégée sont envahis de filandres de la première à la dernière marche (équivalent du sort toile d’araignée). Tant que persiste le sort protections et sceaux, cette masse filandreuse se reconstitue en 10 minutes si on la brûle ou l’arrache.",
+      "***Portes.*** Toutes les portes de la zone protégée sont magiquement verrouillées, comme si elles étaient condamnées par le sort verrou magique. De plus, vous pouvez assortir un maximum de dix portes d’une illusion (équivalent de la fonction d’objet illusoire du sort illusion mineure) afin qu’elles passent pour de simples pans de mur.",
+      "***Autres effets du sort.*** Vous pouvez disposer une combinaison des effets magiques suivants au sein de la zone protégée.",
+      "- Des lumières dansantes dans quatre couloirs. Vous pouvez définir une séquence simple que les lumières répètent tant que le sort persiste.",
+      "- Bouche magique en deux endroits.",
+      "- Nuage nauséabond en deux endroits. Les vapeurs se manifestent dans les lieux désignés ; tant que le sort persiste, elles réapparaissent en 10 minutes si un vent les disperse.",
+      "- Une bourrasque constante dans un couloir ou une pièce.",
+      "- Une suggestion en un lieu. Choisissez une zone carrée d’un maximum de 1,50 m de côté ; toute créature qui y entre ou la traverse est soumise mentalement à la suggestion.",
+      "Toute la zone protégée irradie la magie. Une dissipation de la magie lancée sur un effet donné, si elle réussit, n’élimine que cet effet.",
+      "Si vous lancez quotidiennement ce sort pendant un an sur une structure donnée, protections et sceaux y devient permanent."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De l’encens qui brûle, un peu de soufre et d’huile, une ficelle nouée, un peu de sang de mastodonte des ombres, et un petit sceptre en argent d’une valeur minimale de 10 po",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 6,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 2500
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/guards-and-wards"
+  },
+  {
+    "index": "guidance",
+    "name": "Assistance",
+    "desc": [
+      "Vous touchez une créature consentante. Une fois avant la fin du sort, la cible peut lancer un d4 et en ajouter le résultat au test de caractéristique de son choix. Elle peut lancer ce dé avant ou après avoir effectué le test de caractéristique. Le sort prend alors fin."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/guidance"
+  },
+  {
+    "index": "guiding-bolt",
+    "name": "Rayon traçant",
+    "desc": [
+      "Un trait de lumière jaillit vers une créature de votre choix à portée. Effectuez une attaque de sort à distance contre la cible. Si l’attaque touche, la cible subit 4d6 dégâts radiants et le prochain jet d’attaque qui la vise avant la fin de votre tour suivant est avantagé, grâce à la lumière faible et scintillante qui émane d’elle."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, les dégâts augmentent de 1d6 par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "1": "4d6",
+        "2": "5d6",
+        "3": "6d6",
+        "4": "7d6",
+        "5": "8d6",
+        "6": "9d6",
+        "7": "10d6",
+        "8": "11d6",
+        "9": "12d6"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/guiding-bolt"
+  },
+  {
+    "index": "gust-of-wind",
+    "name": "Bourrasque",
+    "desc": [
+      "Toute créature prise dans la ligne qui se déplace vers vous doit consacrer le double du déplacement normal pour toute distance parcourue.",
+      "Toute créature prise dans la ligne qui se déplace vers vous doit consacrer le double du déplacement normal pour toute distance parcourue.",
+      "La bourrasque disperse les gaz et vapeurs, éteint les bougies, torches et flammes exposées de la zone. Les flammes protégées, comme celles des lanternes, vacillent vigoureusement avec un risque de 50 % de s’éteindre.",
+      "Par une action bonus à chacun de vos tours tant que le sort persiste, vous pouvez changer la direction de la ligne qui émane de vous."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une graine de légumineuse.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "str",
+        "name": "FOR",
+        "url": "/api/2014/ability-scores/str"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/gust-of-wind"
+  },
+  {
+    "index": "hallow",
+    "name": "Sanctification",
+    "desc": [
+      "Vous touchez un point pour investir la zone environnante de pouvoir sacré (ou impie). Le rayon de la zone peut atteindre 18 m, le sort échouant si ce rayon chevauche une zone déjà affectée par le sort sanctification. La zone affectée est soumise aux effets suivants.",
+      "Tout d’abord, les célestes, élémentaires, fées, fiélons et morts-vivants ne peuvent y pénétrer, et ces mêmes créatures ne peuvent pas charmer, effrayer ou posséder celles qui se trouvent dans la zone. Toute créature charmée, effrayée ou possédée par une créature de l’un de ces types n’est plus charmée ni effrayée ni possédée dès qu’elle entre dans la zone. Vous pouvez exclure un ou plusieurs de ces types de créature de l’effet.",
+      "Ensuite, vous pouvez associer un effet supplémentaire à la zone. Choisissez-le dans la liste suivante ou optez pour un effet proposé par le MJ. Certains de ces effets s’appliquent aux créatures de la zone ; vous pouvez décider si l’effet concerne toutes les créatures, celles qui honorent une divinité ou un meneur spécifique ou encore celles d’une variété donnée, comme les orcs ou les trolls. Quand une créature censée être affectée entre dans la zone du sort pour la première fois d’un tour ou y commence son tour, elle peut effectuer un jet de sauvegarde de Charisme. En cas de réussite, elle ne tient pas compte de l’effet supplémentaire jusqu’à ce qu’elle quitte la zone.",
+      "***Courage.*** Les créatures affectées ne peuvent être effrayées tant qu’elles restent dans la zone.",
+      "***Don des langues.*** Les créatures affectées peuvent communiquer avec toute autre créature présente dans la zone, même si elles ne parlent aucune langue en commun.",
+      "***Interférence extradimensionnelle.*** Les créatures affectées ne peuvent pas se déplacer ou voyager par téléportation ni par des moyens extradimensionnels ou planaires.",
+      "***Lumière du jour.*** Une lumière vive emplit la zone. Les ténèbres magiques créées par des sorts de niveau inférieur à celui de l’emplacement utilisé pour cette incantation ne peuvent pas occulter cette lumière.",
+      "***Protection contre l’énergie.*** Les créatures affectées présentes dans la zone bénéficient de la résistance à un type de dégâts de votre choix (hormis contondants, perforant et tranchants).",
+      "***Repos éternel.*** Les dépouilles enterrées dans la zone ne peuvent pas être transformées en morts-vivants.",
+      "***Silence.*** Aucun son ne peut émaner de l’intérieur de la zone et aucun son ne peut y pénétrer.",
+      "***Ténèbres.*** Les ténèbres envahissent la zone. Les lumières ordinaires, ainsi que les lumières magiques créées par des sorts de niveau inférieur à celui de l’emplacement utilisé pour cette incantation, ne peuvent pas éclairer la zone.",
+      "***Terreur.*** Les créatures affectées sont effrayées tant qu’elles restent dans la zone.",
+      "***Vulnérabilité à l’énergie.*** Les créatures affectées présentes dans la zone reçoivent la vulnérabilité à un type de dégâts de votre choix (hormis contondants, perforant et tranchants)."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Des herbes, des huiles et de l’encens d’une valeur minimale de 1 000 po, que le sort détruit",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "24 heures",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/hallow"
+  },
+  {
+    "index": "hallucinatory-terrain",
+    "name": "Terrain hallucinatoire",
+    "desc": [
+      "Un terrain naturel qui pourrait loger dans un cube de 45 m d’arête apparaît comme un autre type de terrain naturel, sur les plans visuel, auditif et olfactif. Ainsi un champ ou une route pourrait se présenter comme un marais, une colline, une crevasse glaciaire ou autre environnement difficile ou infranchissable. Une mare pourrait apparaître comme une jolie prairie, un précipice comme une pente douce et un ravin comme une route large et dégagée. Les bâtiments, l’équipement et les créatures de la zone ne changent pas d’aspect.",
+      "Les propriétés tactiles du terrain ne changent pas non plus, si bien qu’une créature qui pénètre dans la zone ne se laissera pas duper longtemps par l’illusion. Si la différence n’est pas évidente au contact, une créature qui examine soigneusement la zone peut tenter un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts pour percer l’illusion à jour. Une créature qui discerne le subterfuge perçoit une image vague superposée au véritable terrain."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pierre, une brindille et un morceau de plante verte",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 4,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 150
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/hallucinatory-terrain"
+  },
+  {
+    "index": "harm",
+    "name": "Contamination",
+    "desc": [
+      "Vous libérez une maladie virulente sur une créature que vous voyez à portée. La cible effectue un jet de sauvegarde de Constitution. Elle subit 14d6 dégâts nécrotiques en cas d’échec, la moitié en cas de réussite. Ces dégâts ne peuvent réduire ses points de vie en dessous de 1. Si la cible rate le jet de sauvegarde, son maximum de points de vie est réduit pendant 1 heure de l’équivalent des dégâts nécrotiques qu’elle a subis. Tout effet qui élimine une maladie ramène le maximum de points de vie de la créature à la normale sans devoir attendre ce délai."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "6": "14d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/harm"
+  },
+  {
+    "index": "haste",
+    "name": "Hâte",
+    "desc": [
+      "Choisissez une créature consentante que vous voyez à portée. Jusqu’à la fin du sort, la cible voit sa vitesse doubler, sa CA reçoit un bonus de +2, elle est avantagée aux jets de sauvegarde de Dextérité et bénéficie d’une action supplémentaire à chacun de ses tours. Cette action ne peut servir qu’à entreprendre l’action Attaquer (une seule attaque d’arme), Foncer, Se cacher, Se désengager ou Utiliser un objet.",
+      "Lorsque le sort prend fin, jusqu’à la fin de son tour suivant, la cible, en proie à une vague de léthargie, ne peut entreprendre ni déplacement ni action."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un copeau de racine de réglisse",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/haste"
+  },
+  {
+    "index": "heal",
+    "name": "Guérison",
+    "desc": [
+      "Choisissez une créature que vous voyez à portée. Une vague d’énergie positive baigne la créature, qui récupère 70 points de vie. Ce sort met également fin à la cécité, à la surdité et à toute maladie affectant la cible. Il est sans effet sur les artificiels et les morts-vivants."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau ou supérieur, les points de vie récupérés augmentent de 10 par niveau d’emplacement au-delà du 6e."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "heal_at_slot_level": {
+      "6": "70",
+      "7": "80",
+      "8": "90",
+      "9": "100"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/heal"
+  },
+  {
+    "index": "healing-word",
+    "name": "Mot de guérison",
+    "desc": [
+      "Une créature de votre choix que vous voyez à portée récupère autant de points de vie que 1d4 + votre modificateur de caractéristique d’incantation. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, il soigne 1d4 supplémentaires par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "heal_at_slot_level": {
+      "1": "1d4 + MOD",
+      "2": "2d4 + MOD",
+      "3": "3d4 + MOD",
+      "4": "4d4 + MOD",
+      "5": "5d4 + MOD",
+      "6": "6d4 + MOD",
+      "7": "7d4 + MOD",
+      "8": "8d4 + MOD",
+      "9": "9d4 + MOD"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/healing-word"
+  },
+  {
+    "index": "heat-metal",
+    "name": "Métal brûlant",
+    "desc": [
+      "Choisissez un objet manufacturé en métal, tel qu’une arme ou une armure métallique intermédiaire ou lourde que vous voyez à portée. Vous faites chauffer l’objet au rouge incandescent. Toute créature en contact physique avec l’objet subit 2d8 dégâts de feu à l’incantation du sort. Jusqu’à la fin du sort, vous pouvez appliquer de nouveau ces dégâts par une action bonus à chacun de vos tours suivants.",
+      "Une créature qui tient ou porte un tel objet et subit les dégâts correspondants doit réussir un jet de sauvegarde de Constitution sous peine de lâcher l’objet (si elle en a la possibilité). Si elle ne peut pas le lâcher, elle est désavantagée à ses jets d’attaque et tests de caractéristique jusqu’au début de votre tour suivant."
+    ],
+    "higher_level": [
+      " Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, les dégâts augmentent de 1d8 par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un bout de fer et une flamme",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "2": "2d8",
+        "3": "3d8",
+        "4": "4d8",
+        "5": "5d8",
+        "6": "6d8",
+        "7": "7d8",
+        "8": "8d8",
+        "9": "9d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "other",
+      "desc": "Can choose to not drop the object"
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/heat-metal"
+  },
+  {
+    "index": "hellish-rebuke",
+    "name": "Hellish Rebuke",
+    "desc": [
+      "Vous pointez votre doigt et la créature qui vous a infligé des dégâts se retrouve un court instant cernée de flammes des enfers. La créature effectue un jet de sauvegarde de Dextérité. Elle subit 2d10 dégâts de feu en cas d’échec, la moitié en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, les dégâts augmentent de 1d10 par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 réaction, que vous jouez lorsqu’une créature que vous voyez dans un rayon de 18 m vous inflige des dégâts",
+    "level": 1,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "1": "2d10",
+        "2": "3d10",
+        "3": "4d10",
+        "4": "5d10",
+        "5": "6d10",
+        "6": "7d10",
+        "7": "8d10",
+        "8": "9d10",
+        "9": "10d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/hellish-rebuke"
+  },
+  {
+    "index": "heroes-feast",
+    "name": "Festin des héros",
+    "desc": [
+      "Un grand festin se matérialise à votre incantation, garni de mets et de boissons fabuleux. Il faut 1 heure pour ingérer ce festin, tous les plats disparaissant à l’issue de cet intervalle. Les bénéfices ne se font pas sentir avant la fin de l’heure. Choisissez jusqu’à douze créatures qui peuvent participer au banquet.",
+      "Une créature qui a figuré parmi les convives reçoit plusieurs bénéfices. Elle est guérie de toute maladie et tout empoisonnement, se retrouve immunisée contre le poison et l’état effrayé, et effectue tous ses jets de sauvegarde de Sagesse avec l’avantage. Son maximum de points de vie augmente en outre de 2d10 et elle reçoit le même nombre de points de vie. Ces bénéfices persistent pendant 24 heures."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un vase incrusté de gemmes d’une valeur minimale de 1 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 6,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/heroes-feast"
+  },
+  {
+    "index": "heroism",
+    "name": "Héroïsme",
+    "desc": [
+      "Une créature consentante que vous touchez est investie de vaillance. Jusqu’à la fin du sort, la créature est immunisée contre l’état effrayé et reçoit autant de points de vie temporaires que votre modificateur de caractéristique d’incantation au début de chacun de ses tours. Quand le sort prend fin, la cible perd tous les points de vie temporaires restants issus du sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/heroism"
+  },
+  {
+    "index": "hideous-laughter",
+    "name": "Fou rire",
+    "desc": [
+      "Une créature de votre choix parmi celles que vous voyez à portée perçoit tout comme hilarant et se prend d’un fou rire si le sort l’affecte. La cible doit réussir un jet de sauvegarde de Sagesse, sous peine de tomber à terre et d’être neutralisée, incapable de se relever pour toute la durée. Une créature dont la valeur d’Intelligence est de 4 ou moins n’est pas affectée.",
+      "À la fin de chacun de ses tours et chaque fois qu’elle subit des dégâts, la cible peut réitérer le jet de sauvegarde de Sagesse. Elle est avantagée au jet de sauvegarde s’il est déclenché par des dégâts. En cas de réussite, le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De minuscules tartes à la crème et une plume agitée en l’air.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/hideous-laughter"
+  },
+  {
+    "index": "hold-monster",
+    "name": "Immobilisation de monstre",
+    "desc": [
+      "Choisissez une créature que vous voyez à portée. La cible doit réussir un jet de sauvegarde de Sagesse sous peine d’être paralysée pour toute la durée. Ce sort est sans effet sur les morts-vivants. À la fin de chacun de ses tours, la cible peut réitérer le jet de sauvegarde de Sagesse. En cas de réussite, le sort prend fin sur elle."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 6e niveau ou supérieur, vous pouvez cibler une créature de plus par niveau d’emplacement au-delà du 5e. Les créatures ainsi ciblées doivent toutes se trouver dans un rayon de 9 m les unes des autres."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un brin de fer.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/hold-monster"
+  },
+  {
+    "index": "hold-person",
+    "name": "Immobilisation de personne",
+    "desc": [
+      "Choisissez un humanoïde que vous voyez à portée. La cible doit réussir un jet de sauvegarde de Sagesse sous peine d’être paralysée pour toute la durée. À la fin de chacun de ses tours, la cible peut réitérer le jet de sauvegarde de Sagesse. En cas de réussite, le sort prend fin sur elle."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, vous pouvez cibler un humanoïde de plus par niveau d’emplacement au-delà du 2e. Les humanoïdes ainsi ciblés doivent tous se trouver dans un rayon de 9 m les uns des autres."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un brin de fer.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/hold-person"
+  },
+  {
+    "index": "holy-aura",
+    "name": "Aura sacrée",
+    "desc": [
+      "La lumière divine émane de vous pour se fondre en une douce radiance dans un rayon de 9 m autour de vous. Jusqu’à la fin du sort, les créatures que vous désignez dans ce rayon à l’incantation du sort produisent une lumière faible sur 1,50 m et sont avantagées à leurs jets de sauvegarde, tandis que les autres créatures sont désavantagées à leurs jets d’attaque contre les premières. De plus, lorsqu’un fiélon ou un mort-vivant touche une créature désignée avec une attaque de corps à corps, l’aura de lumière s’intensifie soudain. L’assaillant doit réussir un jet de sauvegarde de Constitution sous peine d’être aveuglé jusqu’à la fin du sort."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un minuscule reliquaire d’une valeur minimale de 1 000 po renfermant une sainte relique, telle qu’un lambeau de vêtement de la robe d’un saint ou un fragment de parchemin d’écritures religieuses.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/holy-aura"
+  },
+  {
+    "index": "hunters-mark",
+    "name": "Marque du chasseur",
+    "desc": [
+      "Vous choisissez une créature que vous voyez à portée, que vous désignez mystiquement comme votre proie. Jusqu’à la fin du sort, vous infligez 1d6 dégâts supplémentaires à la cible chaque fois que vous la touchez avec une attaque d’arme et vous avez l’avantage à vos tests de Sagesse (Survie) et de Sagesse (Perception) visant à la retrouver. Si la cible tombe à 0 point de vie avant la fin du sort, vous pouvez, par une action bonus à l’un de vos tours suivants, marquer une nouvelle créature."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e ou 4e niveau, vous pouvez maintenir votre concentration sur le sort pendant un maximum de 8 heures. Avec un emplacement de sort du 5e niveau ou supérieur, vous pouvez maintenir votre concentration sur le sort pendant un maximum de 24 heures."
+    ],
+    "range": "27 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/hunters-mark"
+  },
+  {
+    "index": "hypnotic-pattern",
+    "name": "Motif hypnotique",
+    "desc": [
+      "Vous créez un motif animé de couleurs qui oscillent dans les airs en occupant un cube de 9 m d’arête à portée. Le motif n’apparaît qu’un instant, puis disparaît. Toute créature présente dans la zone qui voit le motif effectue un jet de sauvegarde de Sagesse. En cas d’échec, elle se retrouve charmée pour toute la durée. Tant qu’elle est charmée par ce sort, la créature est neutralisée et sa vitesse est de 0.",
+      "Le sort prend fin pour une créature affectée si elle subit des dégâts ou si quelqu’un d’autre consacre une action à la sortir de son hébétude."
+    ],
+    "range": "36 mètres",
+    "components": ["S", "M"],
+    "material": "Un bâton d’encens incandescent ou une fiole de cristal remplie de matière phosphorescente.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "On a failed save, the creature becomes charmed for the duration."
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/hypnotic-pattern"
+  },
+  {
+    "index": "ice-storm",
+    "name": "Tempête de grêle",
+    "desc": [
+      "Une violente tempête de grêlons durs comme le roc s’abat au sol dans un cylindre de 6 m de rayon et 12 m de hauteur centré en un point à portée. Chaque créature prise dans le cylindre effectue un jet de sauvegarde de Dextérité. Elle subit 2d8 dégâts contondants et 4d6 dégâts de froid en cas d’échec, la moitié en cas de réussite.",
+      "Les grêlons transforment la zone d’effet de la tempête en terrain difficile jusqu’à la fin de votre tour suivant."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 5e niveau ou supérieur, les dégâts contondants augmentent de 1d8 par niveau d’emplacement au-delà du 4e."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "(une pincée de poussière et quelques gouttes d’eau",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Contondant",
+        "url": "/api/2014/damage-types/bludgeoning"
+      },
+      "damage_at_slot_level": {
+        "4": "2d8 + 4d6",
+        "5": "3d8 + 4d6",
+        "6": "4d8 + 4d6",
+        "7": "5d8 + 4d6",
+        "8": "6d8 + 4d6",
+        "9": "7d8 + 4d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 20
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/ice-storm"
+  },
+  {
+    "index": "identify",
+    "name": "Identification",
+    "desc": [
+      "Vous choisissez un objet au contact duquel vous devez rester pendant toute l’incantation. S’il s’agit d’un objet magique ou imprégné de magie, vous en apprenez les propriétés et savez les utiliser ; vous savez également si l’harmonisation est requise et de combien de charges l’objet dispose, le cas échéant. Vous apprenez aussi quels sorts éventuels affectent l’objet. Si l’objet a été créé par un sort, vous apprenez lequel.",
+      "Si au lieu d’un objet, vous touchez une créature pendant toute l’incantation, vous apprenez quels sorts éventuels l’affectent."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une perle d’une valeur minimale de 100 po et une plume de hibou",
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 1,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/identify"
+  },
+  {
+    "index": "illusory-script",
+    "name": "Texte illusoire",
+    "desc": [
+      "Vous écrivez sur du parchemin, du papier ou autre surface adaptée et y insufflez une puissante illusion qui persiste pour toute la durée.",
+      "À vos yeux, ainsi qu’à ceux de toute créature que vous désignez à l’incantation du sort, le texte paraît normalement écrit de votre main et porte le message voulu de votre part. Pour toute autre créature, le texte paraît rédigé selon un alphabet inconnu ou magique, parfaitement incompréhensible. Une autre option consiste à donner un sens entièrement différent au message, qui semble écrit par quelqu’un d’autre et dans une autre langue que vous maîtrisez.",
+      "Si le sort est dissipé, le texte original et l’illusion disparaissent.",
+      "Une créature dotée de la vision lucide peut lire le message caché."
+    ],
+    "range": "Contact",
+    "components": ["S", "M"],
+    "material": "De l’encre au plomb d’une valeur minimale de 10 po, que le sort détrui.",
+    "ritual": true,
+    "duration": "10 jours",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 1,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/illusory-script"
+  },
+  {
+    "index": "imprisonment",
+    "name": "Emprisonnement",
+    "desc": [
+      "Vous créez des entraves magiques pour retenir une créature que vous voyez à portée. La cible doit réussir un jet de sauvegarde de Sagesse sous peine d’être détenue par le sort ; en cas de réussite, elle est immunisée contre ce sort si jamais vous deviez le relancer. Tant qu’elle est affectée par ce sort, la créature peut se passer de respirer, de s’alimenter et de boire, et elle ne vieillit pas. Les sorts de divination ne peuvent ni localiser ni percevoir la cible.",
+      "À l’incantation du sort, choisissez l’une des formes d’emprisonnement suivantes.",
+      "***Chaînes.*** De lourdes chaînes fermement ancrées au sol retiennent la cible. Jusqu’à la fin du sort, la cible est entravée et ne peut se déplacer ni être déplacée par quelque moyen que ce soit. La composante spéciale de cette version du sort est une fine chaîne de métal précieux.",
+      "***Détention miniature..*** La cible est rapetissée jusqu’à mesurer 2,5 cm pour se retrouver séquestrée dans une gemme ou un objet comparable. La lumière traverse normalement cette pierre (ce qui permet à la cible de voir à l’extérieur et aux autres créatures de voir à l’intérieur), mais rien d’autre ne peut y pénétrer, y compris par téléportation ou voyage planaire. On ne peut ni tailler ni briser la gemme tant que le sort reste actif.",
+      "La composante spéciale de cette version du sort est une grande gemme transparente, comme un corindon, un diamant ou un rubis.",
+      "***Enterrement.*** La cible est inhumée dans les entrailles de la terre, à l’intérieur d’une sphère de force magique juste assez grande pour la contenir. Rien ne peut traverser la sphère et nulle créature ne peut se téléporter ou recourir au voyage planaire pour y entrer ou en sortir.",
+      "***Léthargie.*** La cible s’endort et rien ne peut la réveiller. La composante spéciale de cette version du sort est constituée d’herbes somnifères rares.",
+      "The special component for this version of the spell is a large, transparent gemstone, such as a corundum, diamond, or ruby.",
+      "***Prison isolée.*** Le sort transporte la cible dans un minuscule demi-plan protégé contre la téléportation et le voyage planaire. Il peut s’agir d’un labyrinthe, d’une cage, d’une tour ou d’une autre structure confinée de votre choix.",
+      "La composante spéciale de cette version du sort est une représentation miniature de la prison, en jade.",
+      "***Mettre fin au sort.*** À l’incantation du sort, quelle que soit sa version, vous pouvez spécifier une condition qui mettra fin au sort et libérera la cible. Cette condition peut être aussi spécifique et sophistiquée que vous le souhaitez, mais le MJ doit convenir qu’elle est raisonnable et qu’elle a une chance de se présenter. Elle peut être basée sur le nom de la créature, son identité ou son dieu, mais doit correspondre à des faits observables et non à des concepts abstraits comme le niveau, la classe ou les points de vie.",
+      "Le sort dissipation de la magie ne peut mettre un terme au sort que s’il est lancé au 9e niveau et s’il cible soit la prison, soit la composante spéciale utilisée pour créer celle-ci.",
+      "Une même composante spéciale ne peut servir qu’à créer une seule prison. Si vous relancez le sort en vous servant d’une même composante, la cible de la première incantation est aussitôt libérée de sa prison."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un portrait sur vélin ou une statuette à l’effigie de la cible, et une composante spéciale dont la nature dépend de la version retenue du sort, d’une valeur minimale de 500 po par dé de vie de la cible.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 9,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "en cas de réussite, elle est immunisée contre ce sort si jamais vous deviez le relancer. "
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/imprisonment"
+  },
+  {
+    "index": "incendiary-cloud",
+    "name": "Nuage incendiaire",
+    "desc": [
+      "Un nuage tourbillonnant de fumée se manifeste,chargé de braises flottantes, sous forme d’une sphère de 6 m de rayon centrée sur un point à portée. Le nuage contourne les angles et sa zone est à visibilité nulle. La nappe persiste pour toute la durée, sauf si un vent modéré ou supérieur (au moins 15 km/h) la disperse.",
+      "Quand le nuage apparaît, chaque créature prise dans sa zone effectue un jet de sauvegarde de Dextérité. Elle subit 10d8 dégâts de feu en cas d’échec, la moitié en cas de réussite. Une créature effectue aussi ce JS lorsqu’elle pénètre dans la zone du sort pour la première fois d’un tour ou qu’elle y termine son tour.",
+      "Le nuage s’éloigne de 3 m de vous au début de chacun de vos tours, dans la direction de votre choix."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "8": "10d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/incendiary-cloud"
+  },
+  {
+    "index": "inflict-wounds",
+    "name": "Blessure",
+    "desc": [
+      "Effectuez une attaque de sort au corps à corps contre une créature à portée d’allonge. Si l’attaque touche, la cible subit 3d10 dégâts nécrotiques."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, les dégâts augmentent de 1d10 par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "1": "3d10",
+        "2": "4d10",
+        "3": "5d10",
+        "4": "6d10",
+        "5": "7d10",
+        "6": "8d10",
+        "7": "9d10",
+        "8": "10d10",
+        "9": "11d10"
+      }
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/inflict-wounds"
+  },
+  {
+    "index": "insect-plague",
+    "name": "Fléau d’insectes",
+    "desc": [
+      "Des nuées grouillantes de criquets emplissent une sphère de 6 m de rayon centrée sur un point que vous choisissez à portée. La sphère contourne les angles. La sphère persiste pour toute la durée et sa zone est à visibilité réduite. Sa zone constitue un terrain difficile.",
+      "Lorsque la sphère apparaît, toute créature prise à l’intérieur effectue un jet de sauvegarde de Constitution. Elle subit 4d10 dégâts perforants en cas d’échec, la moitié en cas de réussite. Une créature effectue aussi ce JS lorsqu’elle pénètre dans la zone du sort pour la première fois d’un tour ou qu’elle y termine son tour."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 6e niveau ou supérieur, les dégâts augmentent de 1d10 par niveau d’emplacement au-delà du 5e."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Quelques grains de sucre, quelques grains de céréales et une tache de graisse.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "damage": {
+      "damage_type": {
+        "index": "piercing",
+        "name": "Perforant",
+        "url": "/api/2014/damage-types/piercing"
+      },
+      "damage_at_slot_level": {
+        "5": "4d10",
+        "6": "5d10",
+        "7": "6d10",
+        "8": "7d10",
+        "9": "8d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/insect-plague"
+  },
+  {
+    "index": "instant-summons",
+    "name": "Convocations instantanées",
+    "desc": [
+      "Vous touchez un objet d’un poids maximal de 5 kg et dont la dimension la plus grande n’excède pas 1,80 m. Le sort laisse une marque invisible à sa surface et inscrit, tout aussi invisiblement, le nom de l’objet sur le saphir que vous utilisez comme composante matérielle. Chaque fois que vous lancez ce sort, vous devez utiliser un saphir différent.",
+      "À tout moment après l’incantation, vous pouvez consacrer une action pour prononcer le nom de l’objet et broyer le saphir. L’objet apparaît aussitôt dans votre main, quelle que soit la distance qui vous en sépare, même s’il est sur un autre plan, puis le sort prend fin.",
+      "Si une autre créature porte l’objet, le fait de broyer le saphir ne le transporte pas jusqu’à vous, mais vous apprenez l’identité de cette créature, ainsi que sa position approximative du moment.",
+      "Dissipation de la magie ou un effet comparable appliqués sur le saphir mettent un terme aux effets du sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un saphir d’une valeur de 1 000 po.",
+    "ritual": true,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 6,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/instant-summons"
+  },
+  {
+    "index": "invisibility",
+    "name": "Invisibilité",
+    "desc": [
+      "Une créature que vous touchez devient invisible jusqu’à la fin du sort. Tout ce que la cible porte est également invisible tant qu’elle continue à le porter. Le sort prend fin pour une cible qui attaque ou lance un sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, vous pouvez cibler une créature de plus par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un cil incrusté dans de la sève.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/invisibility"
+  },
+  {
+    "index": "irresistible-dance",
+    "name": "Danse irrésistible",
+    "desc": [
+      "Choisissez une créature que vous voyez à portée. La cible entame une danse grotesque sur place : elle tente des claquettes et enchaîne les cabrioles plus ou moins rythmées pour toute la durée. Les créatures qui ne peuvent pas être charmées sont immunisées contre ce sort.",
+      "Une créature qui danse ainsi doit consacrer tout son déplacement à danser sans quitter son espace, et elle est désavantagée aux jets de sauvegarde de Dextérité et aux jets d’attaque. Tant que la cible est affectée par ce sort, les autres créatures sont avantagées à leurs jets d’attaque contre elle. Au prix d’une action, une créature dansante peut effectuer un jet de sauvegarde de Sagesse pour reprendre le contrôle de soi. En cas de réussite, le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/irresistible-dance"
+  },
+  {
+    "index": "jump",
+    "name": "Saut",
+    "desc": [
+      "Vous touchez une créature. La distance de saut de la créature est triplée jusqu’à la fin du sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une patte arrière de sauterelle.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/jump"
+  },
+  {
+    "index": "knock",
+    "name": "Déblocage",
+    "desc": [
+      "Choisissez un objet que vous voyez à portée. Il peut s’agir d’une porte, d’une boîte, d’un coffre, de menottes, d’un cadenas ou autre objet muni d’un système de fermeture, magique ou non.",
+      "Une cible verrouillée par une serrure ordinaire, barrée ou coincée est aussitôt déverrouillée, débloquée ou décoincée. Si l’objet présente plusieurs verrous, un seul d’entre eux est débloqué.",
+      "Si la cible est fermée par verrou magique, ce sort est réprimé pendant 10 minutes, durant lesquelles vous pouvez ouvrir et fermer normalement l’objet.",
+      "L’incantation du sort produit sur l’objet cible un cognement sonore, audible jusqu’à 90 m."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/knock"
+  },
+  {
+    "index": "legend-lore",
+    "name": "Mythes et légendes",
+    "desc": [
+      "Vous nommez ou décrivez une personne, un lieu ou un objet. Le sort vous fait prendre brièvement conscience d’un fait important concernant l’élément mentionné. Cette bribe de savoir peut consister en des connaissances actuelles, des histoires oubliées du passé, voire quelque secret toujours resté méconnu. Si l’élément mentionné n’a rien de légendaire, vous n’obtenez aucune information. Plus vous en savez déjà sur l’élément, plus précises et détaillées seront les informations transmises.",
+      "Les détails reçus sont exacts, mais parfois formulés figurativement. Si vous avez par exemple une mystérieuse hache magique en main, le sort pourrait vous livrer les informations suivantes : \" Gare au scélérat dont la main touche la hache, car son manche suffit à entailler les perfides. Seul un véritable Enfant de la pierre, fidèle de Moradin, peut révéler les vrais pouvoirs de la hache, à condition de porter Rudnogg sur les lèvres. \""
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "De l’encens d’une valeur minimale de 250 po, que le sort détruit, et quatre lamelles d’ivoire d’une valeur minimale de 50 po chacune",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 5,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/legend-lore"
+  },
+  {
+    "index": "lesser-restoration",
+    "name": "Restauration partielle",
+    "desc": [
+      "Vous touchez une créature et mettez un terme à une maladie ou un état qui l’affecte. L’état peut être assourdi, aveuglé, empoisonné ou paralysé."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/lesser-restoration"
+  },
+  {
+    "index": "levitate",
+    "name": "Lévitation",
+    "desc": [
+      "Une créature ou un objet de votre choix que vous voyez à portée s’élève verticalement jusqu’à une hauteur maximale de 6 m et y reste, en suspension, pour toute la durée. Le sort peut faire léviter une cible dont le poids n’excède pas 250 kg. Une créature non consentante qui réussit un jet de sauvegarde de Constitution n’est pas affectée.",
+      "La cible ne peut se déplacer qu’en prenant appui sur des objets et surfaces fixes à portée (murs, plafonds, etc.), comme si elle escaladait. À votre tour, vous pouvez modifier l’altitude de la cible d’un maximum de 6 m vers le haut ou vers le bas. Si vous êtes la cible, vous pouvez vous déplacer ainsi dans le cadre de votre déplacement. Sans cela, vous devez consacrer votre action à déplacer la cible, qui doit rester à portée du sort.",
+      "Lorsque le sort prend fin, la cible redescend en flottant vers le sol si elle est toujours dans les airs."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une petite boucle de cuir ou un fil doré en forme de coupe avec une longue anse.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/levitate"
+  },
+  {
+    "index": "light",
+    "name": "Lumière",
+    "desc": [
+      "Vous touchez un objet dont aucune dimension ne dépasse 3 m. Jusqu’à la fin du sort, l’objet produit une lumière vive sur un rayon de 6 m et une lumière faible sur 6 m de plus. La lumière peut présenter les teintes de votre choix. Recouvrir intégralement l’objet d’une surface opaque bloque la lumière. Le sort prend fin si vous le relancez ou le révoquez au prix d’une action.",
+      "Si vous ciblez un objet porté par une créature hostile, celle-ci doit réussir un jet de sauvegarde de Dextérité pour éviter le sort."
+    ],
+    "range": "Contact",
+    "components": ["V", "M"],
+    "material": "Une luciole ou de la mousse phosphorescente.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/light"
+  },
+  {
+    "index": "lightning-bolt",
+    "name": "Éclair",
+    "desc": [
+      "Un éclair foudroyant jaillit de vous sous la forme d’une ligne de 30 m de long et 1,50 m de large, dans la direction de votre choix. Chaque créature prise dans la ligne effectue un jet de sauvegarde de Dextérité. Elle subit 8d6 dégâts de foudre en cas d’échec, la moitié en cas de réussite.",
+      "La foudre embrase les objets inflammables de la zone qui ne sont portés par personne."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, les dégâts augmentent de 1d6 par niveau d’emplacement au-delà du 3e."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de fourrure et une tige d’ambre, de cristal ou de verre.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "damage": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "damage_at_slot_level": {
+        "3": "8d6",
+        "4": "9d6",
+        "5": "10d6",
+        "6": "11d6",
+        "7": "12d6",
+        "8": "13d6",
+        "9": "14d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 100
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/lightning-bolt"
+  },
+  {
+    "index": "locate-animals-or-plants",
+    "name": "Localisation d'animaux ou de plantes",
+    "desc": [
+      "Décrivez ou nommez un type spécifique de bête ou de plante. Vous écoutez attentivement la voix dela nature environnante qui vous apprend dans quelledirection et à quelle distance se trouve la créature ou la plante de cette sorte la plus proche dans un rayon de 7,5 km, le cas échéant."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une touffe de poils de limier.",
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/locate-animals-or-plants"
+  },
+  {
+    "index": "locate-creature",
+    "name": "Localisation de créature",
+    "desc": [
+      "Décrivez ou nommez une créature qui vous est familière. Vous percevez dans quelle direction la créature se trouve, à condition qu’elle soit située dans un rayon de 300 m. Si la créature se déplace, vous savez dans quelle direction.",
+      "Le sort peut localiser une créature donnée que vous connaissez ou la créature d’une certaine catégorie la plus proche (un humain ou une licorne, par exemple), à condition que vous ayez déjà approché une telle créature dans un rayon de 9 m. Si la créature décrite ou nommée se trouve sous une forme différente, parce qu’elle est sous les effets du sort métamorphose par exemple, le sort ne parvient pas à la localiser.",
+      "Ce sort ne trouve pas davantage la créature si une largeur d’eau courante d’au moins 3 m vous sépare d’elle."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une touffe de poils de limier.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/locate-creature"
+  },
+  {
+    "index": "locate-object",
+    "name": "Localisation d'objet",
+    "desc": [
+      "Décrivez ou nommez un objet qui vous est familier. Vous percevez dans quelle direction l’objet se trouve, à condition qu’il soit situé dans un rayon de 300 m. Si l’objet est en mouvement, vous savez dans quelle direction.",
+      "Le sort peut localiser un objet donné que vous connaissez, à condition que vous l’ayez déjà approché dans un rayon de 9 m. Une autre option vous permet de localiser l’objet d’une certaine catégorie le plus proche, en mentionnant par exemple un certain genre de vêtement, de bijou, de meuble, d’outil ou d’arme.",
+      "Ce sort ne trouve pas davantage l’objet si du plomb, ne serait-ce qu’une mince feuille, se trouve directement entre vous et l’objet."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "une brindille fourchue",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/locate-object"
+  },
+  {
+    "index": "longstrider",
+    "name": "Grande foulée",
+    "desc": [
+      "Vous touchez une créature. La vitesse de la cible augmente de 3 m jusqu’à la fin du sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, vous pouvez cibler une créature de plus par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de terre.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/longstrider"
+  },
+  {
+    "index": "mage-armor",
+    "name": "Armure du mage",
+    "desc": [
+      "Vous touchez une créature consentante qui ne porte pas d’armure et une force magique protectrice l’enveloppe jusqu’à la fin du sort. La CA de base de la cible devient 13 + son modificateur de Dextérité. Le sort prend fin si la cible enfile une armure ou sivous le révoquez au prix d’une action."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de cuir traité.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/mage-armor"
+  },
+  {
+    "index": "mage-hand",
+    "name": "Main du mage",
+    "desc": [
+      "Une main spectrale et flottante apparaît en un point que vous choisissez à portée. La main persiste pour toute la durée ou jusqu’à ce que vous la révoquiez au prix d’une action. Elle disparaît si jamais elle se retrouve à plus de 9 m de vous ou si vous relancez ce sort.",
+      "Vous pouvez consacrer votre action à contrôler la main. Celle-ci peut servir à manipuler un objet, à ouvrir une porte ou un récipient non verrouillés, à ranger ou récupérer un objet dans un conteneur ouvert ou à déverser le contenu d’une fiole. Vous pouvez déplacer la main d’un maximum de 9 m chaque fois que vous l’utilisez.",
+      "Elle ne peut ni attaquer, ni utiliser d’objet magique, ni porter plus de 5 kg."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/mage-hand"
+  },
+  {
+    "index": "magic-circle",
+    "name": "Cercle magique",
+    "desc": [
+      "Vous créez un cylindre d’énergies magiques, de 3 m de rayon et 6 m de haut, centré en un point du sol que vous voyez à portée. Des runes luisantes apparaissent sur toute surface comprise dans le cylindre, y compris le sol.",
+      "Choisissez un ou plusieurs types de créature parmi les suivants : célestes, élémentaires, fiélons, fées et morts-vivants. Le cercle affecte les créatures du ou des types retenus des façons suivantes :",
+      "- La créature ne peut pénétrer dans le cylindre de son plein gré sans recourir à des moyens magiques. Si la créature recourt à la téléportation ou au voyage interplanaire pour ce faire, elle doit d’abord réussir un jet de sauvegarde de Charisme.",
+      "- La créature est désavantagée aux jets d’attaque contre les cibles situées dans le cylindre.",
+      "- Les cibles situées dans le cylindre ne peuvent être charmées, effrayées ou possédées par la créature",
+      "À l’incantation du sort, vous pouvez décider d’inverser l’orientation de sa magie, c’est-à-dire en empêchant toute créature du ou des types retenus de quitter le cylindre et en protégeant les cibles qui se trouvent à l’extérieur."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, la durée augmente de 1 heure par niveau d’emplacement au-delà du 3e."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De l’eau bénite ou de la poudre de fer et d’argent d’une valeur minimale de 100 po, que le sort détruit",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 3,
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 10
+    },
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "other",
+      "desc": "Si la créature recourt à la téléportation ou au voyage interplanaire pour ce faire, elle doit d’abord réussir un jet de sauvegarde de Charisme."
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/magic-circle"
+  },
+  {
+    "index": "magic-jar",
+    "name": "Possession",
+    "desc": [
+      "Votre corps sombre en catatonie tandis que votre âme le quitte pour pénétrer dans le récipient ayant servi de composante matérielle. Tant que votre âme occupe ce contenant, vous restez conscient de l’environnement comme si vous occupiez l’espace du récipient. Vous ne pouvez pas vous déplacer ni jouer de réaction. La seule action que vous pouvez entreprendre consiste à projeter votre âme à une distance maximale de 30 m du récipient, soit en reprenant possession de votre corps (ce qui met un terme au sort) soit en tentant de posséder un autre corps humanoïde.",
+      "Vous pouvez tenter de posséder tout humanoïde dans un rayon de 30 m de vous, à condition de le voir (les créatures protégées par le sort cercle magique ou protection contre le mal et le bien ne peuvent pas être possédées). La cible effectue un jet de sauvegarde de Charisme. En cas d’échec, votre âme se transporte dans le corps de la cible et l’âme de celle-ci se retrouve séquestrée dans le récipient. En cas de réussite, la cible résiste à votre tentative de possession et vous devez attendre 24 heures pour essayer à nouveau de la posséder.",
+      "Une fois que vous possédez le corps d’une créature, vous la contrôlez. Votre profil de jeu est remplacé par celui de la créature, mais vous conservez votre alignement et vos valeurs d’Intelligence, Sagesse et Charisme. Vous gardez aussi le bénéfice de vos propres aptitudes de classe. Si la cible dispose de niveaux de classe, vous ne pouvez pas profiter de ses aptitudes de classe.",
+      "De son côté, l’âme de la créature possédée peut percevoir l’environnement depuis le récipient en usant de ses propres sens, mais elle ne peut ni se déplacer ni entreprendre la moindre action.",
+      "Tant que vous possédez un corps, vous pouvez consacrer une action à quitter le corps hôte pour retourner dans le récipient si celui-ci se trouve dans un rayon de 30 m, l’âme de la créature hôte retrouvant alors son corps. Si le corps hôte meurt alors que vous le possédez, la créature meurt et vous effectuez un jet de sauvegarde de Charisme contre votre propre DD de sauvegarde des sorts. En cas de réussite, vous retournez dans le récipient si celui-ci se trouve dans un rayon de 30 m. Dans le cas contraire, vous mourez.",
+      "Si le contenant est détruit ou que le sort prend fin, votre âme retrouve aussitôt votre corps. Si votre corps est distant de plus de 30 m de vous ou s’il est \" mort \" lorsque vous tentez d’y retourner, vous mourez. Si l’âme d’une autre créature occupe le récipient lorsqu’il est détruit, l’âme de celle-ci retrouve son corps s’il est vivant et dans un rayon de 30 m d’elle. Sans cela, la créature meurt",
+      "Le récipient est détruit quand le sort prend fin."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une gemme, un cristal,un reliquaire ou autre récipient décoratif d’une valeur minimale de 500 po.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 6,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "other",
+      "desc": "En cas d’échec, votre âme se transporte dans le corps de la cible et l’âme de celle-ci se retrouve séquestrée dans le récipient. En cas de réussite, la cible résiste à votre tentative de possession et vous devez attendre 24 heures pour essayer à nouveau de la posséder."
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/magic-jar"
+  },
+  {
+    "index": "magic-missile",
+    "name": "Projectile magique",
+    "desc": [
+      "Vous créez trois traits de force magique et scintillante. Chaque projectile touche une créature de votre choix que vous voyez à portée. Un projectile inflige 1d4 + 1 dégâts de force à sa cible. Les traits frappent tous simultanément, sachant que vous pouvez viser une seule créature ou plusieurs."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, le sort crée un projectile supplémentaire par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_slot_level": {
+        "1": "1d4 + 1",
+        "2": "1d4 + 1",
+        "3": "1d4 + 1",
+        "4": "1d4 + 1",
+        "5": "1d4 + 1",
+        "6": "1d4 + 1",
+        "7": "1d4 + 1",
+        "8": "1d4 + 1",
+        "9": "1d4 + 1"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/magic-missile"
+  },
+  {
+    "index": "magic-mouth",
+    "name": "Bouche magique",
+    "desc": [
+      "Vous chargez un objet à portée d’un message qui sera prononcé lorsqu’une condition activatrice se présentera. Choisissez un objet que vous voyez et qui n’est pas porté par une autre créature. Prononcez alors un message d’un maximum de 25 mots (vous disposez toutefois de 10 minutes pour le peaufiner). Enfin, déterminez les circonstances qui déclencheront la transmission du message par le sort.",
+      "Quand cette condition se présente, une bouche magique apparaît sur l’objet et récite le message avec votre voix, au même volume que vous. Si l’objet choisi est lui-même doté d’une ouverture qui peut passer pour une bouche (comme sur une statue d’humanoïde), la bouche magique s’y manifeste et les mots semblent en émaner.",
+      "À l’incantation du sort, vous pouvez décider que le sort prenne fin après avoir livré son message ou qu’il reste en place et répète son annonce chaque fois que le déclencheur se présente.",
+      "Les circonstances de déclenchement peuvent être générales ou détaillées, à votre convenance, mais doivent correspondre à des conditions visuelles ou auditives intervenant dans un rayon de 9 m de l’objet. Vous pourriez ainsi statuer que la bouche s’exprime quand une créature s’approche à 9 m ou moins de l’objet ou quand une cloche d’argent sonne dans ce même rayon."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de rayon de miel et de poudre de jade d’une valeur minimale de 10 po, que le sort détruit",
+    "ritual": true,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 2,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/magic-mouth"
+  },
+  {
+    "index": "magic-weapon",
+    "name": "Arme magique",
+    "desc": [
+      "Vous touchez une arme non magique. Jusqu’à la fin du sort, l’arme devient magique, dotée d’un bonus de +1 aux jets d’attaque et aux jets de dégâts."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e ou 5e niveau, ce bonus passe à +2. Avec un emplacement de sort du 6e niveau ou supérieur, ce bonus passe à +3."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/magic-weapon"
+  },
+  {
+    "index": "magnificent-mansion",
+    "name": "Manoir somptueux",
+    "desc": [
+      "Vous invoquez une demeure extradimensionnelle à portée, qui persiste pour toute la durée. Vous choisissez où se situe son unique entrée. Cet accès large de 1,50 m et haut de 3 m chatoie imperceptiblement. Vous et toute créature que vous désignez à l’incantation du sort pouvez pénétrer dans cette demeure tant que le portail reste ouvert. Vous pouvez ouvrir ou refermer le portail si vous vous trouvez dans un rayon de 9 m de lui. Si le portail est fermé, il est invisible.",
+      "Par-delà le portail, un magnifique vestibule se dévoile, ouvrant sur de nombreuses pièces. L’atmosphère y est propre, douce et agréable.",
+      "La configuration des étages est laissée à votre convenance, mais l’espace total ne peut excéder l’équivalent de 50 cubes de 3 m d’arête chacun. La demeure est meublée et décorée selon vos désirs. Elle renferme suffisamment de nourriture pour servir un banquet composé de neuf plats pour 100 convives. 100 serviteurs quasi transparents accueillent les invités. Vous décidez de l’aspect visuel de ces domestiques et de leur livrée. Leur obéissance à vos ordres est totale. Chaque serviteur peut accomplir toute tâche à portée d’un humain, mais ils ne peuvent attaquer ni entreprendre d’action qui pourrait nuire directement à une autre créature. Ils peuvent donc aller chercher des objets, nettoyer, réparer, repasser les vêtements, allumer un feu, servir à manger et à boire, etc. Ils peuvent se rendre en n’importe quel point du manoir, mais ne peuvent le quitter. Les meubles et autres objets créés par ce sort se dissipent en fumée si on les soustrait du manoir. Quand le sort prend fin, toutes les créatures qui occupent son espace extradimensionnel sont renvoyées dans les espaces inoccupés les plus proches de l’entrée."
+    ],
+    "range": "90 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un portail miniature gravé dans l’ivoire, un morceau de marbre poli et une petite cuillère en argent, chaque objet étant d’une valeur minimale de 5 po.",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 7,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 5
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/magnificent-mansion"
+  },
+  {
+    "index": "major-image",
+    "name": "Image majeure",
+    "desc": [
+      "Vous créez l’image d’un objet, d’une créature ou autre phénomène visible dont la taille ne dépasse pas celle d’un cube de 6 m d’arête. L’image apparaît en un endroit que vous voyez à portée et persiste pour toute la durée. Elle semble parfaitement réelle, avec les sons, les odeurs et la température attendus. Vous ne pouvez pas créer de températures capables d’infliger des dégâts ou de bruits si forts qu’ils infligent des dégâts de tonnerre ou peuvent assourdir, pas plus qu’une odeur à donner la nausée (comme la puanteur des troglodytes).",
+      "Tant que vous restez à portée de l’illusion, vous pouvez consacrer votre action à déplacer l’image vers un autre point à portée du sort. Lors de ce déplacement, vous pouvez modifier l’aspect de l’image afin que ses mouvements paraissent naturels. Exemple : si vous créez l’image d’une créature que vous faites déplacer, vous pouvez faire en sorte qu’elle donne l’impression de marcher. De même, vous pouvez lui faire produire des sons à votre guise et même la faire participer à une conversation.",
+      "Toute interaction physique avec l’image percera l’illusion, car elle n’est pas tangible. Une créature qui consacre son action à examiner l’image peut comprendre qu’il s’agit d’une illusion en réussissant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. Une créature qui perce l’illusion voit au travers et ne perçoit que de manière amoindrie les propriétés sensorielles produites par l’image."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 6e niveau ou supérieur, le sort persiste jusqu’à dissipation, sans requérir votre concentration."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de laine brute.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/major-image"
+  },
+  {
+    "index": "mass-cure-wounds",
+    "name": "Soins de groupe",
+    "desc": [
+      "Une vague d’énergie curative déferle depuis un point que vous choisissez à portée. Désignez un maximum de six créatures dans une sphère de 9 m de rayon centrée sur ce point. Chaque cible récupère autant de points de vie que 3d8 + votre modificateur de caractéristique d’incantation. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 6e niveau ou supérieur, les soins augmentent de 1d8 par niveau d’emplacement au-delà du 5e."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "heal_at_slot_level": {
+      "5": "3d8 + MOD",
+      "6": "4d8 + MOD",
+      "7": "5d8 + MOD",
+      "8": "6d8 + MOD",
+      "9": "7d8 + MOD"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/mass-cure-wounds"
+  },
+  {
+    "index": "mass-heal",
+    "name": "Guérison de groupe",
+    "desc": [
+      "Vous irradiez une vague d’énergie curative vers les créatures blessées qui vous entourent. Vous restaurez un maximum de 700 points de vie, répartis entre les créatures de votre choix parmi celles que vous voyez à portée. Les créatures soignées par ce sort sont également guéries de toute maladie et tout effet qui les aveugle ou les assourdit. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "heal_at_slot_level": {
+      "9": "700"
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/mass-heal"
+  },
+  {
+    "index": "mass-healing-word",
+    "name": "Mot de guérison de groupe",
+    "desc": [
+      "Alors que vous proférez des paroles de regain, jusqu’à six créatures de votre choix que vous voyez à portée récupèrent autant de points de vie que 1d4 + votre modificateur de caractéristique d’incantation. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, il soigne 1d4 points de vie supplémentaires par niveau d’emplacement au-delà du 3e."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 3,
+    "heal_at_slot_level": {
+      "3": "1d4 + MOD",
+      "4": "2d4 + MOD",
+      "5": "3d4 + MOD",
+      "6": "4d4 + MOD",
+      "7": "5d4 + MOD",
+      "8": "6d4 + MOD",
+      "9": "7d4 + MOD"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/mass-healing-word"
+  },
+  {
+    "index": "mass-suggestion",
+    "name": "Suggestion de groupe",
+    "desc": [
+      "Vous suggérez une ligne de conduite (par une phrase ou deux au plus) pour influencer magiquement un maximum de douze créatures que vous voyez à portée et qui vous entendent et vous comprennent. Les créatures qui ne peuvent pas être charmées sont immunisées contre cet effet. La suggestion doit être formulée de manière à paraître raisonnable. Demander à une créature de se poignarder, de se jeter sur un pieu, de s’immoler par les flammes ou d’exécuter quelque acte indubitablement dangereux pour elle annule automatiquement les effets du sort.",
+      "Chaque cible effectue un jet de sauvegarde de Sagesse. En cas d’échec, elle se conforme de son mieux à la ligne de conduite énoncée. L’activité en question peut se prolonger pour toute la durée. S’il est possible de l’accomplir plus rapidement, le sort prend fin dès que le sujet a terminé ce qu’on lui a demandé.",
+      "Si vous ou l’un de vos compagnons infligez des dégâts à une créature affectée par le sort, celui-ci prend fin en ce qui la concerne."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau, la durée passe à 10 jours. Avec un emplacement de sort du 8e niveau, la durée passe à 30 jours. Avec un emplacement du 9e niveau, la durée passe à un an et un jour."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "M"],
+    "material": "Une langue de serpent, et un peu de rayon de miel ou une goutte d’huile sucrée",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/mass-suggestion"
+  },
+  {
+    "index": "maze",
+    "name": "Dédale",
+    "desc": [
+      "Vous bannissez une créature que vous voyez à portée dans un demi-plan labyrinthique. La cible y reste pour toute la durée, à moins qu’elle n’en trouve la sortie.",
+      "La cible peut consacrer une action à tenter de s’évader. Ce faisant, elle effectue un test d’Intelligence DD 20. En cas de réussite, elle trouve effectivement la sortie et le sort prend fin (un minotaure ou un démon goristro réussit automatiquement ce test).",
+      "Lorsque le sort prend fin, la cible réapparaît dans l’espace qu’elle avait quitté ou, si celui-ci n’est plus libre, dans l’espace inoccupé le plus proche"
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/maze"
+  },
+  {
+    "index": "meld-into-stone",
+    "name": "Fusion dans la pierre",
+    "desc": [
+      "Vous pénétrez d’un pas dans un objet ou une surface de pierre suffisants pour accueillir l’intégralité de votre corps et fusionnez avec tout l’équipement que vous portez dans cette masse minérale pour toute la durée. En consacrant une partie de votre déplacement, vous vous avancez dans la pierre en un point que vous pouvez toucher physiquement. Votre présence n’est aucunement visible ni détectable par des moyens non magiques.",
+      "Tant que vous fusionnez avec la pierre, vous ne voyez pas ce qui se passe à l’extérieur et tous vos tests de Sagesse (Perception) visant à entendre les bruits extérieurs sont désavantagés. Vous gardez la notion du temps et pouvez lancer des sorts sur vous- même tant que vous ne faites qu’un avec la pierre. Vous pouvez consacrer une partie de votre déplacement à émerger de la pierre à l’endroit par lequel vous l’avez intégrée, ce qui met fin au sort. Pour le reste, vous ne pouvez pas vous déplacer.",
+      "Les dommages physiques superficiels subis par la pierre ne vous font aucun mal, mais sa destruction partielle et toute altération de sa forme, si elles sont telles que vous n’y logez plus entièrement, vous éjectent de la pierre en vous infligeant 6d6 dégâts contondants. La destruction totale de la pierre (ou sa transmutation dans une autre matière) vous éjecte aussi, en vous infligeant 50 dégâts contondants. Lors de toute éjection, vous vous retrouvez à terre dans l’espace inoccupé le plus proche de l’endroit par lequel vous aviez intégré la pierre."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/meld-into-stone"
+  },
+  {
+    "index": "mending",
+    "name": "Réparation",
+    "desc": [
+      "Ce sort répare une dégradation (déchirure ou bris) sur l’objet que vous touchez, comme un maillon de chaîne brisé, une clef en deux morceaux, une cape déchirée ou une outre percée. Tant que la dégradation ne dépasse pas 30 cm dans quelque dimension que ce soit, vous la réparez et il n’en reste nulle trace.",
+      "Ce sort peut réparer la structure physique d’un objet magique ou d’un artificiel, mais il ne rendra pas sa magie à un tel objet."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Deux magnétites.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/mending"
+  },
+  {
+    "index": "message",
+    "name": "Message",
+    "desc": [
+      "Vous pointez le doigt vers une créature à portée et murmurez un message. La cible (et seulement elle) entend votre message et peut y répondre par un murmure audible de votre seule personne.",
+      "Vous pouvez lancer ce sort à travers des objets solides si vous connaissez la cible et savez qu’elle se trouve derrière ces obstacles. Le silence magique, 30 cm de pierre, 90 cm de bois ou de terre, ou 2,5 cm de métal (ou une simple feuille dans le cas du plomb) suffisent à bloquer le sort. Le sort n’est pas tenu de suivre une ligne droite ; il peut librement contourner les angles et franchir les ouvertures."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de fil de cuivre.",
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/message"
+  },
+  {
+    "index": "meteor-swarm",
+    "name": "Nuée de météores",
+    "desc": [
+      "Des orbes embrasés s’abattent au sol en quatre points différents que vous voyez à portée. Toute créature prise dans une sphère d’un rayon de 12 m centrée sur l’un des quatre points de votre choix effectue un jet de sauvegarde de Dextérité. La sphère contourne les angles. Une créature subit 20d6 dégâts de feu et 20d6 dégâts contondants en cas d’échec, la moitié en cas de réussite. Une créature prise dans les zones de plus d’une explosion sphérique n’est affectée qu’une fois.",
+      "Le sort endommage les objets de la zone et embrase tous les objets inflammables qui ne sont portés par personne."
+    ],
+    "range": "1,5 km",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "9": "20d6 + 20d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 40
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/meteor-swarm"
+  },
+  {
+    "index": "mind-blank",
+    "name": "Esprit impénétrable",
+    "desc": [
+      "Jusqu’à la fin du sort, une créature consentante que vous touchez est immunisée contre les dégâts psychiques, contre les effets qui perçoivent ses émotions ou lisent ses pensées, contre les sorts de divination et contre l’état charmé. Le sort contrarie même le sort souhait et les sorts ou effets de puissance équivalente employés pour affecter l’esprit de la cible ou se renseigner sur son compte."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/mind-blank"
+  },
+  {
+    "index": "minor-illusion",
+    "name": "Illusion mineure",
+    "desc": [
+      "Vous créez à portée un son ou l’image d’un objet qui persiste pour toute la durée. Cette illusion prend également fin si vous la révoquez au prix d’une action ou relancez ce sort.",
+      "Si vous créez un son, son volume peut aller du murmure au cri. Il peut prendre votre voix, celle de quelqu’un d’autre, imiter le rugissement du lion, un tambour qui bat ou toute autre forme de votre choix. Le son se prolonge sans discontinuer pour toute la durée, à moins que vous préfériez ne le faire intervenir que de temps à autre jusqu’à la fin du sort.",
+      "Si vous créez l’image d’un objet, comme une chaise, des empreintes boueuses ou un petit coffre, il doit pouvoir tenir dans un cube de 1,50 m d’arête. L’image ne peut créer ni son, ni lumière, ni odeur, ni autre effet sensoriel. Toute interaction physique avec  l’image percera l’illusion, car elle n’est pas tangible.",
+      "Une créature qui consacre son action à examiner le son ou l’image peut comprendre qu’il s’agit d’une illusion en réussissant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. Une créature qui perce l’illusion continue de la percevoir, quoiqu’amoindrie."
+    ],
+    "range": "9 mètres",
+    "components": ["S", "M"],
+    "material": "Un peu de laine brute.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/minor-illusion"
+  },
+  {
+    "index": "mirage-arcane",
+    "name": "Mirage",
+    "desc": [
+      "Vous faites en sorte que l’environnement d’une zone carrée de 1,5 km de côté apparaisse comme tout autre sur tous les plans sensoriels. La forme générale du terrain reste toutefois la même. Ainsi, un champ ou une route pourrait se présenter comme un marais,  une colline, une crevasse glaciaire ou quelque autre environnement infranchissable. Une mare pourrait apparaître comme une jolie prairie, un précipice  comme une pente douce et un ravin comme une route large et dégagée.",
+      "De même, vous pouvez altérer l’aspect des bâtiments ou en ajouter là où il n’y en a pas. Le sort ne permet pas de déguiser ni de cacher des créatures, ni d’en ajouter.",
+      "L’illusion comprend des éléments auditifs, visuels, tactiles et olfactifs, si bien qu’un sol dégagé peut être transformé en terrain difficile (et vice versa) ou gêner les déplacements dans la zone. Tout élément du terrain illusoire (pierre ou branche, par exemple) retiré de la zone du sort disparaît aussitôt.",
+      "Les créatures dotées de la vision lucide percent l’illusion et perçoivent le véritable environnement. Tous les autres éléments de l’illusion restent toutefois  en place, si bien qu’une telle créature, consciente de l’illusion, peut toujours interagir physiquement avec ces éléments."
+    ],
+    "range": "Vision",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "10 jours",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 7,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 5280
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/mirage-arcane"
+  },
+  {
+    "index": "mirror-image",
+    "name": "Image miroir",
+    "desc": [
+      "Trois répliques illusoires de vous-même apparaissent dans votre espace. Jusqu’à la fin du sort, les répliques se déplacent avec vous et reproduisent vos actions en changeant constamment de position, si bien  qu’il est impossible de savoir quelle version d’entre vous est réelle. Vous pouvez consacrer une action à révoquer les répliques.",
+      "Chaque fois qu’une créature vous cible avec une attaque avant la fin du sort, lancez un d20 pour déterminer si l’attaque cible en fait l’une de vos répliques.",
+      "Si vous disposez de trois répliques, vous devez obtenir 6 ou plus sur le dé pour que l’attaque cible une réplique. Avec deux répliques restantes, vous devez obtenir 8 ou plus. S’il ne reste plus qu’une réplique, 11 ou plus est nécessaire.",
+      "La CA d’une réplique est de 10 + votre modificateur de Dextérité. Si une attaque touche une réplique, celle-ci est détruite. On ne peut détruire une réplique que par une attaque qui la touche. Elle est par ailleurs insensible à toute autre forme de dégâts et d’effets. Le sort prend fin quand les trois répliques sont détruites.",
+      "Une créature qui ne voit rien n’est pas affectée par ce sort, de même qu’une créature dotée d’une forme de vision autre, comme la vision aveugle, ou capable  de percer les illusions (avec la vision lucide, par exemple)."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/mirror-image"
+  },
+  {
+    "index": "mislead",
+    "name": "Double illusoire",
+    "desc": [
+      "Vous devenez invisible et, dans le même temps, votre double illusoire se présente à l’endroit où vous vous tenez. Ce double persiste pour toute la durée, mais l’invisibilité prend fin si vous attaquez ou lancez un sort.",
+      "Vous pouvez consacrer votre action à déplacer votre double à concurrence du double de votre vitesse et le faire bouger, parler et se comporter à votre guise.",
+      "Vous voyez et entendez comme si vous vous trouviez au même endroit que lui. À chacun de vos tours, par une action bonus, vous pouvez passer  de ses sens aux vôtres et vice versa. Tant que vous percevez par ses sens, vous êtes aveuglé et assourdi vis-à-vis de votre propre environnement."
+    ],
+    "range": "Personnelle",
+    "components": ["S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/mislead"
+  },
+  {
+    "index": "misty-step",
+    "name": "Foulée brumeuse",
+    "desc": [
+      "Brièvement enveloppé d’une brume argentée, vous vous téléportez d’un maximum de 9 m vers un espace inoccupé que vous voyez."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 2,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/misty-step"
+  },
+  {
+    "index": "modify-memory",
+    "name": "Modification de mémoire",
+    "desc": [
+      "Vous tentez de remodeler les souvenirs d’une autre créature. Une créature que vous voyez effectue un jet de sauvegarde de Sagesse. Si vous êtes en train de l’affronter, elle est avantagée au jet de sauvegarde. En cas d’échec, la cible se retrouve charmée par vous pour toute la durée. La cible ainsi charmée est neutralisée et n’a pas conscience de son environnement, mais elle vous entend toujours. Si elle subit des dégâts ou est la cible d’un autre sort, cette modification de mémoire prend fin et aucun souvenir de la cible n’est altéré.",
+      "Tant que persiste ce charme, vous pouvez influer sur un souvenir de la cible ayant eu lieu au cours des 24 dernières heures et ne s’étalant pas sur plus de 10 minutes. Vous pouvez effacer toute mémoire de l’événement, permettre au contraire à la cible de se souvenir parfaitement de l’épisode dans les moindres détails, altérer certains éléments qui y sont liés dans son esprit ou créer de toutes pièces le souvenir d’un autre événement.",
+      "Vous devez parler à la cible pour lui décrire en quoi sa mémoire est modifiée, sachant qu’elle doit comprendre la langue employée pour que le souvenir s’enracine. Son esprit se charge de combler  les lacunes de votre description. Si le sort prend fin avant que vous ayez fini de décrire les souvenirs modifiés, la mémoire de la créature n’est pas altérée. Sinon, l’altération prend effet quand le sort se termine.",
+      "Sa mémoire modifiée, la créature ne va pas forcément se comporter différemment, surtout si ces souvenirs vont à l’encontre de ses penchants  naturels, de son alignement ou de ses croyances. Si le souvenir implanté est absurde, comme un épisode dans lequel la créature se serait aspergée d’acide en y prenant plaisir, il sera simplement perçu comme un mauvais rêve. Le MJ peut décider qu’un souvenir modifié est trop contraire à la raison pour affecter la créature de quelque manière que ce soit.",
+      "Le sort délivrance des malédictions ou restauration suprême lancé sur la cible lui rend sa mémoire d’origine."
+    ],
+    "higher_level": [
+      "Si vous lancez ce sort par un emplacement du 6e niveau ou supérieur, vous pouvez altérer un souvenir de la cible qui remonte à un maximum de 7 jours (6e niveau), 30 jours (7e niveau), 1 an (8e niveau) ou à tout moment du passé de la créature (9e niveau)."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/modify-memory"
+  },
+  {
+    "index": "moonbeam",
+    "name": "Rayon de lune",
+    "desc": [
+      "Un large rayon de lueur argentée ténue plonge sous forme d’un cylindre de 1,50 m de rayon et 12 m de haut, centré sur un point à portée. Jusqu’à la fin du sort, le cylindre est empli d’une lumière faible. Lorsqu’une créature entre dans la zone du sort pour la première fois d’un tour ou y commence son tour, elle est assaillie de flammes spectrales qui calcinent les chairs et effectue un jet de sauvegarde de Constitution. Elle subit 2d10 dégâts radiants en cas d’échec, la moitié en cas de réussite.",
+      "Un métamorphe effectue ce jet de sauvegarde avec le désavantage. S’il le rate, il retrouve également aussitôt sa forme d’origine et ne peut pas adopter d’autre forme tant qu’il n’a pas quitté la lumière produite par le sort.",
+      "À chacun de vos tours suivant l’incantation du sort, vous pouvez consacrer une action à déplacer le rayon de 18 m dans la direction de votre choix."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, les dégâts augmentent de 1d10 par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Plusieurs graines de cocculus et un morceau de feldspath opalin.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "2": "2d10",
+        "3": "3d10",
+        "4": "4d10",
+        "5": "5d10",
+        "6": "6d10",
+        "7": "7d10",
+        "8": "8d10",
+        "9": "9d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 5
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/moonbeam"
+  },
+  {
+    "index": "move-earth",
+    "name": "Glissement de terrain",
+    "desc": [
+      "Choisissez à portée une zone de terrain dont la longueur ne dépasse pas 12 m. Vous pouvez remodeler la terre, le sable ou l’argile de la zone à votre guise pour toute la durée. Vous pouvez accroître ou diminuer la hauteur de la zone, créer une tranchée ou en combler une, ériger un mur ou l’aplanir, ou former une colonne. Aucune de ces altérations ne peut excéder en taille la moitié de la dimension la plus grande de la zone. Ainsi, lorsque vous affectez une zone carrée de 12 m de côté, vous pouvez créer une colonne de 6 m, augmenter ou réduire la hauteur du carré de 6 m, creuser une tranchée profonde de 6 m, etc. Ces modifications s’accomplissent en 10 minutes.",
+      "À la fin de chaque tranche de 10 minutes passées à vous concentrer sur le sort, vous pouvez choisir une nouvelle zone de terrain pour l’affecter.",
+      "Ces transformations ne s’opérant que lentement, les créatures situées dans la zone ne se font généralement pas piéger ni blesser par les mouvements de terrain.",
+      "Ce sort ne peut pas manipuler la pierre naturelle ni les bâtiments en pierre. La roche et les édifices se contentent de s’adapter au terrain modifié. Si l’altération du terrain risque de rendre un édifice instable, il peut effectivement s’effondrer",
+      "De même, ce sort n’affecte pas directement le développement de la flore. La terre déplacée emporte avec elle les plantes qui l’occupent."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une lame de fer et un petit sac contenant un mélange de terres : argile, glaise et sable",
+    "ritual": false,
+    "duration": "Jusqu’à 2 heures",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "area_of_effect": {
+      "type": "cone",
+      "size": 40
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/move-earth"
+  },
+  {
+    "index": "nondetection",
+    "name": "Antidétection",
+    "desc": [
+      "Pour toute la durée, vous cachez à la magie de divination une cible que vous touchez. La cible doit être une créature consentante ou un lieu ou objet dont aucune dimension n’excède 3 m. Elle ne peut alors être ciblée par quelque magie de divination que ce soit, ni perçue par des capteurs de scrutation magique."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poussière de diamant d’une valeur de 25 po, saupoudrée sur la cible, que le sort détruit.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/nondetection"
+  },
+  {
+    "index": "pass-without-trace",
+    "name": "Passage sans trace",
+    "desc": [
+      "Un voile d’ombres et de silence émane de vous pour vous soustraire, ainsi que vos compagnons, à la détection. Pour toute la durée, chaque créature que vous désignez dans un rayon de 9 m (y compris vous) bénéficie d’un bonus de +10 aux tests de Dextérité (Discrétion) et ne peut être pistée que par des moyens magiques. Une créature qui reçoit ce bonus ne laisse aucune trace de son passage."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Les cendres d’une feuille calcinée de gui et une branche de sapin.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/pass-without-trace"
+  },
+  {
+    "index": "passwall",
+    "name": "Passe-muraille",
+    "desc": [
+      "Un passage se forme en un point que vous voyez de votre choix, sur une surface de bois, de plâtre ou de pierre (comme un mur, un plafond ou un sol) à portée, et persiste pour toute la durée. Vous choisissez les dimensions de l’ouverture : jusqu’à 1,50 m de large, 2,40 m de haut et 6 m de profondeur. Le passage n’engendre aucune instabilité dans la structure qui l’entoure.",
+      "Lorsque le passage disparaît, tous les objets et créatures qui s’y trouvent encore sont éjectés sans heurt dans les espaces inoccupés les plus proches de la surface affectée."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de graines de sésame.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/passwall"
+  },
+  {
+    "index": "phantasmal-killer",
+    "name": "Assassin imaginaire",
+    "desc": [
+      "Vous puisez dans les cauchemars d’une créature que vous voyez à portée pour créer une manifestation illusoire de ses plus grandes craintes, visible uniquement de la créature. La cible effectue un jet de sauvegarde de Sagesse. En cas d’échec, la cible se retrouve effrayée pour toute la durée. Jusqu’à la fin du sort, à la fin de chacun de ses tours, la cible doit réussir un jet de sauvegarde de Sagesse sous peine de subir 4d10 dégâts psychiques. En cas de réussite, le sort prend fin."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 5e niveau ou supérieur, les dégâts augmentent de 1d10 par niveau d’emplacement au-delà du 4e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "psychic",
+        "name": "Psychique",
+        "url": "/api/2014/damage-types/psychic"
+      },
+      "damage_at_slot_level": {
+        "4": "4d10"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/phantasmal-killer"
+  },
+  {
+    "index": "phantom-steed",
+    "name": "Monture fantôme",
+    "desc": [
+      "Une créature chevaline quasi réelle de taille G se manifeste au sol en un espace inoccupé que vous choisissez à portée. Vous décidez de son apparence, sachant qu’elle est équipée d’une selle, de mors et d’une bride. Tout l’équipement créé par le sort disparaît dans une bouffée de fumée si on l’éloigne de plus de 3 m de la monture.",
+      "Pour toute la durée, vous ou une créature que vous désignez pouvez chevaucher la monture. La créature reprend le profil du cheval de selle, si ce n’est que sa vitesse est de 30 m et qu’elle peut parcourir 15 km en une heure, ou 19,5 km à allure rapide. Quand le sort prend fin, la monture s’efface progressivement en laissant à son cavalier 1 minute pour en descendre. Le sort prend fin si vous consacrez une action à le révoquer ou si la monture subit des dégâts.."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 3,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/phantom-steed"
+  },
+  {
+    "index": "planar-ally",
+    "name": "Allié planaire",
+    "desc": [
+      "Vous implorez l’assistance d’une entité d’outre-monde. L’être doit vous être familier : un dieu, un primordial, un prince démon ou toute autre entité de puissance cosmique. Il dépêche un céleste, un élémentaire ou un fiélon parmi ses fidèles pour vous porter assistance, et la créature désignée se matérialise dans un espace inoccupé à portée. Si vous connaissez un nom spécifique de créature, vous pouvez le prononcer à l’incantation du sort pour la solliciter nommément, mais rien ne vous garantit qu’une autre ne sera pas envoyée à sa place (à la discrétion du MJ).",
+      "Quand la créature se présente, rien ne la contraint à se comporter d’une manière ou d’une autre. Vous pouvez lui demander d’accomplir un service en contrepartie d’autre chose, mais elle n’est pas tenue d’y consentir. La tâche requise peut aller du simple (fais-nous franchir ce gouffre par les airs ou épaule- nous dans un combat) au plus complexe (espionne nos ennemis ou protège-nous durant notre incursion dans ce donjon). Pour pouvoir négocier les services de la créature, vous devez être en mesure de communiquer avec elle.",
+      "La contrepartie peut prendre diverses formes. Un céleste pourra requérir une coquette donation d’or ou d’objets magiques à quelque temple allié, tandis qu’un fiélon exigera par exemple un sacrifice de sang ou le don d’un trésor. Certaines créatures accepteront de vous rendre service en échange d’une quête que vous devrez entreprendre.",
+      "D’une manière générale, on peut considérer qu’une tâche qui se mesure en minutes correspond à une rétribution de 100 po par minute. Une tâche qui s’exprime en heures, à 1 000 po de l’heure. Une tâche qui s’étale sur plusieurs jours (jusqu’à un maximum de 10), à 10 000 po par jour. Le MJ peut ajuster ces contreparties selon les circonstances dans lesquelles vous lancez le sort. Si la tâche est en adéquation avec l’éthique de la créature, le paiement pourrait être réduit de moitié, voire dispensé. Les tâches sans risque voient généralement la rétribution réduite de moitié, tandis que les plus dangereuses entraînent des dons bien plus importants. Les créatures n’ont pas pour habitude d’accepter les missions qui s’annoncent suicidaires.",
+      "Une fois la tâche accomplie par la créature ou la durée convenue pour le service écoulée, la créature retourne sur son plan d’origine après vous avoir fait son rapport si cela s’accorde avec la mission et dans la mesure du possible. Si vous ne pouvez convenir d’une rémunération pour les services de la créature, elle repart sans attendre sur son plan d’origine.",
+      "Une créature engagée pour se joindre à votre groupe est considérée comme membre à part entière et reçoit donc sa part de points d’expérience."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 6,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/planar-ally"
+  },
+  {
+    "index": "planar-binding",
+    "name": "Entrave planaire",
+    "desc": [
+      "Par ce sort, vous tentez de soumettre un céleste, un élémentaire, une fée ou un fiélon à votre service. La créature doit être à portée pendant toute l’incantation. (En général, on convoque d’abord la créature au centre d’un cercle magique inversé de manière à la confiner pendant l’incantation.) À l’issue de l’incantation, la cible effectue un jet de sauvegarde de Charisme. En cas d’échec, elle est soumise à votre service pour toute la durée. Si la créature a été convoquée ou créée par un autre sort, la durée de celui-ci augmente pour correspondre à la durée de cette entrave planaire.",
+      "Une créature ainsi liée à votre service obéit à vos instructions de son mieux. Vous pouvez lui ordonner de vous accompagner à l’aventure, de garder un site ou de livrer un message. La créature obéit à vos ordres à la lettre, mais si elle vous est hostile, elle fera tout pour interpréter vos directives à sa manière afin de servir ses propres desseins. Si la créature mène à bien toutes vos instructions avant la fin du sort, elle se transporte auprès de vous pour faire son rapport si vous êtes sur le même plan d’existence. Si vous vous trouvez sur un plan différent, elle repart vers le lieu où vous l’avez assujettie et y reste jusqu’à la fin du sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement d’un niveau supérieur, la durée passe à 10 jours pour un emplacement du 6e niveau, à 30 jours pour un emplacement du 7e niveau, à 180 jours pour un emplacement du 8e niveau et à un an et un jour pour un emplacement du 9e niveau."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un bijou d’une valeur minimale de 1 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/planar-binding"
+  },
+  {
+    "index": "plane-shift",
+    "name": "Changement de plan",
+    "desc": [
+      "Vous et un maximum de huit créatures consentantes qui formez un cercle en vous tenant par la main êtes transportés sur un autre plan d’existence. Vous pouvez spécifier une destination en des termes généraux, comme la cité d’Airain sur le Plan Élémentaire du Feu ou le palais de Dispater sur la deuxième strate des Neuf Enfers, auquel cas vous apparaissez à destination ou à proximité. Si vous tentez d’accéder à la cité d’Airain, par exemple, vous pourriez arriver dans la rue de l’Acier, devant la porte des Cendres, ou bien contempler la ville depuis l’autre bout de la mer de Feu, à la discrétion du MJ.",
+      "Ou bien, si vous connaissez la séquence de runes d’un cercle de téléportation sur un autre plan d’existence, ce sort vous transporte directement dans le cercle. Si le cercle de téléportation est trop petit pour accueillir toutes les créatures transportées, elles apparaissent dans les espaces inoccupés les plus proches du cercle.",
+      "Vous pouvez recourir à ce sort pour bannir une créature non consentante vers un autre plan. Choisissez une créature à portée d’allonge et effectuez contre elle une attaque de sort au corps à corps. Si l’attaque touche, la créature effectue un jet de sauvegarde de Charisme. Si la créature rate son JS, elle est transportée en un lieu aléatoire du plan d’existence spécifié. Une créature ainsi bannie devra retrouver son chemin jusqu’à votre plan d’existence actuel par ses propres moyens."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une badine métallique fourchue d’une valeur minimale de 250 po, accordée avec un plan d’existence donné.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "attack_type": "mélée",
+    "dc": {
+      "dc_type": {
+        "index": "cha",
+        "name": "CHA",
+        "url": "/api/2014/ability-scores/cha"
+      },
+      "dc_success": "none",
+      "desc": "Si la créature rate son JS, elle est transportée en un lieu aléatoire du plan d’existence spécifié. Une créature ainsi bannie devra retrouver son chemin jusqu’à votre plan d’existence actuel par ses propres moyens."
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/plane-shift"
+  },
+  {
+    "index": "plant-growth",
+    "name": "Croissance végétale",
+    "desc": [
+      "Ce sort gorge de vitalité les plantes d’une zone donnée. Deux applications existent pour ce sort, selon que vous souhaitez octroyer des bénéfices immédiats ou durables.",
+      "Si vous lancez ce sort au prix d’une action, choisissez un point à portée. Toutes les plantes normales dans un rayon de 30 m centré sur ce point grossissent et grandissent. Une créature qui se déplace dans la zone doit dépenser le quadruple de déplacement pour toute distance parcourue.",
+      "Vous pouvez désigner une ou plusieurs zones de n’importe quelle taille dans la zone d’effet du sort pour qu’elles ne soient pas affectées.",
+      "Si l’incantation du sort dure 8 heures, vous fertilisez durablement la terre locale. Toutes les plantes dans un rayon de 750 m centré en un point à portée gagnent en fécondité pendant 1 an. Ces plantes produisent le double des apports alimentaires normaux lors des récoltes."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/plant-growth"
+  },
+  {
+    "index": "poison-spray",
+    "name": "Bouffée de poison",
+    "desc": [
+      "Vous tendez la main vers une créature que vous voyez à portée et votre paume projette un petit nuage de gaz toxique. La créature doit réussir un jet de sauvegarde de Constitution sous peine de subir 1d12 dégâts de poison.",
+      "Les dégâts du sort augmentent de 1d12 lorsque vous atteignez le niveau 5 (2d12), le niveau 11 (3d12) et le niveau 17 (4d12)."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "damage": {
+      "damage_type": {
+        "index": "poison",
+        "name": "Poison",
+        "url": "/api/2014/damage-types/poison"
+      },
+      "damage_at_character_level": {
+        "1": "1d12",
+        "5": "2d12",
+        "11": "3d12",
+        "17": "4d12"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/poison-spray"
+  },
+  {
+    "index": "polymorph",
+    "name": "Métamorphose",
+    "desc": [
+      "Le sort transforme une créature que vous voyez à portée. Une créature non consentante effectue un jet de sauvegarde de Sagesse pour en éviter les effets. Le sort est sans effet sur un métamorphe ou une créature dotée de 0 point de vie.",
+      "La transformation persiste pour toute la durée, sauf si la cible tombe à 0 point de vie ou meurt. La nouvelle forme peut être n’importe quelle bête dont le facteur de puissance est inférieur ou égal à celui de la cible (ou à son niveau, si elle n’a pas de facteur de puissance). Le profil de la cible, y compris ses valeurs de caractéristique mentales, est remplacé par le profil de la bête retenue. Elle conserve en revanche son alignement et sa personnalité.",
+      "La cible est désormais dotée des points de vie de sa nouvelle forme. Quand elle reprend sa forme normale, la créature retrouve le nombre de points de vie qu’elle avait avant sa transformation. Si elle reprend sa forme parce qu’elle tombe à 0 point de vie, les dégâts excédentaires sont répercutés sur sa forme normale. Tant que ces dégâts excédentaires ne réduisent pas sa forme normale à 0 point de vie, elle ne subit pas l’état inconscient.",
+      "La créature est limitée dans les actions qu’elle peut entreprendre par la nature de sa nouvelle forme, et elle ne peut ni parler ni lancer de sorts, ni entreprendre d’action qui nécessite l’emploi des mains ou de la parole.",
+      "L’équipement porté par la cible se fond dans sa nouvelle forme. La créature ne peut pas activer, utiliser ou manier son équipement ni en bénéficier de quelque manière que ce soit."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un cocon de chenille.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/polymorph"
+  },
+  {
+    "index": "power-word-kill",
+    "name": "Mot de pouvoir mortel",
+    "desc": [
+      "Vous prononcez une parole de pouvoir qui peut condamner une créature que vous voyez à portée à mourir sur-le-champ. Si la créature choisie est dotée de 100 points de vie ou moins, elle meurt. Dans le cas contraire, le sort est sans effet."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/power-word-kill"
+  },
+  {
+    "index": "power-word-stun",
+    "name": "Mot de pouvoir étourdissant",
+    "desc": [
+      "Vous prononcez une parole de pouvoir capable de submerger l’esprit d’une créature que vous voyez à portée et de la sidérer. Si la cible choisie est dotée de 150 points de vie ou moins, elle est étourdie. Dans le cas contraire, le sort est sans effet",
+      "Une cible ainsi étourdie effectue un jet de sauvegarde de Constitution à la fin de chacun de ses tours. En cas de réussite, l’effet étourdissant prend fin."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/power-word-stun"
+  },
+  {
+    "index": "prayer-of-healing",
+    "name": "Prière de guérison",
+    "desc": [
+      "Un maximum de six créatures que vous choisissez parmi celles que vous voyez à portée récupèrent chacune autant de points de vie que 2d8 + votre modificateur de caractéristique d’incantation. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, les soins augmentent de 1d8 par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 2,
+    "heal_at_slot_level": {
+      "2": "2d8 + MOD",
+      "3": "3d8 + MOD",
+      "4": "4d8 + MOD",
+      "5": "5d8 + MOD",
+      "6": "6d8 + MOD",
+      "7": "7d8 + MOD",
+      "8": "8d8 + MOD",
+      "9": "9d8 + MOD"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/prayer-of-healing"
+  },
+  {
+    "index": "prestidigitation",
+    "name": "Prestidigitation",
+    "desc": [
+      "Ce tour de passe-passe sert d’entraînement aux lanceurs de sorts débutants. Vous créez l’un des effets magiques suivants à portée :",
+      "-Vous produisez un effet sensoriel instantané et inoffensif, comme une pluie d’étincelles, une petite rafale, quelques notes de musique ou une odeur étrange.",
+      "-Vous allumez ou éteignez une bougie, une torche ou un petit feu de camp, en un instant.",
+      "-Vous nettoyez ou souillez en un instant un objet dont le volume ne dépasse pas 30 litres (ou 0,03 m3).",
+      "-Vous refroidissez, réchauffez ou parfumez de la matière inerte pendant 1 heure, à condition que son volume ne dépasse pas 30 litres (ou 0,03 m3).",
+      "-Vous faites apparaître pendant 1 heure, sur un objet ou une surface, une couleur, une petite marque ou un symbole.",
+      "-Vous faites apparaître jusqu’à la fin de votre tour suivant une babiole non magique ou une image illusoire tenant dans votre main.",
+      "Si vous lancez ce sort plusieurs fois, vous pouvez faire coexister jusqu’à trois de ces effets non instantanés, sachant que vous pouvez révoquer un tel effet au prix d’une action."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/prestidigitation"
+  },
+  {
+    "index": "prismatic-spray",
+    "name": "Embruns prismatiques",
+    "desc": [
+      "Huit rayons de lumière multicolores jaillissent de votre main. Chaque rayon, d’une couleur différente, a son pouvoir et sa fonction propres. Chaque créature prise dans un cône de 18 m effectue un jet de sauvegarde de Dextérité. Pour chaque cible, lancez un d8 afin de déterminer quel rayon de couleur l’affecte.",
+      "***1. Rouge.*** La cible subit 10d6 dégâts de feu en cas d’échec, la moitié en cas de réussite.",
+      "***2. Orange.*** La cible subit 10d6 dégâts d’acide en cas d’échec, la moitié en cas de réussite.",
+      "***3. Jaune.*** La cible subit 10d6 dégâts de foudre en cas d’échec, la moitié en cas de réussite.",
+      "***4. Vert.*** La cible subit 10d6 dégâts de poison en cas d’échec, la moitié en cas de réussite.",
+      "***5. Bleu.*** La cible subit 10d6 dégâts de froid en cas d’échec, la moitié en cas de réussite.",
+      "***6. Indigo.***  En cas d’échec, la cible est entravée. Elle effectue un jet de sauvegarde de Constitution à la fin de chacun de ses tours. Si elle se sauvegarde trois fois, le sort prend fin. Si elle rate son JS trois fois, elle subit l’état pétrifié de manière permanente. Ces réussites et échecs n’ont pas besoin d’être consécutifs ; notez-les quelque part, jusqu’à ce que la cible atteigne un total de trois pour l’un ou l’autre.",
+      "***7. Violet.*** En cas d’échec, la cible est aveuglée. Elle effectue un jet de sauvegarde de Sagesse au début de votre tour suivant. Une sauvegarde réussie met fin à la cécité. Si le JS est raté, la créature est transportée vers un autre plan d’existence choisi par le MJ et n’est plus aveuglée. (En général, une créature qui se trouvait sur un plan qui n’était pas le sien est bannie sur son plan d’origine, tandis que les autres sont simplement envoyées sur le Plan Astral ou Éthéré.)",
+      "***8. Spéciale.*** Spécial. La cible est frappée par deux rayons. Lancez le dé deux autres fois sans tenir compte des 8."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "damage": {
+      "damage_at_slot_level": {
+        "7": "10d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "other",
+      "desc": "Pour chaque cible, lancez un d8 afin de déterminer quel rayon de couleur l’affecte."
+    },
+    "area_of_effect": {
+      "type": "cone",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/prismatic-spray"
+  },
+  {
+    "index": "prismatic-wall",
+    "name": "Mur prismatique",
+    "desc": [
+      "Un plan multicolore de lueurs chatoyantes s’érige sous forme d’un mur vertical opaque centré sur un point que vous voyez à portée, avec les dimensions maximales suivantes : longueur 27 m, hauteur 9 m et épaisseur 2,5 cm. Vous pouvez au lieu de cela lui donner la forme d’une sphère d’un diamètre maximal de 9 m, centrée en un point que vous choisissez à portée. Le mur reste en place pour toute la durée. Si vous positionnez le mur de façon qu’il traverse un espace occupé par une créature, le sort échoue et votre action comme votre emplacement de sort sont gaspillés.",
+      "Le mur produit une lumière vive sur une distance de 30 m et une lumière faible sur 30 m de plus. Vous et les créatures que vous désignez à l’incantation du sort pouvez sans risque traverser le mur et rester à proximité. Si une autre créature qui voit le mur s’approche dans un rayon de 6 m de sa zone ou y commence son tour, elle doit réussir un jet de sauvegarde de Constitution sous peine d’être aveuglée pendant 1 minute.",
+      "Le mur est constitué de sept couches, chacune d’une couleur différente. Lorsqu’une créature tente de pénétrer le mur ou de le traverser, elle le fait couche après couche jusqu’à toutes les avoir franchies. À mesure qu’elle traverse ou pénètre chaque couche, la créature effectue un jet de sauvegarde de Dextérité sous peine d’être affectée par les propriétés de cette couche, décrites ci-après.",
+      "On peut détruire le mur, couche par couche, de la rouge à la violette, par des moyens propres à chaque couche. Une fois qu’une couche est détruite, elle le reste pour toute la durée du sort. Un sceptre d’oblitération détruit un mur prismatique, mais un champ antimagie est sans effet sur lui.",
+      "***1. Rouge.*** La créature subit 10d6 dégâts de feu en cas d’échec, la moitié en cas de réussite. Tant que cette couche reste en place, les attaques à distance non magiques ne peuvent traverser le mur. La couche se détruit si on lui inflige au moins 25 dégâts de froid.",
+      "***2. Orange.*** La créature subit 10d6 dégâts d’acide en cas d’échec, la moitié en cas de réussite. Tant que cette couche reste en place, les attaques à distance magiques ne peuvent traverser le mur. La couche est détruite par un vent fort.",
+      "***3. Jaune.*** La créature subit 10d6 dégâts de foudre en cas d’échec, la moitié en cas de réussite. La couche se détruit si on lui inflige au moins 60 dégâts de force.",
+      "***4. Verte.*** La créature subit 10d6 dégâts de poison en cas d’échec, la moitié en cas de réussite. Le sort passe-muraille, ou autre sort de niveau supérieur ou égal capable d’ouvrir un portail sur une surface solide, détruit cette couche.",
+      "***5. Bleue.*** La créature subit 10d6 dégâts de froid en cas d’échec, la moitié en cas de réussite. La couche se détruit si on lui inflige au moins 25 dégâts de feu.",
+      "***6. Indigo.*** En cas d’échec, la créature est entravée. Elle effectue un jet de sauvegarde de Constitution à la fin de chacun de ses tours. Si elle se sauvegarde trois fois, le sort prend fin. Si elle rate son JS trois fois, elle subit l’état pétrifié de manière permanente. Ces réussites et échecs n’ont pas besoin d’être consécutifs ; notez-les quelque part, jusqu’à ce que la créature atteigne un total de trois pour l’un ou l’autre.",
+      "Tant que cette couche reste en place, les sorts ne peuvent pas traverser le mur. La couche est détruite par la lumière vive que produit le sort lumière du jour ou un sort comparable de niveau supérieur ou égal.",
+      "***7. Violette.*** En cas d’échec, la créature est aveuglée. Elle effectue un jet de sauvegarde de Sagesse au début de votre tour suivant. Une sauvegarde réussie met fin à la cécité. Si ce JS est raté, la créature est transportée vers un autre plan d’existence choisi par le MJ et n’est plus aveuglée. (En général, une créature qui se trouvait sur un plan qui n’était pas le sien est bannie sur son plan d’origine, tandis que les autres sont simplement envoyées sur le Plan Astral ou Éthéré.) La couche est détruite par le sort dissipation de la magie ou tout sort comparable de niveau supérieur ou égal, capable de mettre un terme aux sorts et effets magiques."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "area_of_effect": {
+      "type": "line",
+      "size": 90
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/prismatic-wall"
+  },
+  {
+    "index": "private-sanctum",
+    "name": "Sanctuaire privé",
+    "desc": [
+      "Vous sécurisez magiquement une zone à portée. La zone est un cube dont l’arête peut aller de 1,50 m à 30 m. Le sort persiste pour toute la durée, sauf si vous consacrez une action à le révoquer.",
+      "À l’incantation du sort, vous décidez quel genre de sécurité octroie le sort, en choisissant autant de propriétés souhaitées parmi les suivantes :",
+      "- Les sons ne franchissent pas le périmètre de la zone protégée.",
+      "- Le périmètre de la zone protégée apparaît sombre et brumeux, ce qui empêche de voir au travers (y compris avec la vision dans le noir).",
+      "- Les capteurs créés par les sorts de divination ne peuvent ni apparaître à l’intérieur de la zone protégée ni franchir son périmètre.",
+      "- Les créatures de la zone ne peuvent pas être ciblées par les sorts divination.",
+      "- Rien ne peut se téléporter dans la zone protégée ou hors d’elle.",
+      "- Le voyage planaire est bloqué au sein de la zone protégée.",
+      "Lancer ce sort quotidiennement au même endroit pendant une année rend cet effet permanent."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 5e niveau ou supérieur, vous augmentez la taille de l’arête du cube de 30 m par niveau d’emplacement au-delà du 4e. Un emplacement de sort du 5e niveau permet ainsi de protéger un cube de 60 m d’arête."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une fine couche de plomb, un fragment de verre opaque, une boule de coton ou d’étoffe, et de la poudre de chrysolite.",
+    "ritual": false,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "10 minutes",
+    "level": 4,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 100
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/private-sanctum"
+  },
+  {
+    "index": "produce-flame",
+    "name": "Flammes",
+    "desc": [
+      "Une flamme vacillante prend vie dans votre main. Elle y reste pour toute la durée, sans vous nuire ni menacer votre équipement. La flamme projette une lumière vive sur un rayon de 3 m, et une lumière faible sur 3 m de plus. Le sort prend fin si vous le révoquez au prix d’une action ou si vous le relancez.",
+      "Vous pouvez également attaquer avec la flamme, ce qui met également un terme au sort. À l’incantation du sort, ou au prix d’une action lors d’un tour ultérieur, vous pouvez projeter la flamme vers une créature située dans un rayon de 9 m. Effectuez une attaque de sort à distance. Si l’attaque touche, la cible subit 1d8 dégâts de feu.",
+      "Les dégâts du sort augmentent de 1d8 lorsque vous atteignez le niveau 5 (2d8), le niveau 11 (3d8) et le niveau 17 (4d8)."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_character_level": {
+        "1": "1d8",
+        "5": "2d8",
+        "11": "3d8",
+        "17": "4d8"
+      }
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/produce-flame"
+  },
+  {
+    "index": "programmed-illusion",
+    "name": "Illusion programmée",
+    "desc": [
+      "Vous créez l’illusion d’un objet, d’une créature ou d’un autre phénomène visible à portée, qui s’active lorsque certaines conditions spécifiques se présentent. L’illusion reste imperceptible jusque-là. Elle doit loger dans un cube de 9 m d’arête et vous décidez à l’incantation du sort comment l’illusion se comporte et quels sons elle produit. Cette performance scénarisée peut durer jusqu’à 5 minutes.",
+      "Quand les conditions spécifiées sont réunies, l’illusion prend vie selon le scénario que vous avez décrit. Une fois qu’elle a terminé son numéro, l’illusion disparaît et reste en veilleuse pendant 10 minutes. À l’issue de cet intervalle, elle peut de nouveau s’activer.",
+      "Les circonstances de déclenchement peuvent être générales ou détaillées, à votre convenance, mais doivent correspondre à des conditions visuelles ou auditives intervenant dans un rayon de 9 m de la zone. Vous pourriez ainsi créer une illusion de vous-même qui apparaît pour mettre autrui en garde contre l’ouverture d’une porte piégée ou la programmer pour qu’elle ne s’active que lorsqu’une créature prononce un certain sésame.",
+      "Toute interaction physique avec l’image percera l’illusion, car elle n’est pas tangible. Une créature qui consacre son action à examiner l’image peut comprendre qu’il s’agit d’une illusion en réussissant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. Une créature qui perce l’illusion voit à travers l’image, tout son produit par l’illusion sonnant par ailleurs creux à ses oreilles."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de laine brute et de poudre de jade d’une valeur minimale de 25 po.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 30
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/programmed-illusion"
+  },
+  {
+    "index": "project-image",
+    "name": "Image projetée",
+    "desc": [
+      "Vous créez une réplique illusoire de vous-même qui persiste pour toute la durée. Ce double peut apparaître en n’importe quel lieu à portée que vous avez déjà vu, quels que soient les obstacles qui vous en séparent. L’illusion présente votre aspect et sonne comme vous, mais elle est intangible. Si elle subit des dégâts, l’illusion disparaît et le sort prend fin.",
+      "Vous pouvez consacrer votre action à déplacer cette illusion à hauteur du double de votre vitesse et à la faire bouger, parler et se comporter à votre guise. Elle reproduit à merveille votre façon d’être.",
+      "Vous voyez et entendez comme si vous vous trouviez dans son espace. À chacun de vos tours, par une action bonus, vous pouvez passer de ses sens aux vôtres, et vice versa. Tant que vous percevez par ses sens, vous êtes aveuglé et assourdi vis-à-vis de votre propre environnement.",
+      "Toute interaction physique avec l’image percera l’illusion, car elle n’est pas tangible. Une créature qui consacre son action à examiner l’image peut comprendre qu’il s’agit d’une illusion en réussissant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. Une créature qui perce l’illusion voit à travers l’image, tout son produit par l’illusion sonnant par ailleurs creux à ses oreilles."
+    ],
+    "range": "750 km",
+    "components": ["V", "S", "M"],
+    "material": "Une réplique miniature de vous-même en matériaux d’une valeur minimale de 5 po.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 jour",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 7,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/project-image"
+  },
+  {
+    "index": "protection-from-energy",
+    "name": "Protection contre l'énergie",
+    "desc": [
+      "Pour toute la durée, la créature consentante que vous touchez bénéficie de la résistance à un type de dégâts de votre choix : acide, feu, foudre, froid ou tonnerre."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/protection-from-energy"
+  },
+  {
+    "index": "protection-from-evil-and-good",
+    "name": "Protection contre le mal et le bien",
+    "desc": [
+      "Vous touchez une créature consentante ; jusqu’à la fin du sort, celle-ci est protégée contre les types de créatures suivants : aberrations, célestes, élémentaires, fées, fiélons et morts-vivants.",
+      "Cette protection octroie plusieurs bénéfices. Les créatures concernées sont désavantagées aux jets d’attaque contre la cible. La cible ne peut également pas être charmée, effrayée ou possédée par ces créatures. Si la cible est déjà charmée, effrayée ou possédée par une telle créature, elle est avantagée aux nouveaux jets de sauvegarde contre l’effet correspondant."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De l’eau bénite ou de la poudre de fer et d’argent, que le sort détruit.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/protection-from-evil-and-good"
+  },
+  {
+    "index": "protection-from-poison",
+    "name": "Protection contre le poison",
+    "desc": [
+      "Vous touchez une créature. Si elle est empoisonnée, vous neutralisez le poison. Si plus d’un poison affecte la cible, vous neutralisez un poison que vous savez présent ou un poison aléatoire.",
+      "Pour toute la durée, la cible est avantagée aux jets de sauvegarde contre l’état empoisonné et bénéficie de la résistance aux dégâts de poison."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/protection-from-poison"
+  },
+  {
+    "index": "purify-food-and-drink",
+    "name": "Purification de la nourriture et de l'eau",
+    "desc": [
+      "Tous les aliments et boissons non magiques dans une sphère de 1,50 m de rayon centrée sur un point que vous choisissez à portée sont purifiés et purgés de tout poison comme de toute maladie."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/purify-food-and-drink"
+  },
+  {
+    "index": "raise-dead",
+    "name": "Rappel à la vie",
+    "desc": [
+      "Vous ramenez à la vie une créature morte que vous touchez, à condition qu’elle ne soit pas morte depuis plus de 10 jours. Si son âme est à la fois consentante et libre de rejoindre son corps, la créature revient à la vie avec 1 point de vie.",
+      "Ce sort neutralise également tous les poisons et soigne toutes les maladies non magiques qui affectaient la créature au moment de mourir. Ce sort n’élimine en revanche pas les maladies magiques, ni les malédictions et autres effets comparables ; si ceux-ci ne sont pas éliminés au préalable, ils reprennent effet quand la créature revient à la vie. Il ne peut pas davantage ramener à la vie une créature de type mort-vivant.",
+      "Ce sort referme toutes les blessures mortelles, mais ne fait pas repousser l’anatomie manquante. Si la créature a perdu une partie de son anatomie ou des organes essentiels à sa survie ; sa tête, par exemple, le sort échoue automatiquement.",
+      "Revenir d’entre les morts demeure une épreuve. La cible subit un malus de –4 à tous ses jets d’attaque, jets de sauvegarde et tests de caractéristique. Chaque fois qu’elle termine un repos long, ce malus diminue de 1, jusqu’à ce qu’il disparaisse."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un diamant d’une valeur minimale de 500 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 5,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/raise-dead"
+  },
+  {
+    "index": "ray-of-enfeeblement",
+    "name": "Rayon affaiblissant",
+    "desc": [
+      "Un rayon noir d’énergies débilitantes jaillit de votre doigt vers une créature à portée. Effectuez une attaque de sort à distance contre la cible. Si l’attaque touche, la cible n’inflige que des dégâts réduits de moitié avec ses attaques d’arme basées sur la Force, jusqu’à la fin du sort.",
+      "À la fin de chacun de ses tours, la cible peut effectuer un jet de sauvegarde de Constitution contre le sort. En cas de réussite, le sort prend fin."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none"
+    },
+    "attack_type": "à distance",
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/ray-of-enfeeblement"
+  },
+  {
+    "index": "ray-of-frost",
+    "name": "Rayon de givre",
+    "desc": [
+      "Un rayon de lueur zébrée bleuâtre et glaciale file vers une créature à portée. Effectuez une attaque de sort à distance contre la cible. Si l’attaque touche, la cible subit 1d8 dégâts de froid et sa vitesse est réduite de 3 m jusqu’au début de votre tour suivant.",
+      "Les dégâts du sort augmentent de 1d8 lorsque vous atteignez le niveau 5 (2d8), le niveau 11 (3d8) et le niveau 17 (4d8)."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "à distance",
+    "damage": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "damage_at_character_level": {
+        "1": "1d8",
+        "5": "2d8",
+        "11": "3d8",
+        "17": "4d8"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/ray-of-frost"
+  },
+  {
+    "index": "regenerate",
+    "name": "Régénération",
+    "desc": [
+      "Vous touchez une créature pour stimuler ses propriétés naturelles de guérison. La cible récupère 4d8 + 15 points de vie. Pour toute la durée du sort, la cible récupère 1 point de vie au début de chacun de ses tours (10 points de vie par minute).",
+      "Les parties anatomiques sectionnées (doigts, jambes, queue, etc.) sont restaurées au bout de 2 minutes. Si vous disposez d’un membre ou appendice tranché et l’apposez contre la plaie, le sort le ressoude aussitôt."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un moulin à prières et de l’eau bénite.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 7,
+    "heal_at_slot_level": {
+      "7": "4d8 + 15"
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/regenerate"
+  },
+  {
+    "index": "reincarnate",
+    "name": "Réincarnation",
+    "desc": [
+      "Vous touchez un humanoïde mort ou l’un de ses restes. À condition que la créature ne soit pas morte depuis plus de 10 jours, le sort forme un nouveau corps adulte et appelle son âme pour prendre possession de ce corps. Si l’âme de la cible n’est pas libre et consentante, le sort échoue.",
+      "Ce sont les caprices de la magie qui façonnent le nouveau corps, si bien que l’espèce de la créature a de grandes chances de changer. Le MJ lance un d100 et consulte la table suivante pour savoir quelle forme la créature prend en revenant à la vie, ou il en choisit une.",
+      "| d100 | Race |",
+      "|---|---|",
+      "| 01-04 | Demi-elfe |",
+      "| 05-08 | Demi-orc |",
+      "| 09–12 | Drakéide |",
+      "| 13–16 | Elfe noir |",
+      "| 17–24 | Elfe sylvestre |",
+      "| 25–28 | Gnome des forêts |",
+      "| 29–34 | Gnome des roches |",
+      "| 35–42 | Halfelin pied-léger |",
+      "| 43–50 | Halfelin robuste |",
+      "| 51–59 | Haut-elfe |",
+      "| 60–79 | Humain |",
+      "| 80–88 | Nain des collines |",
+      "| 89–96 | Nain des montagnes |",
+      "| 97–100 | Tieffelin |",
+      "La créature réincarnée se souvient de son ancienne vie et de ses expériences. Elle conserve les capacités dont elle disposait sous sa forme d’origine, si ce n’est qu’elle substitue sa nouvelle espèce à l’ancienne et donc les traits raciaux correspondants."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Des huiles et onguents rares d’une valeur minimale de 1 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 5,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/reincarnate"
+  },
+  {
+    "index": "remove-curse",
+    "name": "Délivrance des malédictions",
+    "desc": [
+      "À votre contact, toutes les malédictions qui affectent une créature ou un objet prennent fin. Si la cible est un objet magique maudit, la malédiction reste en place mais le sort rompt l’harmonisation du propriétaire avec l’objet, si bien que celui-ci peut s’en défaire ou s’en débarrasser."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/remove-curse"
+  },
+  {
+    "index": "resilient-sphere",
+    "name": "Sphère résiliente",
+    "desc": [
+      "Une sphère de force chatoyante séquestre une créature ou un objet de taille G ou inférieure à portée. Une créature non consentante effectue un jet de sauvegarde de Dextérité. En cas d’échec, elle est confinée pour toute la durée.",
+      "Rien, ni les objets physiques, ni l’énergie, ni les autres effets de sort, ne peut franchir cette barrière dans un sens comme dans l’autre, mais la créature séquestrée peut respirer normalement. La sphère est immunisée contre tous les dégâts, et la créature ou l’objet enfermé ne peut subir de dégâts des attaques et effets émanant de l’autre côté, pas plus qu’une créature séquestrée ne peut infliger de dégâts vers l’extérieur.",
+      "La sphère, qui ne pèse rien, est juste assez grande pour contenir la créature ou l’objet. Une créature confinée peut consacrer son action à pousser sur les parois de la sphère et la faire rouler à concurrence de la moitié de sa propre vitesse. De même, d’autres créatures peuvent ramasser le globe et le déplacer.",
+      "Le sort désintégration, s’il cible le globe, le détruit sans risque pour ce qui se trouve à l’intérieur."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un hémisphère de cristal limpide et un autre de même taille en gomme arabique.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/resilient-sphere"
+  },
+  {
+    "index": "resistance",
+    "name": "Résistance",
+    "desc": [
+      "Vous touchez une créature consentante. Une fois avant la fin du sort, la cible peut lancer un d4 et en ajouter le résultat au jet de sauvegarde de son choix. Elle peut lancer ce dé avant ou après avoir effectué le jet de sauvegarde. Le sort prend alors fin."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une cape miniature.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/resistance"
+  },
+  {
+    "index": "resurrection",
+    "name": "Résurrection",
+    "desc": [
+      "Vous touchez une créature morte depuis un maximum d’un siècle, qui n’a pas succombé à la vieillesse et n’est pas un mort-vivant. Si son âme est libre et consentante, la cible revient à la vie avec tous ses points de vie.",
+      "Ce sort neutralise tous les poisons et soigne toutes les maladies normales qui affectaient la créature au moment de mourir. En revanche, il n’élimine pas les maladies magiques, les malédictions et autres effets comparables ; si ceux-ci ne sont pas éliminés au préalable, ils affectent de nouveau la cible quand celle-ci revient à la vie.",
+      "Ce sort referme toutes les blessures mortelles et restaure l’anatomie manquante",
+      "Revenir d’entre les morts demeure une épreuve. La cible subit un malus de –4 à tous ses jets d’attaque, jets de sauvegarde et tests de caractéristique. Chaque fois qu’elle termine un repos long, ce malus diminue de 1, jusqu’à ce qu’il disparaisse.",
+      "Lancer ce sort pour ramener à la vie une créature morte depuis un an ou plus est aussi éreintant pour vous. Tant que vous n’avez pas terminé de repos long, vous ne pouvez plus lancer de sort et tous vos jets d’attaque, jets de sauvegarde et tests de caractéristique se font avec le désavantage."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un diamant d’une valeur minimale de 1 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 7,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/resurrection"
+  },
+  {
+    "index": "reverse-gravity",
+    "name": "Inversion de la gravité",
+    "desc": [
+      "Ce sort inverse la gravité dans un cylindre de 15 m de rayon et 30 m de haut centré sur un point à portée. Tous les objets et créatures de la zone qui ne sont pas ancrés au sol \" chutent \" vers le haut pour atteindre le sommet de la zone à l’incantation du sort. Une créature a droit à un jet de sauvegarde de Dextérité pour saisir un objet fixé à portée d’allonge et ainsi éviter la chute.",
+      "Si un objet solide (comme un plafond) se présente en travers de la chute, les objets et créatures qui tombent le heurtent comme ils le feraient lors d’une chute normale. Les objets et créatures qui atteignent le sommet de la zone sans rien heurter y restent en suspension, oscillant légèrement pour toute la durée.",
+      "À la fin du sort, les objets et créatures retombent vers le bas.."
+    ],
+    "range": "30 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une magnétite et de la limaille de fer.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 7,
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "other",
+      "desc": "Une créature a droit à un jet de sauvegarde de Dextérité pour saisir un objet fixé à portée d’allonge et ainsi éviter la chute."
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 50
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/reverse-gravity"
+  },
+  {
+    "index": "revivify",
+    "name": "Retour à la vie",
+    "desc": [
+      "Vous touchez une créature morte dans la minute qui vient de s’écouler. La créature est ramenée à la vie avec 1 point de vie. Ce sort ne peut pas ramener à la vie une créature morte de vieillesse, pas plus qu’il ne restaure l’anatomie manquante."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "300 po de diamants, que le sort détruit.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/revivify"
+  },
+  {
+    "index": "rope-trick",
+    "name": "Corde enchantée",
+    "desc": [
+      "Vous touchez une corde d’une longueur maximale de 18 m. Une extrémité de la corde se dresse dans les airs jusqu’à ce que toute la corde soit perpendiculaire au sol. À son extrémité supérieure, un accès invisible donne sur un espace extradimen- sionnel qui persiste jusqu’à la fin du sort.",
+      "On peut accéder à cet espace en grimpant au sommet de la corde. Il peut accueillir un maximum de huit créatures de taille M ou inférieure. On peut haler la corde dans l’espace, si bien qu’elle n’est plus visible de l’extérieur.",
+      "Les attaques et les sorts ne peuvent franchir l’entrée de l’espace extradimensionnel, dans un sens comme dans l’autre, mais ses occupants voient ce qui se passe à l’extérieur comme à travers une fenêtre de 90 cm sur 1,50 m centrée sur la corde.",
+      "Tout ce qui se trouve à l’intérieur de l’espace extradimensionnel tombe quand le sort prend fin."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Extrait de maïs en poudre et une torsade de parchemin.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/rope-trick"
+  },
+  {
+    "index": "sacred-flame",
+    "name": "Flamme sacrée",
+    "desc": [
+      "Une radiance embrasée s’abat sur une créature que vous voyez à portée. La cible doit réussir un jet de sauvegarde de Dextérité sous peine de subir 1d8 dégâts radiants. Les abris ne confèrent aucun avantage dans le cadre de ce jet de sauvegarde",
+      "Les dégâts du sort augmentent de 1d8 lorsquevous atteignez le niveau 5 (2d8), le niveau 11 (3d8) et le niveau 17 (4d8)."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_character_level": {
+        "1": "1d8",
+        "5": "2d8",
+        "11": "3d8",
+        "17": "4d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/sacred-flame"
+  },
+  {
+    "index": "sanctuary",
+    "name": "Sanctuaire",
+    "desc": [
+      "Vous protégez une créature à portée contre les attaques. Jusqu’à la fin du sort, toute créature qui cible la créature protégée avec une attaque ou un sort nuisible effectue d’abord un jet de sauvegarde de Sagesse. En cas d’échec, la créature doit changer de cible sous peine de perdre son attaque ou son sort. Le sort ne protège pas la cible des effets de zone, comme l’explosion d’une boule de feu.",
+      "Si la créature protégée effectue une attaque ou lance un sort qui affecte une créature ennemie, le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit miroir en argent.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/sanctuary"
+  },
+  {
+    "index": "scorching-ray",
+    "name": "Rayon ardent",
+    "desc": [
+      "Vous créez trois rayons de feu que vous projetez sur des cibles à portée. Vous pouvez cibler une seule cible ou plusieurs.",
+      "Effectuez une attaque de sort à distance pour chaque rayon. Une attaque qui touche sa cible lui inflige 2d6 dégâts de feu."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, vous créez un rayon supplémentaire par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "2": "2d6"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/scorching-ray"
+  },
+  {
+    "index": "scrying",
+    "name": "Scrutation",
+    "desc": [
+      "Vous voyez et entendez une créature donnée de votre choix, située sur le même plan d’existence que vous. La cible effectue un jet de sauvegarde de Sagesse, modifié par votre connaissance de la créature et le genre de lien physique que vous entretenez avec elle. Une cible qui sait que vous lancez ce sort peut rater volontairement le JS si elle souhaite que vous l’observiez.",
+      "| Connaissance | Modificateur au JS |",
+      "|---|---|",
+      "| Indirecte  (vous avez entendu parler de la cible) | +5 |",
+      "| Directe (vous avez rencontré la cible) | +0 |",
+      "| Familiarité (vous connaissez bien la cible) | -5 |",
+      "",
+      "| Lien | Modificateur au JS |",
+      "|---|---|",
+      "| Description ou image | -2 |",
+      "| Bien personnel ou vêtement  | -4 |",
+      "| Élément anatomique, mèche de cheveux, rognure d’ongle, etc. | -10 |",
+      "En cas de sauvegarde réussie, la cible n’est pas affectée et vous ne pouvez plus réutiliser ce sort sur elle pendant 24 heures.",
+      "En cas d’échec, le sort crée un capteur invisible dans un rayon de 3 m de la cible. Vous voyez et entendez par l’intermédiaire du capteur comme si vous y étiez. Le capteur se déplace avec la cible, en restant dans un rayon de 3 m d’elle pour toute la durée. Une créature capable de voir les objets invisibles perçoit le capteur comme un orbe lumineux de la taille de votre poing.",
+      "Plutôt que de cibler une créature, vous pouvez désigner comme cible du sort un lieu que vous avez déjà vu. Ce faisant, le capteur apparaît à l’endroit désigné et ne bouge plus."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un focaliseur d’une valeur minimale de 1 000 po, comme une boule de cristal, un miroir en argent ou une vasque remplie d’eau bénite.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "10 minutes",
+    "level": 5,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/scrying"
+  },
+  {
+    "index": "secret-chest",
+    "name": "Coffre secret",
+    "desc": [
+      "Vous cachez un coffre et son contenu sur le Plan Éthéré. Vous devez toucher le coffre et la réplique miniature qui sert de composante matérielle pour le sort. Le coffre peut renfermer un maximum de 0,3 m3 de matière non vivante (90 x 60 x 60 cm).",
+      "Tant que le coffre reste sur le Plan Éthéré, vous pouvez consacrer une action à toucher la réplique pour rappeler le coffre. Il réapparaît au sol, en un espace inoccupé dans un rayon de 1,50 m de vous. Vous pouvez le renvoyer sur le Plan Éthéré au prix d’une action, en touchant simultanément le coffre et sa réplique.",
+      "Au bout de 60 jours, 5 % de risque s’accumulent chaque jour que les effets du sort prennent fin. Cet effet prend fin si vous relancez ce sort, si la réplique miniature est détruite ou si vous décidez de mettre un terme au sort au prix d’une action. Si le sort prend fin alors que le grand coffre se trouve sur le Plan Éthéré, il est irrémédiablement perdu."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une superbe coffre de 90 cm par 60 et 60, fait de matériaux rares d’une valeur minimale de 5 000 po, et sa réplique de taille TP faite des mêmes matériaux d’une valeur minimale de 50 po.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/secret-chest"
+  },
+  {
+    "index": "see-invisibility",
+    "name": "Détection de l'invisibilité",
+    "desc": [
+      "Pour toute la durée, vous voyez les créatures et objets invisibles comme s’ils étaient visibles, et vous percevez le Plan Éthéré. Les créatures et objets éthérés vous paraissent spectraux et translucides."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de talc et une petite quantité de poudre d’argent.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/see-invisibility"
+  },
+  {
+    "index": "seeming",
+    "name": "Apparence trompeuse",
+    "desc": [
+      "Ce sort vous permet de modifier l’aspect d’un certain nombre de créatures que vous voyez à portée. Vous conférez à chacune des cibles retenues un nouvel aspect illusoire. Une créature non consentante peut effectuer un jet de sauvegarde de Charisme. En cas de réussite, elle n’est pas affectée par le sort.",
+      "Le sort déguise l’apparence physique des créatures ainsi que leurs vêtements, leur armure, leurs armes et leur équipement. Vous pouvez aussi les faire paraître plus grandes ou plus petites, individuellement,  à concurrence de 30 cm, et les faire passer pour plus minces ou plus corpulentes. Vous ne pouvez en revanche pas changer leur configuration corporelle, ce qui vous contraint à opter pour des formes dotées de la même composition de membres. Pour le reste, les détails de l’illusion vous appartiennent. Le sort persiste pour toute la durée, sauf si vous consacrez une action à le révoquer avant cela.",
+      "Les changements apportés par le sort ne résistent pas à un examen physique. Exemple : si le sort ajoute un chapeau à un accoutrement, ce couvre-chef n’est pas tangible, si bien que quiconque cherche à le toucher ne sentira sous ses doigts que de l’air, le crâne ou les cheveux de la créature. Si le sort vous fait paraître plus mince que la réalité, quelqu’un qui tend la main pour vous toucher vous heurtera plus tôt que prévu.",
+      "Une créature peut consacrer son action à inspecter une cible en effectuant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. En cas de réussite, elle se rend compte que la cible est déguisée."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/seeming"
+  },
+  {
+    "index": "sending",
+    "name": "Communication à distance",
+    "desc": [
+      "Vous envoyez un bref message n’excédant pas vingt-cinq mots à une créature qui vous est familière. L’esprit de la créature perçoit le message, celle-ci vous identifie comme expéditeur si elle vous connaît et peut vous répondre aussitôt dans le même mode. Ce sort permet aux créatures dont la valeur d’Intelligence est d’au moins 1 de comprendre le sens de votre message.",
+      "La distance qui vous sépare du destinataire n’a pas d’importance et vous pouvez même atteindre d’autres plans d’existence, mais si la cible se trouve sur un plan différent, il y a 5 % de chance pour que le message n’aboutisse pas."
+    ],
+    "range": "Illimitée",
+    "components": ["V", "S", "M"],
+    "material": "Un bout de fil de cuivre.",
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/sending"
+  },
+  {
+    "index": "sequester",
+    "name": "Dissimulation suprême",
+    "desc": [
+      "Grâce à ce sort, vous pouvez cacher une créature consentante ou un objet, à l’abri des détections, pour toute la durée. À l’incantation du sort, au contact de la cible, celle-ci devient invisible et ne peut être ciblée par les sorts de divination ni perçue par les capteurs de scrutation engendrés par ces mêmes sorts.",
+      "Si la cible est une créature, elle sombre dans un état d’animation suspendue. Le temps cesse de s’écouler en ce qui la concerne et elle ne vieillit pas.",
+      "Vous pouvez fixer une condition qui mettra un terme prématuré au sort. Vous êtes libre de choisir n’importe quelle condition, mais elle doit intervenir ou être visible dans un rayon de 1,5 km de la cible. Ce peut être \" au bout de 1 000 ans \" ou \" lorsque la tarasque s’éveillera \", par exemple. Le sort prend également fin si la cible subit des dégâts."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De la poudre composée de poussière de diamant, d’émeraude, de rubis et de saphir, d’une valeur minimale de 5 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/sequester"
+  },
+  {
+    "index": "shapechange",
+    "name": "Changement de forme",
+    "desc": [
+      "Vous prenez la forme d’une autre créature pour toute la durée. Il peut s’agir de n’importe quelle créature dont le facteur de puissance est inférieur ou égal à votre niveau. La créature ne peut pas être un artificiel ni un mort-vivant, et vous devez déjà en avoir vu une de cette sorte. Vous vous métamorphosez en spécimen moyen de la créature, sans le moindre niveau de classe ni le trait Incantation ou Sorts.",
+      "Votre profil de jeu est remplacé par celui de la créature retenue, mais vous conservez votre alignement et vos valeurs d’Intelligence, de Sagesse et de Charisme. Vous conservez également toutes vos maîtrises de compétence et de jets de sauvegarde, en plus de recevoir celles de la créature. Si la créature possède une maîtrise identique à l’une des vôtres, mais avec un bonus supérieur au vôtre dans son profil, son bonus s’applique à la place du vôtre. Vous ne pouvez pas recourir à ses actions légendaires ni à ses actions d’antre.",
+      "Les points de vie et dés de vie de la nouvelle forme remplacent les vôtres. Lorsque vous retrouvez votre forme normale, vous revenez au nombre de points de vie que vous aviez avant la métamorphose. Si ce retour est dû au fait que vous êtes tombé à 0 point de vie, tous les dégâts excédentaires sont répercutés sur votre forme normale. Tant que ces dégâts excédentaires ne réduisent pas votre forme normale à 0 point de vie, vous ne subissez pas l’état inconscient.",
+      "Vous conservez l’usage de toutes les aptitudes de votre classe, race ou autre source et pouvez les utiliser, à condition que votre nouvelle forme soit physiquement apte à le faire. Vous ne pouvez recourir à aucun de vos sens spéciaux, tels que la vision dans le noir, sauf si votre nouvelle forme en dispose aussi. Vous ne pouvez parler que si la créature en a la faculté",
+      "Lors de la transformation, vous décidez si votre équipement tombe au sol, fusionne avec votre nouvelle forme ou est porté par elle. L’équipement porté fonctionne normalement. C’est au MJ de décider si une pièce d’équipement donnée peut être portée par la créature, en fonction de la forme et de la taille de celle-ci. Votre équipement ne change pas de taille ni de forme pour s’adapter à votre nouvelle silhouette ; toute pièce d’équipement que la nouvelle forme ne peut pas porter doit soit tomber au sol, soit fusionner avec elle. L’équipement fusionné reste sans effet dans cet état.",
+      "Pendant toute la durée du sort, vous pouvez consacrer une action à prendre une autre forme soumise aux mêmes contraintes et règles que la première forme, à une exception près : si votre nouvelle forme est dotée de davantage de points de vie que l’actuelle, vous conservez vos points de vie actuels."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un diadème de jade d’une valeur minimale de 1 500 po, que vous placez sur votre tête avant l’incantation du sort.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/shapechange"
+  },
+  {
+    "index": "shatter",
+    "name": "Fracassement",
+    "desc": [
+      "Un vacarme aussi soudain que pénible se produit en un point que vous choisissez à portée. Chaque créature prise dans une sphère de 3 m de rayon centrée sur ce point effectue un jet de sauvegarde de Constitution. Elle subit 3d8 dégâts de tonnerre en cas d’échec, la moitié en cas de réussite. Une créature faite de matière non organique (pierre, cristal, métal ou autre) est désavantagée à ce JS.",
+      "Un objet non magique qui n’est porté par personne subit lui aussi les dégâts s’il est dans la zone d’effet du sort."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, les dégâts augmentent de 1d8 par niveau d’emplacement au-delà du 2e."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un éclat de mica.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "damage": {
+      "damage_type": {
+        "index": "thunder",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/thunder"
+      },
+      "damage_at_slot_level": {
+        "2": "3d8",
+        "3": "4d8",
+        "4": "5d8",
+        "5": "6d8",
+        "6": "7d8",
+        "7": "8d8",
+        "8": "9d8",
+        "9": "10d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/shatter"
+  },
+  {
+    "index": "shield",
+    "name": "Bouclier",
+    "desc": [
+      "Une barrière invisible de force magique apparaît pour vous protéger. Jusqu’au début de votre tour suivant, vous recevez un bonus de +5 à la CA, y compris contre l’attaque qui a déclenché le sort, et vous ne subissez aucun dégât de projectile magique."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 reaction",
+    "level": 1,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/shield"
+  },
+  {
+    "index": "shield-of-faith",
+    "name": "Bouclier de la foi",
+    "desc": [
+      "Un champ scintillant apparaît autour d’une créaturede votre choix à portée et lui octroie un bonus de +2 à la CA pour toute la durée."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit parchemin sur lequel apparaît un extrait d’écritures saintes.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action bonus",
+    "level": 1,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/shield-of-faith"
+  },
+  {
+    "index": "shillelagh",
+    "name": "Crosse des druides",
+    "desc": [
+      "Le bois d’un gourdin ou d’un bâton de combat que vous tenez s’imprègne du pouvoir de la nature. Pour toute la durée, vous pouvez recourir à votre caractéristique d’incantation plutôt qu’à la Force pour les jets d’attaque et de dégâts de vos attaques de corps à corps effectuées avec cette arme, dont le dé de dégâts passe à d8. Si elle ne l’était pas déjà, l’arme est désormais magique. Le sort prend fin si vous le relancez ou si vous lâchez l’arme."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Du gui, une feuille de trèfle et un gourdin ou un bâton de combat.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/shillelagh"
+  },
+  {
+    "index": "shocking-grasp",
+    "name": "Poigne électrique",
+    "desc": [
+      "Votre main se met à crépiter d’énergies qu’elle s’apprête à décharger sur la créature que vous tentez de toucher. Effectuez une attaque de sort au corps à corps contre la cible. Vous êtes avantagé au jet d’attaque si la cible porte une armure en métal. Si l’attaque touche, la cible subit 1d8 dégâts de foudre et ne peut pas jouer de réaction jusqu’au début de son tour suivant.",
+      "Les dégâts du sort augmentent de 1d8 lorsque vous atteignez le niveau 5 (2d8), le niveau 11 (3d8) et le niveau 17 (4d8)."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "damage_at_character_level": {
+        "1": "1d8",
+        "5": "2d8",
+        "11": "3d8",
+        "17": "4d8"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/shocking-grasp"
+  },
+  {
+    "index": "silence",
+    "name": "Silence",
+    "desc": [
+      "Pour toute la durée, nul son ne peut être produit dans une sphère de 6 m de rayon centrée sur un point que vous choisissez à portée. Aucun son ne peut non plus traverser cette zone.",
+      "Tout objet ou créature entièrement compris dans la sphère est immunisé contre les dégâts de tonnerre ; les créatures sont de plus assourdies. Il est impossible de lancer de sort doté d’une composante verbale de l’intérieur de cette sphère."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/silence"
+  },
+  {
+    "index": "silent-image",
+    "name": "Image silencieuse",
+    "desc": [
+      "Vous créez l’image d’un objet, d’une créature ou autre phénomène visible dont la taille ne dépasse pas celle d’un cube de 4,50 m d’arête. L’image apparaît en un endroit à portée et persiste pour toute la durée. Elle est purement visuelle, dépourvue de son, d’odeur et de tout autre effet sensoriel.",
+      "Vous pouvez consacrer votre action à déplacer l’image vers un autre endroit à portée. Lors de ce déplacement, vous pouvez modifier l’aspect de l’image afin que ses mouvements paraissent naturels. Exemple : si vous créez l’image d’une créature que vous faites déplacer, vous pouvez faire en sorte qu’elle donne l’impression de marcher.",
+      "Toute interaction physique avec l’image percera l’illusion, car elle n’est pas tangible. Une créature qui consacre son action à examiner l’image peut comprendre qu’il s’agit d’une illusion en réussissant un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts. Une créature qui perce l’illusion voit à travers l’image."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un peu de laine brute.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 1,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 15
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/silent-image"
+  },
+  {
+    "index": "simulacrum",
+    "name": "Simulacre",
+    "desc": [
+      "Vous façonnez un double illusoire d’une bête ou d’un humanoïde qui se trouve à portée pendant tout le temps d’incantation du sort. La réplique est une créature en partie réelle, faite de neige ou de glace, qui peut entreprendre des actions et que l’on peut affecter comme une créature normale. Elle apparaît en tout point identique à la créature originale, mais ne dispose que de la moitié de son maximum de points de vie et se forme sans équipement. Pour le reste, l’illusion reprend le profil de jeu de la créature qu’elle reproduit.",
+      "Le simulacre est amical envers vous et les créatures que vous désignez. Il obéit à vos ordres verbaux, se déplace et se comporte selon vos souhaits, et agit à votre tour au combat. Le simulacre est incapabled’apprendre ou de gagner en puissance, si bien qu’il ne gagne pas de niveaux ou d’autres facultés, et il ne récupère pas davantage les emplacements de sort qu’il dépense.",
+      "Si le simulacre subit des dégâts, vous pouvez le réparer dans un laboratoire d’alchimie en vous servant d’herbes rares et de minéraux d’une valeur de 100 po par point de vie récupéré. Le simulacre persiste jusqu’à ce qu’il tombe à 0 point de vie, après quoi il retrouve sa substance aqueuse et fond aussitôt.",
+      "Si vous relancez ce sort, toute autre réplique active que vous avez créée par ce même sort est aussitôt détruite."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De la neige ou de la glace en quantité suffisante pour modeler une réplique grandeur nature de la créature ; des cheveux, des rognures d’ongle ou autres fragments du corps de la créature disposés dans la neige ou la glace ; de la poussière de rubis d’une valeur de 1 500 po, saupoudrée sur la réplique et détruite par le sort.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "12 hours",
+    "level": 7,
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/simulacrum"
+  },
+  {
+    "index": "sleep",
+    "name": "Sommeil",
+    "desc": [
+      "Ce sort plonge les créatures dans un sommeil magique. Lancez 5d8 ; le total représente la somme des points de vie de créatures que le sort peut affecter. Les créatures situées dans un rayon de 6 m d’un point que vous choisissez à portée sont affectées par ordre croissant de leurs points de vie actuels (sans tenir compte des créatures inconscientes).",
+      "À commencer par la créature dotée des points de vie actuels les plus faibles, chaque créature affectée par ce sort tombe inconsciente et le reste jusqu’à la fin du sort, jusqu’à ce qu’elle subisse des dégâts ou que quelqu’un consacre une action à la réveiller énergiquement. Soustrayez les points de vie de chaque créature ainsi endormie du total avant de passer à la suivante dans l’ordre croissant des points de vie. Une créature ne peut être affectée que si ses points de vie ne dépassent pas le total restant.",
+      "Les morts-vivants et les créatures immunisées contre l’état charmé ne sont pas affectés par ce sort."
+    ],
+    "higher_level": [
+      " Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, lancez 2d8 supplémentaires par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de sable fin, des pétales de rose ou un grillon.",
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "damage": {
+      "damage_at_slot_level": {
+        "1": "5d8"
+      }
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/sleep"
+  },
+  {
+    "index": "sleet-storm",
+    "name": "Tempête de neige",
+    "desc": [
+      "Jusqu’à la fin du sort, une pluie glaciale mêlée de neige fondue s’abat sous forme d’un cylindre de 6 m de haut et 12 m de diamètre, centré sur un point que vous choisissez à portée. La visibilité de la zone est nulle et les flammes nues s’y éteignent aussitôt.",
+      "Le sol de la zone est recouvert de glace, ce qui en fait un terrain difficile. Lorsqu’une créature entre dans la zone d’effet du sort pour la première fois d’un tour ou y commence son tour, elle effectue un jet de sauvegarde de Dextérité. En cas d’échec, elle tombe à terre.",
+      "Si une créature se concentre sur un sort dans la zone, elle effectue un jet de sauvegarde de Constitution contre votre DD de sauvegarde des sorts et, en cas d’échec, perd sa concentration."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poussière et quelques gouttes d’eau",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 40
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/sleet-storm"
+  },
+  {
+    "index": "slow",
+    "name": "Lenteur",
+    "desc": [
+      "Vous altérez le temps autour d’un maximum de six créatures de votre choix dans un cube de 12 m d’arête à portée. Chaque cible doit réussir un jet de sauvegarde de Sagesse sous peine d’être affectée par ce sort pour toute la durée.",
+      "Une cible affectée voit sa vitesse réduite de moitié, subit un malus de –2 à la CA et aux jets de sauvegarde de Dextérité, et ne peut pas jouer de réactions. À son tour, elle peut entreprendre une action ou une action bonus, mais pas les deux. Quels que soient les objets magiques et les facultés de la créature, elle ne peut effectuer plus d’une attaque au corps à corps ou à distance à son tour.",
+      "Si la créature tente de lancer un sort dont le temps d’incantation est de 1 action, lancez un d20. Sur un résultat de 11 ou plus, le sort ne prend pas effet avant le tour suivant de la créature, et celle-ci doit consacrer son action du tour correspondant à achever l’incantation. Si elle n’en a pas la possibilité, le sort est gaspillé.",
+      "Une créature affectée par ce sort réitère le jet de sauvegarde de Sagesse à la fin de chacun de ses tours. En cas de réussite, l’effet prend fin sur elle."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte de mélasse.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none",
+      "desc": "On failed save, the creature is slowed."
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 40
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/slow"
+  },
+  {
+    "index": "spare-the-dying",
+    "name": "Stabilisation",
+    "desc": [
+      "Vous touchez physiquement une créature vivante dotée de 0 point de vie. La créature est stabilisée. Ce sort est sans effet sur les morts-vivants et les artificiels."
+    ],
+    "range": "Contact",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/spare-the-dying"
+  },
+  {
+    "index": "speak-with-animals",
+    "name": "Communication avec les animaux",
+    "desc": [
+      "Vous recevez la faculté de comprendre les bêtes et de communiquer verbalement avec elles pour toute la durée. Le savoir et le niveau de conscience de bien des bêtes sont limités par leur intellect, mais toutes sont capables de vous informer sur les environs et les monstres locaux, notamment ce qu’elles ont perçu au cours de la dernière journée. À la discrétion du MJ, vous pourriez convaincre une bête de vous rendre un menu service."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": true,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/speak-with-animals"
+  },
+  {
+    "index": "speak-with-dead",
+    "name": "Communication avec les morts",
+    "desc": [
+      "Vous octroyez un semblant de vie et de conscience à un cadavre que vous choisissez à portée, pour qu’il uisse répondre aux questions que vous lui posez. La  dépouille doit disposer d’une bouche et ne peut être un mort-vivant. Le sort échoue si le cadavre a déjà été ciblé par ce sort au cours des 10 derniers jours.",
+      "Jusqu’à la fin du sort, vous pouvez poser jusqu’à cinq questions à la dépouille. Elle ne sait rien de plus que de son vivant et parle toujours les mêmes langues. Ses réponses ont tendance à se montrer brèves, sibyllines ou répétitives, d’autant que le cadavre n’est nullement contraint de vous répondre avec sincérité si vous lui êtes hostile ou si’il vous voit comme un ennemi. Ce sort ne ramène pas l’âme de la créature dans son corps ; il ne fait qu’animer son esprit. Ainsi le cadavre ne peut-il rien apprendre de nouveau ni comprendre ce qui a pu se passer depuis son décès, et ne peut-il pas davantage conjecturer sur l’avenir."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S", "M"],
+    "material": "De l’encens qui brûle.",
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/speak-with-dead"
+  },
+  {
+    "index": "speak-with-plants",
+    "name": "Communication avec les plantes",
+    "desc": [
+      "Vous investissez la flore dans un rayon de 9 m d’une conscience limitée et de mouvements, de quoi lui permettre de communiquer avec vous et de suivre vos instructions rudimentaires. Vous pouvez interroger ces plantes sur ce qui s’est passé dans la zone du sort depuis un jour, notamment la nature des créatures qui l’ont traversée, le temps qu’il a fait et autres détails.",
+      "Vous pouvez également transformer tout terrain difficile engendré par la végétation (buissons et sous- bois, par exemple) en terrain ordinaire qui persiste pour toute la durée. Ou bien transformer un terrain ordinaire pourvu de végétation en terrain difficile qui persiste pour toute la durée, si bien que des plantes grimpantes et des branches gênent les mouvements de vos poursuivants, par exemple.",
+      "Ces végétaux peuvent, à la discrétion du MJ, vous rendre d’autres services. Le sort ne permet pas aux plantes de se déraciner pour se déplacer, mais elles peuvent agiter leurs branches, leurs vrilles et leurs pédoncules.",
+      "Si une créature de type plante se trouve dans la zone, vous pouvez communiquer avec elle comme si vous parliez une langue commune, mais le sort ne vous octroie aucune influence magique sur elle.",
+      "Ce sort permet de contraindre la végétation créée par le sort enchevêtrement à libérer une créature entravée."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/speak-with-plants"
+  },
+  {
+    "index": "spider-climb",
+    "name": "Pattes d'araignée",
+    "desc": [
+      "Jusqu’à la fin du sort, une créature consentante que vous touchez reçoit la capacité de se déplacer dans toutes les directions le long des surfaces verticales, ainsi que sur les plafonds (la tête en bas), tout en gardant les mains libres. La cible reçoit en outre une vitesse d’escalade égale à sa vitesse au sol."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte de bitume et une araignée.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/spider-climb"
+  },
+  {
+    "index": "spike-growth",
+    "name": "Croissance d'épines",
+    "desc": [
+      "Le sol dans un rayon de 6 m centré sur un point à portée s’anime pour faire émerger des pointes et épines coriaces. La zone devient un terrain difficile pour toute la durée. Lorsqu’une créature pénètre dans la zone ou s’y déplace, elle subit 2d4 dégâts perforants par tranche de 1,50 m qu’elle y parcourt.",
+      "La transformation du sol paraît naturelle. Toute créature qui ne voit pas la zone au moment de l’incantation effectue un test de Sagesse (Perception) assorti de votre DD de sauvegarde des sorts pour reconnaître le danger avant de fouler ce sol."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Sept épines acérées ou sept brindilles, toutes affûtées.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 20
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/spike-growth"
+  },
+  {
+    "index": "spirit-guardians",
+    "name": "Esprits gardiens",
+    "desc": [
+      "Vous invoquez la protection d’esprits qui viennent voleter dans un rayon de 4,50 m de vous pour toute la durée. Si vous êtes bon ou neutre, ces formes spectrales paraissent angéliques ou féeriques (à votre convenance). Si vous êtes mauvais, elles paraissent démoniaques ou diaboliques.",
+      "À l’incantation du sort, vous désignez autant de créatures que vous le souhaitez parmi celles que vous voyez ; elles ne seront pas affectées par ces esprits. Toutes les autres créatures voient leur vitesse réduite de moitié dans la zone ; de plus, lorsqu’une telle créature entre dans la zone d’effet pour la première fois d’un tour ou y commence son propre tour, elle effectue un jet de sauvegarde de Sagesse. En cas d’échec, elle subit 3d8 dégâts radiants (si vous êtes bon ou neutre) ou 3d8 dégâts nécrotiques (si vous êtes mauvais). En cas de réussite, la créature subit la moitié de ces dégâts."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, les dégâts augmentent de 1d8 par niveau d’emplacement au-delà du 3e."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Un symbole sacré.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/spirit-guardians"
+  },
+  {
+    "index": "spiritual-weapon",
+    "name": "Arme spirituelle",
+    "desc": [
+      "Vous créez une arme spectrale et flottante à portée, qui persiste pour toute la durée ou jusqu’à ce que vous relanciez ce sort. À l’incantation, vous pouvez effectuer une attaque de sort au corps à corps contre une créature située dans un rayon de 1,50 m de l’arme. Si l’attaque touche, la cible subit des dégâts de force égaux à 1d8 + votre modificateur de caractéristique d’incantation.",
+      "Par une action bonus, vous pouvez déplacer l’arme d’un maximum de 6 m et répéter l’attaque contre une créature située dans un rayon de 1,50 m de l’arme.",
+      "L’arme prend la forme de votre choix. Les clercs de divinités associées à une arme donnée (saint Cuthbert est par exemple connu pour sa masse d’armes et Thor pour son marteau) donnent l’aspect de cet objet à leur arme spirituelle."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 3e niveau ou supérieur, les dégâts augmentent de 1d8 par tranche de deux niveaux d’emplacement au-delà du 2e."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action bonus",
+    "level": 2,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "force",
+        "name": "Force",
+        "url": "/api/2014/damage-types/force"
+      },
+      "damage_at_slot_level": {
+        "2": "1d8 + MOD",
+        "3": "1d8 + MOD",
+        "4": "2d8 + MOD",
+        "5": "2d8 + MOD",
+        "6": "3d8 + MOD",
+        "7": "3d8 + MOD",
+        "8": "4d8 + MOD",
+        "9": "4d8 + MOD"
+      }
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "life",
+        "name": "Vie",
+        "url": "/api/2014/subclasses/life"
+      }
+    ],
+    "url": "/api/2014/spells/spiritual-weapon"
+  },
+  {
+    "index": "stinking-cloud",
+    "name": "Nuage nauséabond",
+    "desc": [
+      "Vous créez une sphère d’un rayon de 6 m remplie de vapeurs nauséeuses jaunes, centrée sur un point à portée. Le nuage contourne les angles et sa zone présente une visibilité nulle. Le nuage persiste en flottant dans les airs pour toute la durée.",
+      "Chaque créature intégralement prise dans le nuage au début de son tour effectue un jet de sauvegarde de Constitution contre le poison. En cas d’échec, la créature consacre son action du tour à lutter contre des haut-le-cœur. Les créatures qui n’ont pas besoin de respirer ou sont immunisées contre le poison réussissent automatiquement ce jet de sauvegarde.",
+      "Un vent modéré (au moins 15 km/h) disperse le nuage au bout de 4 rounds. Un vent fort (au moins 30 km/h) le disperse en 1 round."
+    ],
+    "range": "27 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un œuf pourri ou plusieurs feuilles de chou puant.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none",
+      "desc": "En cas d’échec, la créature consacre son action du tour à lutter contre des haut-le-cœur."
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      },
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/stinking-cloud"
+  },
+  {
+    "index": "stone-shape",
+    "name": "Façonnage de la pierre",
+    "desc": [
+      "Vous touchez physiquement un objet de pierre de taille M ou inférieure ou une section de pierre dont aucune dimension n’excède 1,50 m, pour les modeler à votre guise. Vous pouvez ainsi façonner un gros rocher en arme, en statue ou en caisson, ou pratiquer un passage dans une paroi, à condition que l’épaisseur de celle-ci ne dépasse pas 1,50 m. Vous pourriez aussi modeler une porte de pierre ou en refaçonner l’encadrement pour la condamner. L’objet confectionné peut être doté d’un maximum de deux charnières et d’un loquet, mais les éléments mécaniques plus sophistiqués sont proscrits."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Terre glaise qu’il faut modeler grossièrement selon la forme désirée pour l’objet de pierre.",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/stone-shape"
+  },
+  {
+    "index": "stoneskin",
+    "name": "Peau de pierre",
+    "desc": [
+      "Par ce sort, la chair d’une créature consentante que vous touchez devient aussi dure que la pierre. Jusqu’à la fin du sort, la cible bénéficie de la résistance aux dégâts contondants, perforants et tranchants qui ne sont pas magiques."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "100 po de poudre de diamant, que le sort détruit.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/stoneskin"
+  },
+  {
+    "index": "storm-of-vengeance",
+    "name": "Tempête vengeresse",
+    "desc": [
+      "Un nuage menaçant se forme, centré sur un point que vous voyez, et se déploie sur un rayon de 108 m. La zone est parcourue de zébrures de foudre, de coups de tonnerre et du rugissement des vents. Toute créature directement dominée par le nuage à son apparition (à condition de ne pas se trouver à plus de 1 500 m de lui) effectue un jet de sauvegarde de Constitution. En cas d’échec, elle subit 2d6 dégâts de tonnerre et se retrouve assourdie pendant 5 minutes.",
+      "À chaque round pendant lequel vous maintenez votre concentration sur ce sort, l’orage produit les effets supplémentaires suivants à votre tour.",
+      "***Round 2.*** Une pluie acide s’abat au sol. Tous les objets et créatures directement dominés par le nuage subissent 1d6 dégâts d’acide.",
+      "***Round 3.*** Vous invoquez six éclairs qui jaillissent du nuage pour frapper six créatures ou objets de votre choix directement dominés par le nuage. Un même objet ou une même créature ne peuvent être frappés par plus d’un éclair. Une créature ainsi frappée effectue un jet de sauvegarde de Dextérité. La créature subit 10d6 dégâts de foudre en cas d’échec, la moitié en cas de réussite.",
+      "***Round 4.*** La grêle s’abat depuis le nuage. Toute créature directement dominée par le nuage subit 2d6 dégâts contondants.",
+      "***Round 5 à 10.*** La zone directement dominée par le nuage est assaillie de bourrasques et d’une pluie glaciale. La zone devient terrain difficile et sa visibilité est nulle. Toute créature qui s’y trouve subit 1d6 dégâts de froid. Les attaques d’arme à distance sont impossibles dans la zone. Toute créature qui maintient sa concentration sur un sort est si malmenée qu’un test s’impose pour savoir si elle ne la perd pas. Enfin, les bourrasques de vent fort (allant de 30 à 75 km/h) dispersent automatiquement tous les brouillards, brumes et phénomènes comparables de la zone, qu’ils soient magiques ou non."
+    ],
+    "range": "Vision",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 9,
+    "damage": {
+      "damage_type": {
+        "index": "thunder",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/thunder"
+      },
+      "damage_at_slot_level": {
+        "9": "2d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "none",
+      "desc": "En cas d’échec, elle subit 2d6 dégâts de tonnerre et se retrouve assourdie pendant 5 minutes."
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 360
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/storm-of-vengeance"
+  },
+  {
+    "index": "suggestion",
+    "name": "Suggestion",
+    "desc": [
+      "Vous suggérez une ligne de conduite (par une phrase ou deux) visant à influencer magiquement une créature que vous voyez à portée et qui vous entend et vous comprend. Les créatures qui ne peuvent pas être charmées sont immunisées contre cet effet. La suggestion doit être formulée de manière à paraître raisonnable. Demander à une créature de se poignarder, de se jeter sur un pieu, de s’immoler par les flammes ou d’exécuter quelque acte indubitablement dangereux pour elle met un terme au sort.",
+      "La cible effectue un jet de sauvegarde de Sagesse. En cas d’échec, elle se conforme de son mieux à la ligne de conduite énoncée. L’activité en question peut se prolonger pour toute la durée. S’il est possible de l’accomplir plus rapidement, le sort prend fin dès que le sujet a terminé ce qu’on lui a demandé.",
+      "Vous pouvez également spécifier les conditions qui déclencheront une activité spéciale avant la fin du sort. Exemple : vous pouvez suggérer à une chevalière de faire don de son destrier au premier mendiant qu’elle croisera. Si la situation ne se présente pas avant la fin du sort, l’activité n’est pas exécutée.",
+      "Si vous-même ou l’un de vos compagnons infligez des dégâts à la cible, le sort prend fin."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "M"],
+    "material": "une langue de serpent, et un peu de rayon de miel ou une goutte d’huile sucrée.",
+    "ritual": false,
+    "duration": "Jusqu'à 8 heures",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/suggestion"
+  },
+  {
+    "index": "sunbeam",
+    "name": "Rayon de soleil",
+    "desc": [
+      "Un rayon de lumière intense jaillit de votre main sous forme d’une ligne de 18 m de long pour 1,50 m de large. Chaque créature prise dans la ligne effectue un jet de sauvegarde de Constitution. En cas d’échec, elle subit 6d8 dégâts radiants et se retrouve aveuglée jusqu’à votre tour suivant. En cas de réussite, elle subit la moitié de ces dégâts et n’est pas aveuglée par le sort. Les morts-vivants et les vases sont désavantagés à ce jet de sauvegarde.",
+      "À chacun de vos tours, vous pouvez produire un nouveau rayon radieux au prix d’une action jusqu’à la fin du sort.",
+      "Pour toute la durée, votre main brille d’un point de radiance. Elle émet une lumière vive sur un rayon de 9 m et une lumière faible sur 9 m de plus. Cette lumière est celle du soleil."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une loupe.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "6": "6d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half",
+      "desc": "On a failed save, the creature is blinded until your next turn. On a successful save, it isn't blinded by this spell."
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/sunbeam"
+  },
+  {
+    "index": "sunburst",
+    "name": "Éclat du soleil",
+    "desc": [
+      "La lumière du soleil brille soudain dans un rayon de 18 m, centré sur un point que vous choisissez à portée. Chaque créature prise dans cette lumière effectue un jet de sauvegarde de Constitution. En cas d’échec, elle subit 12d6 dégâts radiants et se retrouve aveuglée pendant 1 minute. En cas de réussite, elle subit la moitié de ces dégâts et n’est pas aveuglée par le sort. Les morts-vivants et les vases sont désavantagés à ce jet de sauvegarde.",
+      "Une créature aveuglée par ce sort réitère le jet de sauvegarde de Constitution à la fin de chacun de ses tours. En cas de réussite, elle n’est plus aveuglée.",
+      "Le sort dissipe toutes les ténèbres de la zone qui résultent d’un sort."
+    ],
+    "range": "45 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Des flammes et un morceau d’héliolite",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 8,
+    "damage": {
+      "damage_type": {
+        "index": "radiant",
+        "name": "Radiant",
+        "url": "/api/2014/damage-types/radiant"
+      },
+      "damage_at_slot_level": {
+        "8": "12d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half",
+      "desc": "En cas d’échec, elle subit 12d6 dégâts radiants et se retrouve aveuglée pendant 1 minute."
+    },
+    "area_of_effect": {
+      "type": "cylinder",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/sunburst"
+  },
+  {
+    "index": "symbol",
+    "name": "Symbole",
+    "desc": [
+      "À l’incantation du sort, vous inscrivez un glyphe nuisible à d’autres créatures, soit sur une surface (comme une table, ou un pan de mur ou de sol), soit à l’intérieur d’un objet que l’on peut fermer (comme un livre, un parchemin ou un coffre au trésor) de manière à dissimuler le symbole. Si vous optez pour une surface, le glyphe peut recouvrir une zone dont le diamètre ne dépasse pas 3 m. Si vous optez pour un objet, celui-ci doit rester à sa place ; si on le déplace de plus de 3 m de l’endroit où vous avez lancé le sort, le glyphe est rompu et le sort prend fin sans avoir été activé.",
+      "Le glyphe est pratiquement invisible ; il faut réussir un test d’Intelligence (Investigation) assorti de votre DD de sauvegarde des sorts pour le détecter.",
+      "Vous décidez ce qui le déclenche à l’incantation du sort. Dans le cas des glyphes de surface, les déclencheurs les plus courants sont les suivants : toucher le glyphe, le fouler, retirer un objet qui le recouvre, s’approcher dans un certain rayon ou manipuler l’objet sur lequel il est inscrit. Pour les glyphes inscrits à l’intérieur d’un objet, les déclencheurs habituels sont l’ouverture de l’objet, une proximité spécifiée avec l’objet, la lecture du glyphe ou sa simple vue.",
+      "Vous pouvez préciser davantage le déclencheur pour que le sort ne s’active que sous certaines conditions ou face à certaines particularités physiques (une taille ou un poids) ou certaines catégories de créatures (la protection pourrait ne s’activer que contre les guenaudes ou les métamorphes). Vous pouvez aussi fixer les critères de créatures qui ne déclenchent pas le glyphe, comme le fait de prononcer un certain mot de passe.",
+      "À l’inscription du glyphe, choisissez l’une desoptions suivantes comme effet. Quand il s’active, le glyphe se met à luire en emplissant une sphère de 18 m de rayon de lumière faible pendant 10 minutes, après quoi le sort prend fin. Chaque créature prise dans la sphère au moment de l’activation du glyphe est ciblée par son effet, de même que toute créature qui pénètre dans la sphère pour la première fois d’un tour ou y termine son tour.",
+      "***Démence.*** Chaque cible effectue un jet de sauvegarde d’Intelligence. En cas d’échec, la cible est en proie à la démence pendant 1 minute. Une créature démente ne peut entreprendre la moindre action, ne comprend pas ce que disent les autres créatures, ne sait pas lire et ne peut que bredouiller des propos incohérents. Le MJ contrôle ses déplacements erratiques.",
+      "***Désespoir.*** Chaque cible effectue un jet de sauvegarde de Charisme. En cas d’échec, elle est submergée par le désespoir pendant 1 minute. Tout ce temps, elle ne peut attaquer ni cibler quiconque avec des pouvoirs, sorts et autres effets magiques conçus pour nuire.",
+      "***Discorde.*** Chaque cible effectue un jet de sauvegarde de Constitution. En cas d’échec, la cible se chamaille verbalement avec une autre créature pendant 1 minute. Tout ce temps, elle est incapable de communiquer de manière cohérente et ses jets d’attaque et tests de caractéristique s’effectuent avec le désavantage.",
+      "***Douleur.*** Chaque cible effectue un jet de sauvegarde de Constitution et se retrouve neutralisée par des douleurs insoutenables pendant 1 minute en cas d’échec.",
+      "***Étourdissement.*** Chaque cible effectue un jet de sauvegarde de Sagesse et se retrouve étourdie pendant 1 minute en cas d’échec.",
+      "***Mort.*** Chaque cible effectue un jet de sauvegarde de Constitution et subit 10d10 dégâts nécrotiques en cas d’échec, la moitié en cas de réussite.",
+      "***Sommeil.*** Chaque cible effectue un jet de sauvegarde de Sagesse et tombe inconsciente pendant 10 minutes en cas d’échec. Une telle créature reprend connaissance si elle subit des dégâts ou si quelqu’un consacre une action à la secouer ou à la gifler.",
+      "***Terreur.*** Chaque cible effectue un jet de sauvegarde de Sagesse et devient effrayée pendant 1 minute en cas d’échec. Tant qu’une cible est ainsi effrayée, elle lâche tout ce qu’elle tient et doit s’éloigner au minimum de 9 m du glyphe à chacun de ses tours si elle en a la possibilité."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Du mercure, du phosphore et de la poudre de diamant et d’opale dont la valeur totale est d’au moins 1 000 po, que le sort détruit.",
+    "ritual": false,
+    "duration": "Jusqu'à dissipation",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 7,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 10
+    },
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/symbol"
+  },
+  {
+    "index": "telekinesis",
+    "name": "Télékinésie",
+    "desc": [
+      "Vous recevez la faculté de déplacer ou manipulerobjets et créatures par la simple pensée. À l’incantation du sort, ainsi qu’au prix de votre action d’un roundpour toute la durée, vous pouvez exercer votre volonté sur une créature ou un objet que vous voyez à portée pour produire l’effet adéquat décrit plus loin. Vous pouvez affecter la même cible round après round, ou en sélectionner une nouvelle chaque fois que vous le souhaitez. Si vous changez de cible, la précédente n’est plus affectée par le  sort.",
+      "***Créature.*** Vous tentez de déplacer une créature de taille TG ou inférieure. Effectuez un test de caractéristique d’incantation opposé au test de Force de la créature. Si vous l’emportez, vous déplacez la créature d’un maximum de 9 m dans la direction de votre choix, éventuellement vers le haut, dans les limites de la portée du sort. Jusqu’à la fin de votre tour suivant, la créature est entravée par votre poigne télékinétique. Une créature hissée dans les airs y reste suspendue.",
+      "Lors des rounds suivants, vous pouvez consacrer votre action à tenter de maintenir votre poigne télékinétique sur la créature, en réitérant le test d’opposition.",
+      "***Objet.*** Vous tentez de déplacer un objet dont le poids n’excède pas 500 kg. Si l’objet n’est porté par personne, vous parvenez automatiquement à le déplacer d’un maximum de 9 m dans la direction de votre choix, mais dans les limites de portée du sort.",
+      "Si l’objet est porté par une créature, vous effectuez un test de caractéristique d’incantation opposé au test de Force de cette créature. Si vous l’emportez, vous éloignez l’objet de la créature d’un maximum de 9 m dans la direction de votre choix, mais dans les limites de portée du sort.",
+      "Vous pouvez exercer un contrôle plus précis sur les objets soumis à votre poigne télékinétique, comme manipuler un outil rudimentaire, ouvrir une porte ou un récipient, ranger un objet dans un contenant ouvert ou l’en extraire, ou encore verser le contenu d’une fiole."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/telekinesis"
+  },
+  {
+    "index": "telepathic-bond",
+    "name": "Lien télépathique",
+    "desc": [
+      "Vous forgez un lien télépathique entre un maximum de huit créatures consentantes que vous choisissez à portée, chacune se retrouvant en relation psychique avec toutes les autres pour toute la durée. Les créatures dont la valeur d’Intelligence est inférieure ou égale à 2 ne sont pas affectées par ce sort.",
+      "Jusqu’à la fin du sort, les cibles peuvent communiquer par télépathie via le lien psychique, qu’elles parlent ou non une même langue. La communication, possible quelle que soit la distance, ne s’étend toutefois pas d’un plan d’existence à l’autre."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Des fragments de coquille d’œuf de deux sortes de créature.",
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/telepathic-bond"
+  },
+  {
+    "index": "teleport",
+    "name": "Téléportation",
+    "desc": [
+      "Ce sort vous transporte instantanément, ainsi que huit créatures consentantes de votre choix parmi celles que vous voyez à portée, ou un seul objet que vous voyez à portée, vers la destination sélectionnée. Si vous ciblez un objet, il doit pouvoir loger entièrement dans un cube de 3 m d’arête et ne doit pas être porté par une créature non consentante.",
+      "Vous devez connaître la destination que vous choisissez et elle doit se trouver sur le même plan d’existence que vous. Votre niveau de familiarité avec la destination détermine si vous y parvenez effectivement. Le MJ lance un d100 et consulte la table.",
+      "| Familiarité | Incident | Zone comparable  | Déviation | Sur place |",
+      "|---|---|---|---|---|",
+      "| Cercle permanent | -- | -- | -- | 01-100 |",
+      "| Objet associé | -- | -- | -- | 01-100 |",
+      "| Grande familiarité | 01-05 | 06-13 | 14-24 | 25-100 |",
+      "| Vu plusieurs fois | 01-33 | 34-43 | 44-53 | 54-100 |",
+      "| Vu une fois | 01-43 | 44-53 | 54-73 | 74-100 |",
+      "| Décrit | 01-43 | 44-53 | 54-73 | 74-100 |",
+      "| Destination factice | 01-50 | 51-100 | -- | -- |",
+      "***Familiarité.*** \"\" Cercle permanent \" fait référence à un cercle de téléportation permanent dont vous connaissez la séquence de runes.",
+      "\" Objet associé \" indique que vous détenez un objet rapporté de la destination souhaitée au cours des six derniers mois, comme un livre issu de la bibliothèque d’un magicien, la literie d’une suite royale ou un éclat de marbre du tombeau secret d’une liche.",
+      "\" Grande familiarité \" correspond à un endroit où vous avez passé du temps, un lieu que vous avez étudié en profondeur ou un site que vous voyez à l’incantation du sort.",
+      "\" Vu plusieurs fois \" représente un lieu que vous avez vu plus d’une fois, mais que vous connaissez finalement assez peu.",
+      "\" Vu une fois \" correspond à un site que vous n’avez vu qu’une fois, éventuellement par magie.",
+      "\" Décrit \" qualifie un endroit dont la position et l’aspect vous ont été rapportés, éventuellement par le biais d’une carte.",
+      "\" Destination factice \" correspond à un lieu qui n’existe pas. Vous avez par exemple tenté de scruter le sanctuaire de l’ennemi, mais avez été dupé par une illusion, à moins que vous cherchiez à atteindre un lieu familier qui n’existe plus.",
+      "***Sur place.*** Vous et votre groupe (ou l’objet ciblé) arrivez à l’endroit souhaité.",
+      "***Déviation.*** Vous et votre groupe (ou l’objet ciblé) arrivez à une distance et une direction aléatoires de la destination souhaitée. La distance qui vous sépare de la destination est égale à 1d10 x 1d10 pour cent de celle que vous deviez parcourir. Si vous cherchiez par exemple à couvrir 180 km et obtenez une déviation, puis que les deux d10 vous donnent 5 et 3, vous terminez à 15 % de votre objectif, soit 27 km. Le MJ détermine la direction de la déviation au hasard en lançant un d8 ; 1 représente le nord, 2, le nord-est, 3 l’est, et ainsi de suite selon la rose des vents. Si vous souhaitiez vous téléporter en une ville côtière et terminez à 27 km en pleine mer, vous risquez d’avoir une drôle de surprise.",
+      "***Zone comparable.*** Vous et votre groupe (ou l’objet ciblé) terminez dans une zone différente dont l’ambiance et l’aspect se rapprochent de la destination souhaitée. Si vous souhaitiez rejoindre votre laboratoire, par exemple, vous pourriez aboutir dans celui d’un autre magicien ou dans une boutique d’alchimie garnie d’outils et ustensiles communs avec ceux de votre laboratoire. En général, vous vous retrouvez dans l’endroit comparable le plus proche en distance, mais le sort n’ayant aucune limite de portée, vous pourriez tout aussi bien terminer n’importe où sur ce plan d’existence.",
+      "***Incident.*** La magie imprévisible de ce sort se traduit par une mésaventure. Chaque créature téléportée (ou l’objet ciblé) subit 3d10 dégâts de force et le MJ rejoue sur la table pour voir où vous terminez (plusieurs incidents consécutifs sont possibles, entraînant chaque fois des dégâts)."
+    ],
+    "range": "3 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 7,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 10
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/teleport"
+  },
+  {
+    "index": "teleportation-circle",
+    "name": "Cercle de téléportation",
+    "desc": [
+      "À l’incantation du sort, vous tracez un cercle de 3 m de diamètre au sol, composé de symboles qui relient votre emplacement à un cercle de téléportation permanent de votre choix dont vous connaissez la séquence de runes et situé sur le même plan d’existence que vous. Un portail chatoyant s’ouvre au sein du cercle ainsi tracé et reste ouvert jusqu’à la fin de votre tour suivant. Toute créature qui pénètre dans le portail apparaît aussitôt dans un rayon de 1,50 m du cercle de destination ou, si cet espace n’est pas libre, dans l’espace inoccupé le plus proche.",
+      "De nombreux sites importants, notamment des temples et guildes, disposent d’un cercle de téléportation permanent dans leurs locaux. Un tel cercle comprend toujours sa propre séquence de runes, une suite de symboles magiques à l’agencement unique. La première fois que vous acquérez la faculté de lancer ce sort, vous apprenez la séquence de runes de deux destinations du Plan Matériel, déterminées par le MJ. Vous y ajouterez éventuellement d’autres séquences au fil de vos aventures. Graver une nouvelle séquence de runes dans votre mémoire nécessite de l’étudier pendant 1 minute.",
+      "Vous pouvez créer un cercle de téléportationpermanent en lançant quotidiennement ce sort au même endroit pendant un an. Il n’est pas besoin d’utiliser le cercle pour se téléporter lorsque vous le lancez de cette façon."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "M"],
+    "material": "50 po d’encres et craies rares imprégnées de gemmes que le sort détruit.",
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 5,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/teleportation-circle"
+  },
+  {
+    "index": "thaumaturgy",
+    "name": "Thaumaturgie",
+    "desc": [
+      "Vous engendrez une manifestation surnaturelle mineure, à portée. Vous créez l’un des effets magiques suivants à portée :",
+      "- Votre voix retentit jusqu’à trois fois plus fort que la normale pendant 1 minute.",
+      "- Vous manipulez des flammes pendant 1 minute : elles vacillent, s’intensifient, s’atténuent ou changent de couleur.",
+      "- Vous provoquez un léger tremblement de terre inoffensif pendant 1 minute.",
+      "- Vous faites émaner un son bref d’un point quevous choisissez à portée, comme un grondement de tonnerre, un croassement ou des murmures inquiétants.",
+      "- Vous provoquez l’ouverture soudaine d’une porte ou fenêtre non verrouillée ou la faites claquer.",
+      "- Vous altérez l’aspect de vos yeux pendant 1 minute.",
+      "Si vous lancez ce sort plusieurs fois, vous pouvez faire coexister jusqu’à trois des effets d’une minute, sachant que vous pouvez révoquer un tel effet au prix d’une action."
+    ],
+    "range": "9 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "1 minute",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/thaumaturgy"
+  },
+  {
+    "index": "thunderwave",
+    "name": "Vague tonnante",
+    "desc": [
+      "Une vague de force tonitruante déferle depuis vous. Chaque créature prise dans un cube de 4,50 m d’arête émanant de vous effectue un jet de sauvegarde de Constitution. En cas d’échec, la créature subit 2d8 dégâts de tonnerre et le choc l’éloigne de 3 m de vous. En cas de réussite, la créature subit la moitié de ces dégâts et n’est pas repoussée.",
+      "En outre, les objets non fixés entièrement compris dans la zone d’effet sont automatiquement repoussés de 3 m de vous par le sort, dont le fracas s’entend à une distance de 90 m."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 2e niveau ou supérieur, les dégâts augmentent de 1d8 par niveau d’emplacement au-delà du 1er."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "damage": {
+      "damage_type": {
+        "index": "thunder",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/thunder"
+      },
+      "damage_at_slot_level": {
+        "1": "2d8",
+        "2": "3d8",
+        "3": "4d8",
+        "4": "5d8",
+        "5": "6d8",
+        "6": "7d8",
+        "7": "8d8",
+        "8": "9d8",
+        "9": "10d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "con",
+        "name": "CON",
+        "url": "/api/2014/ability-scores/con"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "cube",
+      "size": 15
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/thunderwave"
+  },
+  {
+    "index": "time-stop",
+    "name": "Arrêt du temps",
+    "desc": [
+      "Vous mettez un bref coup d’arrêt à l’écoulement du temps, pour tout le monde sauf vous-même. Le temps s’arrête pour les autres créatures tandis que vous prenez 1d4 +1 tours d’affilée, durant lesquels vous pouvez entreprendre des actions et vous déplacer comme en temps normal.",
+      "Ce sort prend fin si l’une des actions que vous entreprenez durant l’intervalle, ou l’un des effets créés, affecte une créature autre que vous ou un objet porté par quelqu’un d’autre que vous. Il se termine également si vous vous déplacez en un lieu distant de plus de 300 m de l’endroit où vous l’avez lancé."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/time-stop"
+  },
+  {
+    "index": "tiny-hut",
+    "name": "Petite hutte",
+    "desc": [
+      "Un dôme de force de 3 m de rayon se matérialise autour et au-dessus de vous, puis reste en place pour toute la durée. Le sort prend fin si vous quittez sa zone.",
+      "Neuf créatures de taille M ou inférieure peuvent tenir dans le dôme, vous y compris. Le sort échoue si la zone comprend une créature de taille G ou plus de neuf créatures. Les créatures et objets situés dans le dôme à l’incantation du sort peuvent s’y déplacer librement, y entrer et en sortir. Tous les autres objets et créatures ne peuvent le traverser. Les sorts et autres effets magiques ne peuvent franchir le dôme ni le chevaucher. L’atmosphère dans l’espace du dôme est sèche et agréable, quel que soit le temps à l’extérieur.",
+      "Jusqu’à la fin du sort, vous pouvez rendre l’intérieur faiblement éclairé ou enténébré, sur commande. Le dôme est opaque depuis l’extérieur, de la couleur de votre choix, mais il est transparent depuis l’intérieur."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S", "M"],
+    "material": "Une petite bille de cristal.",
+    "ritual": true,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 3,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/tiny-hut"
+  },
+  {
+    "index": "tongues",
+    "name": "Don des langues",
+    "desc": [
+      "Ce sort octroie la faculté de comprendre toute langue parlée à la créature que vous touchez. De plus, lorsque la cible parle, toute créature qui connaît au moins une langue comprend ce qu’elle dit à condition de l’entendre."
+    ],
+    "range": "Contact",
+    "components": ["V", "M"],
+    "material": "Une ziggourat miniature en argile.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/tongues"
+  },
+  {
+    "index": "transport-via-plants",
+    "name": "Voie végétale",
+    "desc": [
+      "Ce sort crée un lien magique entre une plante inanimée à portée de taille G ou supérieure et une autre plante du même plan d’existence, sans contrainte de distance. Vous devez avoir déjà vu ou touché la plante de destination au moins une fois. Pour toute la durée, toutes les créatures peuvent s’avancer dans la plante ciblée et ressortir par la plante de destination en y consacrant 1,50 m de leur déplacement."
+    ],
+    "range": "3 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "1 round",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/transport-via-plants"
+  },
+  {
+    "index": "tree-stride",
+    "name": "Passage par les arbres",
+    "desc": [
+      "Vous recevez la faculté d’entrer dans un arbre et de vous y déplacer pour atteindre un autre arbre du même type distant d’un maximum de 150 m. Les deux arbres doivent être vivants et d’une catégorie de taille supérieure ou égale à la vôtre. Entrer dans un arbre nécessite d’y consacrer 1,50 m de déplacement. Vous prenez aussitôt conscience de la position de tous les autres arbres de la même essence dans un rayon de 150 m et, lors du déplacement qui vous permet de pénétrer dans l’arbre, vous avez alors le choix entre passer dans l’un de ces arbres ou ressortir par celui dans lequel vous venez d’entrer. Si vous consacrez 1,50 m de déplacement supplémentaire, vous apparaissez à l’endroit de votre choix dans un rayon de 1,50 m de l’arbre de destination. S’il ne vous reste aucun déplacement, vous réapparaissez dans un rayon de 1,50 m de l’arbre de départ.",
+      "Pour toute la durée, vous pouvez recourir à ce pouvoir de transport une fois par round. Vous devez terminer chaque tour à l’extérieur d’un arbre."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/tree-stride"
+  },
+  {
+    "index": "true-polymorph",
+    "name": "Métamorphose suprême",
+    "desc": [
+      "Choisissez une créature ou un objet non magique que vous voyez à portée. Vous transformez la créature en une autre créature ou en objet, ou l’objet en créature (sachant qu’il ne peut au départ être porté par une autre créature). La transformation persiste pour toute la durée, sauf si la cible tombe à 0 point de vie ou meurt. Si vous restez concentré sur le sort pendant l’heure entière, la transformation persiste jusqu’à dissipation.",
+      "Ce sort est sans effet sur un métamorphe ou une créature dotée de 0 point de vie. Une créature non consentante peut effectuer un jet de sauvegarde de Sagesse. En cas de réussite, elle n’est pas affectée par le sort.",
+      "***Créature en créature.*** Si vous transformez une créature en autre sorte de créature, vous choisissez sa nouvelle forme à votre guise mais le facteur de puissance de celle-ci ne doit pas dépasser celui de la cible (ou son niveau si elle n’a pas de facteur de puissance). Le profil de la cible, y compris ses valeurs de caractéristique mentales, est remplacé par le profil de la nouvelle forme. Elle conserve en revanche son alignement et sa personnalité. La cible adopte les points de vie de sa nouvelle forme. Quand elle reprend sa forme normale, la créature retrouve le nombre de points de vie dont elle disposait avant la transformation. Si elle reprend sa forme parce qu’elle tombe à 0 point de vie, les dégâts excédentaires sont répercutés sur sa forme normale. Tant que ces dégâts excédentaires ne réduisent pas sa forme normale à 0 point de vie, elle ne subit pas l’état inconscient.",
+      "La créature est limitée dans les actions qu’elle peut entreprendre par la nature de sa nouvelle forme, et elle ne peut ni parler ni lancer de sorts, ni entreprendre d’action qui passe par les mains ou la parole, à moins que sa nouvelle forme en soit capable.",
+      "The creature is limited in the actions it can perform by the nature of its new form, and it can't speak, cast spells, or take any other action that requires hands or speech unless its new form is capable of such actions.",
+      "L’équipement porté par la cible se fond dans sa nouvelle forme. La créature ne peut pas activer, utiliser ou manier son équipement ni en bénéficier de quelque manière que ce soit.",
+      "***Objet en créature.*** Vous pouvez transformer un objet en la créature de votre choix, à condition que la catégorie de taille de celle-ci ne dépasse pas celle de l’objet et que son facteur de puissance n’excède pas 9. La créature est amicale envers vous et vos compagnons. Elle agit à chacun de vos tours. Vous décidez quelles actions elle entreprend et comment elle se déplace. Le MJ dispose du profil de la créature, et résout toutes ses actions et tous ses déplacements.",
+      "Si le sort devient permanent, vous ne contrôlez plus la créature. Elle est susceptible de rester amicale à votre égard selon la manière dont vous l’avez traitée.",
+      "***Créature en objet.*** Si vous transformez une créature en objet, elle adopte sa nouvelle forme en fusionnant avec tout ce qu’elle porte. Le profil de la créature devient celui de l’objet et la créature ne garde a posteriori (si le sort prend fin et qu’elle retrouve sa forme normale) aucun souvenir du temps passé sous cette forme."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une goutte de mercure, un bon morceau de gomme arabique et une volute de fumée.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/true-polymorph"
+  },
+  {
+    "index": "true-resurrection",
+    "name": "Résurrection suprême",
+    "desc": [
+      "Vous touchez une créature morte depuis un maximum de 200 ans pour quelque raison que ce soit, sauf à avoir succombé à la vieillesse. Si son âme est libre et consentante, la créature revient à la vie avec tous ses points de vie.",
+      "Ce sort referme toutes les plaies, neutralise tous les poisons, soigne toutes les maladies et lève toutes les malédictions qui affectaient la cible à sa mort. Il remplace les organes et membres endommagés ou manquants.",
+      "Le sort peut même fournir un nouveau corps si celui d’origine n’existe plus, auquel cas vous devez prononcer le nom de la créature. Celle-ci apparaît en un espace inoccupé que vous choisissez dans un rayon de 3 m de vous."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "De l’eau bénite aspergée et de la poussière de diamant que vous saupoudrez d’une valeur minimale de 25 000 po, que le sort détruit",
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 heure",
+    "level": 9,
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/true-resurrection"
+  },
+  {
+    "index": "true-seeing",
+    "name": "Vision suprême",
+    "desc": [
+      "Ce sort octroie à la créature consentante que vous touchez la faculté de voir les choses telles qu’elles sont. Pour toute la durée, la créature est dotée de la vision lucide, détecte les passages secrets cachés par magie et perçoit le Plan Éthéré, le tout sur une portée de 36 m."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Un onguent pour les yeux d’une valeur de 25 po, fait de poudre de champignons, de safran et de graisse, que le sort détruit.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/true-seeing"
+  },
+  {
+    "index": "true-strike",
+    "name": "Coup au but",
+    "desc": [
+      "Vous tendez la main et pointez le doigt vers une cible à portée. Votre magie vous permet d’entrevoir une faiblesse dans les défenses de la cible. À votre tour suivant, vous recevez l’avantage à votre premier jet d’attaque contre la cible, à condition que le sort n’ait pas pris fin."
+    ],
+    "range": "9 mètres",
+    "components": ["S"],
+    "ritual": false,
+    "duration": "Jusqu’à 1 round",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 0,
+    "school": {
+      "index": "divination",
+      "name": "Divination",
+      "url": "/api/2014/magic-schools/divination"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/true-strike"
+  },
+  {
+    "index": "unseen-servant",
+    "name": "Serviteur invisible",
+    "desc": [
+      "Le sort crée une force informe, invisible et dépourvue de conscience qui accomplit des tâches rudimentaires sous vos ordres jusqu’à la fin du sort. Le serviteur se matérialise au sol, en un espace inoccupé à portée. Il est doté d’un CA de 10, de 1 point de vie, d’une Force de 2, et ne peut pas effectuer d’attaques. S’il tombe à 0 point de vie, le sort prend fin.",
+      "À chacun de vos tours, vous pouvez par une action bonus ordonner mentalement au serviteur de se déplacer d’un maximum de 4,50 m et d’interagir avec un objet. Le serviteur peut accomplir des tâches rudimentaires à la portée d’un humain, comme aller chercher des objets, nettoyer, réparer, repasser les vêtements, allumer un feu ou servir à manger et à boire. Une fois l’instruction reçue, le serviteur s’attèle à la tâche de son mieux jusqu’à l’avoir accomplie, puis attend vos prochaines directives.",
+      "Si vous lui assignez une tâche qui lui demande de s’éloigner de plus de 18 m de vous, le sort prend fin."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un bout de ficelle et un morceau de bois.",
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 1,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/unseen-servant"
+  },
+  {
+    "index": "vampiric-touch",
+    "name": "Caresse du vampire",
+    "desc": [
+      "Le contact de votre main nimbée d’ombres siphonne l’énergie vitale d’autrui pour refermer vos plaies. Effectuez une attaque de sort au corps à corps contre une créature à portée d’allonge. Si l’attaque touche, la cible subit 3d6 dégâts nécrotiques et vous récupérez autant de points de vie que la moitié des dégâts nécrotiques infligés. Jusqu’à la fin du sort, vous pouvez répéter l’attaque à chacun de vos tours, au prix d’une action."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 4e niveau ou supérieur, les dégâts augmentent de 1d6 par niveau d’emplacement au-delà du 3e."
+    ],
+    "range": "Personnelle",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "attack_type": "mélée",
+    "damage": {
+      "damage_type": {
+        "index": "necrotic",
+        "name": "Nécrotique",
+        "url": "/api/2014/damage-types/necrotic"
+      },
+      "damage_at_slot_level": {
+        "3": "3d6",
+        "4": "4d6",
+        "5": "5d6",
+        "6": "6d6",
+        "7": "7d6",
+        "8": "8d6",
+        "9": "9d6"
+      }
+    },
+    "school": {
+      "index": "necromancy",
+      "name": "Nécromancie",
+      "url": "/api/2014/magic-schools/necromancy"
+    },
+    "classes": [
+      {
+        "index": "warlock",
+        "name": "Occultiste",
+        "url": "/api/2014/classes/warlock"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/vampiric-touch"
+  },
+  {
+    "index": "vicious-mockery",
+    "name": "Moquerie cruelle",
+    "desc": [
+      "Vous adressez un chapelet d’insultes assaisonnées de subtils enchantements à une créature que vous voyez à portée. Si la cible vous entend (même sans vous comprendre), elle doit réussir un jet de sauvegarde de Sagesse sous peine de subir 1d4 dégâts psychiques et d’être désavantagée au prochain jet d’attaque qu’elle effectue avant la fin de son tour suivant.",
+      "Les dégâts du sort augmentent de 1d4 lorsque vous atteignez le niveau 5 (2d4), le niveau 11 (3d4) et le niveau 17 (4d4)."
+    ],
+    "range": "18 mètres",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 0,
+    "damage": {
+      "damage_type": {
+        "index": "psychic",
+        "name": "Psychique",
+        "url": "/api/2014/damage-types/psychic"
+      },
+      "damage_at_character_level": {
+        "1": "1d4",
+        "5": "2d4",
+        "11": "3d4",
+        "17": "4d4"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/vicious-mockery"
+  },
+  {
+    "index": "wall-of-fire",
+    "name": "Mur de feu",
+    "desc": [
+      "Vous créez un mur de flammes sur une surface solide à portée. Vous pouvez ainsi ériger un mur dont la hauteur n’excède pas 6 m et l’épaisseur 30 cm ; pour le reste, vous avez le choix entre un mur droit long d’un maximum de 18 m et un mur circulaire dont le diamètre ne dépasse pas 6 m. Ce mur opaque persiste pour toute la durée.",
+      "Quand le mur apparaît, chaque créature prise dans sa zone effectue un jet de sauvegarde de Dextérité. Elle subit 5d8 dégâts de feu en cas d’échec, la moitié en cas de réussite.",
+      "L’un des côtés du mur que vous choisissez à l’incantation du sort inflige 5d8 dégâts de feu à toute créature qui termine son tour à 3 m ou moins de ce côté ou dans le mur. Une créature qui pénètre dans le mur pour la première fois d’un tour ou qui y termine son tour subit ces mêmes dégâts.",
+      "L’autre côté du mur n’inflige pas de dégâts."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 5e niveau ou supérieur, les dégâts augmentent de 1d8 par niveau d’emplacement au-delà du 4e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit morceau de phosphore.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 4,
+    "damage": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "damage_at_slot_level": {
+        "4": "5d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 60
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "fiend",
+        "name": "Fiélon",
+        "url": "/api/2014/subclasses/fiend"
+      }
+    ],
+    "url": "/api/2014/spells/wall-of-fire"
+  },
+  {
+    "index": "wall-of-force",
+    "name": "Mur de force",
+    "desc": [
+      "Un mur de force invisible se matérialise en un point que vous choisissez à portée. Le mur se présente dans l’orientation de votre choix, horizontal ou vertical, voire complètement de biais. Il peut rester en suspension ou reposer sur une surface solide. Vous pouvez le façonner en dôme hémisphérique ou en sphère d’un rayon maximal de 3 m, ou en faire une surface plane composée de dix pans de 3 mètres sur 3. Chaque pan doit être contigu avec un autre. Quelle que soit sa forme, le mur est épais de 6 mm. Il persiste pour toute la durée. Si le mur traverse l’espace d’une créature à son apparition, la créature est repoussée d’un côté du mur ou de l’autre (vous choisissez lequel).",
+      "Rien ne peut franchir physiquement le mur. Il est immunisé contre tous les dégâts et insensible à dissipation de la magie. Le sort désintégration détruit en revanche le mur instantanément. Ce mur s’étend en outre sur le Plan Éthéré, ce qui empêche le voyage éthéré le traversant."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une pincée de poudre obtenue en concassant une gemme limpide.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/wall-of-force"
+  },
+  {
+    "index": "wall-of-ice",
+    "name": "Mur de glace",
+    "desc": [
+      "Vous créez un mur de glace sur une surface solide à portée. Vous pouvez le façonner en dôme hémisphérique ou en sphère d’un rayon maximal de 3 m, ou en faire une surface plane composée de dix pans de 3 mètres sur 3. Chaque pan doit être contigu avec un autre. Quelle que soit sa forme, le mur est épais de 30 cm et persiste pour toute la durée.",
+      "Si le mur traverse l’espace d’une créature à son apparition, la créature est repoussée d’un côté du mur ou de l’autre et effectue un jet de sauvegarde de Dextérité. Elle subit 10d6 dégâts de froid en cas d’échec, la moitié en cas de réussite.",
+      "Le mur est un objet que l’on peut endommager, ce qui permet d’y ouvrir une brèche. Il est doté d’une CA de 12, de 30 points de vie par section de 3 m de côté, et il est vulnérable aux dégâts de feu. Une section de 3 m de côté réduite à 0 point de vie est détruite et laisse une nappe d’air glacial dans l’espace qu’elle occupait. Une créature qui traverse une telle nappe pour la première fois d’un tour effectue un jet de sauvegarde de Constitution. Elle subit 5d6 dégâts de froid en cas d’échec, la moitié en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau ou supérieur, les dégâts infligés par le mur à son apparition augmentent de 2d6 et ceux de la nappe d’air glacial de 1d6 par niveau d’emplacement au-delà du 6e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un fragment de quartz.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "damage_at_slot_level": {
+        "6": "10d6",
+        "7": "12d6",
+        "8": "14d6",
+        "9": "16d6"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 10
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/wall-of-ice"
+  },
+  {
+    "index": "wall-of-stone",
+    "name": "Mur de pierre",
+    "desc": [
+      "Un mur non magique de pierre solide se matérialise en un point que vous choisissez à portée. Le mur, épais de 15 cm, se compose de dix pans de 3 m sur 3. Chaque pan doit être contigu avec au moins un autre. Une autre option consiste à créer des pans de 3 m sur 6, épais de seulement 7,5 cm.",
+      "Si le mur traverse l’espace d’une créature à son apparition, la créature est repoussée d’un côté du mur ou de l’autre (vous choisissez lequel). Si une créature est censée se retrouver cernée par le mur de tous les côtés (ou par le mur et une autre surface solide), elle a droit à un jet de sauvegarde de Dextérité. En cas de réussite, elle peut jouer sa réaction pour se déplacer dans les limites de sa vitesse de manière à ne plus être séquestrée par le mur.",
+      "Le mur peut prendre toute forme de votre choix, mais il ne peut pas occuper le même espace que des créatures ou des objets. Il n’a pas besoin d’être vertical ni de reposer sur des fondations robustes. Il doit en revanche fusionner avec de la pierre existante, qui doit pouvoir le soutenir. Vous pouvez ainsi recourir à ce sort pour créer un pont qui enjambe un gouffre, ou un plan incliné.",
+      "Si le pont ainsi créé dépasse 6 m de long, vous devez réduire de moitié la taille de chaque pan de façon à l’étayer. Vous pouvez grossièrement façonner le mur pour produire des créneaux, remparts et autres.",
+      "Le mur est un objet de pierre que l’on peut endommager, ce qui permet d’y ouvrir une brèche. Chaque pan présente une CA de 15 et possède 30 points de vie par tranche de 2,5 cm d’épaisseur. Un pan réduit à 0 point de vie est détruit, ce qui peut en outre provoquer l’effondrement de pans contigus, à l’appréciation du MJ.",
+      "Si vous maintenez la concentration sur ce sort jusqu’au bout de sa durée maximale, le mur devient permanent, sans possibilité de le dissiper. Sans cela, il disparaît quand le sort prend fin."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un petit bloc de granite.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 5,
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/wall-of-stone"
+  },
+  {
+    "index": "wall-of-thorns",
+    "name": "Mur d’épines",
+    "desc": [
+      "Vous créez un mur fait d’un enchevêtrement végétal aussi souple que robuste, hérissé d’épines acérées. Le mur apparaît à portée sur une surface solide et persiste pour toute la durée. Vous pouvez ainsi ériger un mur dont l’épaisseur n’excède pas 1,50 m ; pour le reste, vous avez le choix entre un mur droit long d’un maximum de 18 m et haut de 3 m ou moins, et un mur circulaire dont le diamètre et la hauteur ne dépassent pas 6 m. Le mur bloque le champ de vision.",
+      "Quand le mur apparaît, chaque créature prise dans sa zone effectue un jet de sauvegarde de Dextérité. Elle subit 7d8 dégâts perforants en cas d’échec, la moitié en cas de réussite.",
+      "Une créature peut se déplacer à travers ces ronces, mais l’opération est lente et douloureuse. Toute distance parcourue à travers le mur lui coûte le quadruple en termes de déplacement. En outre, la première fois d’un tour qu’une créature pénètre dans le mur et quand elle y termine son tour, elle effectue un jet de sauvegarde de Dextérité. Elle subit 7d8 dégâts tranchants en cas d’échec, la moitié en cas de réussite."
+    ],
+    "higher_level": [
+      "Lorsque vous lancez ce sort par un emplacement du 7e niveau ou supérieur, les dégâts des deux types augmentent de 1d8 par niveau d’emplacement au-delà du 6e."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Une poignée d’épines.",
+    "ritual": false,
+    "duration": "Jusqu'à 10 minutes",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 6,
+    "damage": {
+      "damage_type": {
+        "index": "piercing",
+        "name": "Perforant",
+        "url": "/api/2014/damage-types/piercing"
+      },
+      "damage_at_slot_level": {
+        "6": "7d8",
+        "7": "8d8",
+        "8": "9d8",
+        "9": "10d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "dex",
+        "name": "DEX",
+        "url": "/api/2014/ability-scores/dex"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 60
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/wall-of-thorns"
+  },
+  {
+    "index": "warding-bond",
+    "name": "Lien de protection",
+    "desc": [
+      "Ce sort protège une créature consentante que vous touchez et crée un lien magique entre elle et vous jusqu’à la fin du sort. Tant que la cible se trouve dans un rayon de 18 m de vous, elle reçoit un bonus de +1 à la CA et aux jets de sauvegarde, et elle est résistante à tous les dégâts. Par ailleurs, chaque fois qu’elle subit des dégâts, vous en subissez autant.",
+      "Le sort prend fin si vous tombez à 0 point de vie ou si la cible et vous vous retrouvez distants de plus de 18 m.",
+      "Il prend également fin s’il est relancé sur l’une des deux créatures ainsi liées. Vous pouvez révoquer le sort au prix d’une action."
+    ],
+    "range": "Contact",
+    "components": ["V", "S", "M"],
+    "material": "Deux bagues de platine d’une valeur de 50 po chacune, que la cible et vous devez porter pour toute la durée.",
+    "ritual": false,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "school": {
+      "index": "abjuration",
+      "name": "Abjuration",
+      "url": "/api/2014/magic-schools/abjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/warding-bond"
+  },
+  {
+    "index": "water-breathing",
+    "name": "Respiration aquatique",
+    "desc": [
+      "Ce sort octroie la faculté de respirer sous l’eau à un maximum de dix créatures consentantes que vous voyez à portée, jusqu’à la fin du sort. Les créatures affectées conservent leurs autres modes respiratoires."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un court roseau ou une paille.",
+    "ritual": true,
+    "duration": "24 heures",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/water-breathing"
+  },
+  {
+    "index": "water-walk",
+    "name": "Marche sur l’onde",
+    "desc": [
+      "Ce sort octroie la faculté de se déplacer sur n’importe quelle surface liquide (eau, acide, boue, neige, sables mouvants et même lave) comme s’il s’agissait d’une surface solide ne présentant aucun risque (sur de la lave, les créatures s’exposent tout de même aux dégâts que peut engendrer la chaleur). Un maximum de dix créatures consentantes que vous voyez à portée reçoivent cette faculté pour toute la durée.",
+      "Si vous ciblez une créature immergée dans un liquide, le sort la ramène à la surface au rythme de 18 m par round."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un morceau de liège.",
+    "ritual": true,
+    "duration": "1 heure",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 3,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      },
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/water-walk"
+  },
+  {
+    "index": "web",
+    "name": "Toile d’araignée",
+    "desc": [
+      "Vous invoquez une masse gluante d’épais fils d’araignée entremêlés en un point que vous choisissez à portée. Pour toute la durée, cette toile remplit un cube de 6 m d’arête émanant du point choisi. Elle constitue un terrain difficile et la visibilité est réduite dans la zone.",
+      "Si les fils ne peuvent pas se fixer à deux volumes solides (comme des murs ou des arbres) et ne sont pas disposés en travers d’un sol, d’un mur ou d’un plafond, la toile s’effondre sur elle-même et le sort prend fin au début de votre tour suivant. Invoquée sur une surface plane, la toile présente une épaisseur de 1,50 m.",
+      "Chaque créature qui commence son tour dans la toile ou qui y pénètre à son tour de jeu effectue un jet de sauvegarde de Dextérité. En cas d’échec, la créature est entravée tant qu’elle reste dans la toile et qu’elle ne s’en est pas libérée.",
+      "Une créature ainsi entravée peut consacrer son action à effectuer un test de Force assorti de votre DD de sauvegarde des sorts. En cas de réussite, elle n’est plus entravée.",
+      "La toile est inflammable. Tout cube de toile de 1,50 m d’arête exposé aux flammes brûle en 1 round et inflige 2d4 dégâts de feu à toute créature qui commence son tour dans les flammes."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Quelques filandres de toile d’araignée.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 heure",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 2,
+    "area_of_effect": {
+      "type": "cube",
+      "size": 20
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "land",
+        "name": "Terre",
+        "url": "/api/2014/subclasses/land"
+      }
+    ],
+    "url": "/api/2014/spells/web"
+  },
+  {
+    "index": "weird",
+    "name": "Ennemi subconscient",
+    "desc": [
+      "Vous puisez dans les terreurs intimes d’un groupe de créatures pour faire apparaître des êtres illusoires dans leur esprit, illusions qu’elles sont les seules à percevoir. Chaque créature prise dans une sphère de 9 m de rayon centrée sur un point que vous choisissez à portée effectue un jet de sauvegarde de Sagesse. En cas d’échec, elle se retrouve effrayée pour toute la durée. L’illusion touche aux peurs les plus intimes de la créature, ses pires cauchemars se manifestant comme des menaces aussi immédiates qu’implacables. À la fin de chacun des tours, une créature ainsi effrayée doit réussir un jet de sauvegarde de Sagesse sous peine de subir 4d10 dégâts psychiques. En cas de réussite, le sort prend fin en ce qui la concerne."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 9,
+    "dc": {
+      "dc_type": {
+        "index": "wis",
+        "name": "SAG",
+        "url": "/api/2014/ability-scores/wis"
+      },
+      "dc_success": "none"
+    },
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 30
+    },
+    "school": {
+      "index": "illusion",
+      "name": "Illusion",
+      "url": "/api/2014/magic-schools/illusion"
+    },
+    "classes": [
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/weird"
+  },
+  {
+    "index": "wind-walk",
+    "name": "Vent divin",
+    "desc": [
+      "Vous et un maximum de dix créatures consentantes que vous voyez à portée adoptez une forme gazeuse our toute la durée et apparaissez comme autant de  volutes. Tant qu’elle est sous cette forme brumeuse, chaque créature est dotée d’une vitesse de vol de 90 m et bénéficie de la résistance aux dégâts des armes non magiques. Les seules actions qu’elle peut entreprendre sous cette forme sont l’action Foncer et reprendre sa forme normale. Il lui faut 1 minute pour retrouver sa forme d’origine, intervalle durant lequel la créature est neutralisée et ne peut se déplacer. Jusqu’à la fin du sort, la créature peut également reprendre une forme gazeuse, transformation qui nécessite aussi 1 minute.",
+      "Si une créature est sous forme gazeuse et en vol au moment où le sort prend fin, elle redescend au rythme de 18 m par round pendant 1 minute, jusqu’à atterrir sans heurt. Si cette minute ne lui a pas suffi à toucher le sol, la créature chute de la distance restante."
+    ],
+    "range": "9 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Des flammes et de l’eau bénite.",
+    "ritual": false,
+    "duration": "8 heures",
+    "concentration": false,
+    "casting_time": "1 minute",
+    "level": 6,
+    "school": {
+      "index": "transmutation",
+      "name": "Transmutation",
+      "url": "/api/2014/magic-schools/transmutation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/wind-walk"
+  },
+  {
+    "index": "wind-wall",
+    "name": "Mur de vent",
+    "desc": [
+      "Un mur de vent fort se dresse depuis le sol en un point que vous choisissez à portée. Vous pouvez ainsi ériger un mur dont la hauteur n’excède pas 4,50 m, la longueur 15 m et l’épaisseur 30 cm. Vous pouvez lui donner la forme de votre choix tant que le mur reste au contact du sol tout du long. Le mur persiste pour toute la durée.",
+      "Quand le mur apparaît, chaque créature prise dans sa zone effectue un jet de sauvegarde de Force. Une créature subit 3d8 dégâts contondants en cas d’échec, la moitié en cas de réussite.",
+      "Le vent fort repousse le brouillard, la fumée et autres gaz et vapeurs. Les créatures et objets volants de taille P ou inférieure ne peuvent pas traverser le mur. Les matériaux légers et libres s’envolent verticalement au contact du mur. Flèches, carreaux d’arbalète et autres projectiles ordinaires tirés sur des cibles situées derrière le mur sont déviés vers le haut et ratent automatiquement. (Les rochers lancés par des géants et des engins de siège, et les projectiles du même acabit ne sont pas affectés.) Les créatures sous forme gazeuse ne peuvent pas le traverser."
+    ],
+    "range": "36 mètres",
+    "components": ["V", "S", "M"],
+    "material": "Un minuscule éventail et une plume d’origine exotique.",
+    "ritual": false,
+    "duration": "Jusqu'à 1 minute",
+    "concentration": true,
+    "casting_time": "1 action",
+    "level": 3,
+    "damage": {
+      "damage_type": {
+        "index": "bludgeoning",
+        "name": "Contondant",
+        "url": "/api/2014/damage-types/bludgeoning"
+      },
+      "damage_at_slot_level": {
+        "3": "3d8"
+      }
+    },
+    "dc": {
+      "dc_type": {
+        "index": "str",
+        "name": "FOR",
+        "url": "/api/2014/ability-scores/str"
+      },
+      "dc_success": "half"
+    },
+    "area_of_effect": {
+      "type": "line",
+      "size": 50
+    },
+    "school": {
+      "index": "evocation",
+      "name": "Évocation",
+      "url": "/api/2014/magic-schools/evocation"
+    },
+    "classes": [
+      {
+        "index": "druid",
+        "name": "Druide",
+        "url": "/api/2014/classes/druid"
+      },
+      {
+        "index": "ranger",
+        "name": "Rôdeur",
+        "url": "/api/2014/classes/ranger"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      }
+    ],
+    "url": "/api/2014/spells/wind-wall"
+  },
+  {
+    "index": "wish",
+    "name": "Souhait",
+    "desc": [
+      "Souhait est le sort le plus puissant que puisse lancer un mortel. De votre seule voix, vous avez le pouvoir de chambouler les fondations mêmes de la réalité selon vos désirs.",
+      "L’utilisation standard du sort revient à reproduire le sort de votre choix du 8e niveau ou inférieur. Vous n’avez pas besoin de remplir les conditions habituelles du sort, y compris ses composantes coûteuses. Le sort prend tout simplement effet.",
+      "Une autre approche vous permet de produire l’un des effets suivants, au choix :",
+      "- Créer un objet non magique d’une valeur maximale de 25 000 po. Aucune des dimensions de l’objet ne peut dépasser 90 m et il apparaît au sol, en un espace inoccupé que vous voyez.",
+      "- Permettre à un maximum de vingt créatures que vous voyez de récupérer tous leurs points de vie et mettre un terme à tous les effets qui les touchent parmi ceux décrits pour le sort restauration suprême.",
+      "- Octroyer la résistance au type de dégâts de votre choix à un maximum de dix créatures que vous voyez.",
+      "- Octroyer l’immunité contre un sort (ou un effet magique) unique pendant 8 heures, à un maximum de dix créatures que vous voyez. Vous pourriez ainsi immuniser toute votre troupe contre l’attaque d’Absorption de vie d’une liche.",
+      "- Modifier un événement récent en faisant rejouer un jet de dés intervenu au cours du dernier round (ce qui comprend votre dernier tour). La réalité s’adapte alors à ce nouveau résultat. Souhait peut ainsi annuler le jet de sauvegarde réussi d’un adversaire, le coup critique d’un ennemi ou le JS raté d’un allié. Vous pouvez décider que le jet se refasse avec avantage ou désavantage, et vous décidez en connaissance de cause lequel s’applique entre le jet d’origine et le nouveau.",
+      "Les exemples précédents ne doivent pas vous contraindre dans l’utilisation du sort. Si vous avez une idée qui n’entre pas dans leur cadre, faites-en part à votre MJ, le plus précisément possible. Le MJ est alors seul juge de ce qui peut se passer : plus le souhait est ambitieux, plus il risque d’engendrer des incidents. Le sort pourrait tout simplement échouer, ou ne produire que partiellement l’effet désiré, ou vous pourriez connaître des imprévus fâcheux en raison d’une formulation hasardeuse. Si vous faites par exemple le souhait que votre grand ennemi meure, vous pourriez vous retrouver projeté dans l’avenir, à une époque où cet adversaire n’est effectivement plus en vie, mais votre héros quitterait du même coup la partie. De même, souhaiter mettre la main sur un objet magique légendaire ou un artefact pourrait vous transporter aussitôt face à l’actuel propriétaire.",
+      "Dès lors qu’il ne s’agit pas seulement de reproduire les effets d’un autre sort, lancer souhait est une véritable épreuve. Après une telle gageure, chaque fois que vous jetez un sort sans avoir terminé un repos long, vous subissez 1d10 dégâts nécrotiques par niveau du sort. Ces dégâts ne peuvent être réduits ni évités d’aucune manière. De plus, votre valeur de Force tombe à 3, si elle n’était pas déjà de 3 ou moins, pendant 2d4 jours. Chaque jour que vous passez alors à vous reposer en vous contentant de menues tâches déduit 2 jours de cette période de convalescence. Enfin, il y a 33 pour cent de risques pour que vous ne soyez plus jamais capable de relancer souhait."
+    ],
+    "range": "Personnelle",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 9,
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "sorcerer",
+        "name": "Ensorceleur",
+        "url": "/api/2014/classes/sorcerer"
+      },
+      {
+        "index": "wizard",
+        "name": "Magicien",
+        "url": "/api/2014/classes/wizard"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/wish"
+  },
+  {
+    "index": "word-of-recall",
+    "name": "Mot de retour",
+    "desc": [
+      "Vous-même et un maximum de cinq créatures consentantes situées dans un rayon de 1,50 m vous téléportez en un sanctuaire désigné à l’avance. Vous et les créatures téléportées apparaissez dans les espaces inoccupés les plus proches du point désigné quand vous avez préparé votre sanctuaire (voir plus loin). Si vous lancez ce sort sans avoir préparé de sanctuaire, il est sans effet.",
+      "Vous devez désigner un sanctuaire en lançant ce sort en un lieu, tel qu’un temple, consacré à votre divinité ou qui lui est, à tout le moins, intimement associé. Si vous tentez de lancer ainsi le sort en un lieu qui n’honore pas votre dieu, le sort est sans effet."
+    ],
+    "range": "1,50 m",
+    "components": ["V"],
+    "ritual": false,
+    "duration": "Instantanée",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 6,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 5
+    },
+    "school": {
+      "index": "conjuration",
+      "name": "Conjuration",
+      "url": "/api/2014/magic-schools/conjuration"
+    },
+    "classes": [
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      }
+    ],
+    "subclasses": [],
+    "url": "/api/2014/spells/word-of-recall"
+  },
+  {
+    "index": "zone-of-truth",
+    "name": "Zone de vérité",
+    "desc": [
+      "Vous créez une zone magique qui interdit les mensonges dans une sphère de 4,50 m centrée sur un point que vous choisissez à portée. Jusqu’à la fin du sort, quand une créature entre dans la zone du sort pour la première fois d’un tour ou y commence son tour, elle effectue un jet de sauvegarde de Charisme. En cas d’échec, elle ne peut mentir sciemment tant qu’elle est dans la zone. Vous savez si une telle créature a raté ou réussi son jet de sauvegarde.",
+      "Une créature affectée a conscience du sort, si bien qu’elle peut éluder les questions auxquelles elle répondrait normalement par un mensonge. Elle peut se montrer évasive, à condition de ne rien affirmer qu’elle sait ne pas être vrai."
+    ],
+    "range": "18 mètres",
+    "components": ["V", "S"],
+    "ritual": false,
+    "duration": "10 minutes",
+    "concentration": false,
+    "casting_time": "1 action",
+    "level": 2,
+    "area_of_effect": {
+      "type": "sphere",
+      "size": 15
+    },
+    "school": {
+      "index": "enchantment",
+      "name": "Enchantement",
+      "url": "/api/2014/magic-schools/enchantment"
+    },
+    "classes": [
+      {
+        "index": "bard",
+        "name": "Barde",
+        "url": "/api/2014/classes/bard"
+      },
+      {
+        "index": "cleric",
+        "name": "Clerc",
+        "url": "/api/2014/classes/cleric"
+      },
+      {
+        "index": "paladin",
+        "name": "Paladin",
+        "url": "/api/2014/classes/paladin"
+      }
+    ],
+    "subclasses": [
+      {
+        "index": "lore",
+        "name": "Savoir",
+        "url": "/api/2014/subclasses/lore"
+      },
+      {
+        "index": "devotion",
+        "name": "Dévotion",
+        "url": "/api/2014/subclasses/devotion"
+      }
+    ],
+    "url": "/api/2014/spells/zone-of-truth"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Subclasses.json
+++ b/src/2014/fr-FR/5e-SRD-Subclasses.json
@@ -1,0 +1,1801 @@
+[
+  {
+    "index": "berserker",
+    "class": {
+      "index": "barbarian",
+      "name": "Barbare",
+      "url": "/api/2014/classes/barbarian"
+    },
+    "name": "Berserker",
+    "subclass_flavor": "Voie primitive",
+    "desc": [
+      "Pour certains barbares, la rage est un moyen de parvenir à une fin… et cette fin est la violence. La voie du berserker est un chemin pavé de fureur débridée et poisseux de sang. Quand vous entrez dans la rage du berserker, tout à l’ivresse de la bataille, vous faites fi de votre santé comme de votre bien-être."
+    ],
+    "subclass_levels": "/api/2014/subclasses/berserker/levels",
+    "url": "/api/2014/subclasses/berserker"
+  },
+  {
+    "index": "lore",
+    "class": {
+      "index": "bard",
+      "name": "Barde",
+      "url": "/api/2014/classes/bard"
+    },
+    "name": "Savoir",
+    "subclass_flavor": "Collège du Savoir",
+    "desc": [
+      "Les connaissances des bardes du Collège du Savoir portent sur presque tous les sujets, les bribes de savoir qu’ils détiennent allant des manuscrits les plus savants aux contes ruraux. Qu’ils entonnent une ballade populaire dans une taverne ou interprètent une composition complexe à la cour d’un roi, ces bardes usent de leurs talents pour captiver l’auditoire. Et quand les applaudissements cessent, l’auditoire se surprend parfois à remettre en question certaines évidences, comme sa foi dans le clergé local ou sa loyauté envers le souverain du cru."
+    ],
+    "subclass_levels": "/api/2014/subclasses/lore/levels",
+    "url": "/api/2014/subclasses/lore"
+  },
+  {
+    "index": "life",
+    "class": {
+      "index": "cleric",
+      "name": "Clerc",
+      "url": "/api/2014/classes/cleric"
+    },
+    "name": "Vie",
+    "subclass_flavor": "Domaine divin",
+    "desc": [
+      "Le domaine de la Vie est centré sur l’énergie positive, l’une des forces fondamentales de l’univers, à l’origine de toute forme de vie. Les dieux de la Vie favorisent la vitalité et la santé en soignant les malades et les blessés, en veillant sur les indigents et en détruisant les forces de la non-vie. La grande majorité des divinités non mauvaises exercent une influence sur ce domaine, notamment les dieux et déesses agricoles (comme Chauntéa, Arawai et Déméter), les dieux du soleil (comme Lathandre, Pélor et Rê-Horakhty), les dieux de la guérison et de l’endurance (comme Ilmater, Mishakal, Apollon et Diancecht) et les dieux du foyer et de la communauté (comme Hestia, Hathor et Boldrei)."
+    ],
+    "spells": [
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-1",
+            "type": "level",
+            "name": "Clerc 1",
+            "url": "/api/2014/classes/cleric/levels/1"
+          }
+        ],
+        "spell": {
+          "index": "bless",
+          "name": "Bénédiction",
+          "url": "/api/2014/spells/bless"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-1",
+            "type": "level",
+            "name": "Clerc 1",
+            "url": "/api/2014/classes/cleric/levels/1"
+          }
+        ],
+        "spell": {
+          "index": "cure-wounds",
+          "name": "Soins",
+          "url": "/api/2014/spells/cure-wounds"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-3",
+            "type": "level",
+            "name": "Clerc 3",
+            "url": "/api/2014/classes/cleric/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "lesser-restoration",
+          "name": "Restauration partielle",
+          "url": "/api/2014/spells/lesser-restoration"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-3",
+            "type": "level",
+            "name": "Clerc 3",
+            "url": "/api/2014/classes/cleric/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "spiritual-weapon",
+          "name": "Arme spirituelle",
+          "url": "/api/2014/spells/spiritual-weapon"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-5",
+            "type": "level",
+            "name": "Clerc 5",
+            "url": "/api/2014/classes/cleric/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "beacon-of-hope",
+          "name": "Lueur d’espoir",
+          "url": "/api/2014/spells/beacon-of-hope"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-5",
+            "type": "level",
+            "name": "Clerc 5",
+            "url": "/api/2014/classes/cleric/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "revivify",
+          "name": "Retour à la vie",
+          "url": "/api/2014/spells/revivify"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-7",
+            "type": "level",
+            "name": "Clerc 7",
+            "url": "/api/2014/classes/cleric/levels/7"
+          }
+        ],
+        "spell": {
+          "index": "death-ward",
+          "name": "Protection contre la mort",
+          "url": "/api/2014/spells/death-ward"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-9",
+            "type": "level",
+            "name": "Clerc 9",
+            "url": "/api/2014/classes/cleric/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "mass-cure-wounds",
+          "name": "Soins de groupe",
+          "url": "/api/2014/spells/mass-cure-wounds"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "cleric-9",
+            "type": "level",
+            "name": "Clerc 9",
+            "url": "/api/2014/classes/cleric/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "raise-dead",
+          "name": "Rappel à la vie",
+          "url": "/api/2014/spells/raise-dead"
+        }
+      }
+    ],
+    "subclass_levels": "/api/2014/subclasses/life/levels",
+    "url": "/api/2014/subclasses/life"
+  },
+  {
+    "index": "land",
+    "class": {
+      "index": "druid",
+      "name": "Druide",
+      "url": "/api/2014/classes/druid"
+    },
+    "name": "Terre",
+    "subclass_flavor": "Cercle druidique",
+    "desc": [
+      "Le Cercle de la Terre réunit des mystiques et des sages chargés de perpétuer d’antiques connaissances et rites au moyen d’une tradition orale considérable. Ces druides se rassemblent dans des cercles sacrés faits d’arbres ou de menhirs pour se murmurer des secrets primitifs en langue druidique. Les membres les plus sages du cercle font office de grands prêtres dans les communautés restées fidèles à la religion des temps anciens et conseillent leurs dirigeants. En tant que membre de ce cercle, votre magie est influencée par le type de terrain sur lequel vous avez subi l’initiation à ses mystères."
+    ],
+    "spells": [
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "hold-person",
+          "name": "Immobilisation de personne",
+          "url": "/api/2014/spells/hold-person"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "spike-growth",
+          "name": "Croissance d’épines",
+          "url": "/api/2014/spells/spike-growth"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "sleet-storm",
+          "name": "Tempête de neige",
+          "url": "/api/2014/spells/sleet-storm"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "slow",
+          "name": "Lenteur",
+          "url": "/api/2014/spells/slow"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "ice-storm",
+          "name": "Tempête de grêle",
+          "url": "/api/2014/spells/ice-storm"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "commune-with-nature",
+          "name": "Communion avec la nature",
+          "url": "/api/2014/spells/commune-with-nature"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-arctic",
+            "type": "feature",
+            "name": "Cercle de la terre : Arctique",
+            "url": "/api/2014/features/circle-of-the-land-arctic"
+          }
+        ],
+        "spell": {
+          "index": "cone-of-cold",
+          "name": "Cône de froid",
+          "url": "/api/2014/spells/cone-of-cold"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "mirror-image",
+          "name": "Image miroir",
+          "url": "/api/2014/spells/mirror-image"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "misty-step",
+          "name": "Foulée brumeuse",
+          "url": "/api/2014/spells/misty-step"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "water-breathing",
+          "name": "Respiration aquatique",
+          "url": "/api/2014/spells/water-breathing"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "water-walk",
+          "name": "Marche sur l’onde",
+          "url": "/api/2014/spells/water-walk"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "control-water",
+          "name": "Contrôle de l’eau",
+          "url": "/api/2014/spells/control-water"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "conjure-elemental",
+          "name": "Invocation d’élémentaire",
+          "url": "/api/2014/spells/conjure-elemental"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-coast",
+            "type": "feature",
+            "name": "Cercle de la terre : Littoral",
+            "url": "/api/2014/features/circle-of-the-land-coast"
+          }
+        ],
+        "spell": {
+          "index": "scrying",
+          "name": "Scrutation",
+          "url": "/api/2014/spells/scrying"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "blur",
+          "name": "Flou",
+          "url": "/api/2014/spells/blur"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "silence",
+          "name": "Silence",
+          "url": "/api/2014/spells/silence"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "create-food-and-water",
+          "name": "Création de nourriture et d’eau",
+          "url": "/api/2014/spells/create-food-and-water"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "protection-from-energy",
+          "name": "Protection contre l’énergie",
+          "url": "/api/2014/spells/protection-from-energy"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "blight",
+          "name": "Flétrissement",
+          "url": "/api/2014/spells/blight"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "hallucinatory-terrain",
+          "name": "Terrain hallucinatoire",
+          "url": "/api/2014/spells/hallucinatory-terrain"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "insect-plague",
+          "name": "Fléau d’insectes",
+          "url": "/api/2014/spells/insect-plague"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-desert",
+            "type": "feature",
+            "name": "Cercle de la terre : Désert",
+            "url": "/api/2014/features/circle-of-the-land-desert"
+          }
+        ],
+        "spell": {
+          "index": "wall-of-stone",
+          "name": "Mur de pierre",
+          "url": "/api/2014/spells/wall-of-stone"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "barkskin",
+          "name": "Peau d’écorce",
+          "url": "/api/2014/spells/barkskin"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "spider-climb",
+          "name": "Pattes d’araignée",
+          "url": "/api/2014/spells/spider-climb"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "call-lightning",
+          "name": "Appel de la foudre",
+          "url": "/api/2014/spells/call-lightning"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "plant-growth",
+          "name": "Croissance végétale",
+          "url": "/api/2014/spells/plant-growth"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "divination",
+          "name": "Divination",
+          "url": "/api/2014/spells/divination"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "commune-with-nature",
+          "name": "Communion avec la nature",
+          "url": "/api/2014/spells/commune-with-nature"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-forest",
+            "type": "feature",
+            "name": "Cercle de la terre : Forêt",
+            "url": "/api/2014/features/circle-of-the-land-forest"
+          }
+        ],
+        "spell": {
+          "index": "tree-stride",
+          "name": "Passage par les arbres",
+          "url": "/api/2014/spells/tree-stride"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "invisibility",
+          "name": "Invisibilité",
+          "url": "/api/2014/spells/invisibility"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "pass-without-trace",
+          "name": "Passage sans trace",
+          "url": "/api/2014/spells/pass-without-trace"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "daylight",
+          "name": "Lumière du jour",
+          "url": "/api/2014/spells/daylight"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "haste",
+          "name": "Hâte",
+          "url": "/api/2014/spells/haste"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "divination",
+          "name": "Divination",
+          "url": "/api/2014/spells/divination"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "dream",
+          "name": "Songe",
+          "url": "/api/2014/spells/dream"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-grassland",
+            "type": "feature",
+            "name": "Cercle de la terre : Plaine",
+            "url": "/api/2014/features/circle-of-the-land-grassland"
+          }
+        ],
+        "spell": {
+          "index": "insect-plague",
+          "name": "Fléau d’insectes",
+          "url": "/api/2014/spells/insect-plague"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "spider-climb",
+          "name": "Pattes d’araignée",
+          "url": "/api/2014/spells/spider-climb"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "spike-growth",
+          "name": "Croissance d’épines",
+          "url": "/api/2014/spells/spike-growth"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "lightning-bolt",
+          "name": "Éclair",
+          "url": "/api/2014/spells/lightning-bolt"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "meld-into-stone",
+          "name": "Fusion dans la pierre",
+          "url": "/api/2014/spells/meld-into-stone"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "stone-shape",
+          "name": "Façonnage de la pierre",
+          "url": "/api/2014/spells/stone-shape"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "stoneskin",
+          "name": "Peau de pierre",
+          "url": "/api/2014/spells/stoneskin"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "passwall",
+          "name": "Passe-muraille",
+          "url": "/api/2014/spells/passwall"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-mountain",
+            "type": "feature",
+            "name": "Cercle de la terre : Montagne",
+            "url": "/api/2014/features/circle-of-the-land-mountain"
+          }
+        ],
+        "spell": {
+          "index": "wall-of-stone",
+          "name": "Mur de pierre",
+          "url": "/api/2014/spells/wall-of-stone"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "acid-arrow",
+          "name": "Flèche acide",
+          "url": "/api/2014/spells/acid-arrow"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-3",
+            "type": "level",
+            "name": "Druide 3",
+            "url": "/api/2014/classes/druid/levels/3"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "darkness",
+          "name": "Ténèbres",
+          "url": "/api/2014/spells/darkness"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "water-walk",
+          "name": "Marche sur l’onde",
+          "url": "/api/2014/spells/water-walk"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-5",
+            "type": "level",
+            "name": "Druide 5",
+            "url": "/api/2014/classes/druid/levels/5"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "stinking-cloud",
+          "name": "Nuage nauséabond",
+          "url": "/api/2014/spells/stinking-cloud"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-7",
+            "type": "level",
+            "name": "Druide 7",
+            "url": "/api/2014/classes/druid/levels/7"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "locate-creature",
+          "name": "Localisation de créature",
+          "url": "/api/2014/spells/locate-creature"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "insect-plague",
+          "name": "Fléau d’insectes",
+          "url": "/api/2014/spells/insect-plague"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "druid-9",
+            "type": "level",
+            "name": "Druide 9",
+            "url": "/api/2014/classes/druid/levels/9"
+          },
+          {
+            "index": "circle-of-the-land-swamp",
+            "type": "feature",
+            "name": "Cercle de la terre : Marais",
+            "url": "/api/2014/features/circle-of-the-land-swamp"
+          }
+        ],
+        "spell": {
+          "index": "scrying",
+          "name": "Scrutation",
+          "url": "/api/2014/spells/scrying"
+        }
+      }
+    ],
+    "subclass_levels": "/api/2014/subclasses/land/levels",
+    "url": "/api/2014/subclasses/land"
+  },
+  {
+    "index": "champion",
+    "class": {
+      "index": "fighter",
+      "name": "Guerrier",
+      "url": "/api/2014/classes/fighter"
+    },
+    "name": "Champion",
+    "subclass_flavor": "Archétype martial",
+    "desc": [
+      "Le champion est l’incarnation du guerrier voué tout entier à devenir un instrument de mort en exploitant à la perfection sa puissance physique. Ceux qui suivent cet archétype allient entraînement rigoureux et excellence physique afin d’asséner des coups dévastateurs."
+    ],
+    "subclass_levels": "/api/2014/subclasses/champion/levels",
+    "url": "/api/2014/subclasses/champion"
+  },
+  {
+    "index": "open-hand",
+    "class": {
+      "index": "monk",
+      "name": "Moine",
+      "url": "/api/2014/classes/monk"
+    },
+    "name": "Voie de la Paume",
+    "subclass_flavor": "Tradition monastique",
+    "desc": [
+      "Les moines de la Voie de la Paume sont les maîtres incontestés des arts martiaux, qu’il s’agisse de combat armé ou non. Ils apprennent les techniques permettant de pousser et faire trébucher l’adversaire, emploient le ki à soigner les dégâts corporels et pratiquent une méditation avancée qui peut les protéger du mal."
+    ],
+    "subclass_levels": "/api/2014/subclasses/open-hand/levels",
+    "url": "/api/2014/subclasses/open-hand"
+  },
+  {
+    "index": "devotion",
+    "class": {
+      "index": "paladin",
+      "name": "Paladin",
+      "url": "/api/2014/classes/paladin"
+    },
+    "name": "Serment de dévotion",
+    "subclass_flavor": "Serment sacré",
+    "desc": [
+      "Le Serment de Dévotion lie un paladin aux idéaux les plus élevés de justice, de vertu et d’ordre. Parfois appelés cavaliers, chevaliers blancs ou guerriers saints, ces paladins sont l’incarnation du chevalier en armure étincelante, agissant avec honneur au nom de la justice et du bien commun. Ils respectent un code de conduite des plus rigoureux et certains, pour le meilleur ou le pire, imposent au reste du monde cette même rigueur. Beaucoup de ceux qui prêtent ce serment sont les fidèles serviteurs d’une divinité loyale bonne et mesurent leur propre dévotion à l’aune des préceptes de ce dieu. Considérant les anges, parfaits serviteurs du bien, comme un idéal vers lequel tendre, il n’est pas rare qu’ils parent leur heaume ou leurs armoiries d’ailes angéliques."
+    ],
+    "spells": [
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-3",
+            "type": "level",
+            "name": "Paladin 3",
+            "url": "/api/2014/classes/paladin/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "protection-from-evil-and-good",
+          "name": "Protection contre le mal et le bien",
+          "url": "/api/2014/spells/protection-from-evil-and-good"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-3",
+            "type": "level",
+            "name": "Paladin 3",
+            "url": "/api/2014/classes/paladin/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "sanctuary",
+          "name": "Sanctuaire",
+          "url": "/api/2014/spells/sanctuary"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-5",
+            "type": "level",
+            "name": "Paladin 5",
+            "url": "/api/2014/classes/paladin/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "lesser-restoration",
+          "name": "Restauration partielle",
+          "url": "/api/2014/spells/lesser-restoration"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-5",
+            "type": "level",
+            "name": "Paladin 5",
+            "url": "/api/2014/classes/paladin/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "zone-of-truth",
+          "name": "Zone de vérité",
+          "url": "/api/2014/spells/zone-of-truth"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-9",
+            "type": "level",
+            "name": "Paladin 9",
+            "url": "/api/2014/classes/paladin/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "beacon-of-hope",
+          "name": "Lueur d’espoir",
+          "url": "/api/2014/spells/beacon-of-hope"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-9",
+            "type": "level",
+            "name": "Paladin 9",
+            "url": "/api/2014/classes/paladin/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "dispel-magic",
+          "name": "Dissipation de la magie",
+          "url": "/api/2014/spells/dispel-magic"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-13",
+            "type": "level",
+            "name": "Paladin 13",
+            "url": "/api/2014/classes/paladin/levels/13"
+          }
+        ],
+        "spell": {
+          "index": "freedom-of-movement",
+          "name": "Liberté de mouvement",
+          "url": "/api/2014/spells/freedom-of-movement"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-13",
+            "type": "level",
+            "name": "Paladin 13",
+            "url": "/api/2014/classes/paladin/levels/13"
+          }
+        ],
+        "spell": {
+          "index": "guardian-of-faith",
+          "name": "Gardien de la foi",
+          "url": "/api/2014/spells/guardian-of-faith"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-17",
+            "type": "level",
+            "name": "Paladin 17",
+            "url": "/api/2014/classes/paladin/levels/17"
+          }
+        ],
+        "spell": {
+          "index": "commune",
+          "name": "Communion",
+          "url": "/api/2014/spells/commune"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "paladin-17",
+            "type": "level",
+            "name": "Paladin 17",
+            "url": "/api/2014/classes/paladin/levels/17"
+          }
+        ],
+        "spell": {
+          "index": "flame-strike",
+          "name": "Colonne de flamme",
+          "url": "/api/2014/spells/flame-strike"
+        }
+      }
+    ],
+    "subclass_levels": "/api/2014/subclasses/devotion/levels",
+    "url": "/api/2014/subclasses/devotion"
+  },
+  {
+    "index": "hunter",
+    "class": {
+      "index": "ranger",
+      "name": "Rôdeur",
+      "url": "/api/2014/classes/ranger"
+    },
+    "name": "Chasseur",
+    "subclass_flavor": "Archétype de rôdeur",
+    "desc": [
+      "Adopter l’archétype du chasseur, c’est accepter de devenir le rempart entre la civilisation et les terreurs issues des contrées sauvages. En arpentant la voie du chasseur, vous apprenez des techniques spéciales permettant de mieux combattre les menaces auxquelles vous faites face, qu’il s’agisse d’ogres déchaînés, de hordes d’orcs, de géants ou de terrifiants dragons."
+    ],
+    "subclass_levels": "/api/2014/subclasses/hunter/levels",
+    "url": "/api/2014/subclasses/hunter"
+  },
+  {
+    "index": "thief",
+    "class": {
+      "index": "rogue",
+      "name": "Roublard",
+      "url": "/api/2014/classes/rogue"
+    },
+    "name": "Voleur",
+    "subclass_flavor": "Archétype de roublard",
+    "desc": [
+      "Votre savoir-faire s’oriente en premier lieu vers le larcin. Cambrioleurs, brigands, voleurs à la tire et autres criminels optent généralement pour cet archétype, ainsi que les roublards qui se voient plutôt comme des chasseurs de trésor professionnels, des explorateurs tout-terrain ou des enquêteurs. En plus de mettre l’accent sur l’agilité et la discrétion, vous apprenez des compétences utiles pour explorer les ruines oubliées, lire les langues exotiques et utiliser des objets magiques dont l’emploi vous serait interdit en temps normal."
+    ],
+    "subclass_levels": "/api/2014/subclasses/thief/levels",
+    "url": "/api/2014/subclasses/thief"
+  },
+  {
+    "index": "draconic",
+    "class": {
+      "index": "sorcerer",
+      "name": "Ensorceleur",
+      "url": "/api/2014/classes/sorcerer"
+    },
+    "name": "Lignée draconique",
+    "subclass_flavor": "Origine magique",
+    "desc": [
+      "Votre magie innée provient de la magie draconique qui s’est mêlée à votre sang ou à celui de vos ancêtres. Le plus souvent, les ensorceleurs de cette origine peuvent remonter jusqu’à un puissant ensorceleur des temps anciens ayant conclu un pacte avec un dragon, à moins que cet ancêtre ait lui-même eu un parent dragon. Si certaines de ces lignées sont bien implantées, la plupart restent obscures. Tout ensorceleur peut fort bien être le premier d’une nouvelle lignée, à la suite d’un pacte ou de toute autre circonstance exceptionnelle."
+    ],
+    "subclass_levels": "/api/2014/subclasses/draconic/levels",
+    "url": "/api/2014/subclasses/draconic"
+  },
+  {
+    "index": "fiend",
+    "class": {
+      "index": "warlock",
+      "name": "Occultiste",
+      "url": "/api/2014/classes/warlock"
+    },
+    "name": "Le Fiélon",
+    "subclass_flavor": "Protecteur d’outre-monde",
+    "desc": [
+      "Vous avez conclu un pacte avec un fiélon des Plans Inférieurs, une entité tout entière vouée au mal, quand bien même vous auriez des objectifs radicalement opposés. De tels êtres sont mus par la soif de corrompre ou détruire toute forme de vie, vous y compris. Parmi les fiélons assez puissants pour conclure un tel pacte, citons des seigneurs démons tels Démogorgon, Orcus, Fraz’Urb-luu ou Baphomet ; des archidiables comme Asmodée, Dispater, Méphistophélès ou Bélial ; les plus puissants des diantrefosses et des balors ; les ultroloths et autres seigneurs des yugoloths."
+    ],
+    "spells": [
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-1",
+            "type": "level",
+            "name": "Occultiste 1",
+            "url": "/api/2014/classes/warlock/levels/1"
+          }
+        ],
+        "spell": {
+          "index": "burning-hands",
+          "name": "Mains brûlantes",
+          "url": "/api/2014/spells/burning-hands"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-1",
+            "type": "level",
+            "name": "Occultiste 1",
+            "url": "/api/2014/classes/warlock/levels/1"
+          }
+        ],
+        "spell": {
+          "index": "command",
+          "name": "Injonction",
+          "url": "/api/2014/spells/command"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-3",
+            "type": "level",
+            "name": "Occultiste 3",
+            "url": "/api/2014/classes/warlock/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "blindness-deafness",
+          "name": "Cécité/Surdité",
+          "url": "/api/2014/spells/blindness-deafness"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-3",
+            "type": "level",
+            "name": "Occultiste 3",
+            "url": "/api/2014/classes/warlock/levels/3"
+          }
+        ],
+        "spell": {
+          "index": "scorching-ray",
+          "name": "Rayon ardent",
+          "url": "/api/2014/spells/scorching-ray"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-5",
+            "type": "level",
+            "name": "Occultiste 5",
+            "url": "/api/2014/classes/warlock/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "fireball",
+          "name": "Boule de feu",
+          "url": "/api/2014/spells/fireball"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-5",
+            "type": "level",
+            "name": "Occultiste 5",
+            "url": "/api/2014/classes/warlock/levels/5"
+          }
+        ],
+        "spell": {
+          "index": "stinking-cloud",
+          "name": "Nuage nauséabond",
+          "url": "/api/2014/spells/stinking-cloud"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-7",
+            "type": "level",
+            "name": "Occultiste 7",
+            "url": "/api/2014/classes/warlock/levels/7"
+          }
+        ],
+        "spell": {
+          "index": "fire-shield",
+          "name": "Bouclier de feu",
+          "url": "/api/2014/spells/fire-shield"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-7",
+            "type": "level",
+            "name": "Occultiste 7",
+            "url": "/api/2014/classes/warlock/levels/7"
+          }
+        ],
+        "spell": {
+          "index": "wall-of-fire",
+          "name": "Mur de feu",
+          "url": "/api/2014/spells/wall-of-fire"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-9",
+            "type": "level",
+            "name": "Occultiste 9",
+            "url": "/api/2014/classes/warlock/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "flame-strike",
+          "name": "Colonne de flamme",
+          "url": "/api/2014/spells/flame-strike"
+        }
+      },
+      {
+        "prerequisites": [
+          {
+            "index": "warlock-9",
+            "type": "level",
+            "name": "Occultiste 9",
+            "url": "/api/2014/classes/warlock/levels/9"
+          }
+        ],
+        "spell": {
+          "index": "hallow",
+          "name": "Sanctification",
+          "url": "/api/2014/spells/hallow"
+        }
+      }
+    ],
+    "subclass_levels": "/api/2014/subclasses/fiend/levels",
+    "url": "/api/2014/subclasses/fiend"
+  },
+  {
+    "index": "evocation",
+    "class": {
+      "index": "wizard",
+      "name": "Magicien",
+      "url": "/api/2014/classes/wizard"
+    },
+    "name": "École de l’Évocation",
+    "subclass_flavor": "Tradition arcanique",
+    "desc": [
+      "Vos études magiques ont essentiellement porté sur les effets élémentaires les plus intenses, comme le gel le plus froid, les flammes les plus torrides, le tonnerre rugissant, les crépitements de la foudre et les corrosions de l’acide. Certains évocateurs œuvrent au service d’armées comme artilleurs spécialisés. D’autres mettent ces pouvoirs spectaculaires au service de la protection des opprimés tandis que certains, motivés par l’appât du gain, embrassent la carrière de bandit, d’aventurier ou d’apprenti tyran."
+    ],
+    "subclass_levels": "/api/2014/subclasses/evocation/levels",
+    "url": "/api/2014/subclasses/evocation"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Traits.json
+++ b/src/2014/fr-FR/5e-SRD-Traits.json
@@ -1,0 +1,1723 @@
+[
+  {
+    "index": "darkvision",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Nain",
+        "url": "/api/2014/races/dwarf"
+      },
+      {
+        "index": "elf",
+        "name": "Elfe",
+        "url": "/api/2014/races/elf"
+      },
+      {
+        "index": "gnome",
+        "name": "Gnome",
+        "url": "/api/2014/races/gnome"
+      },
+      {
+        "index": "half-elf",
+        "name": "Demi-Elfe",
+        "url": "/api/2014/races/half-elf"
+      },
+      {
+        "index": "half-orc",
+        "name": "Demi-Orc",
+        "url": "/api/2014/races/half-orc"
+      },
+      {
+        "index": "tiefling",
+        "name": "Tieffelin",
+        "url": "/api/2014/races/tiefling"
+      }
+    ],
+    "subraces": [],
+    "name": "Vision dans le noir",
+    "desc": [
+      "Habitué à vivre sous terre, vous disposez d’une vision supérieure dans l’obscurité et la pénombre. Dans un rayon de 18 m, vous voyez en conditions de lumière faible comme si la lumière était vive, et dans les ténèbres comme sous une lumière faible. Vous ne discernez pas les couleurs dans les ténèbres, mais percevez des nuances de gris."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/darkvision"
+  },
+  {
+    "index": "dwarven-resilience",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Nain",
+        "url": "/api/2014/races/dwarf"
+      }
+    ],
+    "subraces": [],
+    "name": "Résistance naine",
+    "desc": [
+      "Vous êtes avantagé aux jets de sauvegarde contre le poison et bénéficiez de la résistance aux dégâts de poison."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/dwarven-resilience"
+  },
+  {
+    "index": "dwarven-combat-training",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Nain",
+        "url": "/api/2014/races/dwarf"
+      }
+    ],
+    "subraces": [],
+    "name": "Entraînement martial nain",
+    "desc": [
+      "Vous avez la maîtrise de la hache d’armes, de la hachette, du marteau léger et du marteau de guerre."
+    ],
+    "proficiencies": [
+      {
+        "index": "battleaxes",
+        "name": "Haches d'armes",
+        "url": "/api/2014/proficiencies/battleaxes"
+      },
+      {
+        "index": "handaxes",
+        "name": "Hachettes",
+        "url": "/api/2014/proficiencies/handaxes"
+      },
+      {
+        "index": "light-hammers",
+        "name": "Marteaux légers",
+        "url": "/api/2014/proficiencies/light-hammers"
+      },
+      {
+        "index": "warhammers",
+        "name": "Marteaux de guerre",
+        "url": "/api/2014/proficiencies/warhammers"
+      }
+    ],
+    "url": "/api/2014/traits/dwarven-combat-training"
+  },
+  {
+    "index": "tool-proficiency",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Nain",
+        "url": "/api/2014/races/dwarf"
+      }
+    ],
+    "subraces": [],
+    "name": "Maîtrise d’outils",
+    "desc": [
+      "Vous recevez la maîtrise des outils d’artisan de votre choix parmi : outils de forgeron, matériel de brasseur, outils de maçon."
+    ],
+    "proficiencies": [],
+    "proficiency_choices": {
+      "choose": 1,
+      "type": "proficiencies",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "smiths-tools",
+              "name": "Outils de forgeron",
+              "url": "/api/2014/proficiencies/smiths-tools"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "brewers-supplies",
+              "name": "Matériel de brasseur",
+              "url": "/api/2014/proficiencies/brewers-supplies"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "masons-tools",
+              "name": "Outils de maçon",
+              "url": "/api/2014/proficiencies/masons-tools"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/tool-proficiency"
+  },
+  {
+    "index": "stonecunning",
+    "races": [
+      {
+        "index": "dwarf",
+        "name": "Nain",
+        "url": "/api/2014/races/dwarf"
+      }
+    ],
+    "subraces": [],
+    "name": "Connaissance de la pierre",
+    "desc": [
+      "Chaque fois que vous effectuez un test d’Intelligence (Histoire) lié aux origines d’un travail de maçonnerie, on considère que vous avez la maîtrise de la compétence Histoire et vous appliquez le double de votre bonus de maîtrise au test, au lieu du simple bonus."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/stonecunning"
+  },
+  {
+    "index": "dwarven-toughness",
+    "races": [],
+    "subraces": [
+      {
+        "index": "hill-dwarf",
+        "name": "Nain des collines",
+        "url": "/api/2014/subraces/hill-dwarf"
+      }
+    ],
+    "name": "Ténacité naine",
+    "desc": [
+      "Votre maximum de points de vie augmente de 1, et augmente encore de 1 chaque fois que vous gagnez un niveau."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/dwarven-toughness"
+  },
+  {
+    "index": "keen-senses",
+    "races": [
+      {
+        "index": "elf",
+        "name": "Elfe",
+        "url": "/api/2014/races/elf"
+      }
+    ],
+    "subraces": [],
+    "name": "Sens aiguisés",
+    "desc": ["Vous avez la maîtrise de la compétence Perception."],
+    "proficiencies": [
+      {
+        "index": "skill-perception",
+        "name": "Compétence : Perception",
+        "url": "/api/2014/proficiencies/skill-perception"
+      }
+    ],
+    "url": "/api/2014/traits/keen-senses"
+  },
+  {
+    "index": "fey-ancestry",
+    "races": [
+      {
+        "index": "elf",
+        "name": "Elfe",
+        "url": "/api/2014/races/elf"
+      },
+      {
+        "index": "half-elf",
+        "name": "Demi-Elfe",
+        "url": "/api/2014/races/half-elf"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance féerique",
+    "desc": [
+      "Vous êtes avantagé aux jets de sauvegarde contre l’état charmé et la magie ne peut pas vous endormir."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/fey-ancestry"
+  },
+  {
+    "index": "trance",
+    "races": [
+      {
+        "index": "elf",
+        "name": "Elfe",
+        "url": "/api/2014/races/elf"
+      }
+    ],
+    "subraces": [],
+    "name": "Transe",
+    "desc": [
+      "Les elfes n’ont pas besoin de dormir. En lieu et place de sommeil, ils méditent profondément dans un état de conscience partielle, pendant 4 heures par jour. (Cette méditation est communément appelée « transe »). Elle peut s’accompagner de songes personnalisés qui sont en vérité des exercices mentaux, devenus au fil des ans une seconde nature. Une fois que vous terminez un tel repos, vous recevez les mêmes bénéfices qu’un humain émergeant de 8 heures de sommeil."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/trance"
+  },
+  {
+    "index": "elf-weapon-training",
+    "races": [],
+    "subraces": [
+      {
+        "index": "high-elf",
+        "name": "Haut-elfe",
+        "url": "/api/2014/subraces/high-elf"
+      }
+    ],
+    "name": "Entraînement martial elfique",
+    "desc": [
+      "Vous avez la maîtrise de l’épée longue, de l’épée courte, de l’arc court et de l’arc long."
+    ],
+    "proficiencies": [
+      {
+        "index": "longswords",
+        "name": "Épées longues",
+        "url": "/api/2014/proficiencies/longswords"
+      },
+      {
+        "index": "shortswords",
+        "name": "Épées courtes",
+        "url": "/api/2014/proficiencies/shortswords"
+      },
+      {
+        "index": "shortbows",
+        "name": "Arcs courts",
+        "url": "/api/2014/proficiencies/shortbows"
+      },
+      {
+        "index": "longbows",
+        "name": "Arcs longs",
+        "url": "/api/2014/proficiencies/longbows"
+      }
+    ],
+    "url": "/api/2014/traits/elf-weapon-training"
+  },
+  {
+    "index": "high-elf-cantrip",
+    "races": [],
+    "subraces": [
+      {
+        "index": "high-elf",
+        "name": "Haut-elfe",
+        "url": "/api/2014/subraces/high-elf"
+      }
+    ],
+    "name": "Sort mineur",
+    "desc": [
+      "Vous connaissez un sort mineur de la liste de sorts du magicien (au choix). L’Intelligence est la caractéristique d’incantation correspondante."
+    ],
+    "proficiencies": [],
+    "trait_specific": {
+      "spell_options": {
+        "choose": 1,
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "light",
+                "name": "Lumière",
+                "url": "/api/2014/spells/light"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "mage-hand",
+                "name": "Main du mage",
+                "url": "/api/2014/spells/mage-hand"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "mending",
+                "name": "Réparation",
+                "url": "/api/2014/spells/mending"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "message",
+                "name": "Message",
+                "url": "/api/2014/spells/message"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "minor-illusion",
+                "name": "Illusion mineure",
+                "url": "/api/2014/spells/minor-illusion"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "acid-splash",
+                "name": "Aspersion d’acide",
+                "url": "/api/2014/spells/acid-splash"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "prestidigitation",
+                "name": "Prestidigitation",
+                "url": "/api/2014/spells/prestidigitation"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "ray-of-frost",
+                "name": "Rayon de givre",
+                "url": "/api/2014/spells/ray-of-frost"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "shocking-grasp",
+                "name": "Poigne électrique",
+                "url": "/api/2014/spells/shocking-grasp"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "true-strike",
+                "name": "Coup au but",
+                "url": "/api/2014/spells/true-strike"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "chill-touch",
+                "name": "Contact glacial",
+                "url": "/api/2014/spells/chill-touch"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "dancing-lights",
+                "name": "Lumières dansantes",
+                "url": "/api/2014/spells/dancing-lights"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "fire-bolt",
+                "name": "Trait de feu",
+                "url": "/api/2014/spells/fire-bolt"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "poison-spray",
+                "name": "Bouffée de poison",
+                "url": "/api/2014/spells/poison-spray"
+              }
+            }
+          ]
+        },
+        "type": "spell"
+      }
+    },
+    "url": "/api/2014/traits/high-elf-cantrip"
+  },
+  {
+    "index": "extra-language",
+    "races": [],
+    "subraces": [
+      {
+        "index": "high-elf",
+        "name": "Haut-elfe",
+        "url": "/api/2014/subraces/high-elf"
+      }
+    ],
+    "name": "Langue supplémentaire",
+    "desc": ["Vous parlez, lisez et écrivez une langue supplémentaire de votre choix."],
+    "proficiencies": [],
+    "language_options": {
+      "choose": 1,
+      "type": "languages",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "dwarvish",
+              "name": "Nain",
+              "url": "/api/2014/languages/dwarvish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "giant",
+              "name": "Géant",
+              "url": "/api/2014/languages/giant"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "gnomish",
+              "name": "Gnome",
+              "url": "/api/2014/languages/gnomish"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "goblin",
+              "name": "Gobelin",
+              "url": "/api/2014/languages/goblin"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "halfling",
+              "name": "Halfelin",
+              "url": "/api/2014/languages/halfling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "orc",
+              "name": "Orc",
+              "url": "/api/2014/languages/orc"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "abyssal",
+              "name": "Abyssal",
+              "url": "/api/2014/languages/abyssal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "celestial",
+              "name": "Céleste",
+              "url": "/api/2014/languages/celestial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "draconic",
+              "name": "Draconique",
+              "url": "/api/2014/languages/draconic"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "deep-speech",
+              "name": "Profond",
+              "url": "/api/2014/languages/deep-speech"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "infernal",
+              "name": "Infernal",
+              "url": "/api/2014/languages/infernal"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "primordial",
+              "name": "Primordial",
+              "url": "/api/2014/languages/primordial"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "sylvan",
+              "name": "Sylvain",
+              "url": "/api/2014/languages/sylvan"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "undercommon",
+              "name": "Commun des profondeurs",
+              "url": "/api/2014/languages/undercommon"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/extra-language"
+  },
+  {
+    "index": "lucky",
+    "races": [
+      {
+        "index": "halfling",
+        "name": "Halfelin",
+        "url": "/api/2014/races/halfling"
+      }
+    ],
+    "subraces": [],
+    "name": "Chanceux",
+    "desc": [
+      "Lorsque vous obtenez un 1 sur le d20 d’un jet d’attaque, d’un test de caractéristique ou d’un jet de sauvegarde, vous pouvez relancer ce dé, auquel cas c’est le second résultat qui s’applique."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/lucky"
+  },
+  {
+    "index": "brave",
+    "races": [
+      {
+        "index": "halfling",
+        "name": "Halfelin",
+        "url": "/api/2014/races/halfling"
+      }
+    ],
+    "subraces": [],
+    "name": "Brave",
+    "desc": ["Vous êtes avantagé aux jets de sauvegarde contre l’état effrayé."],
+    "proficiencies": [],
+    "url": "/api/2014/traits/brave"
+  },
+  {
+    "index": "halfling-nimbleness",
+    "races": [
+      {
+        "index": "halfling",
+        "name": "Halfelin",
+        "url": "/api/2014/races/halfling"
+      }
+    ],
+    "subraces": [],
+    "name": "Agilité halfeline",
+    "desc": [
+      "Vous pouvez vous déplacer à travers l’espace de toute créature dont la catégorie de taille est supérieure à la vôtre."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/halfling-nimbleness"
+  },
+  {
+    "index": "naturally-stealthy",
+    "races": [],
+    "subraces": [
+      {
+        "index": "lightfoot-halfling",
+        "name": "Pied-léger",
+        "url": "/api/2014/subraces/lightfoot-halfling"
+      }
+    ],
+    "name": "Discrétion naturelle",
+    "desc": [
+      "Il vous suffit d’être derrière une créature dont la catégorie de taille est d’au moins un cran supérieure à la vôtre pour pouvoir tenter de vous cacher."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/naturally-stealthy"
+  },
+  {
+    "index": "draconic-ancestry",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "proficiencies": [],
+    "trait_specific": {
+      "subtrait_options": {
+        "choose": 1,
+        "from": {
+          "option_set_type": "options_array",
+          "options": [
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-black",
+                "name": "Ascendance draconique (Noir)",
+                "url": "/api/2014/traits/draconic-ancestry-black"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-blue",
+                "name": "Ascendance draconique (Bleu)",
+                "url": "/api/2014/traits/draconic-ancestry-blue"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-brass",
+                "name": "Ascendance draconique (Airain)",
+                "url": "/api/2014/traits/draconic-ancestry-brass"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-bronze",
+                "name": "Ascendance draconique (Bronze)",
+                "url": "/api/2014/traits/draconic-ancestry-bronze"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-copper",
+                "name": "Ascendance draconique (Cuivre)",
+                "url": "/api/2014/traits/draconic-ancestry-copper"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-gold",
+                "name": "Ascendance draconique (Or)",
+                "url": "/api/2014/traits/draconic-ancestry-gold"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-green",
+                "name": "Ascendance draconique (Vert)",
+                "url": "/api/2014/traits/draconic-ancestry-green"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-red",
+                "name": "Ascendance draconique (Rouge)",
+                "url": "/api/2014/traits/draconic-ancestry-red"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-silver",
+                "name": "Ascendance draconique (Argent)",
+                "url": "/api/2014/traits/draconic-ancestry-silver"
+              }
+            },
+            {
+              "option_type": "reference",
+              "item": {
+                "index": "draconic-ancestry-white",
+                "name": "Ascendance draconique (Blanc)",
+                "url": "/api/2014/traits/draconic-ancestry-white"
+              }
+            }
+          ]
+        },
+        "type": "trait"
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry"
+  },
+  {
+    "index": "draconic-ancestry-black",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Noir)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "acid",
+        "name": "Acide",
+        "url": "/api/2014/damage-types/acid"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "acid",
+              "name": "Acide",
+              "url": "/api/2014/damage-types/acid"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-black"
+  },
+  {
+    "index": "draconic-ancestry-blue",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Bleu)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "lightning",
+              "name": "Foudre",
+              "url": "/api/2014/damage-types/lightning"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-blue"
+  },
+  {
+    "index": "draconic-ancestry-brass",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Airain)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "fire",
+              "name": "Feu",
+              "url": "/api/2014/damage-types/fire"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-brass"
+  },
+  {
+    "index": "draconic-ancestry-bronze",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Bronze)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "lightning",
+        "name": "Foudre",
+        "url": "/api/2014/damage-types/lightning"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "lightning",
+              "name": "Foudre",
+              "url": "/api/2014/damage-types/lightning"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-bronze"
+  },
+  {
+    "index": "draconic-ancestry-copper",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Cuivre)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "acid",
+        "name": "Acide",
+        "url": "/api/2014/damage-types/acid"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 30,
+          "type": "line"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "acid",
+              "name": "Acide",
+              "url": "/api/2014/damage-types/acid"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-copper"
+  },
+  {
+    "index": "draconic-ancestry-gold",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Or)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "fire",
+              "name": "Feu",
+              "url": "/api/2014/damage-types/fire"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-gold"
+  },
+  {
+    "index": "draconic-ancestry-green",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Vert)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "poison",
+        "name": "Poison",
+        "url": "/api/2014/damage-types/poison"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "con",
+            "name": "CON",
+            "url": "/api/2014/ability-scores/con"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "poison",
+              "name": "Poison",
+              "url": "/api/2014/damage-types/poison"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-green"
+  },
+  {
+    "index": "draconic-ancestry-red",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Rouge)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "fire",
+        "name": "Feu",
+        "url": "/api/2014/damage-types/fire"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "dex",
+            "name": "DEX",
+            "url": "/api/2014/ability-scores/dex"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "fire",
+              "name": "Feu",
+              "url": "/api/2014/damage-types/fire"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-red"
+  },
+  {
+    "index": "draconic-ancestry-silver",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Argent)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "con",
+            "name": "CON",
+            "url": "/api/2014/ability-scores/con"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "cold",
+              "name": "Froid",
+              "url": "/api/2014/damage-types/cold"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-silver"
+  },
+  {
+    "index": "draconic-ancestry-white",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance draconique (Blanc)",
+    "desc": [
+      "Vous avez des ancêtres draconiques. Choisissez un type de dragon dans la table Ascendance draconique. Ce choix détermine votre souffle et votre résistance aux dégâts, comme indiqué dans la table."
+    ],
+    "parent": {
+      "index": "draconic-ancestry",
+      "name": "Ascendance draconique",
+      "url": "/api/2014/traits/draconic-ancestry"
+    },
+    "proficiencies": [],
+    "trait_specific": {
+      "damage_type": {
+        "index": "cold",
+        "name": "Froid",
+        "url": "/api/2014/damage-types/cold"
+      },
+      "breath_weapon": {
+        "name": "Souffle",
+        "desc": "Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle. Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16. Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long.",
+        "area_of_effect": {
+          "size": 15,
+          "type": "cone"
+        },
+        "usage": {
+          "type": "par repos",
+          "times": 1
+        },
+        "dc": {
+          "dc_type": {
+            "index": "con",
+            "name": "CON",
+            "url": "/api/2014/ability-scores/con"
+          },
+          "success_type": "half"
+        },
+        "damage": [
+          {
+            "damage_type": {
+              "index": "cold",
+              "name": "Froid",
+              "url": "/api/2014/damage-types/cold"
+            },
+            "damage_at_character_level": {
+              "1": "2d6",
+              "6": "3d6",
+              "11": "4d6",
+              "16": "5d6"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/draconic-ancestry-white"
+  },
+  {
+    "index": "breath-weapon",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Souffle",
+    "desc": [
+      "Vous pouvez Vous pouvez consacrer votre action à exhaler une vague d’énergie destructrice. Votre ascendance draconique détermine la taille, la forme et le type de dégâts de ce souffle.",
+      "Quand vous utilisez votre souffle, chaque créature dans la zone d’effet effectue un jet de sauvegarde dont le type est déterminé par votre ascendance draconique. Le DD du jet de sauvegarde contre ce souffle est égal à 8 + votre modificateur de Constitution + votre bonus de maîtrise. Une créature subit 2d6 dégâts en cas d’échec, la moitié en cas de réussite. La quantité de dégâts passe à 3d6 au niveau 6, à 4d6 au niveau 11 et à 5d6 au niveau 16.",
+      "Une fois votre souffle utilisé, vous ne pouvez plus y recourir avant d’avoir terminé un repos court ou long."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/breath-weapon"
+  },
+  {
+    "index": "damage-resistance",
+    "races": [
+      {
+        "index": "dragonborn",
+        "name": "Drakéide",
+        "url": "/api/2014/races/dragonborn"
+      }
+    ],
+    "subraces": [],
+    "name": "Résistance aux dégâts",
+    "desc": [
+      "Vous bénéficiez de la résistance au type de dégâts associé à votre ascendance draconique."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/damage-resistance"
+  },
+  {
+    "index": "gnome-cunning",
+    "races": [
+      {
+        "index": "gnome",
+        "name": "Gnome",
+        "url": "/api/2014/races/gnome"
+      }
+    ],
+    "subraces": [],
+    "name": "Ruse gnome",
+    "desc": [
+      "Vous êtes avantagé à tous les jets de sauvegarde d’Intelligence, de Sagesse et de Charisme contre la magie."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/gnome-cunning"
+  },
+  {
+    "index": "artificers-lore",
+    "races": [],
+    "subraces": [
+      {
+        "index": "rock-gnome",
+        "name": "Gnome des roches",
+        "url": "/api/2014/subraces/rock-gnome"
+      }
+    ],
+    "name": "Connaissances en ingénierie",
+    "desc": [
+      "Chaque fois que vous effectuez un test d’Intelligence (Histoire) relatif aux objets magiques, alchimiques ou technologiques, vous ajoutez le double de votre bonus de maîtrise au lieu du bonus de maîtrise habituel."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/artificers-lore"
+  },
+  {
+    "index": "tinker",
+    "races": [],
+    "subraces": [
+      {
+        "index": "rock-gnome",
+        "name": "Rock Gnome",
+        "url": "/api/2014/subraces/rock-gnome"
+      }
+    ],
+    "name": "Bricoleur",
+    "desc": [
+      "Vous avez la maîtrise des outils d’artisan (outils de bricoleur). Au moyen de ces outils et pour peu que vous passiez 1 heure et dépensiez 10 po de matériaux, vous construisez un mécanisme de taille TP (CA 5, 1 pv). Ce mécanisme cesse de fonctionner au bout de 24 heures (sauf si vous consacrez 1 heure à le réparer pour le maintenir en état de marche) ou si vous consacrez votre action à le démanteler. Vous pouvez alors récupérer les matériaux qui ont servi à sa création. Vous pouvez avoir jusqu’à trois mécanismes de ce type fonctionnant en même temps.",
+      "Quand vous créez un appareil, choisissez l’une des options suivantes :",
+      "Boîte à musique. Quand elle est ouverte, cette boîte à musique joue une mélodie à un volume sonore modéré. La boîte à musique cesse de jouer lorsqu’elle atteint la fin de la chanson ou si elle est refermée.",
+      "Boutefeu. L’appareil produit une petite flamme qui permet d’allumer une bougie, une torche ou un feu de camp. Utiliser cet appareil nécessite que vous y consacriez votre action.",
+      "Jouet mécanique. Ce jouet est un animal, un monstre ou une personne mécanique : une grenouille, une souris, un oiseau, un dragon ou un soldat, par exemple. Placé au sol, le jouet se déplace de 1,50 m à chacun de vos tours dans une direction aléatoire. Il émet un bruit en rapport avec la créature qu’il représente."
+    ],
+    "proficiencies": [
+      {
+        "index": "tinkers-tools",
+        "name": "Outils de bricoleur",
+        "url": "/api/2014/proficiencies/tinkers-tools"
+      }
+    ],
+    "url": "/api/2014/traits/tinker"
+  },
+  {
+    "index": "skill-versatility",
+    "races": [
+      {
+        "index": "half-elf",
+        "name": "Demi-Elfe",
+        "url": "/api/2014/races/half-elf"
+      }
+    ],
+    "subraces": [],
+    "name": "Polyvalence",
+    "desc": ["Vous recevez la maîtrise de deux compétences de votre choix."],
+    "proficiencies": [],
+    "proficiency_choices": {
+      "choose": 2,
+      "type": "proficiencies",
+      "from": {
+        "option_set_type": "options_array",
+        "options": [
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-acrobatics",
+              "name": "Compétence : Acrobaties",
+              "url": "/api/2014/proficiencies/skill-acrobatics"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-animal-handling",
+              "name": "Compétence : Dressage",
+              "url": "/api/2014/proficiencies/skill-animal-handling"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-arcana",
+              "name": "Compétence : Arcanes",
+              "url": "/api/2014/proficiencies/skill-arcana"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-athletics",
+              "name": "Compétence : Athlétisme",
+              "url": "/api/2014/proficiencies/skill-athletics"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-deception",
+              "name": "Compétence : Tromperie",
+              "url": "/api/2014/proficiencies/skill-deception"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-history",
+              "name": "Compétence : Histoire",
+              "url": "/api/2014/proficiencies/skill-history"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-insight",
+              "name": "Compétence : Intuition",
+              "url": "/api/2014/proficiencies/skill-insight"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-intimidation",
+              "name": "Compétence : Intimidation",
+              "url": "/api/2014/proficiencies/skill-intimidation"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-investigation",
+              "name": "Compétence : Investigation",
+              "url": "/api/2014/proficiencies/skill-investigation"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-medicine",
+              "name": "Compétence : Médecine",
+              "url": "/api/2014/proficiencies/skill-medicine"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-nature",
+              "name": "Compétence : Nature",
+              "url": "/api/2014/proficiencies/skill-nature"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-perception",
+              "name": "Compétence : Perception",
+              "url": "/api/2014/proficiencies/skill-perception"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-performance",
+              "name": "Compétence : Représentation",
+              "url": "/api/2014/proficiencies/skill-performance"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-persuasion",
+              "name": "Compétence : Persuasion",
+              "url": "/api/2014/proficiencies/skill-persuasion"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-religion",
+              "name": "Compétence : Religion",
+              "url": "/api/2014/proficiencies/skill-religion"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-sleight-of-hand",
+              "name": "Compétence : Escamotage",
+              "url": "/api/2014/proficiencies/skill-sleight-of-hand"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-stealth",
+              "name": "Compétence : Discrétion",
+              "url": "/api/2014/proficiencies/skill-stealth"
+            }
+          },
+          {
+            "option_type": "reference",
+            "item": {
+              "index": "skill-survival",
+              "name": "Compétence : Survie",
+              "url": "/api/2014/proficiencies/skill-survival"
+            }
+          }
+        ]
+      }
+    },
+    "url": "/api/2014/traits/skill-versatility"
+  },
+  {
+    "index": "menacing",
+    "races": [
+      {
+        "index": "half-orc",
+        "name": "Demi-Orc",
+        "url": "/api/2014/races/half-orc"
+      }
+    ],
+    "subraces": [],
+    "name": "Menaçant",
+    "desc": ["Vous recevez la maîtrise de la compétence Intimidation."],
+    "proficiencies": [
+      {
+        "index": "skill-intimidation",
+        "name": "Compétence : Intimidation",
+        "url": "/api/2014/proficiencies/skill-intimidation"
+      }
+    ],
+    "url": "/api/2014/traits/menacing"
+  },
+  {
+    "index": "relentless-endurance",
+    "races": [
+      {
+        "index": "half-orc",
+        "name": "Demi-Orc",
+        "url": "/api/2014/races/half-orc"
+      }
+    ],
+    "subraces": [],
+    "name": "Acharnement",
+    "desc": [
+      "Si vous tombez à 0 point de vie sans être tué sur le coup, vous pouvez en fait vous retrouver à 1 point de vie. Une fois que vous avez utilisé cette aptitude, vous devez terminer un repos long pour pouvoir y recourir de nouveau."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/relentless-endurance"
+  },
+  {
+    "index": "savage-attacks",
+    "races": [
+      {
+        "index": "half-orc",
+        "name": "Demi-Orc",
+        "url": "/api/2014/races/half-orc"
+      }
+    ],
+    "subraces": [],
+    "name": "Sauvagerie",
+    "desc": [
+      "Quand vous obtenez un coup critique avec une attaque d’arme au corps à corps, vous pouvez lancer l’un des dés de dégâts de l’arme une fois de plus et en ajouter le résultat aux dégâts supplémentaires du coup critique."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/savage-attacks"
+  },
+  {
+    "index": "hellish-resistance",
+    "races": [
+      {
+        "index": "tiefling",
+        "name": "Tieffelin",
+        "url": "/api/2014/races/tiefling"
+      }
+    ],
+    "subraces": [],
+    "name": "Résistance infernale",
+    "desc": ["Vous bénéficiez de la résistance aux dégâts de feu."],
+    "proficiencies": [],
+    "url": "/api/2014/traits/hellish-resistance"
+  },
+  {
+    "index": "infernal-legacy",
+    "races": [
+      {
+        "index": "tiefling",
+        "name": "Tieffelin",
+        "url": "/api/2014/races/tiefling"
+      }
+    ],
+    "subraces": [],
+    "name": "Ascendance infernale",
+    "desc": [
+      "Vous connaissez le sort mineur thaumaturgie. Lorsque vous atteignez le niveau 3, vous pouvez lancer une fois le sort représailles infernales en tant que sort de 2e niveau par l’intermédiaire de ce trait et vous récupérez cette faculté en terminant un repos long. Lorsque vous atteignez le niveau 5, vous pouvez lancer le sort ténèbres une fois par l’intermédiaire de ce trait et récupérez cette faculté en terminant un repos long. Le Charisme est la caractéristique d’incantation pour ces sorts."
+    ],
+    "proficiencies": [],
+    "url": "/api/2014/traits/infernal-legacy"
+  }
+]

--- a/src/2014/fr-FR/5e-SRD-Weapon-Properties.json
+++ b/src/2014/fr-FR/5e-SRD-Weapon-Properties.json
@@ -1,0 +1,89 @@
+[
+  {
+    "index": "ammunition",
+    "name": "Munitions",
+    "desc": [
+      "Vous pouvez utiliser une arme dotée de la propriété munitions pour effectuer une attaque à distance, à condition de disposer de ces munitions. Chaque fois que vous attaquez avec cette arme, vous dépensez l’une de ces munitions. Sortir un projectile d’un carquois, d’un étui ou autre conteneur fait partie de l’attaque (vous devez avoir une main libre pour charger une arme à une main). À la fin du combat, vous pouvez récupérer la moitié des munitions dépensées en consacrant une minute à les retrouver sur le champ de bataille.",
+      "Si vous utilisez une arme dotée de la propriété munitions pour effectuer une attaque de corps à corps, vous la considérez comme une arme improvisée (voir « Armes improvisées », plus loin dans la section). Une fronde que vous utilisez ainsi n’inflige des dégâts que si elle est chargée."
+    ],
+    "url": "/api/2014/weapon-properties/ammunition"
+  },
+  {
+    "index": "finesse",
+    "name": "Finesse",
+    "desc": [
+      "Lorsque vous effectuez une attaque avec une arme de finesse, vous choisissez entre le modificateur de Force et le modificateur de Dextérité celui qui s’applique aux jets d’attaque et de dégâts. Vous devez utiliser le même modificateur pour les deux jets."
+    ],
+    "url": "/api/2014/weapon-properties/finesse"
+  },
+  {
+    "index": "heavy",
+    "name": "Lourde",
+    "desc": [
+      "Les créatures de taille P sont désavantagées aux jets d’attaque avec des armes lourdes. La taille et l’encombrement d’une arme lourde sont tels qu’une créature de taille P ne peut s’en servir efficacement."
+    ],
+    "url": "/api/2014/weapon-properties/heavy"
+  },
+  {
+    "index": "light",
+    "name": "Légère",
+    "desc": [
+      "Une arme légère, d’un maniement aisé, reste l’outil idéal pour combattre à deux armes."
+    ],
+    "url": "/api/2014/weapon-properties/light"
+  },
+  {
+    "index": "loading",
+    "name": "Chargement",
+    "desc": [
+      "En raison du temps demandé pour recharger cette arme, vous ne pouvez tirer qu’un projectile lorsque vous consacrez une action, une action bonus ou une réaction pour attaquer en vous en servant, quel que soit le nombre d’attaques que vous pouvez normalement effectuer."
+    ],
+    "url": "/api/2014/weapon-properties/loading"
+  },
+  {
+    "index": "reach",
+    "name": "Portée",
+    "desc": [
+      "Une arme qui peut servir à effectuer une attaque à distance présente une portée indiquée entre parenthèses après la propriété munitions ou lancer. Cette portée se compose de deux nombres. Le premier correspond à la portée normale en mètres, le second à la portée longue. Lorsque vous attaquez une cible située au-delà de la portée normale, vous êtes désavantagé au jet d’attaque. Vous ne pouvez pas attaquer une cible hors de portée longue."
+    ],
+    "url": "/api/2014/weapon-properties/reach"
+  },
+  {
+    "index": "special",
+    "name": "Special",
+    "desc": [
+      "L’utilisation d’une arme dotée de la propriété spéciale est soumise à des règles spéciales, expliquées dans la description de l’arme (voir « Armes spéciales » plus loin dans cette section)."
+    ],
+    "url": "/api/2014/weapon-properties/special"
+  },
+  {
+    "index": "thrown",
+    "name": "Lancer",
+    "desc": [
+      "Quand une arme a la propriété lancer, vous pouvez la lancer pour effectuer une attaque à distance. S’il s’agit d’une arme de corps à corps, vous utilisez alors le même modificateur de caractéristique que pour le jet d’attaque et le jet de dégâts de vos attaques de corps à corps avec cette arme. Ainsi, lorsque vous lancez une hachette, vous recourez à la Force, mais si vous lancez une dague, vous pouvez utiliser votre Force ou votre Dextérité, car la dague a la propriété finesse."
+    ],
+    "url": "/api/2014/weapon-properties/thrown"
+  },
+  {
+    "index": "two-handed",
+    "name": "À deux mains",
+    "desc": ["Cette arme requiert deux mains lorsque vous l’utilisez pour attaquer."],
+    "url": "/api/2014/weapon-properties/two-handed"
+  },
+  {
+    "index": "versatile",
+    "name": "Polyvalente",
+    "desc": [
+      "Cette arme peut s’utiliser à une ou deux mains. Une valeur de dégâts apparaît entre parenthèses avec la propriété, indiquant les dégâts qui s’appliquent lorsque l’arme est utilisée à deux mains pour une attaque de corps à corps."
+    ],
+    "url": "/api/2014/weapon-properties/versatile"
+  },
+  {
+    "index": "monk",
+    "name": "Moine",
+    "desc": [
+      "Les moines bénéficient de plusieurs avantages lorsqu'ils combattent à mains nues ou avec des armes de moine et qu’ils ne portent ni armure ni bouclier."
+    ],
+    "url": "/api/2014/weapon-properties/monk"
+  }
+]


### PR DESCRIPTION
## What does this do?

This PR adds French translations for the following collections:

- Weapon properties
- Spells
- Rules
- Traits
- Subclasses

This is a second batch of French translations, more will come later!

## How was it tested?

It was tested with `npm run test`.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.
