### PR TITLE
fix: Add starting_gold to Acolyte background

### DIFF
--- a/src/2014/en/5e-SRD-Backgrounds.json
+++ b/src/2014/en/5e-SRD-Backgrounds.json
@@ -40,6 +40,10 @@
         "quantity": 1
       }
     ],
+    "starting_gold": {
+      "quantity": 15,
+      "unit": "gp"
+    },
     "starting_equipment_options": [
       {
         "choose": 1,

--- a/src/2014/schemas/5e-SRD-Backgrounds.ts
+++ b/src/2014/schemas/5e-SRD-Backgrounds.ts
@@ -1,6 +1,11 @@
 import { z } from 'zod';
 import { APIReferenceSchema, ChoiceSchema } from '../../schemas/common';
 
+const CostSchema = z.strictObject({
+  quantity: z.number(),
+  unit: z.string(),
+});
+
 const BackgroundFeatureSchema = z.strictObject({
   name: z.string(),
   desc: z.array(z.string()),
@@ -18,6 +23,7 @@ export const BackgroundSchema = z.strictObject({
   language_options: ChoiceSchema.optional(),
   starting_equipment: z.array(StartingEquipmentSchema).optional(),
   starting_equipment_options: z.array(ChoiceSchema).optional(),
+  starting_gold: CostSchema.optional(),
   feature: BackgroundFeatureSchema.optional(),
   personality_traits: ChoiceSchema.optional(),
   ideals: ChoiceSchema.optional(),


### PR DESCRIPTION
The Acolyte background is missing its 15 gp starting gold per the SRD. Adds the field to the JSON data and the Zod schema (optional, matching the Cost shape used in equipment entries).

Closes 5e-bits/5e-database#536