### PR TITLE
chore(ci): harden Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -8,12 +8,12 @@ permissions:
 
 jobs:
   auto-merge:
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Fetch Dependabot metadata
         id: meta
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
 
       - name: Approve and enable auto-merge (patch/minor only)
         if: steps.meta.outputs.update-type != 'version-update:semver-major'


### PR DESCRIPTION
Follow-up hardening for the auto-merge workflow added in #1188, from a security review.

## Changes

- **Gate on PR author, not triggerer.** `github.actor` reflects whoever triggered the latest event (e.g. a re-run), not the PR author. Switch to `github.event.pull_request.user.login == 'dependabot[bot]'` so the job only runs for PRs actually opened by Dependabot.
- **Pin `dependabot/fetch-metadata` to a commit SHA** (`25dd0e3` # v3.1.0) instead of the mutable `@v3` tag, closing the supply-chain window on that step.

## Not changed (by design)

- Auto-approve/merge itself: intended feature. Code-owner review gate stays enforced (PAT approves as the owner), CI checks still required, major bumps still excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)