### PR TITLE
fix(5e-SRD-Monsters): Whitespaces, spelling

### DIFF
--- a/src/2014/en/5e-SRD-Monsters.json
+++ b/src/2014/en/5e-SRD-Monsters.json
@@ -3354,7 +3354,7 @@
       },
       {
         "name": "Bite",
-        "desc": "Melee Weapon Attack:+ 15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage.",
+        "desc": "Melee Weapon Attack: +15 to hit, reach 15 ft., one target. Hit: 19 (2d10 + 8) piercing damage plus 9 (2d8) acid damage.",
         "attack_bonus": 15,
         "damage": [
           {
@@ -43924,7 +43924,7 @@
       },
       {
         "name": "Lightning Breath",
-        "desc": "The dragon exhales lightning in an 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.",
+        "desc": "The dragon exhales lightning in a 60-foot line that is 5 feet wide. Each creature in that line must make a DC 16 Dexterity saving throw, taking 55 (10d10) lightning damage on a failed save, or half as much damage on a successful one.",
         "usage": {
           "type": "recharge on roll",
           "dice": "1d6",


### PR DESCRIPTION
## What does this do?

Fixes two whitespaces and spelling.

## How was it tested?

Not tested.

## Is there a Github issue this is resolving?

No.

## Did you update the docs in the API? Please link an associated PR if applicable.

No.