### PR TITLE
fix(monsters): Fix monster structured-field/desc errata that contradict each entry's own prose (2014 SRD)

### DIFF
--- a/src/2014/en/5e-SRD-Monsters.json
+++ b/src/2014/en/5e-SRD-Monsters.json
@@ -844,7 +844,7 @@
               "name": "Bludgeoning",
               "url": "/api/2014/damage-types/bludgeoning"
             },
-            "damage_dice": "2d6+6"
+            "damage_dice": "2d6+7"
           }
         ]
       }
@@ -1699,7 +1699,7 @@
               "name": "Bludgeoning",
               "url": "/api/2014/damage-types/bludgeoning"
             },
-            "damage_dice": "13d6+6"
+            "damage_dice": "2d6+6"
           }
         ]
       }
@@ -2927,7 +2927,7 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
       },
       {
         "name": "Legendary Resistance",
@@ -5322,9 +5322,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "2d10+10"
           },
@@ -5833,7 +5833,7 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
       },
       {
         "name": "Legendary Resistance",
@@ -9090,7 +9090,7 @@
               "name": "Acid",
               "url": "/api/2014/damage-types/acid"
             },
-            "damage_dice": "1d8+8"
+            "damage_dice": "1d8"
           }
         ]
       },
@@ -9434,9 +9434,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "lightning",
+              "name": "Lightning",
+              "url": "/api/2014/damage-types/lightning"
             },
             "damage_dice": "4d10"
           }
@@ -12340,9 +12340,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1d10+2"
           }
@@ -12780,9 +12780,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1d6+2"
           }
@@ -13874,9 +13874,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "piercing",
-              "name": "Piercing",
-              "url": "/api/2014/damage-types/piercing"
+              "index": "slashing",
+              "name": "Slashing",
+              "url": "/api/2014/damage-types/slashing"
             },
             "damage_dice": "2d8+7"
           }
@@ -14437,9 +14437,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1d6+2"
           }
@@ -14811,7 +14811,7 @@
     "actions": [
       {
         "name": "Club",
-        "desc": "Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1 d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh.",
+        "desc": "Melee Weapon Attack: +2 to hit (+6 to hit with shillelagh), reach 5 ft., one target. Hit: 2 (1d4) bludgeoning damage, or 8 (1d8 + 4) bludgeoning damage with shillelagh.",
         "attack_bonus": 2,
         "damage": [
           {
@@ -14937,9 +14937,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1d6+2"
           }
@@ -15165,9 +15165,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "slashing",
+              "name": "Slashing",
+              "url": "/api/2014/damage-types/slashing"
             },
             "damage_dice": "1d4+2"
           }
@@ -16029,7 +16029,7 @@
               "name": "Piercing",
               "url": "/api/2014/damage-types/piercing"
             },
-            "damage_dice": "2d6+2"
+            "damage_dice": "1d8+2"
           },
           {
             "damage_type": {
@@ -16048,9 +16048,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "slashing",
+              "name": "Slashing",
+              "url": "/api/2014/damage-types/slashing"
             },
             "damage_dice": "2d4+2"
           }
@@ -16272,7 +16272,7 @@
               "name": "Fire",
               "url": "/api/2014/damage-types/fire"
             },
-            "damage_dice": "5d10"
+            "damage_dice": "1d10"
           }
         ]
       },
@@ -16634,9 +16634,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1"
           },
@@ -19980,9 +19980,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "5d6"
           }
@@ -23628,9 +23628,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "2d8+4"
           }
@@ -29114,9 +29114,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1d8+1"
           }
@@ -31026,9 +31026,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "3d6+4"
           }
@@ -33581,7 +33581,7 @@
       },
       {
         "name": "Shortsword",
-        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1 d6 + 3) piercing damage.",
+        "desc": "Melee Weapon Attack: +5 to hit, reach 5 ft., one target. Hit: 6 (1d6 + 3) piercing damage.",
         "attack_bonus": 5,
         "damage": [
           {
@@ -33658,9 +33658,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "bludgeoning",
-              "name": "Bludgeoning",
-              "url": "/api/2014/damage-types/bludgeoning"
+              "index": "piercing",
+              "name": "Piercing",
+              "url": "/api/2014/damage-types/piercing"
             },
             "damage_dice": "1"
           }
@@ -34843,9 +34843,9 @@
         "damage": [
           {
             "damage_type": {
-              "index": "radiant",
-              "name": "Radiant",
-              "url": "/api/2014/damage-types/radiant"
+              "index": "slashing",
+              "name": "Slashing",
+              "url": "/api/2014/damage-types/slashing"
             },
             "damage_dice": "4d6+8"
           },
@@ -45479,7 +45479,7 @@
     "special_abilities": [
       {
         "name": "Ice Walk",
-        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+        "desc": "The dragon can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra movement."
       }
     ],
     "actions": [


### PR DESCRIPTION
## Summary

26 monsters in `src/2014/en/5e-SRD-Monsters.json` carry a structured field (`damage[].damage_type`, `damage[].damage_dice`) or a `desc` typo that contradicts the entry's own prose. In every case the prose matches the printed stat block and the structured field is the error, so each change conforms the structured field to the prose. Found by diffing structured-vs-prose across all 334 monsters — same class as #427 and #217.

Each `damage_type` change updates `index`, `name`, and `url` consistently; no other fields are touched.

## Wrong `damage_type` (16)

| monster | action | was | now |
|---|---|---|---|
| ancient-red-dragon | Bite | bludgeoning | piercing |
| crocodile | Bite | bludgeoning | piercing |
| death-dog | Bite | bludgeoning | piercing |
| hunter-shark | Bite | bludgeoning | piercing |
| plesiosaurus | Bite | bludgeoning | piercing |
| gibbering-mouther | Bites | bludgeoning | piercing |
| flying-snake | Bite | bludgeoning | piercing |
| scorpion | Sting | bludgeoning | piercing |
| drow | Shortsword | bludgeoning | piercing |
| duergar | Javelin | bludgeoning | piercing |
| noble | Rapier | bludgeoning | piercing |
| eagle | Talons | bludgeoning | slashing |
| ettercap | Claws | bludgeoning | slashing |
| dragon-turtle | Claw | piercing | slashing |
| blue-dragon-wyrmling | Lightning Breath | bludgeoning | lightning |
| solar | Greatsword (1st component) | radiant | slashing |

## Wrong `damage_dice` (5)

| monster | action | was | now | the prose says |
|---|---|---|---|---|
| adult-copper-dragon | Wing Attack | `13d6+6` | `2d6+6` | "13 (2d6 + 6)" — avg 49 → 13 |
| adult-blue-dragon | Wing Attack | `2d6+6` | `2d6+7` | "14 (2d6 + 7)" |
| ettercap | Bite | `2d6+2` | `1d8+2` | "6 (1d8 + 2)" |
| black-pudding | Corrosive Form | `1d8+8` | `1d8` | "4 (1d8)" |
| fire-elemental | Fire Form | `5d10` | `1d10` | "5 (1d10)" |

## `desc` typos (5)

- `adult-white-dragon` / `ancient-white-dragon` / `young-white-dragon` — Ice Walk: "extra moment" → "extra movement"
- `dryad` — Club: "2 (1 d4)" → "2 (1d4)"
- `satyr` — Shortsword: "6 (1 d6 + 3)" → "6 (1d6 + 3)"
