### PR TITLE
fix(5e-SRD-Monsters.json): OCR mistake

### DIFF
--- a/src/2014/en/5e-SRD-Monsters.json
+++ b/src/2014/en/5e-SRD-Monsters.json
@@ -5935,7 +5935,7 @@
       },
       {
         "name": "Cold Breath",
-        "desc": "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (l6d8) cold damage on a failed save, or half as much damage on a successful one.",
+        "desc": "The dragon exhales an icy blast in a 90-foot cone. Each creature in that area must make a DC 22 Constitution saving throw, taking 72 (16d8) cold damage on a failed save, or half as much damage on a successful one.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",

--- a/src/2014/en/5e-SRD-Monsters.json
+++ b/src/2014/en/5e-SRD-Monsters.json
@@ -34902,7 +34902,7 @@
       },
       {
         "name": "Searing Burst (Costs 2 Actions)",
-        "desc": "The solar emits magical, divine energy. Each creature of its choice in a 10 -foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one.",
+        "desc": "The solar emits magical, divine energy. Each creature of its choice in a 10-foot radius must make a DC 23 Dexterity saving throw, taking 14 (4d6) fire damage plus 14 (4d6) radiant damage on a failed save, or half as much damage on a successful one.",
         "dc": {
           "dc_type": {
             "index": "dex",


### PR DESCRIPTION
## What does this do?

Corrects a small mistake likely introduced by OCR.

## How was it tested?

Not tested.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.

## Here's a fun image for your troubles