### PR TITLE
chore(ci): auto-merge Dependabot patch/minor PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,27 @@
+name: Dependabot auto-merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: meta
+        uses: dependabot/fetch-metadata@v3
+
+      - name: Approve and enable auto-merge (patch/minor only)
+        if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          # PAT owned by a code owner (@bagelbits) — approves as you to satisfy
+          # the code-owner review gate. GITHUB_TOKEN and App tokens cannot.
+          GH_TOKEN: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN }}


### PR DESCRIPTION
## What

Adds `.github/workflows/dependabot-auto-merge.yml`: approves and enables auto-merge on Dependabot **patch/minor** PRs.

## How it works

- Triggers on `pull_request_target`, gated to `github.actor == 'dependabot[bot]'`.
- `dependabot/fetch-metadata` classifies the update; **major** bumps are skipped (still need manual review).
- Approves + `gh pr merge --auto --squash`. Auto-merge waits for required checks (Lint Code, Run tests, Validate PR title) before merging; `delete_branch_on_merge` cleans up.

## Why a PAT instead of the deploy App

The `main` ruleset requires a **code-owner** review (CODEOWNERS = `@bagelbits`). A bot/App can't be a code owner, so an App approval wouldn't satisfy the gate — using it would force dropping `require_code_owner_review`, widening merge authority to all push collaborators. A code-owner PAT approves *as the owner*, so the ruleset stays untouched and human PRs are unaffected.

## Setup required before this works

- Repo secret `DEPENDABOT_AUTOMERGE_TOKEN`: fine-grained PAT owned by @bagelbits, scoped to this repo, Pull requests + Contents read/write.

## Not included

- Major-version auto-merge (intentional).
- Dependabot PR grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)