### PR TITLE
feat: Add Docker argument for MongoDB version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 # This recipe is pulled from: https://stackoverflow.com/a/33601894
 
 # Parent Dockerfile https://github.com/docker-library/mongo/blob/982328582c74dd2f0a9c8c77b84006f291f974c3/3.0/Dockerfile
-FROM mongo:6.0.1
+ARG MONGODB='6.0.1'
+
+FROM mongo:${MONGODB}
 
 # Modify child mongo to use /data/db2 as dbpath (because /data/db wont persist the build)
 COPY ./docker/mongodb.conf /etc

--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ docker build -t 5e-database .
 docker run -i -t 5e-database:latest
 ```
 
+During the `build` step, you can specify the version of MongoDB to use with the following:
+
+```bash
+docker build --build-arg MONGODB=4.4 -t 5e-database .
+```
+
+*MongoDB v4.4 is the latest version that does not require the AVX instruction set to run.*
+
 ### Without Docker
 
 First you need to make sure you have [MongoDB installed locally.](https://docs.mongodb.com/manual/installation/)


### PR DESCRIPTION
## What does this do?

This PR modifies the Dockerfile to allow it to take a parameter to select the MongoDB version that the image will be built from.

## How was it tested?

Locally using Docker Desktop

## Is there a Github issue this is resolving?

This resolves #605.

## Did you update the docs in the API? Please link an associated PR if applicable.

The API is unaffected by this change; however I did update the README.md to describe the modified build command.

## Here's a fun image for your troubles

<img width="1221" height="920" alt="image" src="https://github.com/user-attachments/assets/ad25c3de-5de1-4954-b0f3-b777d0978855" />
