### PR TITLE
feat: Add feat 2014 EN

### DIFF
--- a/src/2014/en/5e-SRD-Feats.json
+++ b/src/2014/en/5e-SRD-Feats.json
@@ -1,5 +1,488 @@
 [
   {
+    "index": "actor",
+    "name": "Actor",
+    "prerequisites": [],
+    "desc": [
+      "Skilled at mimicry and dramatics, you gain the following benefits:",
+      "Increase your Charisma score by 1, to a maximum of 20.",
+      "You have an advantage on Charisma (Deception) and Charisma (Performance) checks when trying to pass yourself off as a different person.",
+      "You can mimic the speech of another person or the sounds made by other creatures. You must have heard the person speaking, or heard the creature make the sound, for at least 1 minute. A successful Wisdom (Insight) check contested by your Charisma (Deception) check allows a listener to determine that the effect is faked."
+    ],
+    "url": "/api/2014/feats/actor",
+    "source": "players-handbook"
+  },
+  {
+    "index": "alert",
+    "name": "Alert",
+    "prerequisites": [],
+    "desc": [
+      "Always on the lookout for danger, you gain the following benefits:",
+      "You gain a +5 bonus to initiative.",
+      "You can't be surprised while you are conscious.",
+      "Other creatures don't gain advantage on attack rolls against you as a result of being unseen by you."
+    ],
+    "url": "/api/2014/feats/alert",
+    "source": "players-handbook"
+  },
+  {
+    "index": "artificer-initiate",
+    "name": "Artificer Initiate",
+    "prerequisites": [],
+    "desc": [
+      "You learn one cantrip and one 1st-level artificer spell (cast without slot), proficiency with one type of artisan's tools."
+    ],
+    "url": "/api/2014/feats/artificer-initiate",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "athlete",
+    "name": "Athlete",
+    "prerequisites": [],
+    "desc": [
+      "You have undergone extensive physical training to gain the following benefits:",
+      "Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "When you are prone, standing up uses only 5 feet of your movement.",
+      "Climbing doesn't cost you extra movement.",
+      "You can make a running long jump or a running high jump after moving only 5 feet on foot, rather than 10 feet."
+    ],
+    "url": "/api/2014/feats/athlete",
+    "source": "players-handbook"
+  },
+  {
+    "index": "bountiful-luck",
+    "name": "Bountiful Luck",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "halfling",
+          "name": "Halfling",
+          "url": "/api/2014/races/halfling"
+        }
+      }
+    ],
+    "desc": [
+      "You can let an ally within 30 ft of you reroll a 1 on a d20."
+    ],
+    "url": "/api/2014/feats/bountiful-luck",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "charger",
+    "name": "Charger",
+    "prerequisites": [],
+    "desc": [
+      "When you use your action to Dash, you can use a bonus action to make one melee weapon attack or to shove a creature.",
+      "If you move at least 10 feet in a straight line immediately before taking this bonus action, you either gain a +5 bonus to the attack's damage roll (if you chose to make a melee attack and hit) or push the target up to 10 feet away from you (if you chose to shove and you succeed)."
+    ],
+    "url": "/api/2014/feats/charger",
+    "source": "players-handbook"
+  },
+  {
+    "index": "chef",
+    "name": "Chef",
+    "prerequisites": [],
+    "desc": [
+      "+1 in Con. or Wis., proficiency with cook's utensils and cook special food to regain hp."
+    ],
+    "url": "/api/2014/feats/chef",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "crossbow-expert",
+    "name": "Crossbow Expert",
+    "prerequisites": [],
+    "desc": [
+      "Thanks to extensive practice with the crossbow, you gain the following benefits:",
+      "You ignore the loading quality of crossbows with which you are proficient.",
+      "Being within 5 feet of a hostile creature doesn't impose disadvantage on your ranged attack rolls.",
+      "When you use the Attack action and attack with a one handed weapon, you can use a bonus action to attack with a hand crossbow you are holding."
+    ],
+    "url": "/api/2014/feats/crossbow-expert",
+    "source": "players-handbook"
+  },
+  {
+    "index": "crusher",
+    "name": "Crusher",
+    "prerequisites": [],
+    "desc": [
+      "You are practiced in the art of crushing your enemies, granting you the following benefits:",
+      "Increase your Strength or Constitution by 1, to a maximum of 20.",
+      "Once per turn, when you hit a creature with an attack that deals bludgeoning damage, you can move it 5 feet to an unoccupied space, provided the target is no more than one size larger than you.",
+      "When you score a critical hit that deals bludgeoning damage to a creature, attack rolls against that creature are made with advantage until the start of your next turn."
+    ],
+    "url": "/api/2014/feats/crusher",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "defensive-duelist",
+    "name": "Defensive Duelist",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2014/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "When you are wielding a finesse weapon with which you are proficient and another creature hits you with a melee attack, you can use your reaction to add your proficiency bonus to your AC for that attack, potentially causing the attack to miss you."
+    ],
+    "url": "/api/2014/feats/defensive-duelist",
+    "source": "players-handbook"
+  },
+  {
+    "index": "dragon-fear",
+    "name": "Dragon Fear",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dragonborn",
+          "name": "Dragonborn",
+          "url": "/api/2014/races/dragonborn"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Cha. and your Breath Weapon can frighten instead of inflicting damages."
+    ],
+    "url": "/api/2014/feats/dragon-fear",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "dragon-hide",
+    "name": "Dragon Hide",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dragonborn",
+          "name": "Dragonborn",
+          "url": "/api/2014/races/dragonborn"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Cha., your AC becomes 13+Dex. modifier and your retractable claws deal 1d4+Str. modifier slashing damage."
+    ],
+    "url": "/api/2014/feats/dragon-hide",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "drow-high-magic",
+    "name": "Drow High Magic",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "elven-lineage-drow",
+          "name": "Elven Lineage: Drow",
+          "url": "/api/2014/subspecies/elven-lineage-drow"
+        }
+      }
+    ],
+    "desc": [
+      "You can cast the detect magic spell (at will) and the levitate and dispel magic spells (1/long rest)."
+    ],
+    "url": "/api/2014/feats/drow-high-magic",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "dual-wielder",
+    "name": "Dual Wielder",
+    "prerequisites": [],
+    "desc": [
+      "You master fighting with two weapons, gaining the following benefits:",
+      "You gain a +1 bonus to AC while you are wielding a separate melee weapon in each hand.",
+      "You can use two-weapon fighting even when the one handed melee weapons you are wielding aren't light.",
+      "You can draw or stow two one-handed weapons when you would normally be able to draw or stow only one."
+    ],
+    "url": "/api/2014/feats/dual-wielder",
+    "source": "players-handbook"
+  },
+  {
+    "index": "dungeon-delver",
+    "name": "Dungeon Delver",
+    "prerequisites": [],
+    "desc": [
+      "Alert to the hidden traps and secret doors found in many dungeons, you gain the following benefits:",
+      "You have advantage on Wisdom (Perception) and Intelligence (Investigation) checks made to detect the presence of secret doors.",
+      "You have advantage on saving throws made to avoid or resist traps.",
+      "You have resistance to the damage dealt by traps.",
+      "Traveling at a fast pace doesn't impose the normal −5 penalty on your passive Wisdom (Perception) score."
+    ],
+    "url": "/api/2014/feats/dungeon-delver",
+    "source": "players-handbook"
+  },
+  {
+    "index": "durable",
+    "name": "Durable",
+    "prerequisites": [],
+    "desc": [
+      "Hardy and resilient, you gain the following benefits:",
+      "Increase your Constitution score by 1, to a maximum of 20.",
+      "When you roll a Hit Die to regain hit points, the minimum number of hit points you regain from the roll equals twice your Constitution modifier (minimum of 2)."
+    ],
+    "url": "/api/2014/feats/durable",
+    "source": "players-handbook"
+  },
+  {
+    "index": "dwarf-fortitude",
+    "name": "Dwarf Fortitude",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "dwarf",
+          "name": "Dwarf",
+          "url": "/api/2014/races/dwarf"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Con., and you can spend one Hit Die to heal yourself taking the Dodge action."
+    ],
+    "url": "/api/2014/feats/dwarf-fortitude",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "eldritch-adept",
+    "name": "Eldritch Adept",
+    "prerequisites": [
+      {
+        "feature": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/2014/features/spellcasting"
+          },
+          {
+            "index": "pact-magic",
+            "name": "Pact Magic",
+            "url": "/api/2014/features/pact-magic"
+          }
+        ],
+        "type": "OR"
+      }
+    ],
+    "desc": [
+      "Studying occult lore, you have unlocked eldritch power within yourself: you learn one Eldritch Invocation option of your choice from the warlock class. If the invocation has a prerequisite of any kind, you can choose that invocation only if you're a warlock who meets the prerequisite.",
+      "Whenever you gain a level, you can replace the invocation with another one from the warlock class."
+    ],
+    "url": "/api/2014/feats/eldritch-adept",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "elemental-adept",
+    "name": "Elemental Adept",
+    "prerequisites": [
+      {
+        "spellcasting": true
+      }
+    ],
+    "desc": [
+      "When you gain this feat, choose one of the following damage types: acid, cold, fire, lightning, or thunder.",
+      "Spells you cast ignore resistance to damage of the chosen type. In addition, when you roll damage for a spell you cast that deals damage of that type, you can treat any 1 on a damage die as a 2.",
+      "You can select this feat multiple times. Each time you do so, you must choose a different damage type."
+    ],
+    "url": "/api/2014/feats/elemental-adept",
+    "source": "players-handbook"
+  },
+  {
+    "index": "elven-accuracy",
+    "name": "Elven Accuracy",
+    "prerequisites": [
+      {
+        "race": [
+          {
+            "index": "elf",
+            "name": "Elf",
+            "url": "/api/2014/races/elf"
+          },
+          {
+            "index": "half-elf",
+            "name": "Half-Elf",
+            "url": "/api/2014/races/half-elf"
+          }
+        ],
+        "type": "OR"
+      }
+    ],
+    "desc": [
+      "The accuracy of elves is legendary, especially that of elf archers and spellcasters. You have uncanny aim with attacks that rely on precision rather than brute force. You gain the following benefits:",
+      "Increase your Dexterity, Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "Whenever you have advantage on an attack roll using Dexterity, Intelligence, Wisdom, or Charisma, you can reroll one of the dice once."
+    ],
+    "url": "/api/2014/feats/elven-accuracy",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "ember-of-the-fire-giant",
+    "name": "Ember of the Fire Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-fire-strike",
+          "name": "Strike of the Giants (Fire Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-fire-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Resistance to fire damage",
+      "1d8+PB fire damage + blinded (15-ft-radius, PB/day)."
+    ],
+    "url": "/api/2014/feats/ember-of-the-fire-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "fade-away",
+    "name": "Fade Away",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "gnome",
+          "name": "Gnome",
+          "url": "/api/2014/races/gnome"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Dex. or Int., and you can use your reaction to become invisible if you take damage."
+    ],
+    "url": "/api/2014/feats/fade-away",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "fey-teleportation",
+    "name": "Fey Teleportation",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "elf-high",
+          "name": "Elf (High)",
+          "url": "/api/2014/races/elf/subraces/high"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Int. or Cha., you speak Sylvan, and you can cast the misty step spell (1/short rest)."
+    ],
+    "url": "/api/2014/feats/fey-teleportation",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "fey-touched",
+    "name": "Fey Touched",
+    "prerequisites": [],
+    "desc": [
+      "Your exposure to the Feywild's magic has changed you, granting you the following benefits:",
+      "Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "You learn the misty step spell and one 1st-level spell of your choice. The 1st-level spell must be from the divination or enchantment school of magic. You can cast each of these spells without expending a spell slot. Once you cast either of these spells in this way, you can't cast that spell in this way again until you finish a long rest. You can also cast these spells using spell slots you have of the appropriate level. The spells' spellcasting ability is the ability increased by this feat."
+    ],
+    "url": "/api/2014/feats/fey-touched",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "fighting-initiate",
+    "name": "Fighting Initiate",
+    "prerequisites": [
+      {
+        "proficiency": {
+          "index": "martial-weapons",
+          "name": "Martial Weapons",
+          "type": "weapon"
+        }
+      }
+    ],
+    "desc": [
+      "Your martial training has helped you develop a particular style of fighting. As a result, you learn one Fighting Style option of your choice from the fighter class. If you already have a style, the one you choose must be different.",
+      "Whenever you reach a level that grants the Ability Score Improvement feature, you can replace this feat's fighting style with another one from the fighter class that you don't have."
+    ],
+    "url": "/api/2014/feats/fighting-initiate",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "flames-of-phlegethos",
+    "name": "Flames of Phlegethos",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "tiefling",
+          "name": "Tiefling",
+          "url": "/api/2014/races/tiefling"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Int. or Cha., reroll any 1 on fire spell damage, and cause flames to wreathe you if you cast a fire spell."
+    ],
+    "url": "/api/2014/feats/flames-of-phlegethos",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "fury-of-the-frost-giant",
+    "name": "Fury of the Frost Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-frost-strike",
+          "name": "Strike of the Giants (Frost Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-frost-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Resistance to cold damage",
+      "1d8+PB cold damage + speed reduced to 0 (PB/day)."
+    ],
+    "url": "/api/2014/feats/fury-of-the-frost-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "gift-of-the-chromatic-dragon",
+    "name": "Gift of the Chromatic Dragon",
+    "prerequisites": [],
+    "desc": [
+      "Chromatic Infusion. As a bonus action, you can touch a simple or martial weapon and infuse it with one of the following damage types: acid, cold, fire, lightning, or poison. For the next minute, the weapon deals an extra 1d4 damage of the chosen type when it hits. After you use this bonus action, you can't do so again until you finish a long rest.",
+      "Reactive Resistance. When you take acid, cold, fire, lightning, or poison damage, you can use your reaction to give yourself resistance to that instance of damage. You can use this reaction a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+    ],
+    "url": "/api/2014/feats/gift-of-the-chromatic-dragon",
+    "source": "fizbans-treasury-of-dragons"
+  },
+  {
+    "index": "gift-of-the-gem-dragon",
+    "name": "Gift of the Gem Dragon",
+    "prerequisites": [],
+    "desc": [
+      "+1 in Int., Wis., or Cha., Strength saving throw or 2d8 force damage and pushed away 10 ft in reaction to an attack (PB/day)."
+    ],
+    "url": "/api/2014/feats/gift-of-the-gem-dragon",
+    "source": "fizbans-treasury-of-dragons"
+  },
+  {
+    "index": "gift-of-the-metallic-dragon",
+    "name": "Gift of the Metallic Dragon",
+    "prerequisites": [],
+    "desc": [
+      "You can cast cure wounds (1/long rest).",
+      "As a reaction to an attack, can manifest wings to get +PB to your AC (PB/day)."
+    ],
+    "url": "/api/2014/feats/gift-of-the-metallic-dragon",
+    "source": "fizbans-treasury-of-dragons"
+  },
+  {
     "index": "grappler",
     "name": "Grappler",
     "prerequisites": [
@@ -13,10 +496,883 @@
       }
     ],
     "desc": [
-      "You’ve developed the Skills necessary to hold your own in close--quarters Grappling. You gain the following benefits:",
-      "- You have advantage on Attack Rolls against a creature you are Grappling.",
-      "- You can use your action to try to pin a creature Grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both Restrained until the grapple ends."
+      "You've developed the skills necessary to hold your own in close-quarters grappling. You gain the following benefits:",
+      "You have advantage on attack rolls against a creature you are grappling.",
+      "You can use your action to try to pin a creature grappled by you. To do so, make another grapple check. If you succeed, you and the creature are both restrained until the grapple ends."
     ],
-    "url": "/api/2014/feats/grappler"
+    "url": "/api/2014/feats/grappler",
+    "source": "players-handbook"
+  },
+  {
+    "index": "great-weapon-master",
+    "name": "Great Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You've learned to put the weight of a weapon to your advantage, letting its momentum empower your strikes. You gain the following benefits:",
+      "On your turn, when you score a critical hit with a melee weapon or reduce a creature to 0 hit points with one, you can make one melee weapon attack as a bonus action.",
+      "Before you make a melee attack with a heavy weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If the attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/2014/feats/great-weapon-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "guile-of-the-cloud-giant",
+    "name": "Guile of the Cloud Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-cloud-strike",
+          "name": "Strike of the Giants (Cloud Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-cloud-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Resistance to attack's damage",
+      "Teleport within 30 ft (PB/day)."
+    ],
+    "url": "/api/2014/feats/guile-of-the-cloud-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "gunner",
+    "name": "Gunner",
+    "prerequisites": [],
+    "desc": [
+      "+1 in Dex., proficiency with firearms, ignore loading property of firearms and no disadvantage to attacks within 5 ft."
+    ],
+    "url": "/api/2014/feats/gunner",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "healer",
+    "name": "Healer",
+    "prerequisites": [],
+    "desc": [
+      "You are an able physician, allowing you to mend wounds quickly and get your allies back in the fight. You gain the following benefits:",
+      "When you use a healer's kit to stabilize a dying creature, that creature also regains 1 hit point.",
+      "As an action, you can spend one use of a healer's kit to tend to a creature and restore 1d6 + 4 hit points to it, plus additional hit points equal to the creature's maximum number of Hit Dice. The creature can't regain hit points from this feat again until it finishes a short or long rest."
+    ],
+    "url": "/api/2014/feats/healer",
+    "source": "players-handbook"
+  },
+  {
+    "index": "heavily-armored",
+    "name": "Heavily Armored",
+    "prerequisites": [
+      {
+        "proficiency": {
+          "index": "medium-armor",
+          "name": "Medium Armor",
+          "type": "armor"
+        }
+      }
+    ],
+    "desc": [
+      "You have trained to master the use of heavy armor, gaining the following benefits:",
+      "Increase your Strength score by 1, to a maximum of 20.",
+      "You gain proficiency with heavy armor."
+    ],
+    "url": "/api/2014/feats/heavily-armored",
+    "source": "players-handbook"
+  },
+  {
+    "index": "heavy-armor-master",
+    "name": "Heavy Armor Master",
+    "prerequisites": [
+      {
+        "proficiency": {
+          "index": "heavy-armor",
+          "name": "Heavy Armor",
+          "type": "armor"
+        }
+      }
+    ],
+    "desc": [
+      "You can use your armor to deflect strikes that would kill others. You gain the following benefits:",
+      "Increase your Strength score by 1, to a maximum of 20.",
+      "While you are wearing heavy armor, bludgeoning, piercing, and slashing damage that you take from nonmagical attacks is reduced by 3."
+    ],
+    "url": "/api/2014/feats/heavy-armor-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "infernal-constitution",
+    "name": "Infernal Constitution",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "tiefling",
+          "name": "Tiefling",
+          "url": "/api/2014/races/tiefling"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Con., resistance to cold and poison damage, and you have advantage on saving throws against being poisoned."
+    ],
+    "url": "/api/2014/feats/infernal-constitution",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "inspiring-leader",
+    "name": "Inspiring Leader",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "cha",
+          "name": "CHA",
+          "url": "/api/2014/ability-scores/cha"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You can spend 10 minutes inspiring your companions, shoring up their resolve to fight. When you do so, choose up to six friendly creatures (which can include yourself) within 30 feet of you who can see or hear you and who can understand you. Each creature can gain temporary hit points equal to your level + your Charisma modifier. A creature can't gain temporary hit points from this feat again until it has finished a short or long rest."
+    ],
+    "url": "/api/2014/feats/inspiring-leader",
+    "source": "players-handbook"
+  },
+  {
+    "index": "keen-mind",
+    "name": "Keen Mind",
+    "prerequisites": [],
+    "desc": [
+      "You have a mind that can track time, direction, and detail with uncanny precision. You gain the following benefits:",
+      "Increase your Intelligence score by 1, to a maximum of 20.",
+      "You always know which way is north.",
+      "You always know the number of hours left before the next sunrise or sunset.",
+      "You can accurately recall anything you have seen or heard within the past month."
+    ],
+    "url": "/api/2014/feats/keen-mind",
+    "source": "players-handbook"
+  },
+  {
+    "index": "keenness-of-the-stone-giant",
+    "name": "Keenness of the Stone Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-stone-strike",
+          "name": "Strike of the Giants (Stone Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-stone-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Darkvision 60 ft",
+      "1d10 force damage with a range of 60 ft + prone (PB/day)."
+    ],
+    "url": "/api/2014/feats/keenness-of-the-stone-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "lightly-armored",
+    "name": "Lightly Armored",
+    "prerequisites": [],
+    "desc": [
+      "You have trained to master the use of light armor, gaining the following benefits:",
+      "Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "You gain proficiency with light armor."
+    ],
+    "url": "/api/2014/feats/lightly-armored",
+    "source": "players-handbook"
+  },
+  {
+    "index": "linguist",
+    "name": "Linguist",
+    "prerequisites": [],
+    "desc": [
+      "You have studied languages and codes, gaining the following benefits:",
+      "Increase your Intelligence score by 1, to a maximum of 20.",
+      "You learn three languages of your choice.",
+      "You can ably create written ciphers. Others can't decipher a code you create unless you teach them, they succeed on an Intelligence check (DC equal to your Intelligence score + your proficiency bonus), or they use magic to decipher it."
+    ],
+    "url": "/api/2014/feats/linguist",
+    "source": "players-handbook"
+  },
+  {
+    "index": "lucky",
+    "name": "Lucky",
+    "prerequisites": [],
+    "desc": [
+      "You have inexplicable luck that seems to kick in at just the right moment.",
+      "You have 3 luck points. Whenever you make an attack roll, an ability check, or a saving throw, you can spend one luck point to roll an additional d20. You can choose to spend one of your luck points after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw.",
+      "You can also spend one luck point when an attack roll is made against you. Roll a d20 and then choose whether the attack uses the attacker's roll or yours.",
+      "If more than one creature spends a luck point to influence the outcome of a roll, the points cancel each other out; no additional dice are rolled.",
+      "You regain your expended luck points when you finish a long rest."
+    ],
+    "url": "/api/2014/feats/lucky",
+    "source": "players-handbook"
+  },
+  {
+    "index": "mage-slayer",
+    "name": "Mage Slayer",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced techniques in melee combat against spellcasters, gaining the following benefits:",
+      "When a creature within 5 feet of you casts a spell, you can use your reaction to make a melee weapon attack against that creature.",
+      "When you damage a creature that is concentrating on a spell, that creature has disadvantage on the saving throw it makes to maintain its concentration.",
+      "You have advantage on saving throws against spells cast by creatures within 5 feet of you."
+    ],
+    "url": "/api/2014/feats/mage-slayer",
+    "source": "players-handbook"
+  },
+  {
+    "index": "magic-initiate",
+    "name": "Magic Initiate",
+    "prerequisites": [],
+    "desc": [
+      "Choose a class: bard, cleric, druid, sorcerer, warlock, or wizard. You learn two cantrips of your choice from that class's spell list.",
+      "In addition, choose one 1st-level spell to learn from that same list. Using this feat, you can cast the spell once at its lowest level, and you must finish a long rest before you can cast it in this way again.",
+      "Your spellcasting ability for these spells depends on the class you chose: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "url": "/api/2014/feats/magic-initiate",
+    "source": "players-handbook"
+  },
+  {
+    "index": "martial-adept",
+    "name": "Martial Adept",
+    "prerequisites": [],
+    "desc": [
+      "You have martial training that allows you to perform special combat maneuvers. You gain the following benefits:",
+      "You learn two maneuvers of your choice from among those available to the Battle Master archetype in the fighter class. If a maneuver you use requires your target to make a saving throw to resist the maneuver's effects, the saving throw DC equals 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+      "You gain one superiority die, which is a d6 (this die is added to any superiority dice you have from another source). This die is used to fuel your maneuvers. A superiority die is expended when you use it. You regain your expended superiority dice when you finish a short or long rest."
+    ],
+    "url": "/api/2014/feats/martial-adept",
+    "source": "players-handbook"
+  },
+  {
+    "index": "medium-armor-master",
+    "name": "Medium Armor Master",
+    "prerequisites": [
+      {
+        "proficiency": {
+          "index": "medium-armor",
+          "name": "Medium Armor",
+          "type": "armor"
+        }
+      }
+    ],
+    "desc": [
+      "You have practiced moving in medium armor to gain the following benefits:",
+      "Wearing medium armor doesn't impose disadvantage on your Dexterity (Stealth) checks.",
+      "When you wear medium armor, you can add 3, rather than 2, to your AC if you have a Dexterity of 16 or higher."
+    ],
+    "url": "/api/2014/feats/medium-armor-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "metamagic-adept",
+    "name": "Metamagic Adept",
+    "prerequisites": [
+      {
+        "feature": [
+          {
+            "index": "spellcasting",
+            "name": "Spellcasting",
+            "url": "/api/2014/features/spellcasting"
+          },
+          {
+            "index": "pact-magic",
+            "name": "Pact Magic",
+            "url": "/api/2014/features/pact-magic"
+          }
+        ],
+        "type": "OR"
+      }
+    ],
+    "desc": [
+      "You learn two metamagic options and gain 2 sorcery points."
+    ],
+    "url": "/api/2014/feats/metamagic-adept",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "mobile",
+    "name": "Mobile",
+    "prerequisites": [],
+    "desc": [
+      "You are exceptionally speedy and agile. You gain the following benefits:",
+      "Your speed increases by 10 feet.",
+      "When you use the Dash action, difficult terrain doesn't cost you extra movement on that turn.",
+      "When you make a melee attack against a creature, you don't provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+    ],
+    "url": "/api/2014/feats/mobile",
+    "source": "players-handbook"
+  },
+  {
+    "index": "moderately-armored",
+    "name": "Moderately Armored",
+    "prerequisites": [
+      {
+        "proficiency": {
+          "index": "light-armor",
+          "name": "Light Armor",
+          "type": "armor"
+        }
+      }
+    ],
+    "desc": [
+      "You have trained to master the use of medium armor and shields, gaining the following benefits:",
+      "Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "You gain proficiency with medium armor and shields."
+    ],
+    "url": "/api/2014/feats/moderately-armored",
+    "source": "players-handbook"
+  },
+  {
+    "index": "mounted-combatant",
+    "name": "Mounted Combatant",
+    "prerequisites": [],
+    "desc": [
+      "You are a dangerous foe to face while mounted. While you are mounted and aren't incapacitated, you gain the following benefits:",
+      "You have advantage on melee attack rolls against any unmounted creature that is smaller than your mount.",
+      "You can force an attack targeted at your mount to target you instead.",
+      "If your mount is subjected to an effect that allows it to make a Dexterity saving throw to take only half damage, it instead takes no damage if it succeeds on the saving throw, and only half damage if it fails."
+    ],
+    "url": "/api/2014/feats/mounted-combatant",
+    "source": "players-handbook"
+  },
+  {
+    "index": "observant",
+    "name": "Observant",
+    "prerequisites": [],
+    "desc": [
+      "Quick to notice details of your environment, you gain the following benefits:",
+      "Increase your Intelligence or Wisdom score by 1, to a maximum of 20.",
+      "If you can see a creature's mouth while it is speaking a language you understand, you can interpret what it's saying by reading its lips.",
+      "You have a +5 bonus to your passive Wisdom (Perception) and passive Intelligence (Investigation) scores."
+    ],
+    "url": "/api/2014/feats/observant",
+    "source": "players-handbook"
+  },
+  {
+    "index": "orcish-fury",
+    "name": "Orcish Fury",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "half-orc",
+          "name": "Half-Orc",
+          "url": "/api/2014/races/half-orc"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str. or Con., add one of the weapon's damage dice, and use a reaction to attack after using Relentless Endurance."
+    ],
+    "url": "/api/2014/feats/orcish-fury",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "piercer",
+    "name": "Piercer",
+    "prerequisites": [],
+    "desc": [
+      "You have achieved a penetrating precision in combat, granting you the following benefits:",
+      "Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "Once per turn, when you hit a creature with an attack that deals piercing damage, you can re-roll one of the attack's damage dice, and you must use the new roll.",
+      "When you score a critical hit that deals piercing damage to a creature, you can roll one additional damage die when determining the extra piercing damage the target takes."
+    ],
+    "url": "/api/2014/feats/piercer",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "poisoner",
+    "name": "Poisoner",
+    "prerequisites": [],
+    "desc": [
+      "Proficiency with poisoner's kit, apply as a bonus action and your attacks ignore resistance to poison damage."
+    ],
+    "url": "/api/2014/feats/poisoner",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "polearm-master",
+    "name": "Polearm Master",
+    "prerequisites": [],
+    "desc": [
+      "You gain the following benefits:",
+      "When you take the Attack action and attack with only a glaive, halberd, quarterstaff, or spear, you can use a bonus action to make a melee attack with the opposite end of the weapon. This attack uses the same ability modifier as the primary attack. The weapon's damage die for this attack is a d4, and it deals bludgeoning damage.",
+      "While you are wielding a glaive, halberd, pike, quarterstaff, or spear, other creatures provoke an opportunity attack from you when they enter the reach you have with that weapon."
+    ],
+    "url": "/api/2014/feats/polearm-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "prodigy",
+    "name": "Prodigy",
+    "prerequisites": [
+      {
+        "race": [
+          {
+            "index": "half-elf",
+            "name": "Half-Elf",
+            "url": "/api/2014/races/half-elf"
+          },
+          {
+            "index": "half-orc",
+            "name": "Half-Orc",
+            "url": "/api/2014/races/half-orc"
+          },
+          {
+            "index": "human",
+            "name": "Human",
+            "url": "/api/2014/races/human"
+          }
+        ],
+        "type": "OR"
+      }
+    ],
+    "desc": [
+      "You have a knack for learning new things. You gain the following benefits:",
+      "You gain one skill proficiency of your choice, one tool proficiency of your choice, and fluency in one language of your choice.",
+      "Choose one skill in which you have proficiency. You gain expertise with that skill, which means your proficiency bonus is doubled for any ability check you make with it. The skill you choose must be one that isn't already benefiting from a feature, such as Expertise, that doubles your proficiency bonus."
+    ],
+    "url": "/api/2014/feats/prodigy",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "resilient",
+    "name": "Resilient",
+    "prerequisites": [],
+    "desc": [
+      "Choose one ability score. You gain the following benefits:",
+      "Increase the chosen ability score by 1, to a maximum of 20.",
+      "You gain proficiency in saving throws using the chosen ability."
+    ],
+    "url": "/api/2014/feats/resilient",
+    "source": "players-handbook"
+  },
+  {
+    "index": "ritual-caster",
+    "name": "Ritual Caster",
+    "prerequisites": [
+      {
+        "ability_score": [
+          {
+            "index": "int",
+            "name": "INT",
+            "url": "/api/2014/ability-scores/int"
+          },
+          {
+            "index": "wis",
+            "name": "WIS",
+            "url": "/api/2014/ability-scores/wis"
+          }
+        ],
+        "minimum_score": 13,
+        "type": "OR"
+      }
+    ],
+    "desc": [
+      "You have learned a number of spells that you can cast as rituals. These spells are written in a ritual book, which you must have in hand while casting one of them.",
+      "When you choose this feat, you acquire a ritual book holding two 1st-level spells of your choice. Choose one of the following classes: bard, cleric, druid, sorcerer, warlock, or wizard. You must choose your spells from that class's spell list, and the spells you choose must have the ritual tag. The class you choose also determines your spellcasting ability for these spells: Charisma for bard, sorcerer, or warlock; Wisdom for cleric or druid; or Intelligence for wizard.",
+      "If you come across a spell in written form, such as a magical spell scroll or a wizard's spellbook, you might be able to add it to your ritual book. The spell must be on the spell list for the class you chose, the spell's level can be no higher than half your level (rounded up), and it must have the ritual tag. The process of copying the spell into your ritual book takes 2 hours per level of the spell, and costs 50 gp per level. The cost represents the material components you expend as you experiment with the spell to master it, as well as the fine inks you need to record it."
+    ],
+    "url": "/api/2014/feats/ritual-caster",
+    "source": "players-handbook"
+  },
+  {
+    "index": "rune-shaper",
+    "name": "Rune Shaper",
+    "prerequisites": [
+      {
+        "type": "OR",
+        "options": [
+          {
+            "feature": {
+              "index": "spellcasting",
+              "name": "Spellcasting",
+              "url": "/api/2014/features/spellcasting"
+            }
+          },
+          {
+            "background": {
+              "index": "rune-carver",
+              "name": "Rune Carver",
+              "url": "/api/2014/backgrounds/rune-carver"
+            }
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "You learn comprehend languages and 1/2 PB 1st-level spells (cast with rune or spell slot)."
+    ],
+    "url": "/api/2014/feats/rune-shaper",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "savage-attacker",
+    "name": "Savage Attacker",
+    "prerequisites": [],
+    "desc": [
+      "Once per turn when you roll damage for a melee weapon attack, you can reroll the weapon's damage dice and use either total."
+    ],
+    "url": "/api/2014/feats/savage-attacker",
+    "source": "players-handbook"
+  },
+  {
+    "index": "second-chance",
+    "name": "Second Chance",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "halfling",
+          "name": "Halfling",
+          "url": "/api/2014/races/halfling"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Dex., Con., or Cha., and you can force a creature to reroll its attack roll if it hits you."
+    ],
+    "url": "/api/2014/feats/second-chance",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "sentinel",
+    "name": "Sentinel",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered techniques to take advantage of every drop in any enemy's guard, gaining the following benefits:",
+      "When you hit a creature with an opportunity attack, the creature's speed becomes 0 for the rest of the turn.",
+      "Creatures provoke opportunity attacks from you even if they take the Disengage action before leaving your reach.",
+      "When a creature makes an attack against a target other than you (and that target doesn't have this feat), you can use your reaction to make a melee weapon attack against the attacking creature."
+    ],
+    "url": "/api/2014/feats/sentinel",
+    "source": "players-handbook"
+  },
+  {
+    "index": "shadow-touched",
+    "name": "Shadow Touched",
+    "prerequisites": [],
+    "desc": [
+      "Your exposure to the Shadowfell's magic has changed you, granting you the following benefits:",
+      "Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "You learn the invisibility spell and one 1st-level spell of your choice. The 1st-level spell must be from the illusion or necromancy school of magic. You can cast each of these spells without expending a spell slot. Once you cast either of these spells in this way, you can't cast that spell in this way again until you finish a long rest. You can also cast these spells using spell slots you have of the appropriate level. The spells' spellcasting ability is the ability increased by this feat."
+    ],
+    "url": "/api/2014/feats/shadow-touched",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "sharpshooter",
+    "name": "Sharpshooter",
+    "prerequisites": [],
+    "desc": [
+      "You have mastered ranged weapons and can make shots that others find impossible. You gain the following benefits:",
+      "Attacking at long range doesn't impose disadvantage on your ranged weapon attack rolls.",
+      "Your ranged weapon attacks ignore half and three-quarters cover.",
+      "Before you make an attack with a ranged weapon that you are proficient with, you can choose to take a -5 penalty to the attack roll. If that attack hits, you add +10 to the attack's damage."
+    ],
+    "url": "/api/2014/feats/sharpshooter",
+    "source": "players-handbook"
+  },
+  {
+    "index": "shield-master",
+    "name": "Shield Master",
+    "prerequisites": [],
+    "desc": [
+      "You use shields not just for protection but also for offense. You gain the following benefits while you are wielding a shield:",
+      "If you take the Attack action on your turn, you can use a bonus action to try to shove a creature within 5 feet of you with your shield.",
+      "If you aren't incapacitated, you can add your shield's AC bonus to any Dexterity saving throw you make against a spell or other harmful effect that targets only you.",
+      "If you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you can use your reaction to take no damage if you succeed on the saving throw, interposing your shield between yourself and the source of the effect."
+    ],
+    "url": "/api/2014/feats/shield-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "skill-expert",
+    "name": "Skill Expert",
+    "prerequisites": [],
+    "desc": [
+      "You have honed your proficiency with particular skills, granting you the following benefits:",
+      "Increase one ability score of your choice by 1, to a maximum of 20.",
+      "You gain proficiency in one skill of your choice.",
+      "Choose one skill in which you have proficiency. You gain expertise with that skill, which means your proficiency bonus is doubled for any ability check you make with it. The skill you choose must be one that isn't already benefiting from a feature, such as Expertise, that doubles your proficiency bonus."
+    ],
+    "url": "/api/2014/feats/skill-expert",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "skilled",
+    "name": "Skilled",
+    "prerequisites": [],
+    "desc": [
+      "You gain proficiency in any combination of three skills or tools of your choice."
+    ],
+    "url": "/api/2014/feats/skilled",
+    "source": "players-handbook"
+  },
+  {
+    "index": "skulker",
+    "name": "Skulker",
+    "prerequisites": [
+      {
+        "ability_score": {
+          "index": "dex",
+          "name": "DEX",
+          "url": "/api/2014/ability-scores/dex"
+        },
+        "minimum_score": 13
+      }
+    ],
+    "desc": [
+      "You are an expert at slinking through shadows. You gain the following benefits:",
+      "You can try to hide when you are lightly obscured from the creature from which you are hiding.",
+      "When you are hidden from a creature and miss it with a ranged weapon attack, making the attack doesn't reveal your position.",
+      "Dim light doesn't impose disadvantage on your Wisdom (Perception) checks relying on sight."
+    ],
+    "url": "/api/2014/feats/skulker",
+    "source": "players-handbook"
+  },
+  {
+    "index": "slasher",
+    "name": "Slasher",
+    "prerequisites": [],
+    "desc": [
+      "You've learned where to cut to have the greatest results, granting you the following benefits:",
+      "Increase your Strength or Dexterity by 1, to a maximum of 20.",
+      "Once per turn when you hit a creature with an attack that deals slashing damage, you can reduce the speed of the target by 10 feet until the start of your next turn.",
+      "When you score a critical hit that deals slashing damage to a creature, you grievously wound it. Until the start of your next turn, the target has disadvantage on all attack rolls."
+    ],
+    "url": "/api/2014/feats/slasher",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "soul-of-the-storm-giant",
+    "name": "Soul of the Storm Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-storm-strike",
+          "name": "Strike of the Giants (Storm Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-storm-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Resistance to lightning and thunder damage",
+      "Disadvantage vs you",
+      "1/2 speed (PB/day)."
+    ],
+    "url": "/api/2014/feats/soul-of-the-storm-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "spell-sniper",
+    "name": "Spell Sniper",
+    "prerequisites": [
+      {
+        "spellcasting": true
+      }
+    ],
+    "desc": [
+      "You have learned techniques to enhance your attacks with certain kinds of spells, gaining the following benefits:",
+      "When you cast a spell that requires you to make an attack roll, the spell's range is doubled.",
+      "Your ranged spell attacks ignore half cover and three-quarters cover.",
+      "You learn one cantrip that requires an attack roll. Choose the cantrip from the bard, cleric, druid, sorcerer, warlock, or wizard spell list. Your spellcasting ability for this cantrip depends on the spell list you chose from: Charisma for bard, sorcerer, and warlock; Wisdom for cleric or druid; or Intelligence for wizard."
+    ],
+    "url": "/api/2014/feats/spell-sniper",
+    "source": "players-handbook"
+  },
+  {
+    "index": "squat-nimbleness",
+    "name": "Squat Nimbleness",
+    "prerequisites": [
+      {
+        "type": "OR",
+        "options": [
+          {
+            "race": {
+              "index": "dwarf",
+              "name": "Dwarf",
+              "url": "/api/2014/races/dwarf"
+            }
+          },
+          {
+            "size": "Small"
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "+1 in Str. or Dex., your speed increases by 5 ft, and proficiency and advantage to escape with Acrobatics or Athletics checks."
+    ],
+    "url": "/api/2014/feats/squat-nimbleness",
+    "source": "xanathars-guide-to-everything"
+  },
+  {
+    "index": "strike-of-the-giants",
+    "name": "Strike of the Giants",
+    "prerequisites": [
+      {
+        "type": "OR",
+        "options": [
+          {
+            "proficiency": {
+              "index": "martial-weapons",
+              "name": "Martial Weapons",
+              "type": "weapon"
+            }
+          },
+          {
+            "background": {
+              "index": "giant-foundling",
+              "name": "Giant Foundling",
+              "url": "/api/2014/backgrounds/giant-foundling"
+            }
+          }
+        ]
+      }
+    ],
+    "desc": [
+      "Extra damage and additional effect when hit with a weapon attack, according to the giant type chosen (PB/day)."
+    ],
+    "url": "/api/2014/feats/strike-of-the-giants",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "tavern-brawler",
+    "name": "Tavern Brawler",
+    "prerequisites": [],
+    "desc": [
+      "Accustomed to rough-and-tumble fighting using whatever weapons happen to be at hand, you gain the following benefits:",
+      "Increase your Strength or Constitution score by 1, to a maximum of 20.",
+      "You are proficient with improvised weapons and unarmed strikes.",
+      "Your unarmed strike uses a d4 for damage.",
+      "When you hit a creature with an unarmed strike or an improvised weapon on your turn, you can use a bonus action to attempt to grapple the target."
+    ],
+    "url": "/api/2014/feats/tavern-brawler",
+    "source": "players-handbook"
+  },
+  {
+    "index": "telekinetic",
+    "name": "Telekinetic",
+    "prerequisites": [],
+    "desc": [
+      "You learn to move things with your mind, granting you the following benefits:",
+      "Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "You learn the mage hand cantrip. You can cast it without verbal or somatic components, and you can make the spectral hand invisible. If you already know this spell, its range increases by 30 feet when you cast it. Its spellcasting ability is the ability increased by this feat.",
+      "As a bonus action, you can try to telekinetically shove one creature you can see within 30 feet of you. When you do so, the target must succeed on a Strength saving throw (DC 8 + your proficiency bonus + the ability modifier of the score increased by this feat) or be moved 5 feet toward or away from you. A creature can willingly fail this save."
+    ],
+    "url": "/api/2014/feats/telekinetic",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "telepathic",
+    "name": "Telepathic",
+    "prerequisites": [],
+    "desc": [
+      "You awaken the ability to mentally connect with others, granting you the following benefits:",
+      "Increase your Intelligence, Wisdom, or Charisma score by 1, to a maximum of 20.",
+      "You can speak telepathically to any creature you can see within 60 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn't give the creature the ability to respond to you telepathically.",
+      "You can cast the Detect Thoughts spell, requiring no spell slot or components, and you must finish a long rest before you can cast it this way again. Your spellcasting ability for the spell is the ability increased by this feat. If you have spell slots of 2nd level or higher, you can cast this spell with them."
+    ],
+    "url": "/api/2014/feats/telepathic",
+    "source": "tashas-cauldron-of-everything"
+  },
+  {
+    "index": "tough",
+    "name": "Tough",
+    "prerequisites": [],
+    "desc": [
+      "Your hit point maximum increases by an amount equal to twice your level when you gain this feat.",
+      "Whenever you gain a level thereafter, your hit point maximum increases by an additional 2 hit points."
+    ],
+    "url": "/api/2014/feats/tough",
+    "source": "players-handbook"
+  },
+  {
+    "index": "vigor-of-the-hill-giant",
+    "name": "Vigor of the Hill Giant",
+    "prerequisites": [
+      {
+        "level": {
+          "minimum": 4
+        }
+      },
+      {
+        "feat": {
+          "index": "strike-of-the-giants-hill-strike",
+          "name": "Strike of the Giants (Hill Strike)",
+          "url": "/api/2014/feats/strike-of-the-giants-hill-strike"
+        }
+      }
+    ],
+    "desc": [
+      "+1 in Str., Con., or Wis.",
+      "Resistance to being prone",
+      "Hit Dice to regain additional hit points equals to your Con. modifier + PB."
+    ],
+    "url": "/api/2014/feats/vigor-of-the-hill-giant",
+    "source": "glory-of-the-giants"
+  },
+  {
+    "index": "war-caster",
+    "name": "War Caster",
+    "prerequisites": [
+      {
+        "spellcasting": true
+      }
+    ],
+    "desc": [
+      "You have practiced casting spells in the midst of combat, learning techniques that grant you the following benefits:",
+      "You have advantage on Constitution saving throws that you make to maintain your concentration on a spell when you take damage.",
+      "You can perform the somatic components of spells even when you have weapons or a shield in one or both hands.",
+      "When a hostile creature's movement provokes an opportunity attack from you, you can use your reaction to cast a spell at the creature, rather than making an opportunity attack. The spell must have a casting time of 1 action and must target only that creature."
+    ],
+    "url": "/api/2014/feats/war-caster",
+    "source": "players-handbook"
+  },
+  {
+    "index": "weapon-master",
+    "name": "Weapon Master",
+    "prerequisites": [],
+    "desc": [
+      "You have practiced extensively with a variety of weapons, gaining the following benefits:",
+      "Increase your Strength or Dexterity score by 1, to a maximum of 20.",
+      "You gain proficiency with four weapons of your choice. Each one must be a simple or a martial weapon."
+    ],
+    "url": "/api/2014/feats/weapon-master",
+    "source": "players-handbook"
+  },
+  {
+    "index": "wood-elf-magic",
+    "name": "Wood Elf Magic",
+    "prerequisites": [
+      {
+        "race": {
+          "index": "elf-wood",
+          "name": "Elf (Wood)",
+          "url": "/api/2014/races/elf/subraces/wood"
+        }
+      }
+    ],
+    "desc": [
+      "You learn one druid cantrip and can cast the longstrider and pass without trace spells (1/long rest)."
+    ],
+    "url": "/api/2014/feats/wood-elf-magic",
+    "source": "xanathars-guide-to-everything"
   }
 ]


### PR DESCRIPTION
## What does this do?

Implements feat 2014 in English
Update structure : 

- ability_score became an array, for multiple ability_score and gain an entry type which is OR|AND
- prerequisites > race, feat, level, class added from scratch but with the same structure
- source : new entry also, in kebab-case, which is [see image]

## How was it tested?

Locally

## Is there a Github issue this is resolving?

nope

## Did you update the docs in the API? Please link an associated PR if applicable.

nope

## Here's a fun image for your troubles

No troubles here :)
